### PR TITLE
Persist cluster configuration to config center

### DIFF
--- a/shardingsphere-control-panel/shardingsphere-orchestration/shardingsphere-orchestration-core/shardingsphere-orchestration-core-configuration/pom.xml
+++ b/shardingsphere-control-panel/shardingsphere-orchestration/shardingsphere-orchestration-core/shardingsphere-orchestration-core-configuration/pom.xml
@@ -43,5 +43,10 @@
             <artifactId>shardingsphere-metrics-configuration</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-cluster-configuration</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/shardingsphere-control-panel/shardingsphere-orchestration/shardingsphere-orchestration-core/shardingsphere-orchestration-core-facade/src/main/java/org/apache/shardingsphere/orchestration/core/facade/ShardingOrchestrationFacade.java
+++ b/shardingsphere-control-panel/shardingsphere-orchestration/shardingsphere-orchestration-core/shardingsphere-orchestration-core-facade/src/main/java/org/apache/shardingsphere/orchestration/core/facade/ShardingOrchestrationFacade.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.cluster.configuration.config.ClusterConfiguration;
 import org.apache.shardingsphere.infra.auth.Authentication;
 import org.apache.shardingsphere.metrics.configuration.config.MetricsConfiguration;
 import org.apache.shardingsphere.orchestration.center.ConfigCenterRepository;
@@ -141,10 +142,19 @@ public final class ShardingOrchestrationFacade implements AutoCloseable {
     /**
      * Init metrics configuration to config center.
      *
-     * @param metricsConfiguration metrics configuration.
+     * @param metricsConfiguration metrics configuration
      */
     public void initMetricsConfiguration(final MetricsConfiguration metricsConfiguration) {
         configCenter.persistMetricsConfiguration(metricsConfiguration, isOverwrite);
+    }
+    
+    /**
+     * Init cluster configuration to config center.
+     *
+     * @param clusterConfiguration cluster configuration
+     */
+    public void initClusterConfiguration(final ClusterConfiguration clusterConfiguration) {
+        configCenter.persistClusterConfiguration(clusterConfiguration, isOverwrite);
     }
     
     @Override


### PR DESCRIPTION
For #5989 .

Changes proposed in this pull request:
- Persist cluster configuration to config center
- Use configurations of config center to initialize the cluster
