### PR TITLE
AbstractConnectionAdapter implement Connection#isValid(int) method

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
@@ -239,6 +239,16 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
         recordMethodInvocation(Connection.class, "setTransactionIsolation", new Class[]{int.class}, new Object[]{level});
         forceExecuteTemplate.execute(cachedConnections.values(), connection -> connection.setTransactionIsolation(level));
     }
+
+    @Override
+    public final boolean isValid(final int timeout) throws SQLException {
+        for (Connection connection : cachedConnections.values()) {
+            if (!connection.isValid(timeout)) {
+                return false;
+            }
+        }
+        return true;
+    }
     
     // ------- Consist with MySQL driver implementation -------
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
@@ -151,12 +151,7 @@ public abstract class AbstractUnsupportedOperationConnection extends WrapperAdap
     public final Struct createStruct(final String typeName, final Object[] attributes) throws SQLException {
         throw new SQLFeatureNotSupportedException("createStruct");
     }
-    
-    @Override
-    public final boolean isValid(final int timeout) throws SQLException {
-        throw new SQLFeatureNotSupportedException("isValid");
-    }
-    
+
     @Override
     public final Properties getClientInfo() throws SQLException {
         throw new SQLFeatureNotSupportedException("getClientInfo");

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
@@ -42,8 +42,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -127,5 +129,23 @@ public final class ShardingSphereConnectionTest {
         assertTrue(BASEShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.COMMIT));
         connection.rollback();
         assertTrue(BASEShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.ROLLBACK));
+    }
+
+    @Test
+    public void assertIsValid() throws SQLException {
+        Connection masterConnection = mock(Connection.class);
+        Connection upSlaveConnection = mock(Connection.class);
+        Connection downSlaveConnection = mock(Connection.class);
+
+        when(masterConnection.isValid(anyInt())).thenReturn(true);
+        when(upSlaveConnection.isValid(anyInt())).thenReturn(true);
+        when(downSlaveConnection.isValid(anyInt())).thenReturn(false);
+
+        connection.getCachedConnections().put("test_master", masterConnection);
+        connection.getCachedConnections().put("test_slave_up", upSlaveConnection);
+        assertTrue(connection.isValid(0));
+
+        connection.getCachedConnections().put("test_slave_down", downSlaveConnection);
+        assertFalse(connection.isValid(0));
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
@@ -209,13 +209,6 @@ public final class UnsupportedOperationConnectionTest extends AbstractShardingSp
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertIsValid() throws SQLException {
-        for (ShardingSphereConnection each : shardingSphereConnections) {
-            each.isValid(0);
-        }
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetClientInfo() throws SQLException {
         for (ShardingSphereConnection each : shardingSphereConnections) {
             each.getClientInfo();

--- a/shardingsphere-jdbc/shardingsphere-jdbc-orchestration/src/main/java/org/apache/shardingsphere/driver/orchestration/internal/circuit/connection/CircuitBreakerConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-orchestration/src/main/java/org/apache/shardingsphere/driver/orchestration/internal/circuit/connection/CircuitBreakerConnection.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.driver.orchestration.internal.circuit.statement
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.SQLWarning;
 import java.sql.Statement;
 
@@ -127,7 +128,12 @@ public final class CircuitBreakerConnection extends AbstractUnsupportedOperation
     public PreparedStatement prepareStatement(final String sql, final String[] columnNames) {
         return new CircuitBreakerPreparedStatement();
     }
-    
+
+    @Override
+    public boolean isValid(final int timeout) throws SQLException {
+        return true;
+    }
+
     @Override
     public Statement createStatement() {
         return new CircuitBreakerStatement();


### PR DESCRIPTION
Fixes #5882.

Changes proposed in this pull request:
- AbstractConnectionAdapter implement Connection#isValid(int timeout) method
- CircuitBreakerConnection implement Connection#isValid(int timeout) method
- ShardingSphereConnectionTest
