### PR TITLE
For issue4778, modify registry center root node

### DIFF
--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-facade/src/main/java/org/apache/shardingsphere/orchestration/core/facade/listener/ShardingOrchestrationListenerManager.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-facade/src/main/java/org/apache/shardingsphere/orchestration/core/facade/listener/ShardingOrchestrationListenerManager.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.orchestration.center.ConfigCenterRepository;
 import org.apache.shardingsphere.orchestration.center.RegistryCenterRepository;
 import org.apache.shardingsphere.orchestration.core.configcenter.listener.ConfigurationChangedListenerManager;
 import org.apache.shardingsphere.orchestration.core.metadatacenter.listener.MetaDataListenerManager;
-import org.apache.shardingsphere.orchestration.core.registrycenter.listener.StateChangedListenerManager;
+import org.apache.shardingsphere.orchestration.core.registrycenter.listener.RegistryListenerManager;
 
 import java.util.Collection;
 
@@ -33,7 +33,7 @@ public final class ShardingOrchestrationListenerManager {
     
     private final ConfigurationChangedListenerManager configurationChangedListenerManager;
     
-    private final StateChangedListenerManager stateChangedListenerManager;
+    private final RegistryListenerManager registryListenerManager;
     
     private final MetaDataListenerManager metaDataListenerManager;
     
@@ -42,7 +42,7 @@ public final class ShardingOrchestrationListenerManager {
                                                 final String metadataCenterRepositoryName, final CenterRepository centerRepository,
                                                 final Collection<String> shardingSchemaNames) {
         configurationChangedListenerManager = new ConfigurationChangedListenerManager(configCenterRepositoryName, configCenterRepository, shardingSchemaNames);
-        stateChangedListenerManager = new StateChangedListenerManager(registryCenterRepositoryName, registryCenterRepository);
+        registryListenerManager = new RegistryListenerManager(registryCenterRepositoryName, registryCenterRepository);
         metaDataListenerManager = new MetaDataListenerManager(metadataCenterRepositoryName, centerRepository, shardingSchemaNames);
     }
     
@@ -51,7 +51,7 @@ public final class ShardingOrchestrationListenerManager {
      */
     public void initListeners() {
         configurationChangedListenerManager.initListeners();
-        stateChangedListenerManager.initListeners();
+        registryListenerManager.initListeners();
         metaDataListenerManager.initListeners();
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-facade/src/test/java/org/apache/shardingsphere/orchestration/core/facade/ShardingOrchestrationListenerManagerTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-facade/src/test/java/org/apache/shardingsphere/orchestration/core/facade/ShardingOrchestrationListenerManagerTest.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.orchestration.core.configcenter.listener.Config
 import org.apache.shardingsphere.orchestration.core.facade.listener.ShardingOrchestrationListenerManager;
 import org.apache.shardingsphere.orchestration.core.facade.util.FieldUtil;
 import org.apache.shardingsphere.orchestration.core.metadatacenter.listener.MetaDataListenerManager;
-import org.apache.shardingsphere.orchestration.core.registrycenter.listener.StateChangedListenerManager;
+import org.apache.shardingsphere.orchestration.core.registrycenter.listener.RegistryListenerManager;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -50,7 +50,7 @@ public final class ShardingOrchestrationListenerManagerTest {
     private MetaDataListenerManager metaDataListenerManager;
 
     @Mock
-    private StateChangedListenerManager stateChangedListenerManager;
+    private RegistryListenerManager registryListenerManager;
     
     @Test
     public void assertInitListeners() {
@@ -58,11 +58,11 @@ public final class ShardingOrchestrationListenerManagerTest {
                                                      "FirstTestConfigCenter", configCenterRepository,
                                                      "FirstTestConfigCenter", configCenterRepository, Collections.emptyList());
         FieldUtil.setField(actual, "configurationChangedListenerManager", configurationChangedListenerManager);
-        FieldUtil.setField(actual, "stateChangedListenerManager", stateChangedListenerManager);
+        FieldUtil.setField(actual, "registryListenerManager", registryListenerManager);
         FieldUtil.setField(actual, "metaDataListenerManager", metaDataListenerManager);
         actual.initListeners();
         verify(configurationChangedListenerManager).initListeners();
-        verify(stateChangedListenerManager).initListeners();
+        verify(registryListenerManager).initListeners();
         verify(metaDataListenerManager).initListeners();
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNode.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNode.java
@@ -22,7 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.orchestration.core.registrycenter.schema.OrchestrationShardingSchema;
 
 /**
- * State node.
+ * RegistryCenter node.
  */
 @RequiredArgsConstructor
 public final class RegistryCenterNode {

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNode.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNode.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.orchestration.core.registrycenter.schema.Orches
 @RequiredArgsConstructor
 public final class RegistryCenterNode {
     
-    private static final String ROOT = "state";
+    private static final String ROOT = "registry";
     
     private static final String INSTANCES_NODE_PATH = "instances";
     

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/DataSourceStateChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/DataSourceStateChangedListener.java
@@ -33,11 +33,11 @@ import java.util.Collections;
  */
 public final class DataSourceStateChangedListener extends PostShardingCenterRepositoryEventListener {
     
-    private final RegistryCenterNode stateNode;
+    private final RegistryCenterNode registryCenterNode;
     
     public DataSourceStateChangedListener(final String name, final RegistryCenterRepository registryCenterRepository) {
         super(registryCenterRepository, Collections.singleton(new RegistryCenterNode(name).getDataSourcesNodeFullRootPath()));
-        stateNode = new RegistryCenterNode(name);
+        registryCenterNode = new RegistryCenterNode(name);
     }
     
     @Override
@@ -46,7 +46,7 @@ public final class DataSourceStateChangedListener extends PostShardingCenterRepo
     }
     
     private OrchestrationShardingSchema getShardingSchema(final String dataSourceNodeFullPath) {
-        return stateNode.getOrchestrationShardingSchema(dataSourceNodeFullPath);
+        return registryCenterNode.getOrchestrationShardingSchema(dataSourceNodeFullPath);
     }
     
     private boolean isDataSourceDisabled(final DataChangedEvent event) {

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/RegistryListenerManager.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/main/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/RegistryListenerManager.java
@@ -21,15 +21,15 @@ import org.apache.shardingsphere.orchestration.center.RegistryCenterRepository;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent.ChangedType;
 
 /**
- * State changed listener manager.
+ * Registry listener manager.
  */
-public final class StateChangedListenerManager {
+public final class RegistryListenerManager {
     
     private final InstanceStateChangedListener instanceStateChangedListener;
     
     private final DataSourceStateChangedListener dataSourceStateChangedListener;
     
-    public StateChangedListenerManager(final String name, final RegistryCenterRepository registryCenterRepository) {
+    public RegistryListenerManager(final String name, final RegistryCenterRepository registryCenterRepository) {
         instanceStateChangedListener = new InstanceStateChangedListener(name, registryCenterRepository);
         dataSourceStateChangedListener = new DataSourceStateChangedListener(name, registryCenterRepository);
     }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNodeTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterNodeTest.java
@@ -24,25 +24,25 @@ import static org.junit.Assert.assertThat;
 
 public final class RegistryCenterNodeTest {
     
-    private final RegistryCenterNode stateNode = new RegistryCenterNode("test");
+    private final RegistryCenterNode registryCenterNode = new RegistryCenterNode("test");
     
     @Test
     public void assertGetInstancesNodeFullPath() {
-        assertThat(stateNode.getInstancesNodeFullPath("testId"), is("/test/state/instances/testId"));
+        assertThat(registryCenterNode.getInstancesNodeFullPath("testId"), is("/test/registry/instances/testId"));
     }
     
     @Test
     public void assertGetDataSourcesNodeFullRootPath() {
-        assertThat(stateNode.getDataSourcesNodeFullRootPath(), is("/test/state/datasources"));
+        assertThat(registryCenterNode.getDataSourcesNodeFullRootPath(), is("/test/registry/datasources"));
     }
     
     @Test
     public void assertGetDataSourcesNodeFullPath() {
-        assertThat(stateNode.getDataSourcesNodeFullPath("sharding_db"), is("/test/state/datasources/sharding_db"));
+        assertThat(registryCenterNode.getDataSourcesNodeFullPath("sharding_db"), is("/test/registry/datasources/sharding_db"));
     }
     
     @Test
     public void assertGetOrchestrationShardingSchema() {
-        assertThat(stateNode.getOrchestrationShardingSchema("/test/state/datasources/master_slave_db.slave_ds_0").getSchemaName(), is("master_slave_db"));
+        assertThat(registryCenterNode.getOrchestrationShardingSchema("/test/registry/datasources/master_slave_db.slave_ds_0").getSchemaName(), is("master_slave_db"));
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/RegistryCenterTest.java
@@ -54,6 +54,6 @@ public final class RegistryCenterTest {
     @Test
     public void assertPersistDataSourcesNode() {
         registryCenter.persistDataSourcesNode();
-        verify(registryCenterRepository).persist("/test/state/datasources", "");
+        verify(registryCenterRepository).persist("/test/registry/datasources", "");
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/DataSourceStateChangedListenerTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/DataSourceStateChangedListenerTest.java
@@ -46,7 +46,7 @@ public final class DataSourceStateChangedListenerTest {
     @Test
     public void assertCreateShardingOrchestrationEvent() {
         OrchestrationShardingSchema expected = new OrchestrationShardingSchema("master_slave_db", "slave_ds_0");
-        DataChangedEvent dataChangedEvent = new DataChangedEvent("/test/state/datasources/master_slave_db.slave_ds_0", "disabled", ChangedType.UPDATED);
+        DataChangedEvent dataChangedEvent = new DataChangedEvent("/test/registry/datasources/master_slave_db.slave_ds_0", "disabled", ChangedType.UPDATED);
         assertThat(dataSourceStateChangedListener.createShardingOrchestrationEvent(dataChangedEvent).getShardingSchema().getSchemaName(), is(expected.getSchemaName()));
     }
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/RegistryListenerManagerTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-registrycenter/src/test/java/org/apache/shardingsphere/orchestration/core/registrycenter/listener/RegistryListenerManagerTest.java
@@ -28,7 +28,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class StateChangedListenerManagerTest {
+public final class RegistryListenerManagerTest {
     
     @Mock
     private RegistryCenterRepository registryCenterRepository;
@@ -41,7 +41,7 @@ public final class StateChangedListenerManagerTest {
     
     @Test
     public void assertInitListeners() {
-        StateChangedListenerManager actual = new StateChangedListenerManager("test", registryCenterRepository);
+        RegistryListenerManager actual = new RegistryListenerManager("test", registryCenterRepository);
         FieldUtil.setField(actual, "instanceStateChangedListener", instanceStateChangedListener);
         FieldUtil.setField(actual, "dataSourceStateChangedListener", dataSourceStateChangedListener);
         actual.initListeners();

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryEncryptTest.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryEncryptTest.java
@@ -74,7 +74,7 @@ public class OrchestrationSpringBootRegistryEncryptTest {
             + "         cipherColumn: user_id\n"
             + "         encryptor: order_encrypt\n");
         testCenter.persist("/demo_spring_boot_ds_center/config/props", "sql.show: 'true'\n");
-        testCenter.persist("/demo_spring_boot_ds_center/state/datasources", "");
+        testCenter.persist("/demo_spring_boot_ds_center/registry/datasources", "");
     }
     
     @Test

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryMasterSlaveTest.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryMasterSlaveTest.java
@@ -80,7 +80,7 @@ public class OrchestrationSpringBootRegistryMasterSlaveTest {
             + "  - ds_slave_0\n"
             + "  - ds_slave_1\n");
         testCenter.persist("/demo_spring_boot_ds_center/config/props", "{}\n");
-        testCenter.persist("/demo_spring_boot_ds_center/state/datasources", "");
+        testCenter.persist("/demo_spring_boot_ds_center/registry/datasources", "");
     }
     
     @Test

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryShardingTest.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/type/OrchestrationSpringBootRegistryShardingTest.java
@@ -125,7 +125,7 @@ public class OrchestrationSpringBootRegistryShardingTest {
             + "            algorithm.expression: t_order_item_${order_id % 2}\n"
             + "        shardingColumn: order_id\n");
         testCenter.persist("/demo_spring_boot_ds_center/config/props", "executor.size: '100'\nsql.show: 'true'\n");
-        testCenter.persist("/demo_spring_boot_ds_center/state/datasources", "");
+        testCenter.persist("/demo_spring_boot_ds_center/registry/datasources", "");
     }
     
     @Test


### PR DESCRIPTION
For #4778 .

Changes proposed in this pull request:

- change registry center root node from `state` to `registry`
- modify registry center listener manager class name
- refactor unit tests