### PR TITLE
Fix #3954 : Sharding-JDBC querying support PostgreSQL array type

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/resourced/jdbc/queryresult/MemoryQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/resourced/jdbc/queryresult/MemoryQueryResult.java
@@ -107,6 +107,8 @@ public final class MemoryQueryResult implements QueryResult {
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
                 return resultSet.getBlob(columnIndex);
+            case Types.ARRAY:
+                return resultSet.getArray(columnIndex);
             default:
                 return resultSet.getObject(columnIndex);
         }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/resourced/jdbc/queryresult/StreamQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/resourced/jdbc/queryresult/StreamQueryResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.resourced.jdbc.queryresult;
 
+import java.sql.Array;
 import org.apache.shardingsphere.infra.executor.sql.QueryResult;
 
 import java.io.InputStream;
@@ -87,6 +88,8 @@ public final class StreamQueryResult implements QueryResult {
             return resultSet.getBlob(columnIndex);
         } else if (Clob.class == type) {
             return resultSet.getClob(columnIndex);
+        } else if (Array.class == type) {
+            return resultSet.getArray(columnIndex);
         } else {
             return resultSet.getObject(columnIndex);
         }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/jdbc/queryresult/MemoryQueryResultTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/jdbc/queryresult/MemoryQueryResultTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.jdbc.queryresult;
 
+import java.sql.Array;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.executor.sql.resourced.jdbc.queryresult.MemoryQueryResult;
 import org.hamcrest.core.Is;
@@ -303,6 +304,17 @@ public final class MemoryQueryResultTest {
         MemoryQueryResult actual = new MemoryQueryResult(resultSet);
         assertTrue(actual.next());
         assertThat(actual.getValue(1, Blob.class), is(value));
+        assertFalse(actual.next());
+    }
+    
+    @Test
+    public void assertGetValueByArray() throws SQLException {
+        ResultSet resultSet = getMockedResultSet(Types.ARRAY);
+        Array value = mock(Array.class);
+        when(resultSet.getArray(1)).thenReturn(value);
+        MemoryQueryResult actual = new MemoryQueryResult(resultSet);
+        assertTrue(actual.next());
+        assertThat(actual.getValue(1, Array.class), is(value));
         assertFalse(actual.next());
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/jdbc/queryresult/StreamQueryResultTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/jdbc/queryresult/StreamQueryResultTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.jdbc.queryresult;
 
+import java.sql.Array;
 import org.apache.shardingsphere.infra.executor.sql.resourced.jdbc.queryresult.StreamQueryResult;
 import org.junit.Test;
 
@@ -148,6 +149,14 @@ public final class StreamQueryResultTest {
         Clob value = mock(Clob.class);
         when(resultSet.getClob(1)).thenReturn(value);
         assertThat(new StreamQueryResult(resultSet).getValue(1, Clob.class), is(value));
+    }
+    
+    @Test
+    public void assertGetValueByArray() throws SQLException {
+        ResultSet resultSet = mock(ResultSet.class);
+        Array value = mock(Array.class);
+        when(resultSet.getArray(1)).thenReturn(value);
+        assertThat(new StreamQueryResult(resultSet).getValue(1, Array.class), is(value));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
+import java.sql.Array;
 import org.apache.shardingsphere.driver.jdbc.adapter.AbstractResultSetAdapter;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
@@ -317,10 +318,20 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     public Clob getClob(final int columnIndex) throws SQLException {
         return (Clob) mergeResultSet.getValue(columnIndex, Clob.class);
     }
-        
+    
+    @Override
+    public Array getArray(final int columnIndex) throws SQLException {
+        return (Array) mergeResultSet.getValue(columnIndex, Array.class);
+    }
+    
     @Override
     public Clob getClob(final String columnLabel) throws SQLException {
         return getClob(getIndexFromColumnLabelAndIndexMap(columnLabel));
+    }
+    
+    @Override
+    public Array getArray(final String columnLabel) throws SQLException {
+        return getArray(getIndexFromColumnLabelAndIndexMap(columnLabel));
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -320,13 +320,13 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     }
     
     @Override
-    public Array getArray(final int columnIndex) throws SQLException {
-        return (Array) mergeResultSet.getValue(columnIndex, Array.class);
+    public Clob getClob(final String columnLabel) throws SQLException {
+        return getClob(getIndexFromColumnLabelAndIndexMap(columnLabel));
     }
     
     @Override
-    public Clob getClob(final String columnLabel) throws SQLException {
-        return getClob(getIndexFromColumnLabelAndIndexMap(columnLabel));
+    public Array getArray(final int columnIndex) throws SQLException {
+        return (Array) mergeResultSet.getValue(columnIndex, Array.class);
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedDatabaseMetaDataResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedDatabaseMetaDataResultSet.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.net.URL;
+import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -111,6 +112,16 @@ public abstract class AbstractUnsupportedDatabaseMetaDataResultSet extends Abstr
     @Override
     public final Statement getStatement() throws SQLException {
         throw new SQLFeatureNotSupportedException("getStatement");
+    }
+    
+    @Override
+    public final Array getArray(final int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getArray");
+    }
+    
+    @Override
+    public final Array getArray(final String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getArray");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedGeneratedKeysResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedGeneratedKeysResultSet.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.driver.jdbc.unsupported;
 import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
+import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
@@ -104,6 +105,16 @@ public abstract class AbstractUnsupportedGeneratedKeysResultSet extends Abstract
     @Override
     public final Timestamp getTimestamp(final String columnLabel, final Calendar cal) throws SQLException {
         throw new SQLFeatureNotSupportedException("getTimestamp");
+    }
+    
+    @Override
+    public final Array getArray(final int columnIndex) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getArray");
+    }
+    
+    @Override
+    public final Array getArray(final String columnLabel) throws SQLException {
+        throw new SQLFeatureNotSupportedException("getArray");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationResultSet.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.driver.jdbc.unsupported;
 
 import java.io.Reader;
-import java.sql.Array;
 import java.sql.NClob;
 import java.sql.Ref;
 import java.sql.RowId;
@@ -179,16 +178,6 @@ public abstract class AbstractUnsupportedOperationResultSet extends AbstractUnsu
     @Override
     public final Ref getRef(final String columnLabel) throws SQLException {
         throw new SQLFeatureNotSupportedException("getRef");
-    }
-    
-    @Override
-    public Array getArray(final int columnIndex) throws SQLException {
-        throw new SQLFeatureNotSupportedException("getArray");
-    }
-    
-    @Override
-    public Array getArray(final String columnLabel) throws SQLException {
-        throw new SQLFeatureNotSupportedException("getArray");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationResultSet.java
@@ -182,12 +182,12 @@ public abstract class AbstractUnsupportedOperationResultSet extends AbstractUnsu
     }
     
     @Override
-    public final Array getArray(final int columnIndex) throws SQLException {
+    public Array getArray(final int columnIndex) throws SQLException {
         throw new SQLFeatureNotSupportedException("getArray");
     }
     
     @Override
-    public final Array getArray(final String columnLabel) throws SQLException {
+    public Array getArray(final String columnLabel) throws SQLException {
         throw new SQLFeatureNotSupportedException("getArray");
     }
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
+import java.sql.Array;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
@@ -416,6 +417,20 @@ public final class ShardingSphereResultSetTest {
         Clob clob = mock(Clob.class);
         when(mergeResultSet.getValue(1, Clob.class)).thenReturn(clob);
         assertThat(shardingSphereResultSet.getClob("label"), is(clob));
+    }
+    
+    @Test
+    public void assertGetArrayWithColumnIndex() throws SQLException {
+        Array array = mock(Array.class);
+        when(mergeResultSet.getValue(1, Array.class)).thenReturn(array);
+        assertThat(shardingSphereResultSet.getArray(1), is(array));
+    }
+    
+    @Test
+    public void assertGetArrayWithColumnLabel() throws SQLException {
+        Array array = mock(Array.class);
+        when(mergeResultSet.getValue(1, Array.class)).thenReturn(array);
+        assertThat(shardingSphereResultSet.getArray("label"), is(array));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationResultSetTest.java
@@ -272,21 +272,7 @@ public final class UnsupportedOperationResultSetTest extends AbstractShardingSph
             each.getRef("label");
         }
     }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertGetArrayForColumnIndex() throws SQLException {
-        for (ResultSet each : resultSets) {
-            each.getArray(1);
-        }
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertGetArrayForColumnLabel() throws SQLException {
-        for (ResultSet each : resultSets) {
-            each.getArray("label");
-        }
-    }
-    
+
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetRowIdForColumnIndex() throws SQLException {
         for (ResultSet each : resultSets) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-orchestration/src/main/java/org/apache/shardingsphere/driver/orchestration/internal/circuit/resultset/CircuitBreakerResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-orchestration/src/main/java/org/apache/shardingsphere/driver/orchestration/internal/circuit/resultset/CircuitBreakerResultSet.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.orchestration.internal.circuit.resultset;
 
+import java.sql.Array;
 import org.apache.shardingsphere.driver.jdbc.unsupported.AbstractUnsupportedOperationResultSet;
 
 import java.io.InputStream;
@@ -335,6 +336,16 @@ public final class CircuitBreakerResultSet extends AbstractUnsupportedOperationR
     
     @Override
     public Statement getStatement() {
+        return null;
+    }
+    
+    @Override
+    public Array getArray(final int columnIndex) {
+        return null;
+    }
+    
+    @Override
+    public Array getArray(final String columnLabel) {
         return null;
     }
     


### PR DESCRIPTION
Fixes #3954 .

Changes proposed in this pull request:
- Sharding-JDBC querying support PostgreSQL array type
