### PR TITLE
remove redecryption codes in getQueryData()

### DIFF
--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/communication/jdbc/JDBCDatabaseCommunicationEngine.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/communication/jdbc/JDBCDatabaseCommunicationEngine.java
@@ -151,13 +151,6 @@ public final class JDBCDatabaseCommunicationEngine implements DatabaseCommunicat
         List<Object> row = new ArrayList<>(queryHeaders.size());
         for (int columnIndex = 1; columnIndex <= queryHeaders.size(); columnIndex++) {
             Object value = mergedResult.getValue(columnIndex, Object.class);
-            if (isQueryWithCipherColumn && encryptRule.isPresent()) {
-                QueryHeader queryHeader = ((QueryResponse) response).getQueryHeaders().get(columnIndex - 1);
-                Optional<Encryptor> encryptor = encryptRule.get().findEncryptor(queryHeader.getTable(), queryHeader.getColumnName());
-                if (encryptor.isPresent()) {
-                    value = encryptor.get().decrypt(getCiphertext(value));
-                }
-            }
             row.add(value);
         }
         return new QueryData(getColumnTypes(queryHeaders), row);


### PR DESCRIPTION
 Object value = mergedResult.getValue(columnIndex, Object.class) has already decrypt the value, so no need do decryption again. Please do the double check.

Reviewers @terrymanu @tristaZero @cherrylzhao
Changes proposed in this pull request:
 
-remove duplicate decryption codes
