### PR TITLE
Rename example service to fix the naming conflict between example and spring boot starter

### DIFF
--- a/examples/example-core/example-spring-jpa/src/main/java/org/apache/shardingsphere/example/core/jpa/service/ShadowUserServiceImpl.java
+++ b/examples/example-core/example-spring-jpa/src/main/java/org/apache/shardingsphere/example/core/jpa/service/ShadowUserServiceImpl.java
@@ -28,7 +28,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-@Service("shadow")
+@Service("shadowExample")
 public class ShadowUserServiceImpl implements ExampleService {
     
     @Resource

--- a/examples/example-core/example-spring-jpa/src/main/java/org/apache/shardingsphere/example/core/jpa/service/UserServiceImpl.java
+++ b/examples/example-core/example-spring-jpa/src/main/java/org/apache/shardingsphere/example/core/jpa/service/UserServiceImpl.java
@@ -28,7 +28,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-@Service("encrypt")
+@Service("encryptExample")
 public class UserServiceImpl implements ExampleService {
     
     @Resource

--- a/examples/shardingsphere-jdbc-example/other-feature-example/encrypt-example/encrypt-spring-boot-example/src/main/java/org/apache/shardingsphere/example/encrypt/table/spring/boot/ExampleMain.java
+++ b/examples/shardingsphere-jdbc-example/other-feature-example/encrypt-example/encrypt-spring-boot-example/src/main/java/org/apache/shardingsphere/example/encrypt/table/spring/boot/ExampleMain.java
@@ -36,7 +36,7 @@ public class ExampleMain {
     @Deprecated
     public static void main(final String[] args) throws SQLException {
         try (ConfigurableApplicationContext applicationContext = SpringApplication.run(ExampleMain.class, args)) {
-            ExampleExecuteTemplate.run(applicationContext.getBean("encrypt", ExampleService.class));
+            ExampleExecuteTemplate.run(applicationContext.getBean("encryptExample", ExampleService.class));
         }
     }
 }

--- a/examples/shardingsphere-jdbc-example/other-feature-example/shadow-example/shadow-spring-boot-example/src/main/java/org/apache/shardingsphere/example/shadow/table/spring/boot/ExampleMain.java
+++ b/examples/shardingsphere-jdbc-example/other-feature-example/shadow-example/shadow-spring-boot-example/src/main/java/org/apache/shardingsphere/example/shadow/table/spring/boot/ExampleMain.java
@@ -35,7 +35,7 @@ public class ExampleMain {
     
     public static void main(final String[] args) throws SQLException {
         try (ConfigurableApplicationContext applicationContext = SpringApplication.run(ExampleMain.class, args)) {
-            ExampleExecuteTemplate.run(applicationContext.getBean("shadow", ExampleService.class));
+            ExampleExecuteTemplate.run(applicationContext.getBean("shadowExample", ExampleService.class));
         }
     }
 }


### PR DESCRIPTION
The rule is named shadow/encrypt and it will conflict with example service
```
@Bean
    @ConfigurationProperties(prefix = "spring.shardingsphere.rules.shadow")
    @ConditionalOnClass(YamlShadowRuleConfiguration.class)
    @Conditional(ShadowSpringBootCondition.class)
    public YamlRuleConfiguration shadow() {
        return new YamlShadowRuleConfiguration();
    }
```