### PR TITLE
a custom datetime shard algorithm used to shard tables by days/weeks/months/QUARTER_OF_YEAR

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithm.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.core.strategy.algorithm.sharding;
+
+import com.google.common.base.Preconditions;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.api.sharding.standard.PreciseShardingValue;
+import org.apache.shardingsphere.api.sharding.standard.RangeShardingValue;
+import org.apache.shardingsphere.api.sharding.standard.StandardShardingAlgorithm;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalField;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * Datetime sharding algorithm that adapt various shard method by define properties below.
+ *
+ * <p>properties defined here:
+ *
+ * <p>datetime.format: the datetime format used by applications, must can be transformed to {@link LocalDateTime},
+ * used by {@link LocalDateTime#parse(CharSequence, DateTimeFormatter)}.
+ *
+ * <p>table.suffix.format: suffix for sharded tables, used by {@link LocalDateTime#format(DateTimeFormatter)},
+ * examples:
+ * suffix=yyyyQQ means shard by {@link IsoFields#QUARTER_OF_YEAR};
+ * suffix=yyyyMMdd means shard by {@link ChronoField#DAY_OF_YEAR}.
+ *
+ * <p>detail explain for each char in datetime.format and table.suffix.format can refer {@link TemporalField}.
+ *
+ * <p>datetime.lower and datetime.upper: if app query with only half bound, lower and upper helps to build other half bound,
+ * datetime.lower must be specified and datetime.upper has a default value to {@link LocalDateTime#now}
+ * (default value of datetime.upper could only be used when query sql needn't get result that time larger than query time).
+ *
+ * <p>datetime.step.unit and datetime.step.amount used for calculate tables for range shard, datetime.step.unit is name of
+ * {@link ChronoUnit}, default unit is Days and amount is 1, amount + unit should not be larger than but close to your shard range.
+ *
+ * <p>examples: when shard by {@link IsoFields#QUARTER_OF_YEAR}, datetime.step.unit = Months and datetime.step.amount = 3 is a better choice.
+ */
+public class CustomDateTimeShardingAlgorithm implements StandardShardingAlgorithm<Comparable<?>> {
+
+    private static final String DATE_TIME_FORMAT = "datetime.format";
+
+    private static final String TABLE_SUFFIX_FORMAT = "table.suffix.format";
+
+    private static final String DEFAULT_LOWER = "datetime.lower";
+
+    private static final String DEFAULT_UPPER = "datetime.upper";
+
+    private static final String STEP_UNIT = "datetime.step.unit";
+
+    private static final String STEP_AMOUNT = "datetime.step.amount";
+
+    private DateTimeFormatter datetimeFormatter;
+
+    private ChronoUnit stepUnit;
+
+    private int stepAmount;
+
+    private volatile boolean init;
+
+    @Getter
+    @Setter
+    private Properties properties = new Properties();
+
+    @Override
+    public String doSharding(final Collection<String> availableTargetNames, final PreciseShardingValue<Comparable<?>> shardingValue) {
+        checkInit();
+        return availableTargetNames.stream()
+                .filter(tableName -> tableName.endsWith(formatForDateTime(parseDateTimeForValue(shardingValue.getValue().toString()))))
+                .findFirst().orElseThrow(() -> new UnsupportedOperationException(
+                        String.format("failed to shard value %s, and availableTables %s", shardingValue, availableTargetNames)));
+    }
+
+    @Override
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingValue<Comparable<?>> shardingValue) {
+        checkInit();
+        boolean hasStart = shardingValue.getValueRange().hasLowerBound();
+        boolean hasEnd = shardingValue.getValueRange().hasUpperBound();
+        Set<String> tables = new HashSet<>();
+        if (!hasStart && !hasEnd) {
+            return availableTargetNames;
+        }
+        LocalDateTime start = hasStart
+                ? parseDateTimeForValue(shardingValue.getValueRange().lowerEndpoint().toString())
+                : parseDateTimeForValue(properties.getProperty(DEFAULT_LOWER));
+        LocalDateTime end = hasEnd
+                ? parseDateTimeForValue(shardingValue.getValueRange().upperEndpoint().toString())
+                : properties.getProperty(DEFAULT_UPPER) == null
+                ? LocalDateTime.now()
+                : parseDateTimeForValue(properties.getProperty(DEFAULT_UPPER));
+        LocalDateTime tmp = start;
+        while (!tmp.isAfter(end)) {
+            mergeTableIfMatch(tmp, tables, availableTargetNames);
+            tmp = tmp.plus(stepAmount, stepUnit);
+        }
+        mergeTableIfMatch(end, tables, availableTargetNames);
+        return tables;
+    }
+
+    private LocalDateTime parseDateTimeForValue(final String value) {
+        return LocalDateTime.parse(value.substring(0, properties.getProperty(DATE_TIME_FORMAT).length()), datetimeFormatter);
+    }
+
+    private String formatForDateTime(final LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(properties.get(TABLE_SUFFIX_FORMAT).toString()));
+    }
+
+    private void mergeTableIfMatch(final LocalDateTime dateTime, final Collection<String> tables, final Collection<String> availableTargetNames) {
+        String suffix = formatForDateTime(dateTime);
+        availableTargetNames.parallelStream().filter(tableName -> tableName.endsWith(suffix)).findAny().map(tables::add);
+    }
+
+    private void checkInit() {
+        if (!init) {
+            synchronized (this) {
+                if (!init) {
+                    verifyProperties();
+                    init = true;
+                }
+            }
+        }
+    }
+
+    private void verifyProperties() {
+        Preconditions.checkNotNull(properties.getProperty(DATE_TIME_FORMAT));
+        Preconditions.checkNotNull(properties.getProperty(TABLE_SUFFIX_FORMAT));
+        Preconditions.checkNotNull(properties.getProperty(DEFAULT_LOWER));
+        stepUnit = properties.getProperty(STEP_UNIT) == null
+                ? stepUnit = ChronoUnit.DAYS
+                : generateStepUnit();
+        stepAmount = Integer.parseInt(properties.getProperty(STEP_AMOUNT, "1"));
+        datetimeFormatter = DateTimeFormatter.ofPattern(properties.getProperty(DATE_TIME_FORMAT));
+        try {
+            parseDateTimeForValue(properties.getProperty(DEFAULT_LOWER));
+            if (properties.getProperty(DEFAULT_UPPER) != null) {
+                parseDateTimeForValue(properties.getProperty(DEFAULT_UPPER));
+            }
+        } catch (DateTimeParseException e) {
+            throw new UnsupportedOperationException("can't apply shard value for default lower/upper values", e);
+        }
+    }
+
+    private ChronoUnit generateStepUnit() {
+        for (ChronoUnit unit : ChronoUnit.values()) {
+            if (unit.toString().equalsIgnoreCase(properties.getProperty(STEP_UNIT))) {
+                return unit;
+            }
+        }
+        throw new UnsupportedOperationException(
+                String.format("can't find step unit for specified datetime.step.unit prop: %s", properties.getProperty(STEP_UNIT)));
+    }
+
+    @Override
+    public String getType() {
+        return "CUSTOM_DATE_TIME";
+    }
+
+}

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithm.java
@@ -47,6 +47,7 @@ import java.util.Set;
  * <p>table.suffix.format: suffix for sharded tables, used by {@link LocalDateTime#format(DateTimeFormatter)},
  * examples:
  * suffix=yyyyQQ means shard by {@link IsoFields#QUARTER_OF_YEAR};
+ * suffix=yyyyMM means shard by {@link ChronoUnit#MONTHS};
  * suffix=yyyyMMdd means shard by {@link ChronoField#DAY_OF_YEAR}.
  *
  * <p>detail explain for each char in datetime.format and table.suffix.format can refer {@link TemporalField}.
@@ -150,7 +151,7 @@ public class CustomDateTimeShardingAlgorithm implements StandardShardingAlgorith
         Preconditions.checkNotNull(properties.getProperty(TABLE_SUFFIX_FORMAT));
         Preconditions.checkNotNull(properties.getProperty(DEFAULT_LOWER));
         stepUnit = properties.getProperty(STEP_UNIT) == null
-                ? stepUnit = ChronoUnit.DAYS
+                ? ChronoUnit.DAYS
                 : generateStepUnit();
         stepAmount = Integer.parseInt(properties.getProperty(STEP_AMOUNT, "1"));
         datetimeFormatter = DateTimeFormatter.ofPattern(properties.getProperty(DATE_TIME_FORMAT));

--- a/sharding-core/sharding-core-common/src/main/resources/META-INF/services/org.apache.shardingsphere.spi.algorithm.ShardingAlgorithm
+++ b/sharding-core/sharding-core-common/src/main/resources/META-INF/services/org.apache.shardingsphere.spi.algorithm.ShardingAlgorithm
@@ -19,4 +19,5 @@ org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineSharding
 org.apache.shardingsphere.core.strategy.algorithm.sharding.ModuloShardingAlgorithm
 org.apache.shardingsphere.core.strategy.algorithm.sharding.HashShardingAlgorithm
 org.apache.shardingsphere.core.strategy.algorithm.sharding.DatetimeShardingAlgorithm
+org.apache.shardingsphere.core.strategy.algorithm.sharding.CustomDateTimeShardingAlgorithm
 org.apache.shardingsphere.core.strategy.algorithm.sharding.RangeShardingAlgorithm

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
@@ -45,12 +45,86 @@ import static org.junit.Assert.assertTrue;
  */
 public class CustomDateTimeShardingAlgorithmTest {
 
-    private final List<String> availableTables = new ArrayList<>();
+    private final List<String> availableTablesForMonthStrategy = new ArrayList<>();
 
-    private StandardShardingStrategy shardingStrategy;
+    private final List<String> availableTablesForQuarterStrategy = new ArrayList<>();
+
+    private StandardShardingStrategy shardingStrategyByMonth;
+
+    private StandardShardingStrategy shardingStrategyByQuarter;
 
     @Before
     public void setup() {
+        initShardStrategyByMonth();
+        initShardStrategyByQuarter();
+    }
+
+    @Test
+    public void assertPreciseDoShardingByQuarter() {
+        List<RouteValue> shardingValues = Lists.newArrayList(new ListRouteValue<>("create_time", "t_order",
+                Lists.newArrayList("2020-01-01 00:00:01", "2020-01-01 00:00:02", "2020-04-15 10:59:08")));
+        Collection<String> actual = shardingStrategyByQuarter.doSharding(availableTablesForQuarterStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(2));
+        assertTrue(actual.contains("t_order_202001"));
+        assertTrue(actual.contains("t_order_202002"));
+    }
+
+    @Test
+    public void assertRangeDoShardingByQuarter() {
+        Range<String> rangeValue = Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategyByQuarter.doSharding(availableTablesForQuarterStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(3));
+    }
+
+    @Test
+    public void assertPreciseDoShardingByMonth() {
+        List<RouteValue> shardingValues = Lists.newArrayList(new ListRouteValue<>("create_time", "t_order",
+                Lists.newArrayList("2020-01-01 00:00:01", "2020-01-01 00:00:02", "2020-04-15 10:59:08")));
+        Collection<String> actual = shardingStrategyByMonth.doSharding(availableTablesForMonthStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(2));
+        assertTrue(actual.contains("t_order_202001"));
+        assertTrue(actual.contains("t_order_202004"));
+    }
+
+    @Test
+    public void assertRangeDoShardingByMonth() {
+        Range<String> rangeValue = Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategyByMonth.doSharding(availableTablesForMonthStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(7));
+    }
+
+    @Test
+    public void assertLowerHalfRangeDoSharding() {
+        Range<String> rangeValue = Range.atLeast("2018-10-15 10:59:08");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategyByQuarter.doSharding(availableTablesForQuarterStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(9));
+    }
+
+    @Test
+    public void assertUpperHalfRangeDoSharding() {
+        Range<String> rangeValue = Range.atMost("2019-09-01 00:00:00");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategyByQuarter.doSharding(availableTablesForQuarterStrategy, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(15));
+    }
+
+    @Test
+    public void assertFormat() {
+        String inputFormat = "yyyy-MM-dd HH:mm:ss.SSS";
+        String tableFormatByQuarter = "yyyyQQ";
+        String tableFormatByMonth = "yyyyMM";
+        String value = "2020-10-11 00:00:00.000000";
+        LocalDateTime localDateTime = LocalDateTime.parse(value.substring(0, inputFormat.length()), DateTimeFormatter.ofPattern(inputFormat));
+        String tableNameShardedByQuarter = localDateTime.format(DateTimeFormatter.ofPattern(tableFormatByQuarter));
+        String tableNameShardedByMonth = localDateTime.format(DateTimeFormatter.ofPattern(tableFormatByMonth));
+        assertEquals("202004", tableNameShardedByQuarter);
+        assertEquals("202010", tableNameShardedByMonth);
+    }
+
+    private void initShardStrategyByQuarter() {
         CustomDateTimeShardingAlgorithm shardingAlgorithm = new CustomDateTimeShardingAlgorithm();
         shardingAlgorithm.getProperties().setProperty("datetime.format", "yyyy-MM-dd HH:mm:ss");
         shardingAlgorithm.getProperties().setProperty("table.suffix.format", "yyyyQQ");
@@ -59,56 +133,28 @@ public class CustomDateTimeShardingAlgorithmTest {
         shardingAlgorithm.getProperties().setProperty("datetime.step.unit", "Months");
         shardingAlgorithm.getProperties().setProperty("datetime.step.amount", "3");
         StandardShardingStrategyConfiguration shardingStrategyConfig = new StandardShardingStrategyConfiguration("create_time", shardingAlgorithm);
-        this.shardingStrategy = new StandardShardingStrategy(shardingStrategyConfig);
-
+        this.shardingStrategyByQuarter = new StandardShardingStrategy(shardingStrategyConfig);
         for (int i = 2016; i <= 2020; i++) {
             for (int j = 1; j <= 4; j++) {
-                availableTables.add(String.format("t_order_%04d%02d", i, j));
+                availableTablesForQuarterStrategy.add(String.format("t_order_%04d%02d", i, j));
             }
         }
     }
 
-    @Test
-    public void assertPreciseDoSharding() {
-        List<RouteValue> shardingValues = Lists.newArrayList(new ListRouteValue<>("create_time", "t_order",
-                Lists.newArrayList("2020-01-01 00:00:01", "2020-01-01 00:00:02", "2020-04-15 10:59:08")));
-        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
-        assertThat(actual.size(), is(2));
-        assertTrue(actual.contains("t_order_202001"));
-        assertTrue(actual.contains("t_order_202002"));
-    }
-
-    @Test
-    public void assertRangeDoSharding() {
-        Range<String> rangeValue = Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08");
-        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
-        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
-        assertThat(actual.size(), is(3));
-    }
-
-    @Test
-    public void assertLowerHalfRangeDoSharding() {
-        Range<String> rangeValue = Range.atLeast("2018-10-15 10:59:08");
-        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
-        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
-        assertThat(actual.size(), is(9));
-    }
-
-    @Test
-    public void assertUpperHalfRangeDoSharding() {
-        Range<String> rangeValue = Range.atMost("2019-09-01 00:00:00");
-        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
-        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
-        assertThat(actual.size(), is(15));
-    }
-
-    @Test
-    public void testFormat() {
-        String inputFormat = "yyyy-MM-dd HH:mm:ss.SSS";
-        String tableFormat = "yyyyQQ";
-        String value = "2020-10-11 00:00:00.000000";
-        LocalDateTime localDateTime = LocalDateTime.parse(value.substring(0, inputFormat.length()), DateTimeFormatter.ofPattern(inputFormat));
-        String tableName = localDateTime.format(DateTimeFormatter.ofPattern(tableFormat));
-        assertEquals("202004", tableName);
+    private void initShardStrategyByMonth() {
+        CustomDateTimeShardingAlgorithm shardingAlgorithm = new CustomDateTimeShardingAlgorithm();
+        shardingAlgorithm.getProperties().setProperty("datetime.format", "yyyy-MM-dd HH:mm:ss");
+        shardingAlgorithm.getProperties().setProperty("table.suffix.format", "yyyyMM");
+        shardingAlgorithm.getProperties().setProperty("datetime.lower", "2016-01-01 00:00:00.000");
+        shardingAlgorithm.getProperties().setProperty("datetime.upper", "2021-12-31 00:00:00.000");
+        shardingAlgorithm.getProperties().setProperty("datetime.step.unit", "Months");
+        shardingAlgorithm.getProperties().setProperty("datetime.step.amount", "1");
+        StandardShardingStrategyConfiguration shardingStrategyConfig = new StandardShardingStrategyConfiguration("create_time", shardingAlgorithm);
+        this.shardingStrategyByMonth = new StandardShardingStrategy(shardingStrategyConfig);
+        for (int i = 2016; i <= 2020; i++) {
+            for (int j = 1; j <= 12; j++) {
+                availableTablesForMonthStrategy.add(String.format("t_order_%04d%02d", i, j));
+            }
+        }
     }
 }

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
@@ -54,13 +54,14 @@ public class CustomDateTimeShardingAlgorithmTest {
         CustomDateTimeShardingAlgorithm shardingAlgorithm = new CustomDateTimeShardingAlgorithm();
         shardingAlgorithm.getProperties().setProperty("datetime.format", "yyyy-MM-dd HH:mm:ss");
         shardingAlgorithm.getProperties().setProperty("table.suffix.format", "yyyyQQ");
-        shardingAlgorithm.getProperties().setProperty("datetime.lower", "2010-01-01 00:00:00.000");
+        shardingAlgorithm.getProperties().setProperty("datetime.lower", "2016-01-01 00:00:00.000");
+        shardingAlgorithm.getProperties().setProperty("datetime.upper", "2021-12-31 00:00:00.000");
         shardingAlgorithm.getProperties().setProperty("datetime.step.unit", "Months");
         shardingAlgorithm.getProperties().setProperty("datetime.step.amount", "3");
         StandardShardingStrategyConfiguration shardingStrategyConfig = new StandardShardingStrategyConfiguration("create_time", shardingAlgorithm);
         this.shardingStrategy = new StandardShardingStrategy(shardingStrategyConfig);
 
-        for (int i = 2016; i < 2021; i++) {
+        for (int i = 2016; i <= 2020; i++) {
             for (int j = 1; j <= 4; j++) {
                 availableTables.add(String.format("t_order_%04d%02d", i, j));
             }
@@ -83,6 +84,22 @@ public class CustomDateTimeShardingAlgorithmTest {
         List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
         Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
         assertThat(actual.size(), is(3));
+    }
+
+    @Test
+    public void assertLowerHalfRangeDoSharding() {
+        Range<String> rangeValue = Range.atLeast("2018-10-15 10:59:08");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(9));
+    }
+
+    @Test
+    public void assertUpperHalfRangeDoSharding() {
+        Range<String> rangeValue = Range.atMost("2019-09-01 00:00:00");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(15));
     }
 
     @Test

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/CustomDateTimeShardingAlgorithmTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.core.strategy.algorithm.sharding;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Range;
+import org.apache.shardingsphere.api.config.sharding.strategy.StandardShardingStrategyConfiguration;
+import org.apache.shardingsphere.core.strategy.route.standard.StandardShardingStrategy;
+import org.apache.shardingsphere.core.strategy.route.value.ListRouteValue;
+import org.apache.shardingsphere.core.strategy.route.value.RangeRouteValue;
+import org.apache.shardingsphere.core.strategy.route.value.RouteValue;
+import org.apache.shardingsphere.underlying.common.config.properties.ConfigurationProperties;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * datetime sharding algorithm test.
+ */
+public class CustomDateTimeShardingAlgorithmTest {
+
+    private final List<String> availableTables = new ArrayList<>();
+
+    private StandardShardingStrategy shardingStrategy;
+
+    @Before
+    public void setup() {
+        CustomDateTimeShardingAlgorithm shardingAlgorithm = new CustomDateTimeShardingAlgorithm();
+        shardingAlgorithm.getProperties().setProperty("datetime.format", "yyyy-MM-dd HH:mm:ss");
+        shardingAlgorithm.getProperties().setProperty("table.suffix.format", "yyyyQQ");
+        shardingAlgorithm.getProperties().setProperty("datetime.lower", "2010-01-01 00:00:00.000");
+        shardingAlgorithm.getProperties().setProperty("datetime.step.unit", "Months");
+        shardingAlgorithm.getProperties().setProperty("datetime.step.amount", "3");
+        StandardShardingStrategyConfiguration shardingStrategyConfig = new StandardShardingStrategyConfiguration("create_time", shardingAlgorithm);
+        this.shardingStrategy = new StandardShardingStrategy(shardingStrategyConfig);
+
+        for (int i = 2016; i < 2021; i++) {
+            for (int j = 1; j <= 4; j++) {
+                availableTables.add(String.format("t_order_%04d%02d", i, j));
+            }
+        }
+    }
+
+    @Test
+    public void assertPreciseDoSharding() {
+        List<RouteValue> shardingValues = Lists.newArrayList(new ListRouteValue<>("create_time", "t_order",
+                Lists.newArrayList("2020-01-01 00:00:01", "2020-01-01 00:00:02", "2020-04-15 10:59:08")));
+        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(2));
+        assertTrue(actual.contains("t_order_202001"));
+        assertTrue(actual.contains("t_order_202002"));
+    }
+
+    @Test
+    public void assertRangeDoSharding() {
+        Range<String> rangeValue = Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08");
+        List<RouteValue> shardingValues = Lists.newArrayList(new RangeRouteValue<>("create_time", "t_order", rangeValue));
+        Collection<String> actual = shardingStrategy.doSharding(availableTables, shardingValues, new ConfigurationProperties(new Properties()));
+        assertThat(actual.size(), is(3));
+    }
+
+    @Test
+    public void testFormat() {
+        String inputFormat = "yyyy-MM-dd HH:mm:ss.SSS";
+        String tableFormat = "yyyyQQ";
+        String value = "2020-10-11 00:00:00.000000";
+        LocalDateTime localDateTime = LocalDateTime.parse(value.substring(0, inputFormat.length()), DateTimeFormatter.ofPattern(inputFormat));
+        String tableName = localDateTime.format(DateTimeFormatter.ofPattern(tableFormat));
+        assertEquals("202004", tableName);
+    }
+}


### PR DESCRIPTION
Ref #5282.

Changes proposed in this pull request:
- supply a sharding algorithm used to shard tables by days/weeks/months/QUARTER_OF_YEAR/...
- usage examples
  - shard by QUARTER_OF_YEAR (按季度分表)
  ``` yaml 
      actualDataNodes: ds.t_order_20${10..20}0${1..4}
      tableStrategy:
        standard:
          shardingColumn: created_at
          shardingAlgorithm:
            type: CUSTOM_DATE_TIME
            props:
              datetime.format: yyyy-MM-dd HH:mm:ss
              table.suffix.format: yyyyQQ
              datetime.lower: "2010-01-01 00:00:00.000"
              datetime.upper: "2020-12-31 00:00:00.000"
              datetime.step.unit: Months
              datetime.step.amount: 3
  ```
- config detail can refer to java doc of `org.apache.shardingsphere.core.strategy.algorithm.sharding.CustomDateTimeShardingAlgorithmTest`