### PR TITLE
Deprecate ShardingDataSourceFactory.createDataSource() for single rule

### DIFF
--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-range.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-range.yaml
@@ -35,14 +35,14 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item
       keyGenerator:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-tables-range.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-tables-range.yaml
@@ -40,7 +40,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item_${0..1}
       tableStrategy:
@@ -52,7 +52,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-tables.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases-tables.yaml
@@ -42,7 +42,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item_${0..1}
       tableStrategy:
@@ -56,7 +56,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-databases.yaml
@@ -35,14 +35,14 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item
       keyGenerator:
         type: SNOWFLAKE
         column: order_item_id
         props:
-           worker.id: 123       
+           worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-master-slave-range.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-master-slave-range.yaml
@@ -60,7 +60,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item_${0..1}
       tableStrategy:
@@ -72,7 +72,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-master-slave.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-master-slave.yaml
@@ -62,7 +62,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_${0..1}.t_order_item_${0..1}
       tableStrategy:
@@ -76,7 +76,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-tables-range.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-tables-range.yaml
@@ -35,7 +35,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds.t_order_item_${0..1}
       tableStrategy:
@@ -47,7 +47,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-tables.yaml
+++ b/examples/sharding-jdbc-example/sharding-example/sharding-raw-jdbc-example/src/main/resources/META-INF/sharding-tables.yaml
@@ -51,7 +51,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   broadcastTables:

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/log/ConfigurationLogger.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/log/ConfigurationLogger.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.encrypt.yaml.swapper.EncryptRuleConfigurationYa
 import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
 import org.apache.shardingsphere.underlying.common.yaml.engine.YamlEngine;
 
+import java.util.Collection;
 import java.util.Properties;
 
 /**
@@ -42,6 +43,17 @@ import java.util.Properties;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class ConfigurationLogger {
+    
+    /**
+     * Log rule configuration.
+     *
+     * @param ruleConfigurations rule configurations
+     */
+    public static void log(final Collection<RuleConfiguration> ruleConfigurations) {
+        for (RuleConfiguration each : ruleConfigurations) {
+            log(each);
+        }
+    }
     
     /**
      * Log rule configuration.

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/RuleBuilder.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/RuleBuilder.java
@@ -37,13 +37,13 @@ import java.util.stream.Collectors;
 public final class RuleBuilder {
     
     /**
-     * Build rules.
+     * Build rules with sharding rule configuration.
      * 
      * @param dataSourceNames data source names
      * @param shardingRuleConfig sharding rule configuration
      * @return rules
      */
-    public static Collection<ShardingSphereRule> build(final Collection<String> dataSourceNames, final ShardingRuleConfiguration shardingRuleConfig) {
+    public static Collection<ShardingSphereRule> buildSharding(final Collection<String> dataSourceNames, final ShardingRuleConfiguration shardingRuleConfig) {
         Collection<ShardingSphereRule> result = new LinkedList<>();
         result.add(new ShardingRule(shardingRuleConfig, dataSourceNames));
         result.addAll(shardingRuleConfig.getMasterSlaveRuleConfigs().stream().map(MasterSlaveRule::new).collect(Collectors.toList()));

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/ConfigurationBuilder.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/ConfigurationBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.core.rule.builder;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
+
+import java.util.Collection;
+import java.util.LinkedList;
+
+/**
+ * Rule configuration builder.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ConfigurationBuilder {
+    
+    /**
+     * Build rules with sharding rule configuration.
+     * 
+     * @param shardingRuleConfig sharding rule configuration
+     * @return rule configurations
+     */
+    public static Collection<RuleConfiguration> buildSharding(final ShardingRuleConfiguration shardingRuleConfig) {
+        Collection<RuleConfiguration> result = new LinkedList<>();
+        result.add(shardingRuleConfig);
+        result.addAll(shardingRuleConfig.getMasterSlaveRuleConfigs());
+        if (null != shardingRuleConfig.getEncryptRuleConfig() && !shardingRuleConfig.getEncryptRuleConfig().getTables().isEmpty()) {
+            result.add(shardingRuleConfig.getEncryptRuleConfig());
+        }
+        return result;
+    }
+}

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/RuleBuilder.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/RuleBuilder.java
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.core.rule;
+package org.apache.shardingsphere.core.rule.builder;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.core.rule.MasterSlaveRule;
+import org.apache.shardingsphere.core.rule.ShardingRule;
 import org.apache.shardingsphere.encrypt.api.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;

--- a/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/RuleBuilder.java
+++ b/sharding-core/sharding-core-common/src/main/java/org/apache/shardingsphere/core/rule/builder/RuleBuilder.java
@@ -30,30 +30,12 @@ import org.apache.shardingsphere.underlying.common.rule.ShardingSphereRule;
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.stream.Collectors;
 
 /**
  * Rule builder.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class RuleBuilder {
-    
-    /**
-     * Build rules with sharding rule configuration.
-     * 
-     * @param dataSourceNames data source names
-     * @param shardingRuleConfig sharding rule configuration
-     * @return rules
-     */
-    public static Collection<ShardingSphereRule> buildSharding(final Collection<String> dataSourceNames, final ShardingRuleConfiguration shardingRuleConfig) {
-        Collection<ShardingSphereRule> result = new LinkedList<>();
-        result.add(new ShardingRule(shardingRuleConfig, dataSourceNames));
-        result.addAll(shardingRuleConfig.getMasterSlaveRuleConfigs().stream().map(MasterSlaveRule::new).collect(Collectors.toList()));
-        if (null != shardingRuleConfig.getEncryptRuleConfig()) {
-            result.add(new EncryptRule(shardingRuleConfig.getEncryptRuleConfig()));
-        }
-        return result;
-    }
     
     /**
      * Build rules.

--- a/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
+++ b/sharding-core/sharding-core-common/src/test/java/org/apache/shardingsphere/core/rule/ShardingRuleTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.core.rule;
 
-import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.KeyGeneratorConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
@@ -26,10 +25,10 @@ import org.apache.shardingsphere.api.config.sharding.strategy.StandardShardingSt
 import org.apache.shardingsphere.core.shard.fixture.StandardShardingAlgorithmFixture;
 import org.apache.shardingsphere.core.strategy.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
 import org.apache.shardingsphere.core.strategy.algorithm.keygen.fixture.IncrementKeyGenerateAlgorithm;
+import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineShardingAlgorithm;
 import org.apache.shardingsphere.core.strategy.route.ShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.none.NoneShardingStrategy;
 import org.apache.shardingsphere.core.strategy.route.standard.StandardShardingStrategy;
-import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineShardingAlgorithm;
 import org.apache.shardingsphere.spi.keygen.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.spi.type.TypedSPIRegistry;
 import org.apache.shardingsphere.underlying.common.config.exception.ShardingSphereConfigurationException;
@@ -313,8 +312,6 @@ public final class ShardingRuleTest {
         ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
         TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ms_ds_${0..1}.table_${0..2}");
         shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
-        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_0", "master_ds_0", "slave_ds_0"));
-        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_1", "master_ds_1", "slave_ds_1"));
         new ShardingRule(shardingRuleConfiguration, null);
     }
     
@@ -367,23 +364,6 @@ public final class ShardingRuleTest {
     
     private Collection<String> createDataSourceNames() {
         return Arrays.asList("ds_0", "ds_1");
-    }
-    
-    private ShardingRule createMasterSlaveShardingRule() {
-        ShardingRuleConfiguration shardingRuleConfiguration = new ShardingRuleConfiguration();
-        TableRuleConfiguration tableRuleConfiguration = createTableRuleConfiguration("LOGIC_TABLE", "ms_ds_${0..1}.table_${0..2}");
-        shardingRuleConfiguration.getTableRuleConfigs().add(tableRuleConfiguration);
-        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_0", "master_ds_0", "slave_ds_0"));
-        shardingRuleConfiguration.getMasterSlaveRuleConfigs().add(createMasterSlaveRuleConfiguration("ms_ds_1", "master_ds_1", "slave_ds_1"));
-        return new ShardingRule(shardingRuleConfiguration, createMasterSlaveDataSourceNames());
-    }
-    
-    private MasterSlaveRuleConfiguration createMasterSlaveRuleConfiguration(final String name, final String masterDataSourceName, final String slaveDataSourceName) {
-        return new MasterSlaveRuleConfiguration(name, masterDataSourceName, Collections.singletonList(slaveDataSourceName));
-    }
-    
-    private Collection<String> createMasterSlaveDataSourceNames() {
-        return Arrays.asList("master_ds_0", "slave_ds_0", "master_ds_1", "slave_ds_1");
     }
     
     private TableRuleConfiguration createTableRuleConfigWithAllStrategies() {

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
@@ -76,7 +76,8 @@ public final class MixSQLRewriterParameterizedTest extends AbstractSQLRewriterPa
     @Override
     protected Collection<SQLRewriteUnit> createSQLRewriteUnits() throws IOException {
         YamlRootShardingConfiguration ruleConfiguration = createRuleConfiguration();
-        Collection<ShardingSphereRule> rules = RuleBuilder.build(ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
+        Collection<ShardingSphereRule> rules = RuleBuilder.buildSharding(
+                ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
         SQLParserEngine sqlParserEngine = SQLParserEngineFactory.getSQLParserEngine(null == getTestParameters().getDatabaseType() ? "SQL92" : getTestParameters().getDatabaseType());
         ShardingSphereMetaData metaData = createShardingSphereMetaData();
         ConfigurationProperties properties = new ConfigurationProperties(ruleConfiguration.getProps());

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized;
 
 import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
@@ -76,8 +77,8 @@ public final class MixSQLRewriterParameterizedTest extends AbstractSQLRewriterPa
     @Override
     protected Collection<SQLRewriteUnit> createSQLRewriteUnits() throws IOException {
         YamlRootShardingConfiguration ruleConfiguration = createRuleConfiguration();
-        Collection<ShardingSphereRule> rules = RuleBuilder.buildSharding(
-                ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
+        Collection<ShardingSphereRule> rules = RuleBuilder.build(
+                ruleConfiguration.getDataSources().keySet(), ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule())));
         SQLParserEngine sqlParserEngine = SQLParserEngineFactory.getSQLParserEngine(null == getTestParameters().getDatabaseType() ? "SQL92" : getTestParameters().getDatabaseType());
         ShardingSphereMetaData metaData = createShardingSphereMetaData();
         ConfigurationProperties properties = new ConfigurationProperties(ruleConfiguration.getProps());

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/MixSQLRewriterParameterizedTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
@@ -76,7 +76,8 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
     @Override
     protected Collection<SQLRewriteUnit> createSQLRewriteUnits() throws IOException {
         YamlRootShardingConfiguration ruleConfiguration = createRuleConfiguration();
-        Collection<ShardingSphereRule> rules = RuleBuilder.build(ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
+        Collection<ShardingSphereRule> rules = RuleBuilder.buildSharding(
+                ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
         SQLParserEngine sqlParserEngine = SQLParserEngineFactory.getSQLParserEngine(null == getTestParameters().getDatabaseType() ? "SQL92" : getTestParameters().getDatabaseType());
         ShardingSphereMetaData metaData = createShardingSphereMetaData();
         ConfigurationProperties properties = new ConfigurationProperties(ruleConfiguration.getProps());

--- a/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
+++ b/sharding-core/sharding-core-rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/ShardingSQLRewriterParameterizedTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized;
 
 import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
@@ -76,8 +77,8 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
     @Override
     protected Collection<SQLRewriteUnit> createSQLRewriteUnits() throws IOException {
         YamlRootShardingConfiguration ruleConfiguration = createRuleConfiguration();
-        Collection<ShardingSphereRule> rules = RuleBuilder.buildSharding(
-                ruleConfiguration.getDataSources().keySet(), new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule()));
+        Collection<ShardingSphereRule> rules = RuleBuilder.build(
+                ruleConfiguration.getDataSources().keySet(), ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(ruleConfiguration.getShardingRule())));
         SQLParserEngine sqlParserEngine = SQLParserEngineFactory.getSQLParserEngine(null == getTestParameters().getDatabaseType() ? "SQL92" : getTestParameters().getDatabaseType());
         ShardingSphereMetaData metaData = createShardingSphereMetaData();
         ConfigurationProperties properties = new ConfigurationProperties(ruleConfiguration.getProps());

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShadowDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShadowDataSourceFactory.java
@@ -22,11 +22,11 @@ import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.api.config.shadow.ShadowRuleConfiguration;
 import org.apache.shardingsphere.core.rule.ShadowRule;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShadowDataSource;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -90,7 +90,7 @@ public final class ShadowDataSourceFactory {
         if (shadowRule.isEncrypt()) {
             return EncryptDataSourceFactory.createDataSource(dataSources.values().iterator().next(), shadowRule.getEncryptRuleConfig(), props);
         } else if (shadowRule.isSharding()) {
-            return ShardingDataSourceFactory.createDataSource(dataSources, Collections.singletonList(shadowRule.getShardingRuleConfig()), props);
+            return ShardingDataSourceFactory.createDataSource(dataSources, ConfigurationBuilder.buildSharding(shadowRule.getShardingRuleConfig()), props);
         } else if (shadowRule.isMasterSlave()) {
             return MasterSlaveDataSourceFactory.createDataSource(dataSources, shadowRule.getMasterSlaveRuleConfig(), props);
         } else {

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
@@ -40,12 +40,15 @@ public final class ShardingDataSourceFactory {
     /**
      * Create sharding data source.
      *
+     * @deprecated use createDataSource(final Map dataSourceMap, final Collection ruleConfigurations, final Properties props) instead of it.
+     * 
      * @param dataSourceMap data source map
      * @param shardingRuleConfig rule configuration for databases and tables sharding
      * @param props properties for data source
      * @return sharding data source
      * @throws SQLException SQL exception
      */
+    @Deprecated
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig, final Properties props) throws SQLException {
         return new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)), props);
     }

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.shardingjdbc.api;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
 

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.shardingjdbc.api;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
@@ -46,7 +47,7 @@ public final class ShardingDataSourceFactory {
      * @throws SQLException SQL exception
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig, final Properties props) throws SQLException {
-        return new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
+        return new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)), props);
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactory.java
@@ -46,7 +46,7 @@ public final class ShardingDataSourceFactory {
      * @throws SQLException SQL exception
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig, final Properties props) throws SQLException {
-        return new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), shardingRuleConfig), props);
+        return new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/yaml/YamlShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/main/java/org/apache/shardingsphere/shardingjdbc/api/yaml/YamlShardingDataSourceFactory.java
@@ -19,11 +19,12 @@ package org.apache.shardingsphere.shardingjdbc.api.yaml;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlRootShardingConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
-import org.apache.shardingsphere.underlying.common.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.shardingjdbc.api.ShardingDataSourceFactory;
+import org.apache.shardingsphere.underlying.common.yaml.engine.YamlEngine;
 
 import javax.sql.DataSource;
 import java.io.File;
@@ -47,7 +48,8 @@ public final class YamlShardingDataSourceFactory {
      */
     public static DataSource createDataSource(final File yamlFile) throws SQLException, IOException {
         YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlFile, YamlRootShardingConfiguration.class, new YamlRootShardingConfigurationConstructor());
-        return ShardingDataSourceFactory.createDataSource(config.getDataSources(), new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+        return ShardingDataSourceFactory.createDataSource(
+                config.getDataSources(), ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule())), config.getProps());
     }
     
     /**
@@ -60,7 +62,8 @@ public final class YamlShardingDataSourceFactory {
      */
     public static DataSource createDataSource(final byte[] yamlBytes) throws SQLException, IOException {
         YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlBytes, YamlRootShardingConfiguration.class, new YamlRootShardingConfigurationConstructor());
-        return ShardingDataSourceFactory.createDataSource(config.getDataSources(), new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+        return ShardingDataSourceFactory.createDataSource(
+                config.getDataSources(), ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule())), config.getProps());
     }
     
     /**
@@ -74,7 +77,8 @@ public final class YamlShardingDataSourceFactory {
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final File yamlFile) throws SQLException, IOException {
         YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlFile, YamlRootShardingConfiguration.class, new YamlRootShardingConfigurationConstructor());
-        return ShardingDataSourceFactory.createDataSource(dataSourceMap, new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+        return ShardingDataSourceFactory.createDataSource(
+                dataSourceMap, ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule())), config.getProps());
     }
     
     /**
@@ -88,6 +92,7 @@ public final class YamlShardingDataSourceFactory {
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final byte[] yamlBytes) throws SQLException, IOException {
         YamlRootShardingConfiguration config = YamlEngine.unmarshal(yamlBytes, YamlRootShardingConfiguration.class, new YamlRootShardingConfigurationConstructor());
-        return ShardingDataSourceFactory.createDataSource(dataSourceMap, new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule()), config.getProps());
+        return ShardingDataSourceFactory.createDataSource(
+                dataSourceMap, ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(config.getShardingRule())), config.getProps());
     }
 }

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactoryTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/api/ShardingDataSourceFactoryTest.java
@@ -30,6 +30,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -43,9 +44,8 @@ public final class ShardingDataSourceFactoryTest {
     
     @Test
     public void assertCreateDataSourceWithShardingRuleAndProperties() throws SQLException {
-        ShardingRuleConfiguration shardingRuleConfig = createShardingRuleConfig();
         Properties props = new Properties();
-        ShardingDataSource dataSource = (ShardingDataSource) ShardingDataSourceFactory.createDataSource(getDataSourceMap(), shardingRuleConfig, props);
+        ShardingDataSource dataSource = (ShardingDataSource) ShardingDataSourceFactory.createDataSource(getDataSourceMap(), Collections.singleton(createShardingRuleConfiguration()), props);
         assertThat(dataSource.getRuntimeContext().getProperties().getProps(), is(props));
     }
     
@@ -73,7 +73,7 @@ public final class ShardingDataSourceFactoryTest {
         return result;
     }
     
-    private ShardingRuleConfiguration createShardingRuleConfig() {
+    private ShardingRuleConfiguration createShardingRuleConfiguration() {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
         result.getTableRuleConfigs().add(new TableRuleConfiguration("logicTable", "ds.table_${0..2}"));
         return result;

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
@@ -196,7 +196,7 @@ public final class ShardingDataSourceTest {
     }
     
     private ShardingDataSource createShardingDataSource(final Map<String, DataSource> dataSourceMap) throws SQLException {
-        return new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), createShardingRuleConfig(dataSourceMap)), new Properties());
+        return new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), createShardingRuleConfig(dataSourceMap)), new Properties());
     }
     
     private ShardingRuleConfiguration createShardingRuleConfig(final Map<String, DataSource> dataSourceMap) {

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.api.config.masterslave.LoadBalanceStrategyConfi
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.api.MasterSlaveDataSourceFactory;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.connection.ShardingConnection;
@@ -196,7 +197,7 @@ public final class ShardingDataSourceTest {
     }
     
     private ShardingDataSource createShardingDataSource(final Map<String, DataSource> dataSourceMap) throws SQLException {
-        return new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), createShardingRuleConfig(dataSourceMap)), new Properties());
+        return new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(createShardingRuleConfig(dataSourceMap))), new Properties());
     }
     
     private ShardingRuleConfiguration createShardingRuleConfig(final Map<String, DataSource> dataSourceMap) {

--- a/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
+++ b/sharding-jdbc/sharding-jdbc-core/src/test/java/org/apache/shardingsphere/shardingjdbc/jdbc/core/datasource/ShardingDataSourceTest.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.api.config.masterslave.LoadBalanceStrategyConfi
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.TableRuleConfiguration;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.api.MasterSlaveDataSourceFactory;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.connection.ShardingConnection;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.fixture.XAShardingTransactionManagerFixture;

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
@@ -51,7 +51,7 @@ public final class OrchestrationShardingDataSourceFactory {
         if (null == shardingRuleConfig || shardingRuleConfig.getTableRuleConfigs().isEmpty()) {
             return createDataSource(orchestrationConfig);
         }
-        ShardingDataSource shardingDataSource = new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), shardingRuleConfig), props);
+        ShardingDataSource shardingDataSource = new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
         return new OrchestrationShardingDataSource(shardingDataSource, orchestrationConfig);
     }
     

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.shardingjdbc.orchestration.api;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.center.config.OrchestrationConfiguration;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 import org.apache.shardingsphere.shardingjdbc.orchestration.internal.datasource.OrchestrationShardingDataSource;

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/OrchestrationShardingDataSourceFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.shardingjdbc.orchestration.api;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.center.config.OrchestrationConfiguration;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
@@ -51,7 +52,7 @@ public final class OrchestrationShardingDataSourceFactory {
         if (null == shardingRuleConfig || shardingRuleConfig.getTableRuleConfigs().isEmpty()) {
             return createDataSource(orchestrationConfig);
         }
-        ShardingDataSource shardingDataSource = new ShardingDataSource(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
+        ShardingDataSource shardingDataSource = new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)), props);
         return new OrchestrationShardingDataSource(shardingDataSource, orchestrationConfig);
     }
     

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;
@@ -106,7 +107,7 @@ public final class YamlOrchestrationShardingDataSourceFactory {
             return new OrchestrationShardingDataSource(new OrchestrationConfiguration(YamlCenterRepositoryConfigurationSwapperUtil.marshal(yamlInstanceConfigurationMap)));
         } else {
             ShardingDataSource shardingDataSource = new ShardingDataSource(
-                    dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), SHARDING_RULE_SWAPPER.swap(yamlShardingRuleConfiguration)), props);
+                    dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(SHARDING_RULE_SWAPPER.swap(yamlShardingRuleConfiguration))), props);
             return new OrchestrationShardingDataSource(shardingDataSource, new OrchestrationConfiguration(YamlCenterRepositoryConfigurationSwapperUtil.marshal(yamlInstanceConfigurationMap)));
         }
     }

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
@@ -105,7 +105,8 @@ public final class YamlOrchestrationShardingDataSourceFactory {
         if (null == yamlShardingRuleConfiguration) {
             return new OrchestrationShardingDataSource(new OrchestrationConfiguration(YamlCenterRepositoryConfigurationSwapperUtil.marshal(yamlInstanceConfigurationMap)));
         } else {
-            ShardingDataSource shardingDataSource = new ShardingDataSource(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), SHARDING_RULE_SWAPPER.swap(yamlShardingRuleConfiguration)), props);
+            ShardingDataSource shardingDataSource = new ShardingDataSource(
+                    dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), SHARDING_RULE_SWAPPER.swap(yamlShardingRuleConfiguration)), props);
             return new OrchestrationShardingDataSource(shardingDataSource, new OrchestrationConfiguration(YamlCenterRepositoryConfigurationSwapperUtil.marshal(yamlInstanceConfigurationMap)));
         }
     }

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/api/yaml/YamlOrchestrationShardingDataSourceFactory.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.shardingjdbc.orchestration.api.yaml;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.orchestration.center.config.OrchestrationConfiguration;

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
@@ -24,7 +24,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.center.config.OrchestrationConfiguration;
 import org.apache.shardingsphere.orchestration.core.common.event.DataSourceChangedEvent;
 import org.apache.shardingsphere.orchestration.core.common.event.PropertiesChangedEvent;

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
@@ -62,7 +62,7 @@ public class OrchestrationShardingDataSource extends AbstractOrchestrationDataSo
         Preconditions.checkState(null != shardingRuleConfig && !shardingRuleConfig.getTableRuleConfigs().isEmpty(), "Missing the sharding rule configuration on registry center");
         Map<String, DataSourceConfiguration> dataSourceConfigurations = configService.loadDataSourceConfigurations(DefaultSchema.LOGIC_NAME);
         dataSource = new ShardingDataSource(DataSourceConverter.getDataSourceMap(dataSourceConfigurations),
-                RuleBuilder.build(dataSourceConfigurations.keySet(), shardingRuleConfig), configService.loadProperties());
+                RuleBuilder.buildSharding(dataSourceConfigurations.keySet(), shardingRuleConfig), configService.loadProperties());
         initShardingOrchestrationFacade();
         persistMetaData(dataSource.getRuntimeContext().getMetaData().getSchema());
     }
@@ -104,7 +104,7 @@ public class OrchestrationShardingDataSource extends AbstractOrchestrationDataSo
     @SneakyThrows
     public final synchronized void renew(final ShardingRuleChangedEvent shardingRuleChangedEvent) {
         dataSource = new ShardingDataSource(dataSource.getDataSourceMap(), 
-                RuleBuilder.build(dataSource.getDataSourceMap().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()), dataSource.getRuntimeContext().getProperties().getProps());
+                RuleBuilder.buildSharding(dataSource.getDataSourceMap().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()), dataSource.getRuntimeContext().getProperties().getProps());
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.center.config.OrchestrationConfiguration;
 import org.apache.shardingsphere.orchestration.core.common.event.DataSourceChangedEvent;
@@ -62,7 +63,7 @@ public class OrchestrationShardingDataSource extends AbstractOrchestrationDataSo
         Preconditions.checkState(null != shardingRuleConfig && !shardingRuleConfig.getTableRuleConfigs().isEmpty(), "Missing the sharding rule configuration on registry center");
         Map<String, DataSourceConfiguration> dataSourceConfigurations = configService.loadDataSourceConfigurations(DefaultSchema.LOGIC_NAME);
         dataSource = new ShardingDataSource(DataSourceConverter.getDataSourceMap(dataSourceConfigurations),
-                RuleBuilder.buildSharding(dataSourceConfigurations.keySet(), shardingRuleConfig), configService.loadProperties());
+                RuleBuilder.build(dataSourceConfigurations.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)), configService.loadProperties());
         initShardingOrchestrationFacade();
         persistMetaData(dataSource.getRuntimeContext().getMetaData().getSchema());
     }

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSource.java
@@ -104,7 +104,7 @@ public class OrchestrationShardingDataSource extends AbstractOrchestrationDataSo
     @SneakyThrows
     public final synchronized void renew(final ShardingRuleChangedEvent shardingRuleChangedEvent) {
         dataSource = new ShardingDataSource(dataSource.getDataSourceMap(), 
-                RuleBuilder.buildSharding(dataSource.getDataSourceMap().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()), dataSource.getRuntimeContext().getProperties().getProps());
+                RuleBuilder.build(dataSource.getDataSourceMap().keySet(), shardingRuleChangedEvent.getRuleConfigurations()), dataSource.getRuntimeContext().getProperties().getProps());
     }
     
     /**

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSourceTest.java
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/test/java/org/apache/shardingsphere/shardingjdbc/orchestration/internal/datasource/OrchestrationShardingDataSourceTest.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -112,14 +113,13 @@ public final class OrchestrationShardingDataSourceTest {
     
     @Test
     public void assertRenewRule() {
-        shardingDataSource.renew(new ShardingRuleChangedEvent(DefaultSchema.LOGIC_NAME, getShardingRuleConfig()));
+        shardingDataSource.renew(new ShardingRuleChangedEvent(DefaultSchema.LOGIC_NAME, Arrays.asList(getShardingRuleConfiguration(), getMasterSlaveRuleConfiguration())));
         assertThat(((ShardingRule) shardingDataSource.getDataSource().getRuntimeContext().getRules().iterator().next()).getTableRules().size(), is(1));
     }
     
-    private ShardingRuleConfiguration getShardingRuleConfig() {
+    private ShardingRuleConfiguration getShardingRuleConfiguration() {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
         result.getTableRuleConfigs().add(new TableRuleConfiguration("logic_table", "ds_ms.table_${0..1}"));
-        result.getMasterSlaveRuleConfigs().add(getMasterSlaveRuleConfiguration());
         return result;
     }
     

--- a/sharding-jdbc/sharding-jdbc-orchestration/src/test/resources/yaml/unit/sharding.yaml
+++ b/sharding-jdbc/sharding-jdbc-orchestration/src/test/resources/yaml/unit/sharding.yaml
@@ -49,7 +49,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_id
         props:
-          worker.id: 123        
+          worker.id: 123
     t_order_item:
       actualDataNodes: ds_ms.t_order_item_${0..1}
       tableStrategy:
@@ -63,7 +63,7 @@ shardingRule:
         type: SNOWFLAKE
         column: order_item_id
         props:
-          worker.id: 123        
+          worker.id: 123
   bindingTables:
     - t_order,t_order_item
   masterSlaveRules:

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-common/src/main/java/org/apache/shardingsphere/orchestration/core/common/event/ShardingRuleChangedEvent.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-common/src/main/java/org/apache/shardingsphere/orchestration/core/common/event/ShardingRuleChangedEvent.java
@@ -19,7 +19,9 @@ package org.apache.shardingsphere.orchestration.core.common.event;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
+
+import java.util.Collection;
 
 /**
  * Sharding rule changed event.
@@ -30,5 +32,5 @@ public final class ShardingRuleChangedEvent implements ShardingOrchestrationEven
     
     private final String shardingSchemaName;
     
-    private final ShardingRuleConfiguration shardingRuleConfiguration;
+    private final Collection<RuleConfiguration> ruleConfigurations;
 }

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-configcenter/src/main/java/org/apache/shardingsphere/orchestration/core/configcenter/listener/SchemaChangedListener.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-configcenter/src/main/java/org/apache/shardingsphere/orchestration/core/configcenter/listener/SchemaChangedListener.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.orchestration.core.configcenter.listener;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.commons.collections4.SetUtils;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.yaml.config.masterslave.YamlMasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.core.yaml.config.sharding.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.core.yaml.constructor.YamlRootShardingConfigurationConstructor;
@@ -138,8 +139,8 @@ public final class SchemaChangedListener extends PostShardingCenterRepositoryEve
     }
     
     private ShardingRuleChangedEvent createShardingRuleChangedEvent(final String shardingSchemaName, final String ruleValue) {
-        return new ShardingRuleChangedEvent(shardingSchemaName, new ShardingRuleConfigurationYamlSwapper().swap(
-            YamlEngine.unmarshal(ruleValue, YamlShardingRuleConfiguration.class, new YamlRootShardingConfigurationConstructor())));
+        return new ShardingRuleChangedEvent(shardingSchemaName, ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(
+            YamlEngine.unmarshal(ruleValue, YamlShardingRuleConfiguration.class, new YamlRootShardingConfigurationConstructor()))));
     }
     
     private EncryptRuleChangedEvent createEncryptRuleChangedEvent(final String shardingSchemaName, final String ruleValue) {

--- a/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-configcenter/src/test/java/org/apache/shardingsphere/orchestration/core/configcenter/listener/SchemaChangedListenerTest.java
+++ b/sharding-orchestration/sharding-orchestration-core/sharding-orchestration-core-configcenter/src/test/java/org/apache/shardingsphere/orchestration/core/configcenter/listener/SchemaChangedListenerTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.orchestration.core.configcenter.listener;
 
-import org.apache.shardingsphere.encrypt.api.EncryptRuleConfiguration;
-import org.apache.shardingsphere.encrypt.api.EncryptorRuleConfiguration;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.EncryptorRuleConfiguration;
 import org.apache.shardingsphere.orchestration.center.ConfigCenterRepository;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent;
 import org.apache.shardingsphere.orchestration.center.listener.DataChangedEvent.ChangedType;
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.orchestration.core.common.event.SchemaDeletedEv
 import org.apache.shardingsphere.orchestration.core.common.event.ShardingOrchestrationEvent;
 import org.apache.shardingsphere.orchestration.core.common.event.ShardingRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration;
+import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +41,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map.Entry;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -97,7 +99,9 @@ public final class SchemaChangedListenerTest {
         ShardingOrchestrationEvent actual = schemaChangedListener.createShardingOrchestrationEvent(dataChangedEvent);
         assertThat(actual, instanceOf(ShardingRuleChangedEvent.class));
         assertThat(((ShardingRuleChangedEvent) actual).getShardingSchemaName(), is("sharding_db"));
-        assertThat(((ShardingRuleChangedEvent) actual).getShardingRuleConfiguration().getTableRuleConfigs().size(), is(1));
+        Collection<RuleConfiguration> ruleConfigurations = ((ShardingRuleChangedEvent) actual).getRuleConfigurations();
+        assertThat(ruleConfigurations.size(), is(1));
+        assertThat(((ShardingRuleConfiguration) ruleConfigurations.iterator().next()).getTableRuleConfigs().size(), is(1));
     }
     
     @Test

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
@@ -58,8 +58,8 @@ public final class ShardingSchema extends LogicSchema {
     @Subscribe
     public synchronized void renew(final ShardingRuleChangedEvent shardingRuleChangedEvent) {
         if (getName().equals(shardingRuleChangedEvent.getShardingSchemaName())) {
-            ConfigurationLogger.log(shardingRuleChangedEvent.getShardingRuleConfiguration());
-            setRules(RuleBuilder.buildSharding(getDataSources().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()));
+            ConfigurationLogger.log(shardingRuleChangedEvent.getRuleConfigurations());
+            setRules(RuleBuilder.build(getDataSources().keySet(), shardingRuleChangedEvent.getRuleConfigurations()));
         }
     }
     

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
@@ -21,6 +21,7 @@ import com.google.common.eventbus.Subscribe;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.core.log.ConfigurationLogger;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.core.common.event.ShardingRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.core.facade.ShardingOrchestrationFacade;
@@ -47,7 +48,7 @@ import java.util.Optional;
 public final class ShardingSchema extends LogicSchema {
     
     public ShardingSchema(final String name, final Map<String, YamlDataSourceParameter> dataSources, final ShardingRuleConfiguration shardingRuleConfig) throws SQLException {
-        super(name, dataSources, RuleBuilder.buildSharding(dataSources.keySet(), shardingRuleConfig));
+        super(name, dataSources, RuleBuilder.build(dataSources.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)));
     }
     
     /**

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
@@ -21,7 +21,7 @@ import com.google.common.eventbus.Subscribe;
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
 import org.apache.shardingsphere.core.log.ConfigurationLogger;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.orchestration.core.common.event.ShardingRuleChangedEvent;
 import org.apache.shardingsphere.orchestration.core.facade.ShardingOrchestrationFacade;
 import org.apache.shardingsphere.orchestration.core.registrycenter.event.DisabledStateChangedEvent;

--- a/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
+++ b/sharding-proxy/sharding-proxy-backend/src/main/java/org/apache/shardingsphere/shardingproxy/backend/schema/impl/ShardingSchema.java
@@ -47,7 +47,7 @@ import java.util.Optional;
 public final class ShardingSchema extends LogicSchema {
     
     public ShardingSchema(final String name, final Map<String, YamlDataSourceParameter> dataSources, final ShardingRuleConfiguration shardingRuleConfig) throws SQLException {
-        super(name, dataSources, RuleBuilder.build(dataSources.keySet(), shardingRuleConfig));
+        super(name, dataSources, RuleBuilder.buildSharding(dataSources.keySet(), shardingRuleConfig));
     }
     
     /**
@@ -59,7 +59,7 @@ public final class ShardingSchema extends LogicSchema {
     public synchronized void renew(final ShardingRuleChangedEvent shardingRuleChangedEvent) {
         if (getName().equals(shardingRuleChangedEvent.getShardingSchemaName())) {
             ConfigurationLogger.log(shardingRuleChangedEvent.getShardingRuleConfiguration());
-            setRules(RuleBuilder.build(getDataSources().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()));
+            setRules(RuleBuilder.buildSharding(getDataSources().keySet(), shardingRuleChangedEvent.getShardingRuleConfiguration()));
         }
     }
     

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Maps;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineExpressionParser;
 import org.apache.shardingsphere.core.yaml.swapper.MasterSlaveRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
@@ -129,7 +129,7 @@ public class OrchestrationSpringBootConfiguration implements EnvironmentAware {
     @Conditional(LocalShardingRuleCondition.class)
     public DataSource shardingDataSourceByLocal(final OrchestrationConfiguration orchestrationConfiguration) throws SQLException {
         return new OrchestrationShardingDataSource(new ShardingDataSource(dataSourceMap, 
-                RuleBuilder.build(dataSourceMap.keySet(), new ShardingRuleConfigurationYamlSwapper().swap(this.shardingRule)), root.getProps()), orchestrationConfiguration);
+                RuleBuilder.buildSharding(dataSourceMap.keySet(), new ShardingRuleConfigurationYamlSwapper().swap(this.shardingRule)), root.getProps()), orchestrationConfiguration);
     }
     
     /**

--- a/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
+++ b/sharding-spring/sharding-jdbc-orchestration-spring/sharding-jdbc-orchestration-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/orchestration/spring/boot/OrchestrationSpringBootConfiguration.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.core.rule.MasterSlaveRule;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineExpressionParser;
 import org.apache.shardingsphere.core.yaml.swapper.MasterSlaveRuleConfigurationYamlSwapper;
@@ -128,8 +129,8 @@ public class OrchestrationSpringBootConfiguration implements EnvironmentAware {
     @Bean
     @Conditional(LocalShardingRuleCondition.class)
     public DataSource shardingDataSourceByLocal(final OrchestrationConfiguration orchestrationConfiguration) throws SQLException {
-        return new OrchestrationShardingDataSource(new ShardingDataSource(dataSourceMap, 
-                RuleBuilder.buildSharding(dataSourceMap.keySet(), new ShardingRuleConfigurationYamlSwapper().swap(this.shardingRule)), root.getProps()), orchestrationConfiguration);
+        return new OrchestrationShardingDataSource(new ShardingDataSource(dataSourceMap, RuleBuilder.build(
+                dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(shardingRule))), root.getProps()), orchestrationConfiguration);
     }
     
     /**

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/boot/SpringBootConfiguration.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-boot-starter/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/boot/SpringBootConfiguration.java
@@ -19,9 +19,11 @@ package org.apache.shardingsphere.shardingjdbc.spring.boot;
 
 import com.google.common.base.Preconditions;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
+import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineExpressionParser;
 import org.apache.shardingsphere.core.yaml.swapper.MasterSlaveRuleConfigurationYamlSwapper;
-import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.core.yaml.swapper.ShadowRuleConfigurationYamlSwapper;
+import org.apache.shardingsphere.core.yaml.swapper.ShardingRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.encrypt.yaml.swapper.EncryptRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.shardingjdbc.api.EncryptDataSourceFactory;
 import org.apache.shardingsphere.shardingjdbc.api.MasterSlaveDataSourceFactory;
@@ -40,7 +42,6 @@ import org.apache.shardingsphere.spring.boot.datasource.DataSourcePropertiesSett
 import org.apache.shardingsphere.spring.boot.util.DataSourceUtil;
 import org.apache.shardingsphere.spring.boot.util.PropertyUtil;
 import org.apache.shardingsphere.transaction.spring.ShardingTransactionTypeScanner;
-import org.apache.shardingsphere.core.strategy.algorithm.sharding.inline.InlineExpressionParser;
 import org.apache.shardingsphere.underlying.common.exception.ShardingSphereException;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -100,7 +101,7 @@ public class SpringBootConfiguration implements EnvironmentAware {
     @Bean
     @Conditional(ShardingRuleCondition.class)
     public DataSource shardingDataSource() throws SQLException {
-        return ShardingDataSourceFactory.createDataSource(dataSourceMap, new ShardingRuleConfigurationYamlSwapper().swap(shardingRule), props.getProps());
+        return ShardingDataSourceFactory.createDataSource(dataSourceMap, ConfigurationBuilder.buildSharding(new ShardingRuleConfigurationYamlSwapper().swap(shardingRule)), props.getProps());
     }
     
     /**

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.shardingjdbc.spring.datasource;
 
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
-import org.apache.shardingsphere.core.rule.RuleBuilder;
+import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 
 import javax.sql.DataSource;

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.shardingjdbc.spring.datasource;
 
 import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.core.rule.builder.ConfigurationBuilder;
 import org.apache.shardingsphere.core.rule.builder.RuleBuilder;
 import org.apache.shardingsphere.shardingjdbc.jdbc.core.datasource.ShardingDataSource;
 
@@ -32,6 +33,6 @@ import java.util.Properties;
 public final class SpringShardingDataSource extends ShardingDataSource {
     
     public SpringShardingDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig, final Properties props) throws SQLException {
-        super(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
+        super(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), ConfigurationBuilder.buildSharding(shardingRuleConfig)), props);
     }
 }

--- a/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
+++ b/sharding-spring/sharding-jdbc-spring/sharding-jdbc-spring-namespace/src/main/java/org/apache/shardingsphere/shardingjdbc/spring/datasource/SpringShardingDataSource.java
@@ -32,6 +32,6 @@ import java.util.Properties;
 public final class SpringShardingDataSource extends ShardingDataSource {
     
     public SpringShardingDataSource(final Map<String, DataSource> dataSourceMap, final ShardingRuleConfiguration shardingRuleConfig, final Properties props) throws SQLException {
-        super(dataSourceMap, RuleBuilder.build(dataSourceMap.keySet(), shardingRuleConfig), props);
+        super(dataSourceMap, RuleBuilder.buildSharding(dataSourceMap.keySet(), shardingRuleConfig), props);
     }
 }

--- a/shardingsphere-ui/shardingsphere-ui-backend/src/main/java/org/apache/shardingsphere/ui/servcie/impl/OrchestrationServiceImpl.java
+++ b/shardingsphere-ui/shardingsphere-ui-backend/src/main/java/org/apache/shardingsphere/ui/servcie/impl/OrchestrationServiceImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.ui.servcie.impl;
 
+import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
 import org.apache.shardingsphere.orchestration.core.registrycenter.RegistryCenterNodeStatus;
 import org.apache.shardingsphere.ui.common.dto.InstanceDTO;
 import org.apache.shardingsphere.ui.common.dto.SlaveDataSourceDTO;
@@ -24,14 +25,14 @@ import org.apache.shardingsphere.ui.servcie.OrchestrationService;
 import org.apache.shardingsphere.ui.servcie.RegistryCenterService;
 import org.apache.shardingsphere.ui.servcie.ShardingSchemaService;
 import org.apache.shardingsphere.ui.util.ConfigurationYamlConverter;
-import org.apache.shardingsphere.api.config.masterslave.MasterSlaveRuleConfiguration;
-import org.apache.shardingsphere.api.config.sharding.ShardingRuleConfiguration;
+import org.apache.shardingsphere.underlying.common.config.RuleConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Implementation of orchestration operation service.
@@ -90,8 +91,9 @@ public final class OrchestrationServiceImpl implements OrchestrationService {
     }
     
     private void handleShardingRuleConfiguration(final Collection<SlaveDataSourceDTO> slaveDataSourceDTOS, final String configData, final String schemaName) {
-        ShardingRuleConfiguration shardingRuleConfiguration = ConfigurationYamlConverter.loadShardingRuleConfiguration(configData);
-        Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = shardingRuleConfiguration.getMasterSlaveRuleConfigs();
+        Collection<RuleConfiguration> configurations = ConfigurationYamlConverter.loadRuleConfigurations(configData);
+        Collection<MasterSlaveRuleConfiguration> masterSlaveRuleConfigs = configurations.stream().filter(
+            config -> config instanceof MasterSlaveRuleConfiguration).map(config -> (MasterSlaveRuleConfiguration) config).collect(Collectors.toList());
         for (MasterSlaveRuleConfiguration masterSlaveRuleConfiguration : masterSlaveRuleConfigs) {
             addSlaveDataSource(slaveDataSourceDTOS, masterSlaveRuleConfiguration, schemaName);
         }

--- a/shardingsphere-ui/shardingsphere-ui-backend/src/main/java/org/apache/shardingsphere/ui/servcie/impl/ShardingSchemaServiceImpl.java
+++ b/shardingsphere-ui/shardingsphere-ui-backend/src/main/java/org/apache/shardingsphere/ui/servcie/impl/ShardingSchemaServiceImpl.java
@@ -96,7 +96,7 @@ public final class ShardingSchemaServiceImpl implements ShardingSchemaService {
             if (configData.contains("encryptors:\n")) {
                 ConfigurationYamlConverter.loadEncryptRuleConfiguration(configData);
             } else if (configData.contains("tables:\n") || configData.contains("defaultTableStrategy:\n")) {
-                ConfigurationYamlConverter.loadShardingRuleConfiguration(configData);
+                ConfigurationYamlConverter.loadRuleConfigurations(configData);
             } else {
                 ConfigurationYamlConverter.loadMasterSlaveRuleConfiguration(configData);
             }
@@ -135,7 +135,7 @@ public final class ShardingSchemaServiceImpl implements ShardingSchemaService {
         ConfigCenterRepository configCenterRepository = configCenterService.getActivatedConfigCenter();
         String schemaPath = configCenterService.getActivateConfigurationNode().getSchemaPath();
         String schemaNames = configCenterRepository.get(schemaPath);
-        List<String> schemaNameList = Strings.isNullOrEmpty(schemaNames)?new ArrayList<>():new ArrayList<>(Splitter.on(",").splitToList(schemaNames));
+        List<String> schemaNameList = Strings.isNullOrEmpty(schemaNames) ? new ArrayList<>() : new ArrayList<>(Splitter.on(",").splitToList(schemaNames));
         if (!schemaNameList.contains(schemaName)) {
             schemaNameList.add(schemaName);
             configCenterRepository.persist(schemaPath, Joiner.on(",").join(schemaNameList));


### PR DESCRIPTION
For #3691.
