### PR TITLE
HintManager's getInstance returns the instance held by the current th…

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/hint/HintManager.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/hint/HintManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.infra.hint;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import lombok.AccessLevel;
@@ -31,7 +30,7 @@ import java.util.Collections;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class HintManager implements AutoCloseable {
-    
+
     private static final ThreadLocal<HintManager> HINT_MANAGER_HOLDER = new ThreadLocal<>();
     
     private final Multimap<String, Comparable<?>> databaseShardingValues = HashMultimap.create();
@@ -43,15 +42,20 @@ public final class HintManager implements AutoCloseable {
     private boolean masterRouteOnly;
     
     /**
-     * Get a new instance for {@code HintManager}.
+     * Get a  instance for {@code HintManager}.
      *
-     * @return  {@code HintManager} instance
+     * @return  {@code HintManager}  current thread hold or new instance
      */
     public static HintManager getInstance() {
-        Preconditions.checkState(null == HINT_MANAGER_HOLDER.get(), "Hint has previous value, please clear first.");
-        HintManager result = new HintManager();
-        HINT_MANAGER_HOLDER.set(result);
-        return result;
+
+        final HintManager hintManager = HINT_MANAGER_HOLDER.get();
+        if (hintManager != null) {
+            return hintManager;
+        } else {
+            final HintManager newHintManager = new HintManager();
+            HINT_MANAGER_HOLDER.set(newHintManager);
+            return newHintManager;
+        }
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
@@ -20,17 +20,23 @@ package org.apache.shardingsphere.infra.hint;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class HintManagerTest {
-    
-    @Test(expected = IllegalStateException.class)
+
+    @Test
     public void assertGetInstanceTwice() {
         try {
-            HintManager.getInstance();
-            HintManager.getInstance();
+            final HintManager instance = HintManager.getInstance();
+            final HintManager instance1 = HintManager.getInstance();
+            assertEquals(instance, instance1);
+            HintManager.clear();
+            final HintManager instance2 = HintManager.getInstance();
+            assertNotEquals(instance, instance2);
         } finally {
             HintManager.clear();
         }


### PR DESCRIPTION
…read or returns a new instance and corrects the junit test (#6342)

Fixes #6342.

Changes proposed in this pull request:
- If the current thread holds an instance of HintManager, return it, otherwise create a new instance, put it into ThreadLocal and, return it
- corrects the junit test
