### PR TITLE
optimize lifecycle management of ShardingTransactionType

### DIFF
--- a/examples/shardingsphere-jdbc-example/transaction-example/transaction-2pc-xa-bitronix-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/xa/bitronix/raw/jdbc/OrderServiceImpl.java
+++ b/examples/shardingsphere-jdbc-example/transaction-example/transaction-2pc-xa-bitronix-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/xa/bitronix/raw/jdbc/OrderServiceImpl.java
@@ -65,6 +65,8 @@ class OrderServiceImpl implements ExampleService {
             doInsert(preparedStatement);
             connection.commit();
             System.out.println("INSERT 10 orders success");
+        } finally {
+            TransactionTypeHolder.clear();
         }
         int quantity = selectAll();
         System.out.printf("Commit, expect:10, actual:%d \n", quantity);
@@ -82,6 +84,8 @@ class OrderServiceImpl implements ExampleService {
             doInsert(preparedStatement);
             connection.rollback();
             System.out.println("INSERT 10 orders failed");
+        } finally {
+            TransactionTypeHolder.clear();
         }
         int quantity = selectAll();
         System.out.printf("Rollback, expect:0, actual:%d \n", quantity);

--- a/examples/shardingsphere-jdbc-example/transaction-example/transaction-2pc-xa-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/xa/raw/jdbc/XAOrderService.java
+++ b/examples/shardingsphere-jdbc-example/transaction-example/transaction-2pc-xa-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/xa/raw/jdbc/XAOrderService.java
@@ -81,6 +81,8 @@ class XAOrderService {
             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t_order (user_id, status) VALUES (?, ?)");
             doInsert(preparedStatement);
             connection.commit();
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -96,6 +98,8 @@ class XAOrderService {
             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t_order (user_id, status) VALUES (?, ?)");
             doInsert(preparedStatement);
             connection.rollback();
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     

--- a/examples/shardingsphere-jdbc-example/transaction-example/transaction-base-seata-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/base/seata/raw/jdbc/SeataATOrderService.java
+++ b/examples/shardingsphere-jdbc-example/transaction-example/transaction-base-seata-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/transaction/base/seata/raw/jdbc/SeataATOrderService.java
@@ -79,6 +79,8 @@ class SeataATOrderService {
             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t_order (user_id, status) VALUES (?, ?)");
             doInsert(preparedStatement);
             connection.commit();
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -94,6 +96,8 @@ class SeataATOrderService {
             PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t_order (user_id, status) VALUES (?, ?)");
             doInsert(preparedStatement);
             connection.rollback();
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
@@ -30,7 +30,6 @@ import org.apache.shardingsphere.infra.hook.RootInvokeHook;
 import org.apache.shardingsphere.infra.hook.SPIRootInvokeHook;
 import org.apache.shardingsphere.kernel.context.SchemaContexts;
 import org.apache.shardingsphere.masterslave.route.engine.impl.MasterVisitedManager;
-import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -74,7 +73,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     private volatile boolean closed;
     
     private int transactionIsolation = TRANSACTION_READ_UNCOMMITTED;
-    
+
     protected AbstractConnectionAdapter(final Map<String, DataSource> dataSourceMap, final SchemaContexts schemaContexts) {
         this.dataSourceMap = dataSourceMap;
         this.schemaContexts = schemaContexts;
@@ -198,7 +197,6 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     public final void close() throws SQLException {
         closed = true;
         MasterVisitedManager.clear();
-        TransactionTypeHolder.clear();
         int connectionSize = cachedConnections.size();
         try {
             forceExecuteTemplateForClose.execute(cachedConnections.entries(), cachedConnections -> cachedConnections.getValue().close());

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractConnectionAdapter.java
@@ -73,7 +73,7 @@ public abstract class AbstractConnectionAdapter extends AbstractUnsupportedOpera
     private volatile boolean closed;
     
     private int transactionIsolation = TRANSACTION_READ_UNCOMMITTED;
-
+    
     protected AbstractConnectionAdapter(final Map<String, DataSource> dataSourceMap, final SchemaContexts schemaContexts) {
         this.dataSourceMap = dataSourceMap;
         this.schemaContexts = schemaContexts;

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
@@ -79,6 +79,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
             for (Connection each : cachedConnections.values()) {
                 assertTrue(each.getAutoCommit());
             }
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -88,6 +90,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
         try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
             actual.setAutoCommit(true);
             assertFalse(actual.getShardingTransactionManager().isInTransaction());
+        } finally {
+            TransactionTypeHolder.clear();
         }
         TransactionTypeHolder.set(TransactionType.XA);
         try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
@@ -96,6 +100,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
             assertThat(XAShardingTransactionManagerFixture.getInvocations().size(), is(1));
             actual.setAutoCommit(false);
             assertThat(XAShardingTransactionManagerFixture.getInvocations().size(), is(1));
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -114,6 +120,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
         try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
             actual.commit();
             assertTrue(XAShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.COMMIT));
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -124,6 +132,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
             actual.setAutoCommit(false);
             actual.setAutoCommit(true);
             assertTrue(XAShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.COMMIT));
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     
@@ -142,6 +152,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
         try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
             actual.rollback();
             assertTrue(XAShardingTransactionManagerFixture.getInvocations().contains(TransactionOperationType.ROLLBACK));
+        } finally {
+            TransactionTypeHolder.clear();
         }
     }
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
@@ -35,7 +35,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourceForShardingTest {
     
@@ -175,9 +178,8 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
         TransactionType currentTransactionType = TransactionTypeHolder.get();
         try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
             actual.createStatement().executeQuery(sql);
-            actual.close();
         }
-        assertEquals(currentTransactionType, TransactionTypeHolder.get());
+        assertThat(TransactionTypeHolder.get(), is(currentTransactionType));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/ConnectionAdapterTest.java
@@ -35,10 +35,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourceForShardingTest {
     
@@ -170,6 +167,17 @@ public final class ConnectionAdapterTest extends AbstractShardingSphereDataSourc
         assertTrue(actual.isClosed());
         Multimap<String, Connection> cachedConnections = getCachedConnections(actual);
         assertTrue(cachedConnections.isEmpty());
+    }
+    
+    @Test
+    public void assertCloseShouldNotClearTransactionType() throws SQLException {
+        TransactionTypeHolder.set(TransactionType.XA);
+        TransactionType currentTransactionType = TransactionTypeHolder.get();
+        try (ShardingSphereConnection actual = getShardingSphereDataSource().getConnection()) {
+            actual.createStatement().executeQuery(sql);
+            actual.close();
+        }
+        assertEquals(currentTransactionType, TransactionTypeHolder.get());
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/main/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeInterceptor.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/main/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeInterceptor.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.spring.transaction;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.shardingsphere.transaction.annotation.ShardingTransactionType;
+import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.BridgeMethodResolver;
@@ -37,8 +38,16 @@ public final class ShardingTransactionTypeInterceptor implements MethodIntercept
     public Object invoke(final MethodInvocation methodInvocation) throws Throwable {
         ShardingTransactionType shardingTransactionType = getAnnotation(methodInvocation);
         Objects.requireNonNull(shardingTransactionType, "could not found sharding transaction type annotation");
+        TransactionType preTransactionType = TransactionTypeHolder.get();
         TransactionTypeHolder.set(shardingTransactionType.value());
-        return methodInvocation.proceed();
+        try {
+            return methodInvocation.proceed();
+        } finally {
+            TransactionTypeHolder.clear();
+            if (preTransactionType != null) {
+                TransactionTypeHolder.set(preTransactionType);
+            }
+        }
     }
     
     private ShardingTransactionType getAnnotation(final MethodInvocation invocation) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/main/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeInterceptor.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/main/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeInterceptor.java
@@ -44,7 +44,7 @@ public final class ShardingTransactionTypeInterceptor implements MethodIntercept
             return methodInvocation.proceed();
         } finally {
             TransactionTypeHolder.clear();
-            if (preTransactionType != null) {
+            if (null != preTransactionType) {
                 TransactionTypeHolder.set(preTransactionType);
             }
         }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/test/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeScannerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/test/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeScannerTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.spring.transaction;
 import org.apache.shardingsphere.spring.transaction.fixture.FixtureSpringConfiguration;
 import org.apache.shardingsphere.spring.transaction.fixture.MockService;
 import org.apache.shardingsphere.transaction.core.TransactionType;
+import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -41,5 +43,16 @@ public class ShardingTransactionTypeScannerTest {
         assertThat(mockService.executeLocal(), is(TransactionType.LOCAL));
         assertThat(mockService.executeBase(), is(TransactionType.BASE));
         assertThat(mockService.execute(), is(TransactionType.XA));
+    }
+    
+    @Test
+    public void assertShardingTransactionType() {
+        TransactionType preTransactionType = TransactionTypeHolder.get();
+        mockService.executeLocal();
+        assertEquals(preTransactionType, TransactionTypeHolder.get());
+        mockService.executeBase();
+        assertEquals(preTransactionType, TransactionTypeHolder.get());
+        mockService.execute();
+        assertEquals(preTransactionType, TransactionTypeHolder.get());
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/test/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeScannerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-transaction-spring/src/test/java/org/apache/shardingsphere/spring/transaction/ShardingTransactionTypeScannerTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 @RunWith(SpringRunner.class)
@@ -49,10 +48,10 @@ public class ShardingTransactionTypeScannerTest {
     public void assertShardingTransactionType() {
         TransactionType preTransactionType = TransactionTypeHolder.get();
         mockService.executeLocal();
-        assertEquals(preTransactionType, TransactionTypeHolder.get());
+        assertThat(TransactionTypeHolder.get(), is(preTransactionType));
         mockService.executeBase();
-        assertEquals(preTransactionType, TransactionTypeHolder.get());
+        assertThat(TransactionTypeHolder.get(), is(preTransactionType));
         mockService.execute();
-        assertEquals(preTransactionType, TransactionTypeHolder.get());
+        assertThat(TransactionTypeHolder.get(), is(preTransactionType));
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-ShardingTransactionTypeInterceptor maintains the creation of TransactionType in the thread, and it should also manage its destruction.
-Let @ShardingTransactionType's value support transfer in multiple connections.
-Disadvantages: If the TransactionType is assigned to the thread through api(TransactionTypeHolder.set), it needs to be manually(TransactionTypeHolder.clear) destroyed.
