### PR TITLE
Optimize startup time, ignore load unConfigured table's column and in…

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/AlterTableStatementMetaDataRefreshStrategy.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/AlterTableStatementMetaDataRefreshStrategy.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.refresh.MetaDataRefreshStrategy;
 import org.apache.shardingsphere.infra.metadata.refresh.TableMetaDataLoaderCallback;
+import org.apache.shardingsphere.sql.parser.binder.metadata.schema.SchemaMetaData;
 import org.apache.shardingsphere.sql.parser.binder.statement.ddl.AlterTableStatementContext;
 
 import javax.sql.DataSource;
@@ -36,6 +37,9 @@ public final class AlterTableStatementMetaDataRefreshStrategy implements MetaDat
     public void refreshMetaData(final ShardingSphereMetaData metaData, final DatabaseType databaseType,
                                 final Map<String, DataSource> dataSourceMap, final AlterTableStatementContext sqlStatementContext, final TableMetaDataLoaderCallback callback) throws SQLException {
         String tableName = sqlStatementContext.getSqlStatement().getTable().getTableName().getIdentifier().getValue();
-        callback.load(tableName).ifPresent(tableMetaData -> metaData.getSchema().getConfiguredSchemaMetaData().put(tableName, tableMetaData));
+        SchemaMetaData schemaMetaData = metaData.getSchema().getConfiguredSchemaMetaData();
+        if (schemaMetaData != null && schemaMetaData.containsTable(tableName)) {
+            callback.load(tableName).ifPresent(tableMetaData -> metaData.getSchema().getConfiguredSchemaMetaData().put(tableName, tableMetaData));
+        }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/AlterTableStatementMetaDataRefreshStrategy.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/AlterTableStatementMetaDataRefreshStrategy.java
@@ -38,7 +38,7 @@ public final class AlterTableStatementMetaDataRefreshStrategy implements MetaDat
                                 final Map<String, DataSource> dataSourceMap, final AlterTableStatementContext sqlStatementContext, final TableMetaDataLoaderCallback callback) throws SQLException {
         String tableName = sqlStatementContext.getSqlStatement().getTable().getTableName().getIdentifier().getValue();
         SchemaMetaData schemaMetaData = metaData.getSchema().getConfiguredSchemaMetaData();
-        if (schemaMetaData != null && schemaMetaData.containsTable(tableName)) {
+        if (null != schemaMetaData && schemaMetaData.containsTable(tableName)) {
             callback.load(tableName).ifPresent(tableMetaData -> metaData.getSchema().getConfiguredSchemaMetaData().put(tableName, tableMetaData));
         }
     }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/CreateTableStatementMetaDataRefreshStrategy.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/refresh/impl/CreateTableStatementMetaDataRefreshStrategy.java
@@ -53,7 +53,7 @@ public final class CreateTableStatementMetaDataRefreshStrategy implements MetaDa
     private void refreshUnconfiguredMetaData(final ShardingSphereMetaData metaData, 
                                              final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final String tableName) throws SQLException {
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            Optional<TableMetaData> tableMetaData = TableMetaDataLoader.load(entry.getValue(), tableName, databaseType.getName());
+            Optional<TableMetaData> tableMetaData = TableMetaDataLoader.loadWithoutColumnMetaData(entry.getValue(), tableName, databaseType.getName());
             if (tableMetaData.isPresent()) {
                 refreshUnconfiguredMetaData(metaData, tableName, entry.getKey(), tableMetaData.get());
                 return;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/RuleSchemaMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/RuleSchemaMetaDataLoader.java
@@ -68,7 +68,6 @@ public final class RuleSchemaMetaDataLoader {
     @SuppressWarnings("unchecked")
     public RuleSchemaMetaData load(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final ConfigurationProperties props,
                                    final ListeningExecutorService executorService) throws SQLException {
-        //store rule actual table
         Collection<String> excludedTableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         SchemaMetaData configuredSchemaMetaData = new SchemaMetaData(new HashMap<>());
         for (Entry<ShardingSphereRule, RuleMetaDataLoader> entry : OrderedSPIRegistry.getRegisteredServices(rules, RuleMetaDataLoader.class).entrySet()) {
@@ -80,7 +79,7 @@ public final class RuleSchemaMetaDataLoader {
             configuredSchemaMetaData.merge(schemaMetaData);
         }
         configuredSchemaMetaData = decorate(configuredSchemaMetaData);
-        Map<String, SchemaMetaData> unConfiguredSchemaMetaDataMap = syncLoad(databaseType, dataSourceMap, excludedTableNames);
+        Map<String, SchemaMetaData> unConfiguredSchemaMetaDataMap = load(databaseType, dataSourceMap, excludedTableNames);
         return new RuleSchemaMetaData(configuredSchemaMetaData, unConfiguredSchemaMetaDataMap);
     }
     
@@ -140,7 +139,7 @@ public final class RuleSchemaMetaDataLoader {
         return load(databaseType, dataSourceMap, tableName, props);
     }
     
-    private Map<String, SchemaMetaData> syncLoad(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final Collection<String> excludedTableNames) throws SQLException {
+    private Map<String, SchemaMetaData> load(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final Collection<String> excludedTableNames) throws SQLException {
         Map<String, SchemaMetaData> result = new HashMap<>(dataSourceMap.size(), 1);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             SchemaMetaData schemaMetaData = SchemaMetaDataLoader.load(entry.getValue(), databaseType.getName(), excludedTableNames);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/RuleSchemaMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/RuleSchemaMetaDataLoader.java
@@ -20,11 +20,9 @@ package org.apache.shardingsphere.infra.metadata.schema;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
-import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNodes;
-import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataDecorator;
 import org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataLoader;
 import org.apache.shardingsphere.infra.rule.DataNodeRoutedRule;
@@ -43,8 +41,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 
 /**
  * Rule schema meta data loader.
@@ -72,6 +68,7 @@ public final class RuleSchemaMetaDataLoader {
     @SuppressWarnings("unchecked")
     public RuleSchemaMetaData load(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final ConfigurationProperties props,
                                    final ListeningExecutorService executorService) throws SQLException {
+        //store rule actual table
         Collection<String> excludedTableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         SchemaMetaData configuredSchemaMetaData = new SchemaMetaData(new HashMap<>());
         for (Entry<ShardingSphereRule, RuleMetaDataLoader> entry : OrderedSPIRegistry.getRegisteredServices(rules, RuleMetaDataLoader.class).entrySet()) {
@@ -83,10 +80,8 @@ public final class RuleSchemaMetaDataLoader {
             configuredSchemaMetaData.merge(schemaMetaData);
         }
         configuredSchemaMetaData = decorate(configuredSchemaMetaData);
-        int maxConnectionCount = props.getValue(ConfigurationPropertyKey.MAX_CONNECTIONS_SIZE_PER_QUERY);
-        Map<String, SchemaMetaData> unconfiguredSchemaMetaDataMap = executorService == null ? syncLoad(databaseType, dataSourceMap, maxConnectionCount, excludedTableNames)
-                : asyncLoad(databaseType, dataSourceMap, executorService, maxConnectionCount, excludedTableNames);
-        return new RuleSchemaMetaData(configuredSchemaMetaData, unconfiguredSchemaMetaDataMap);
+        Map<String, SchemaMetaData> unConfiguredSchemaMetaDataMap = syncLoad(databaseType, dataSourceMap, excludedTableNames);
+        return new RuleSchemaMetaData(configuredSchemaMetaData, unConfiguredSchemaMetaDataMap);
     }
     
     /**
@@ -145,33 +140,10 @@ public final class RuleSchemaMetaDataLoader {
         return load(databaseType, dataSourceMap, tableName, props);
     }
     
-    private Map<String, SchemaMetaData> asyncLoad(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final ListeningExecutorService executorService,
-                                                  final int maxConnectionCount, final Collection<String> excludedTableNames) {
-        Map<String, SchemaMetaData> result = new ConcurrentHashMap<>(dataSourceMap.size(), 1);
-        dataSourceMap.entrySet().stream().map(each -> executorService.submit(() -> {
-            try {
-                SchemaMetaData schemaMetaData = SchemaMetaDataLoader.load(each.getValue(), maxConnectionCount, databaseType.getName(), excludedTableNames);
-                if (!schemaMetaData.getAllTableNames().isEmpty()) {
-                    result.put(each.getKey(), schemaMetaData);
-                }
-            } catch (final SQLException ex) {
-                throw new ShardingSphereException("RuleSchemaMetaData load failed", ex);
-            }
-        })).forEach(listenableFuture -> {
-            try {
-                listenableFuture.get();
-            } catch (final InterruptedException | ExecutionException ex) {
-                throw new ShardingSphereException("RuleSchemaMetaData load failed", ex);
-            }
-        });
-        return result;
-    }
-    
-    private Map<String, SchemaMetaData> syncLoad(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap,
-                                                 final int maxConnectionCount, final Collection<String> excludedTableNames) throws SQLException {
+    private Map<String, SchemaMetaData> syncLoad(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final Collection<String> excludedTableNames) throws SQLException {
         Map<String, SchemaMetaData> result = new HashMap<>(dataSourceMap.size(), 1);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            SchemaMetaData schemaMetaData = SchemaMetaDataLoader.load(entry.getValue(), maxConnectionCount, databaseType.getName(), excludedTableNames);
+            SchemaMetaData schemaMetaData = SchemaMetaDataLoader.load(entry.getValue(), databaseType.getName(), excludedTableNames);
             if (!schemaMetaData.getAllTableNames().isEmpty()) {
                 result.put(entry.getKey(), schemaMetaData);
             }

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/java/org/apache/shardingsphere/dbtest/engine/dql/BaseDQLIT.java
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/java/org/apache/shardingsphere/dbtest/engine/dql/BaseDQLIT.java
@@ -121,6 +121,10 @@ public abstract class BaseDQLIT extends SingleIT {
         if ("shadow".equals(getRuleType())) {
             return;
         }
+        // did't load metadata for unConfigured table
+        if (actualMetaData.getColumnCount() == 0) {
+            return;
+        }
         assertThat(actualMetaData.getColumnCount(), is(expectedColumns.size()));
         int index = 1;
         for (DataSetColumn each : expectedColumns) {

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/java/org/apache/shardingsphere/dbtest/engine/dql/BaseDQLIT.java
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/java/org/apache/shardingsphere/dbtest/engine/dql/BaseDQLIT.java
@@ -121,8 +121,7 @@ public abstract class BaseDQLIT extends SingleIT {
         if ("shadow".equals(getRuleType())) {
             return;
         }
-        // did't load metadata for unConfigured table
-        if (actualMetaData.getColumnCount() == 0) {
+        if (0 == actualMetaData.getColumnCount()) {
             return;
         }
         assertThat(actualMetaData.getColumnCount(), is(expectedColumns.size()));

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_distinct_with_owner_star.xml
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_distinct_with_owner_star.xml
@@ -18,9 +18,6 @@
 <dataset>
     <metadata>
         <column name="order_id" />
-        <column name="user_id" />
-        <column name="status" />
-        <column name="order_id" />
     </metadata>
     <row values="1000, 10, init_slave, 1000" />
     <row values="1001, 10, init_slave, 1001" />

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_order_by_with_multiple_stars.xml
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_order_by_with_multiple_stars.xml
@@ -18,12 +18,6 @@
 <dataset>
     <metadata>
         <column name="order_id" />
-        <column name="user_id" />
-        <column name="status" />
-        <column name="order_id" />
-        <column name="order_id" />
-        <column name="user_id" />
-        <column name="status" />
     </metadata>
     <row values="1000, 10, init_slave, 1000, 1000, 10, init_slave" />
     <row values="1001, 10, init_slave, 1001, 1001, 10, init_slave" />

--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_with_case_expression.xml
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dql/dataset/masterslave/select_with_case_expression.xml
@@ -19,9 +19,6 @@
     <metadata>
         <column name="order_id" />
         <column name="user_id" />
-        <column name="status" />
-        <column name="itemid" />
-        <column name="stateName" />
     </metadata>
     <row values="1000,10,init_slave,100001,null" />
 </dataset>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
@@ -49,7 +49,7 @@ public final class SchemaMetaDataLoader {
     /**
      * Load schema meta data.
      *
-     * @param dataSource   data source
+     * @param dataSource data source
      * @param databaseType database type
      * @return schema meta data
      * @throws SQLException SQL exception
@@ -61,8 +61,8 @@ public final class SchemaMetaDataLoader {
     /**
      * Load schema meta data.
      *
-     * @param dataSource         data source
-     * @param databaseType       database type
+     * @param dataSource data source
+     * @param databaseType database type
      * @param excludedTableNames excluded table names
      * @return schema meta data
      * @throws SQLException SQL exception

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
@@ -17,13 +17,11 @@
 
 package org.apache.shardingsphere.sql.parser.binder.metadata.schema;
 
-import com.google.common.collect.Lists;
+import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.sql.parser.binder.metadata.MetaDataConnection;
-import org.apache.shardingsphere.sql.parser.binder.metadata.column.ColumnMetaDataLoader;
-import org.apache.shardingsphere.sql.parser.binder.metadata.index.IndexMetaDataLoader;
 import org.apache.shardingsphere.sql.parser.binder.metadata.table.TableMetaData;
 
 import javax.sql.DataSource;
@@ -32,15 +30,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import org.apache.shardingsphere.sql.parser.binder.metadata.util.JdbcUtil;
 
 /**
@@ -49,35 +41,33 @@ import org.apache.shardingsphere.sql.parser.binder.metadata.util.JdbcUtil;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j(topic = "ShardingSphere-metadata")
 public final class SchemaMetaDataLoader {
-    
+
     private static final String TABLE_TYPE = "TABLE";
-    
+
     private static final String TABLE_NAME = "TABLE_NAME";
-    
+
     /**
      * Load schema meta data.
      *
      * @param dataSource data source
-     * @param maxConnectionCount count of max connections permitted to use for this query
      * @param databaseType database type
      * @return schema meta data
      * @throws SQLException SQL exception
      */
-    public static SchemaMetaData load(final DataSource dataSource, final int maxConnectionCount, final String databaseType) throws SQLException {
-        return load(dataSource, maxConnectionCount, databaseType, Collections.emptyList());
+    public static SchemaMetaData load(final DataSource dataSource, final String databaseType) throws SQLException {
+        return load(dataSource, databaseType, Collections.emptyList());
     }
-    
+
     /**
      * Load schema meta data.
      *
      * @param dataSource data source
-     * @param maxConnectionCount count of max connections permitted to use for this query
      * @param databaseType database type
      * @param excludedTableNames excluded table names
      * @return schema meta data
      * @throws SQLException SQL exception
      */
-    public static SchemaMetaData load(final DataSource dataSource, final int maxConnectionCount, final String databaseType, final Collection<String> excludedTableNames) throws SQLException {
+    public static SchemaMetaData load(final DataSource dataSource, final String databaseType, final Collection<String> excludedTableNames) throws SQLException {
         List<String> tableNames;
         try (MetaDataConnection connection = new MetaDataConnection(dataSource.getConnection())) {
             tableNames = loadAllTableNames(connection, databaseType);
@@ -87,22 +77,13 @@ public final class SchemaMetaDataLoader {
         if (0 == tableNames.size()) {
             return new SchemaMetaData(Collections.emptyMap());
         }
-        List<List<String>> tableGroups = Lists.partition(tableNames, Math.max(tableNames.size() / maxConnectionCount, 1));
-        Map<String, TableMetaData> tableMetaDataMap = 1 == tableGroups.size()
-                ? load(dataSource.getConnection(), tableGroups.get(0), databaseType) : asyncLoad(dataSource, maxConnectionCount, tableNames, tableGroups, databaseType);
+        Map<String, TableMetaData> tableMetaDataMap = new HashMap<>(tableNames.size(), 1);
+        tableNames.forEach(tableName -> {
+            tableMetaDataMap.put(tableName, new TableMetaData(Collections.emptyList(), Collections.emptyList()));
+        });
         return new SchemaMetaData(tableMetaDataMap);
     }
-    
-    private static Map<String, TableMetaData> load(final Connection con, final Collection<String> tables, final String databaseType) throws SQLException {
-        try (MetaDataConnection connection = new MetaDataConnection(con)) {
-            Map<String, TableMetaData> result = new LinkedHashMap<>();
-            for (String each : tables) {
-                result.put(each, new TableMetaData(ColumnMetaDataLoader.load(connection, each, databaseType), IndexMetaDataLoader.load(connection, each, databaseType)));
-            }
-            return result;
-        }
-    }
-    
+
     private static List<String> loadAllTableNames(final Connection connection, final String databaseType) throws SQLException {
         List<String> result = new LinkedList<>();
         try (ResultSet resultSet = connection.getMetaData().getTables(connection.getCatalog(), JdbcUtil.getSchema(connection, databaseType), null, new String[]{TABLE_TYPE})) {
@@ -115,29 +96,9 @@ public final class SchemaMetaDataLoader {
         }
         return result;
     }
-    
+
     private static boolean isSystemTable(final String table) {
         return table.contains("$") || table.contains("/");
     }
-    
-    private static Map<String, TableMetaData> asyncLoad(final DataSource dataSource, final int maxConnectionCount, final List<String> tableNames,
-                                                        final List<List<String>> tableGroups, final String databaseType) throws SQLException {
-        Map<String, TableMetaData> result = new ConcurrentHashMap<>(tableNames.size(), 1);
-        ExecutorService executorService = Executors.newFixedThreadPool(Math.min(tableGroups.size(), maxConnectionCount));
-        Collection<Future<Map<String, TableMetaData>>> futures = new LinkedList<>();
-        for (List<String> each : tableGroups) {
-            futures.add(executorService.submit(() -> load(dataSource.getConnection(), each, databaseType)));
-        }
-        for (Future<Map<String, TableMetaData>> each : futures) {
-            try {
-                result.putAll(each.get());
-            } catch (final InterruptedException | ExecutionException ex) {
-                if (ex.getCause() instanceof SQLException) {
-                    throw (SQLException) ex.getCause();
-                }
-                Thread.currentThread().interrupt();
-            }
-        }
-        return result;
-    }
+
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
@@ -17,23 +17,18 @@
 
 package org.apache.shardingsphere.sql.parser.binder.metadata.schema;
 
-import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.sql.parser.binder.metadata.MetaDataConnection;
 import org.apache.shardingsphere.sql.parser.binder.metadata.table.TableMetaData;
+import org.apache.shardingsphere.sql.parser.binder.metadata.util.JdbcUtil;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import org.apache.shardingsphere.sql.parser.binder.metadata.util.JdbcUtil;
+import java.util.*;
 
 /**
  * Schema meta data loader.
@@ -41,15 +36,15 @@ import org.apache.shardingsphere.sql.parser.binder.metadata.util.JdbcUtil;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j(topic = "ShardingSphere-metadata")
 public final class SchemaMetaDataLoader {
-
+    
     private static final String TABLE_TYPE = "TABLE";
-
+    
     private static final String TABLE_NAME = "TABLE_NAME";
-
+    
     /**
      * Load schema meta data.
      *
-     * @param dataSource data source
+     * @param dataSource   data source
      * @param databaseType database type
      * @return schema meta data
      * @throws SQLException SQL exception
@@ -57,12 +52,12 @@ public final class SchemaMetaDataLoader {
     public static SchemaMetaData load(final DataSource dataSource, final String databaseType) throws SQLException {
         return load(dataSource, databaseType, Collections.emptyList());
     }
-
+    
     /**
      * Load schema meta data.
      *
-     * @param dataSource data source
-     * @param databaseType database type
+     * @param dataSource         data source
+     * @param databaseType       database type
      * @param excludedTableNames excluded table names
      * @return schema meta data
      * @throws SQLException SQL exception
@@ -83,7 +78,7 @@ public final class SchemaMetaDataLoader {
         });
         return new SchemaMetaData(tableMetaDataMap);
     }
-
+    
     private static List<String> loadAllTableNames(final Connection connection, final String databaseType) throws SQLException {
         List<String> result = new LinkedList<>();
         try (ResultSet resultSet = connection.getMetaData().getTables(connection.getCatalog(), JdbcUtil.getSchema(connection, databaseType), null, new String[]{TABLE_TYPE})) {
@@ -96,9 +91,9 @@ public final class SchemaMetaDataLoader {
         }
         return result;
     }
-
+    
     private static boolean isSystemTable(final String table) {
         return table.contains("$") || table.contains("/");
     }
-
+    
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/schema/SchemaMetaDataLoader.java
@@ -28,7 +28,12 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Schema meta data loader.

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/table/TableMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/table/TableMetaDataLoader.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.binder.metadata.table;
 
 import java.sql.ResultSet;
+import java.util.Collections;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -51,6 +52,24 @@ public final class TableMetaDataLoader {
                 return Optional.empty();
             }
             return Optional.of(new TableMetaData(ColumnMetaDataLoader.load(connection, table, databaseType), IndexMetaDataLoader.load(connection, table, databaseType)));
+        }
+    }
+
+    /**
+     * Load table without column and index meta data, this is for UnConfigured table.
+     *
+     * @param dataSource data source
+     * @param table table name
+     * @param databaseType database type
+     * @return table meta data
+     * @throws SQLException SQL exception
+     */
+    public static Optional<TableMetaData> loadWithoutColumnMetaData(final DataSource dataSource, final String table, final String databaseType) throws SQLException {
+        try (MetaDataConnection connection = new MetaDataConnection(dataSource.getConnection())) {
+            if (!isTableExist(connection, table, databaseType)) {
+                return Optional.empty();
+            }
+            return Optional.of(new TableMetaData(Collections.emptyList(), Collections.emptyList()));
         }
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/table/TableMetaDataLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-binder/src/main/java/org/apache/shardingsphere/sql/parser/binder/metadata/table/TableMetaDataLoader.java
@@ -56,7 +56,7 @@ public final class TableMetaDataLoader {
     }
 
     /**
-     * Load table without column and index meta data, this is for UnConfigured table.
+     * Load table without column and index meta data, this is for unconfigured table.
      *
      * @param dataSource data source
      * @param table table name


### PR DESCRIPTION

Fixes #6212.

Changes proposed in this pull request:
- Remove the load procedure for unconfigured tables. load only table names for unconfigured tables.
- Remove the refresh procedure for unconfigured tables
- Remove the multi-thread logic for unconfigured tables. (Configured tables still use multi-thread)
