### PR TITLE
Parse `Top(expression)` query of SQLServer with ANTLR

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -93,7 +93,7 @@ projection
     ;
 
 top
-    : TOP LP_? expr RP_? ROW_NUMBER LP_ RP_ OVER LP_ orderByClause RP_ 
+    : TOP LP_? numberLiterals RP_? PERCENT? (WITH TIES)?
     ;
 
 alias

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
@@ -918,3 +918,11 @@ GEOMETRY
 GEOGRAPHY
     : G E O G R A P H Y
     ;
+
+TIES
+    : T I E S
+    ;
+
+PERCENT
+    : P E R C E N T
+    ;


### PR DESCRIPTION
Fixes #4867.

Changes proposed in this pull request:
- Correct the `TOP` definition in `DMLStatement.g4` of SQLServer.
- Add function `visitTop()` of SQLServerDMLVisitor to parse out `NumberLiteralRowNumberValueSegment`.
- Modify `visitProjection()` of SQLServerDMLVisitor to parse out `TopProjectionSegment`.
