### PR TITLE
using maven-dockerfile-plugin to simplify released proxy docker

### DIFF
--- a/docs/community/content/contribute/release.cn.md
+++ b/docs/community/content/contribute/release.cn.md
@@ -507,7 +507,7 @@ https://shardingsphere.apache.org/document/current/cn/downloads/
 
 ```shell
 cd ~/shardingsphere/sharding-distribution/sharding-proxy-distribution/
-mvn clean package docker:build
+mvn clean package -Prelease,docker
 ```
 
 #### 给本地Docker镜像打标记

--- a/docs/community/content/contribute/release.en.md
+++ b/docs/community/content/contribute/release.en.md
@@ -516,7 +516,7 @@ Install docker locally and start the docker service
 
 ```shell
 cd ~/shardingsphere/sharding-distribution/sharding-proxy-distribution/
-mvn clean package docker:build
+mvn clean package -Prelease,docker
 ```
 
 #### Tag the local Docker Image

--- a/docs/document/content/manual/sharding-proxy/docker.cn.md
+++ b/docs/document/content/manual/sharding-proxy/docker.cn.md
@@ -16,7 +16,7 @@ docker pull apache/sharding-proxy
 git clone https://github.com/apache/shardingsphere
 mvn clean install
 cd sharding-sphere/sharding-distribution/sharding-proxy-distribution
-mvn clean package docker:build
+mvn clean package -Prelease,docker
 ```
 
 ## 配置Sharding-Proxy

--- a/docs/document/content/manual/sharding-proxy/docker.en.md
+++ b/docs/document/content/manual/sharding-proxy/docker.en.md
@@ -16,7 +16,7 @@ docker pull apache/sharding-proxy
 git clone https://github.com/apache/shardingsphere
 mvn clean install
 cd sharding-distribution/sharding-proxy-distribution
-mvn clean package docker:build
+mvn clean package -Prelease,docker
 ```
 
 ## Configure Sharding-Proxy

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,6 @@
         <jdepend-maven-plugin.version>2.0</jdepend-maven-plugin.version>
         <taglist-maven-plugin.version>2.4</taglist-maven-plugin.version>
         <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
-        <docker-maven-plugin.version>0.4.14</docker-maven-plugin.version>
         <dockerfile-maven.version>1.4.6</dockerfile-maven.version>
         
         <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>
@@ -650,11 +649,6 @@
                     <groupId>org.antlr</groupId>
                     <artifactId>antlr4-maven-plugin</artifactId>
                     <version>${antlr4.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.spotify</groupId>
-                    <artifactId>docker-maven-plugin</artifactId>
-                    <version>${docker-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.spotify</groupId>

--- a/sharding-distribution/sharding-proxy-distribution/Dockerfile
+++ b/sharding-distribution/sharding-proxy-distribution/Dockerfile
@@ -18,15 +18,11 @@
 FROM java:8
 MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
 
-ENV CURRENT_VERSION 5.0.0-RC1
-ENV APP_NAME apache-shardingsphere
-ENV MODULE_NAME sharding-proxy
+ARG APP_NAME
 ENV LOCAL_PATH /opt/sharding-proxy
 
-RUN wget https://dist.apache.org/repos/dist/release/shardingsphere/${CURRENT_VERSION}/${APP_NAME}-${CURRENT_VERSION}-${MODULE_NAME}-bin.tar.gz && \
-    tar -xzvf ${APP_NAME}-${CURRENT_VERSION}-${MODULE_NAME}-bin.tar.gz && \
-    mv ${APP_NAME}-${CURRENT_VERSION}-${MODULE_NAME}-bin ${LOCAL_PATH} && \
-    rm -f ${APP_NAME}-${CURRENT_VERSION}-${MODULE_NAME}-bin.tar.gz
+ADD target/${APP_NAME}.tar.gz /opt
+RUN mv /opt/${APP_NAME} ${LOCAL_PATH}
 RUN mkdir -p ${LOCAL_PATH}/ext-lib
 
 ENTRYPOINT ${LOCAL_PATH}/bin/start.sh ${PORT} && tail -f ${LOCAL_PATH}/logs/stdout.log

--- a/sharding-distribution/sharding-proxy-distribution/pom.xml
+++ b/sharding-distribution/sharding-proxy-distribution/pom.xml
@@ -53,26 +53,6 @@
         </dependency>
     </dependencies>
     
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <configuration>
-                    <imageName>apache/sharding-proxy:5.0.0-RC1</imageName>
-                    <dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.tar.gz</include>
-                        </resource>
-                    </resources>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    
     <profiles>
         <profile>
             <id>release</id>
@@ -94,6 +74,32 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>docker</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sharding-proxy-bin</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>apache/sharding-proxy</repository>
+                            <tag>${project.version}</tag>
+                            <buildArgs>
+                                <APP_NAME>${project.build.finalName}-sharding-proxy-bin</APP_NAME>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/shardingsphere-integration-test/sharding-proxy-docker-build/pom.xml
+++ b/shardingsphere-integration-test/sharding-proxy-docker-build/pom.xml
@@ -97,7 +97,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <repository>apache/sharding-proxy</repository>
+                            <repository>apache/sharding-proxy-test</repository>
                             <tag>${project.version}</tag>
                             <buildArgs>
                                 <APP_NAME>${project.build.finalName}</APP_NAME>


### PR DESCRIPTION
1. build command is changed from `mvn clean package docker:build` => `mvn clean package -Prelease,docker`

2. hard-coding version have removed from dockfile
