### PR TITLE
fix 6495

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/ShardingScalingJob.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/ShardingScalingJob.java
@@ -42,9 +42,9 @@ public final class ShardingScalingJob {
     
     private final transient List<SyncConfiguration> syncConfigurations = new LinkedList<>();
     
-    private final List<ScalingTask> inventoryDataTasks = new LinkedList<>();
+    private final transient List<ScalingTask> inventoryDataTasks = new LinkedList<>();
     
-    private final List<ScalingTask> incrementalDataTasks = new LinkedList<>();
+    private final transient List<ScalingTask> incrementalDataTasks = new LinkedList<>();
     
     private final String jobName;
     


### PR DESCRIPTION
Fixes #6495.

Changes proposed in this pull request:
- When ScalingScalingJob is serialized, the ScalingTask field is ignored. Because there is no need to serialize and display too many fields in the entire project, the UI only uses the three fields of JobID, JobName and Status.
- Ignoring the field containing HikariDataSource can solve the #6495 issue caused by it inheriting the field with the same name from the parent class.
