### PR TITLE
Defect more when concurrently registering services

### DIFF
--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/sharding/spi/ShardingSphereServiceLoader.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/sharding/spi/ShardingSphereServiceLoader.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ShardingSphereServiceLoader {
-    
-    private static final Map<Class, Collection<Class<?>>> SERVICE_MAP = new ConcurrentHashMap<>();
-    
+
+    private static final Map<Class<?>, Collection<Class<?>>> SERVICE_MAP = new ConcurrentHashMap<>();
+
     /**
      * Register SPI service into map for new instance.
      *
@@ -51,17 +51,12 @@ public final class ShardingSphereServiceLoader {
             registerServiceClass(service, each);
         }
     }
-    
-    @SuppressWarnings("unchecked")
+
     private static <T> void registerServiceClass(final Class<T> service, final T instance) {
-        Collection<Class<?>> serviceClasses = SERVICE_MAP.get(service);
-        if (null == serviceClasses) {
-            serviceClasses = new LinkedHashSet<>();
-        }
+        Collection<Class<?>> serviceClasses = SERVICE_MAP.computeIfAbsent(service, unused -> new LinkedHashSet<>());
         serviceClasses.add(instance.getClass());
-        SERVICE_MAP.put(service, serviceClasses);
     }
-    
+
     /**
      * New service instances.
      *
@@ -73,7 +68,7 @@ public final class ShardingSphereServiceLoader {
     public static <T> Collection<T> newServiceInstances(final Class<T> service) {
         return SERVICE_MAP.containsKey(service) ? SERVICE_MAP.get(service).stream().map(each -> (T) newServiceInstance(each)).collect(Collectors.toList()) : Collections.emptyList();
     }
-    
+
     private static Object newServiceInstance(final Class<?> clazz) {
         try {
             return clazz.newInstance();

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/sharding/spi/ShardingSphereServiceLoader.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/sharding/spi/ShardingSphereServiceLoader.java
@@ -34,9 +34,9 @@ import java.util.stream.Collectors;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ShardingSphereServiceLoader {
-
+    
     private static final Map<Class<?>, Collection<Class<?>>> SERVICE_MAP = new ConcurrentHashMap<>();
-
+    
     /**
      * Register SPI service into map for new instance.
      *
@@ -51,12 +51,12 @@ public final class ShardingSphereServiceLoader {
             registerServiceClass(service, each);
         }
     }
-
+    
     private static <T> void registerServiceClass(final Class<T> service, final T instance) {
         Collection<Class<?>> serviceClasses = SERVICE_MAP.computeIfAbsent(service, unused -> new LinkedHashSet<>());
         serviceClasses.add(instance.getClass());
     }
-
+    
     /**
      * New service instances.
      *
@@ -68,7 +68,7 @@ public final class ShardingSphereServiceLoader {
     public static <T> Collection<T> newServiceInstances(final Class<T> service) {
         return SERVICE_MAP.containsKey(service) ? SERVICE_MAP.get(service).stream().map(each -> (T) newServiceInstance(each)).collect(Collectors.toList()) : Collections.emptyList();
     }
-
+    
     private static Object newServiceInstance(final Class<?> clazz) {
         try {
             return clazz.newInstance();


### PR DESCRIPTION
This pull request follows up #5618.

`ConcurrentHashMap` is thread safe, but `get-and-check-and-put` are composite operations and are thus not atomic, this patch replaces the former with `computeIfAbsent`, which is atomic now.

