### PR TITLE
fix issue#5893:

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -167,23 +167,7 @@ public final class EncryptRule implements ShardingSphereRule {
      * @return cipher column or not
      */
     public boolean isCipherColumn(final String tableName, final String columnName) {
-        return tables.containsKey(tableName) && isCipherColumn(tables.get(tableName).getCipherColumns(), columnName);
-    }
-
-    /**
-     * Is cipher column or not.
-     *
-     * @param cipherColumns cipher columns
-     * @param columnName column name
-     * @return cipher column or not
-     */
-    private boolean isCipherColumn(final Collection<String> cipherColumns, final String columnName) {
-        for (String each : cipherColumns) {
-            if (each.equalsIgnoreCase(columnName)) {
-                return true;
-            }
-        }
-        return false;
+        return tables.containsKey(tableName) && tables.get(tableName).getCipherColumns().stream().anyMatch(each -> each.equalsIgnoreCase(columnName));
     }
     
     /**

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -167,7 +167,23 @@ public final class EncryptRule implements ShardingSphereRule {
      * @return cipher column or not
      */
     public boolean isCipherColumn(final String tableName, final String columnName) {
-        return tables.containsKey(tableName) && tables.get(tableName).getCipherColumns().contains(columnName);
+        return tables.containsKey(tableName) && isCipherColumn(tables.get(tableName).getCipherColumns(), columnName);
+    }
+
+    /**
+     * Is cipher column or not.
+     *
+     * @param cipherColumns cipher columns
+     * @param columnName column name
+     * @return cipher column or not
+     */
+    private boolean isCipherColumn(final Collection<String> cipherColumns, final String columnName) {
+        for (String each : cipherColumns) {
+            if (each.equalsIgnoreCase(columnName)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     /**


### PR DESCRIPTION
EncryptRule use equalsIgnoreCase method to match encrypt column, but use equals method to match decrypt column. #5893

Fixes #5893.

Changes proposed in this pull request:
- In decrypt mode, use method of String#equalsIgnoreCase to match columnName is cipher column or not.
-
-
