### PR TITLE
support failover url in MySQLDataSourceMetaData

### DIFF
--- a/shardingsphere-underlying/shardingsphere-common/src/main/java/org/apache/shardingsphere/underlying/common/database/metadata/dialect/MySQLDataSourceMetaData.java
+++ b/shardingsphere-underlying/shardingsphere-common/src/main/java/org/apache/shardingsphere/underlying/common/database/metadata/dialect/MySQLDataSourceMetaData.java
@@ -41,7 +41,7 @@ public final class MySQLDataSourceMetaData implements DataSourceMetaData {
     
     private final String schema;
     
-    private final Pattern pattern = Pattern.compile("jdbc:(mysql|mysqlx)(:loadbalance|:replication)?:(\\w*:)?//([\\w\\-\\.]+):?([0-9]*)/([\\w\\-]+);?\\S*", Pattern.CASE_INSENSITIVE);
+    private final Pattern pattern = Pattern.compile("jdbc:(mysql|mysqlx)(:loadbalance|:replication)?:(\\w*:)?//([\\w\\-\\.]+):?([0-9]*),?.*?/([\\w\\-]+);?\\S*", Pattern.CASE_INSENSITIVE);
     
     public MySQLDataSourceMetaData(final String url) {
         Matcher matcher = pattern.matcher(url);

--- a/shardingsphere-underlying/shardingsphere-common/src/test/java/org/apache/shardingsphere/underlying/common/database/metadata/dialect/MySQLDataSourceMetaDataTest.java
+++ b/shardingsphere-underlying/shardingsphere-common/src/test/java/org/apache/shardingsphere/underlying/common/database/metadata/dialect/MySQLDataSourceMetaDataTest.java
@@ -36,6 +36,15 @@ public final class MySQLDataSourceMetaDataTest {
     }
     
     @Test
+    public void assertFailoverUrl() {
+        MySQLDataSourceMetaData actual = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999,127.0.0.1:3306,127.0.0.1:3307/ds_0?serverTimezone=UTC&useSSL=false");
+        assertThat(actual.getHostName(), is("127.0.0.1"));
+        assertThat(actual.getPort(), is(9999));
+        assertThat(actual.getCatalog(), is("ds_0"));
+        assertNull(actual.getSchema());
+    }
+    
+    @Test
     public void assertNewConstructorWithDefaultPort() {
         MySQLDataSourceMetaData actual = new MySQLDataSourceMetaData("jdbc:mysql:loadbalance://127.0.0.1/ds_0?serverTimezone=UTC&useSSL=false");
         assertThat(actual.getHostName(), is("127.0.0.1"));


### PR DESCRIPTION
for #5220 
support failover url in MySQLDataSourceMetaData(just extract primary hostname and port)