### PR TITLE
use docker-compose-wait to resolve container dependency order

### DIFF
--- a/shardingsphere-integration-test/shardingsphere-proxy-docker-build/Dockerfile
+++ b/shardingsphere-integration-test/shardingsphere-proxy-docker-build/Dockerfile
@@ -18,6 +18,10 @@
 FROM openjdk:8-jdk-alpine
 
 ARG APP_NAME
-ADD target/${APP_NAME}.tar.gz /export
-RUN mv /export/${APP_NAME} /export/shardingsphere-proxy
-ENTRYPOINT /export/shardingsphere-proxy/bin/start.sh && tail -f /export/shardingsphere-proxy/logs/stdout.log
+ENV WAIT_VERSION 2.7.2
+
+ADD target/${APP_NAME}.tar.gz /opt
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
+RUN chmod +x /wait
+RUN mv /opt/${APP_NAME} /opt/shardingsphere-proxy
+ENTRYPOINT /wait && /opt/shardingsphere-proxy/bin/start.sh && tail -f /opt/shardingsphere-proxy/logs/stdout.log

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/docker/docker-compose.yml
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/docker/docker-compose.yml
@@ -24,16 +24,18 @@ services:
     volumes:
       - ./mysql:/docker-entrypoint-initdb.d/
     ports:
-      - "3336:3306"
-  sharding-proxy:
+      - "33060:3306"
+  shardingsphere-proxy:
       image: apache/shardingsphere-proxy-test
-      container_name: sharding-proxy
-      depends_on:
-        - mysql
+      container_name: shardingsphere-proxy
       ports:
-        - "3337:3307"
+        - "33070:3307"
       links:
         - "mysql:db.mysql"
-      entrypoint: >
-        /bin/sh -c 'sleep 10s'
-
+      depends_on:
+        - mysql
+      environment:
+        - WAIT_HOSTS=mysql:3306
+        - WAIT_HOSTS_TIMEOUT=300
+        - WAIT_SLEEP_INTERVAL=10
+        - WAIT_HOST_CONNECT_TIMEOUT=30


### PR DESCRIPTION
[docker-compose-wait](https://github.com/ufoscout/docker-compose-wait) is apache license project which support to wait for other docker images to be started while using docker-compose.
