### PR TITLE
Remove useless overwrite attribute of spring namespace with orchestration

### DIFF
--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-encrypt.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-encrypt.xml
@@ -33,7 +33,7 @@
     
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
     
-    <orchestration:data-source id="encryptDataSource" instance-ref="regCenter,confCenter" overwrite="false" />
+    <orchestration:data-source id="encryptDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="encryptDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-master-slave.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-master-slave.xml
@@ -32,7 +32,7 @@
     <import resource="classpath*:META-INF/nacos/registry-center.xml" />
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
 
-    <orchestration:master-slave-data-source id="masterSlaveDataSource" instance-ref="regCenter,confCenter" overwrite="false" />
+    <orchestration:data-source id="masterSlaveDataSource" instance-ref="regCenter,confCenter" />
 
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="masterSlaveDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-shadow.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-shadow.xml
@@ -33,7 +33,7 @@
     
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
     
-    <orchestration:data-source id="shadowDataSource" instance-ref="regCenter,confCenter" overwrite="false" />
+    <orchestration:data-source id="shadowDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shadowDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-sharding-databases-tables.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/cloud/application-sharding-databases-tables.xml
@@ -32,7 +32,7 @@
     <import resource="classpath*:META-INF/nacos/registry-center.xml" />
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
 
-    <orchestration:sharding-data-source id="shardingDatabasesTablesDataSource" instance-ref="regCenter,confCenter" overwrite="false" />
+    <orchestration:data-source id="shardingDatabasesTablesDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shardingDatabasesTablesDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-encrypt.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-encrypt.xml
@@ -66,7 +66,7 @@
         </props>
     </shardingsphere:data-source>
     
-    <orchestration:data-source id="encryptDataSource" data-source-ref="realEncryptDataSource" instance-ref="regCenter,confCenter" overwrite="true" />
+    <orchestration:data-source id="encryptDataSource" data-source-ref="realEncryptDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="encryptDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-master-slave.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-master-slave.xml
@@ -68,7 +68,7 @@
     
     <shardingsphere:data-source id="realMasterSlaveDataSource" data-source-names="demo_ds_master, demo_ds_slave_0, demo_ds_slave_1" rule-refs="masterSlaveRule" />
     
-    <orchestration:data-source id="masterSlaveDataSource" data-source-ref="realMasterSlaveDataSource" instance-ref="regCenter,confCenter" overwrite="true" />
+    <orchestration:data-source id="masterSlaveDataSource" data-source-ref="realMasterSlaveDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="masterSlaveDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-shadow.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-shadow.xml
@@ -61,7 +61,7 @@
     
     <shardingsphere:data-source id="realShadowDataSource" data-source-names="demo_ds,shadow_demo_ds" rule-refs="shadowRule" />
 
-    <orchestration:data-source id="shadowDataSource" data-source-ref="realShadowDataSource" instance-ref="regCenter,confCenter" overwrite="true" />
+    <orchestration:data-source id="shadowDataSource" data-source-ref="realShadowDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shadowDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-sharding-databases-tables.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/local/application-sharding-databases-tables.xml
@@ -96,7 +96,7 @@
     </sharding:rule>
     
     <shardingsphere:data-source id="realShardingDatabasesTablesDataSource" data-source-names="demo_ds_0, demo_ds_1" rule-refs="shardingRule" />
-    <orchestration:data-source id="shardingDatabasesTablesDataSource" data-source-ref="realShardingDatabasesTablesDataSource" instance-ref="regCenter,confCenter" overwrite="true" />
+    <orchestration:data-source id="shardingDatabasesTablesDataSource" data-source-ref="realShardingDatabasesTablesDataSource" instance-ref="regCenter,confCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shardingDatabasesTablesDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/registry-center.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/nacos/registry-center.xml
@@ -28,6 +28,7 @@
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">3000</prop>
+            <prop key="overwrite">false</prop>
         </props>
     </orchestration:instance>
     
@@ -35,6 +36,7 @@
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">3000</prop>
+            <prop key="overwrite">false</prop>
         </props>
     </orchestration:instance>
 </beans>

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-encrypt.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-encrypt.xml
@@ -33,7 +33,7 @@
     
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
     
-    <orchestration:data-source id="encryptDataSource" instance-ref="regCenter" overwrite="false" />
+    <orchestration:data-source id="encryptDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="encryptDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-master-slave.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-master-slave.xml
@@ -32,7 +32,7 @@
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
     <import resource="classpath*:META-INF/zookeeper/registry-center.xml" />
     
-    <orchestration:master-slave-data-source id="masterSlaveDataSource" instance-ref="regCenter" overwrite="false" />
+    <orchestration:data-source id="masterSlaveDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="masterSlaveDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-shadow.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-shadow.xml
@@ -33,7 +33,7 @@
     
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
     
-    <orchestration:data-source id="shadowDataSource" instance-ref="regCenter" overwrite="false" />
+    <orchestration:data-source id="shadowDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shadowDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-sharding-databases-tables.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/cloud/application-sharding-databases-tables.xml
@@ -32,7 +32,7 @@
     <import resource="classpath*:META-INF/zookeeper/registry-center.xml" />
     <context:component-scan base-package="org.apache.shardingsphere.example.core.mybatis" />
 
-    <orchestration:sharding-data-source id="shardingDatabasesTablesDataSource" instance-ref="regCenter" overwrite="false" />
+    <orchestration:data-source id="shardingDatabasesTablesDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shardingDatabasesTablesDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-encrypt.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-encrypt.xml
@@ -66,7 +66,7 @@
         </props>
     </shardingsphere:data-source>
     
-    <orchestration:data-source id="encryptDataSource" data-source-ref="realEncryptDataSource" instance-ref="regCenter" overwrite="true" />
+    <orchestration:data-source id="encryptDataSource" data-source-ref="realEncryptDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="encryptDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-master-slave.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-master-slave.xml
@@ -68,7 +68,7 @@
     
     <shardingsphere:data-source id="realMasterSlaveDataSource" data-source-names="demo_ds_master, demo_ds_slave_0, demo_ds_slave_1" rule-refs="masterSlaveRule" />
     
-    <orchestration:data-source id="masterSlaveDataSource" data-source-ref="realMasterSlaveDataSource" instance-ref="regCenter" overwrite="true" />
+    <orchestration:data-source id="masterSlaveDataSource" data-source-ref="realMasterSlaveDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="masterSlaveDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-shadow.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-shadow.xml
@@ -61,7 +61,7 @@
     
     <shardingsphere:data-source id="realShadowDataSource" data-source-names="demo_ds,shadow_demo_ds" rule-refs="shadowRule" />
 
-    <orchestration:data-source id="shadowDataSource" data-source-ref="realShadowDataSource" instance-ref="regCenter" overwrite="true" />
+    <orchestration:data-source id="shadowDataSource" data-source-ref="realShadowDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shadowDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-sharding-databases-tables.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/local/application-sharding-databases-tables.xml
@@ -99,7 +99,7 @@
     </sharding:rule>
     
     <shardingsphere:data-source id="realShardingDatabasesTablesDataSource" data-source-names="demo_ds_0, demo_ds_1" rule-refs="shardingRule" />
-    <orchestration:data-source id="shardingDatabasesTablesDataSource" data-source-ref="realShardingDatabasesTablesDataSource" instance-ref="regCenter" overwrite="true" />
+    <orchestration:data-source id="shardingDatabasesTablesDataSource" data-source-ref="realShardingDatabasesTablesDataSource" instance-ref="regCenter" />
     
     <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
         <property name="dataSource" ref="shardingDatabasesTablesDataSource" />

--- a/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/registry-center.xml
+++ b/examples/shardingsphere-jdbc-example/orchestration-example/orchestration-spring-namespace-example/src/main/resources/META-INF/zookeeper/registry-center.xml
@@ -28,6 +28,7 @@
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">3000</prop>
+            <prop key="overwrite">false</prop>
         </props>
     </orchestration:instance>
 </beans>

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-namespace/src/main/resources/META-INF/namespace/orchestration.xsd
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-orchestration-spring/shardingsphere-jdbc-orchestration-spring-namespace/src/main/resources/META-INF/namespace/orchestration.xsd
@@ -28,7 +28,6 @@
             <xsd:attribute name="id" type="xsd:string" use="required" />
             <xsd:attribute name="data-source-ref" type="xsd:string" />
             <xsd:attribute name="instance-ref" type="xsd:string" use="required" />
-            <xsd:attribute name="overwrite" type="xsd:string" default="false" />
             <xsd:attribute name="cluster-ref" type="xsd:string"/>
         </xsd:complexType>
     </xsd:element>


### PR DESCRIPTION
Fixes #6196 .

Changes proposed in this pull request:
- remove attribute `overwrite` of <orchestration:data-source>
- revise examples of spring namespace with orchestration