### PR TITLE
Add placeholder handle for 'algorithm.expression' parameter of InlineShardingAlgorithm class

### DIFF
--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/inline/InlineShardingAlgorithm.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/strategy/algorithm/sharding/inline/InlineShardingAlgorithm.java
@@ -41,7 +41,8 @@ public final class InlineShardingAlgorithm implements StandardShardingAlgorithm<
     @Override
     public String doSharding(final Collection<String> availableTargetNames, final PreciseShardingValue<Comparable<?>> shardingValue) {
         Preconditions.checkNotNull(properties.get(ALGORITHM_EXPRESSION), "Inline sharding algorithm expression cannot be null.");
-        Closure<?> closure = new InlineExpressionParser(properties.get(ALGORITHM_EXPRESSION).toString()).evaluateClosure();
+        String algorithmExpression = InlineExpressionParser.handlePlaceHolder(properties.get(ALGORITHM_EXPRESSION).toString().trim());
+        Closure<?> closure = new InlineExpressionParser(algorithmExpression).evaluateClosure();
         Closure<?> result = closure.rehydrate(new Expando(), null, null);
         result.setResolveStrategy(Closure.DELEGATE_ONLY);
         result.setProperty(shardingValue.getColumnName(), shardingValue.getValue());


### PR DESCRIPTION
Add 'algorithm.expression' parameter placeholder handle for `InlineShardingAlgorithm` class.

Fixes #5378.

