### PR TITLE
Use YAML file instead of inline string in test cases in OrchestrationSpringBootRegistryShardingTest.java #5428

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/orchestration/type/OrchestrationSpringBootRegistryShardingTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/orchestration/type/OrchestrationSpringBootRegistryShardingTest.java
@@ -40,6 +40,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import javax.annotation.Resource;
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -52,84 +55,21 @@ import static org.junit.Assert.assertTrue;
 @ActiveProfiles("registry")
 public class OrchestrationSpringBootRegistryShardingTest {
     
+    private static final String SHARDING_DATABASES_FILE = "yaml/sharding-databases.yaml";
+    
+    private static final String SHARDING_RULE_FILE = "yaml/sharding-rule.yaml";
+    
     @Resource
     private DataSource dataSource;
     
     @BeforeClass
     public static void init() {
         EmbedTestingServer.start();
+        String shardingDatabases = readYAML(SHARDING_DATABASES_FILE);
+        String shardingRule = readYAML(SHARDING_RULE_FILE);
         TestCenterRepository testCenter = new TestCenterRepository();
-        testCenter.persist("/demo_spring_boot_ds_center/config/schema/logic_db/datasource", ""
-                + "ds: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration\n"
-                + "  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource\n"
-                + "  props:\n"
-                + "    url: jdbc:h2:mem:ds;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL\n"
-                + "    maxTotal: 16\n"
-                + "    password: ''\n"
-                + "    username: sa\n"
-                + "ds_0: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration\n"
-                + "  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource\n"
-                + "  props:\n"
-                + "    url: jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL\n"
-                + "    maxTotal: 16\n"
-                + "    password: ''\n"
-                + "    username: sa\n"
-                + "ds_1: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration\n"
-                + "  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource\n"
-                + "  props:\n"
-                + "    url: jdbc:h2:mem:ds_1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL\n"
-                + "    maxTotal: 16\n"
-                + "    password: ''\n"
-                + "    username: sa\n");
-        testCenter.persist("/demo_spring_boot_ds_center/config/schema/logic_db/rule", ""
-                + "rules:\n"
-                + "- !SHARDING\n"
-                + "  bindingTables:\n"
-                + "  - t_order\n"
-                + "  - t_order_item\n"
-                + "  broadcastTables:\n"
-                + "  - t_config\n"
-                + "  defaultDatabaseStrategy:\n"
-                + "    standard:\n"
-                + "      shardingAlgorithmName: database_inline\n" 
-                + "      shardingColumn: user_id\n"
-                + "  tables:\n"
-                + "    t_order:\n"
-                + "      actualDataNodes: ds_${0..1}.t_order_${0..1}\n"
-                + "      keyGenerateStrategy:\n"
-                + "        column: order_id\n"
-                + "        keyGeneratorName: snowflake\n"
-                + "      logicTable: t_order\n"
-                + "      tableStrategy:\n"
-                + "        standard:\n"
-                + "          shardingAlgorithmName: t_order_inline\n"
-                + "          shardingColumn: order_id\n"
-                + "    t_order_item:\n"
-                + "      actualDataNodes: ds_${0..1}.t_order_item_${0..1}\n"
-                + "      keyGenerateStrategy:\n"
-                + "        column: order_item_id\n"
-                + "        keyGeneratorName: snowflake\n"
-                + "      logicTable: t_order_item\n"
-                + "      tableStrategy:\n"
-                + "        standard:\n"
-                + "          shardingAlgorithmName: t_order_item_inline\n"
-                + "          shardingColumn: order_id\n"
-                + "  shardingAlgorithms:\n"
-                + "    database_inline:\n"
-                + "      type: INLINE\n"
-                + "      props:\n"
-                + "        algorithm.expression: ds_${user_id % 2}\n"
-                + "    t_order_inline:\n"
-                + "      type: INLINE\n"
-                + "      props:\n"
-                + "        algorithm.expression: t_order_${order_id % 2}\n"
-                + "    t_order_item_inline:\n"
-                + "      type: INLINE\n"
-                + "      props:\n"
-                + "        algorithm.expression: t_order_item_${order_id % 2}\n"
-                + "  keyGenerators:\n"
-                + "    snowflake:\n"
-                + "      type: SNOWFLAKE\n");
+        testCenter.persist("/demo_spring_boot_ds_center/config/schema/logic_db/datasource", shardingDatabases);
+        testCenter.persist("/demo_spring_boot_ds_center/config/schema/logic_db/rule", shardingRule);
         testCenter.persist("/demo_spring_boot_ds_center/config/props", ""
                 + "executor.size: '100'\n"
                 + "sql.show: 'true'\n");
@@ -235,5 +175,10 @@ public class OrchestrationSpringBootRegistryShardingTest {
         Field field = fieldClass.getDeclaredField(fieldName);
         field.setAccessible(true);
         return (T) field.get(target);
+    }
+    
+    @SneakyThrows
+    private static String readYAML(final String yamlFile) {
+        return Files.readAllLines(Paths.get(ClassLoader.getSystemResource(yamlFile).toURI())).stream().map(each -> each + System.lineSeparator()).collect(Collectors.joining());
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/resources/yaml/sharding-databases.yaml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/resources/yaml/sharding-databases.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+ds: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration
+  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource
+  props:
+    url: jdbc:h2:mem:ds;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL
+    maxTotal: 16
+    password: ''
+    username: sa
+ds_0: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration
+  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource
+  props:
+    url: jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL
+    maxTotal: 16
+    password: ''
+    username: sa
+ds_1: !!org.apache.shardingsphere.orchestration.core.configuration.YamlDataSourceConfiguration
+  dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource
+  props:
+    url: jdbc:h2:mem:ds_1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MYSQL
+    maxTotal: 16
+    password: ''
+    username: sa

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/resources/yaml/sharding-rule.yaml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-boot-starter/src/test/resources/yaml/sharding-rule.yaml
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !SHARDING
+    bindingTables:
+      - t_order
+      - t_order_item
+    broadcastTables:
+      - t_config
+    defaultDatabaseStrategy:
+      standard:
+        shardingAlgorithmName: database_inline
+        shardingColumn: user_id
+    tables:
+      t_order:
+        actualDataNodes: ds_${0..1}.t_order_${0..1}
+        keyGenerateStrategy:
+          column: order_id
+          keyGeneratorName: snowflake
+        logicTable: t_order
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: t_order_inline
+            shardingColumn: order_id
+      t_order_item:
+        actualDataNodes: ds_${0..1}.t_order_item_${0..1}
+        keyGenerateStrategy:
+          column: order_item_id
+          keyGeneratorName: snowflake
+        logicTable: t_order_item
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: t_order_item_inline
+            shardingColumn: order_id
+    shardingAlgorithms:
+      database_inline:
+        type: INLINE
+        props:
+          algorithm.expression: ds_${user_id % 2}
+      t_order_inline:
+        type: INLINE
+        props:
+          algorithm.expression: t_order_${order_id % 2}
+      t_order_item_inline:
+        type: INLINE
+        props:
+          algorithm.expression: t_order_item_${order_id % 2}
+    keyGenerators:
+      snowflake:
+        type: SNOWFLAKE


### PR DESCRIPTION
…SpringBootRegistryShardingTest.java #5428

Fixes #5428.

Changes proposed in this pull request:
- create sharding-databases.yaml and sharding-rule.yaml on resource/yaml directory
- added private static method readYAML to read these files into string  instead of inline string in test cases
