### PR TITLE
add test case for CreateTableStatementMetaDataRefreshStrategy

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/AbstractMetaDataRefreshStrategyTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/AbstractMetaDataRefreshStrategyTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.metadata.refresh;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
@@ -26,8 +27,6 @@ import org.apache.shardingsphere.sql.parser.binder.metadata.index.IndexMetaData;
 import org.apache.shardingsphere.sql.parser.binder.metadata.schema.SchemaMetaData;
 import org.apache.shardingsphere.sql.parser.binder.metadata.table.TableMetaData;
 import org.junit.Before;
-
-import java.util.Collections;
 
 @Getter
 public abstract class AbstractMetaDataRefreshStrategyTest {
@@ -40,9 +39,10 @@ public abstract class AbstractMetaDataRefreshStrategyTest {
     }
     
     private ShardingSphereMetaData buildMetaData() {
-        return new ShardingSphereMetaData(null, 
-                new RuleSchemaMetaData(new SchemaMetaData(ImmutableMap.of("t_order", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", 1, "String", false, false, false)),
-                Collections.singletonList(new IndexMetaData("index"))))), Collections.emptyMap()));
+        return new ShardingSphereMetaData(null, new RuleSchemaMetaData(new SchemaMetaData(ImmutableMap
+            .of("t_order", new TableMetaData(Collections.singletonList(new ColumnMetaData("order_id", 1, "String", false, false, false)), Collections.singletonList(new IndexMetaData("index"))))),
+            ImmutableMap.of("t_order_item", new SchemaMetaData(ImmutableMap.of("t_order_item",
+                new TableMetaData(Collections.singletonList(new ColumnMetaData("order_item_id", 1, "String", true, false, false)), Collections.singletonList(new IndexMetaData("index"))))))));
     }
 }
 

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/CreateTableStatementMetaDataRefreshStrategyTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/CreateTableStatementMetaDataRefreshStrategyTest.java
@@ -60,18 +60,18 @@ public final class CreateTableStatementMetaDataRefreshStrategyTest extends Abstr
     @Test
     public void assertRefreshMetaDataWithUnConfigured() throws SQLException {
         MetaDataRefreshStrategy<CreateTableStatementContext> metaDataRefreshStrategy = new CreateTableStatementMetaDataRefreshStrategy();
-        CreateTableStatement createTableStatement = new CreateTableStatement(new SimpleTableSegment(new TableNameSegment(1, 3, new IdentifierValue("t_order_item"))));
+        CreateTableStatement createTableStatement = new CreateTableStatement(new SimpleTableSegment(new TableNameSegment(1, 3, new IdentifierValue("t_order_item_0"))));
         CreateTableStatementContext createTableStatementContext = new CreateTableStatementContext(createTableStatement);
         Map<String, DataSource> dataSourceSourceMap = new LinkedHashMap<>(1, 1);
         dataSourceSourceMap.put("t_order_item", initDataSource());
         metaDataRefreshStrategy.refreshMetaData(getMetaData(), new MySQLDatabaseType(), dataSourceSourceMap, createTableStatementContext,
             tableName -> Optional.empty());
-        assertTrue(getMetaData().getSchema().getUnconfiguredSchemaMetaDataMap().containsKey("t_order_item"));
+        assertTrue(getMetaData().getSchema().getUnconfiguredSchemaMetaDataMap().get("t_order_item").containsTable("t_order_item_0"));
     }
     
     private DataSource initDataSource() throws SQLException {
         final String catalog = "catalog";
-        final String table = "t_order_item";
+        final String table = "t_order_item_0";
         DataSource result = mock(DataSource.class);
         Connection connection = mock(Connection.class);
         when(result.getConnection()).thenReturn(connection);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/CreateTableStatementMetaDataRefreshStrategyTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/refresh/CreateTableStatementMetaDataRefreshStrategyTest.java
@@ -17,7 +17,18 @@
 
 package org.apache.shardingsphere.infra.metadata.refresh;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import javax.sql.DataSource;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.metadata.refresh.impl.CreateTableStatementMetaDataRefreshStrategy;
 import org.apache.shardingsphere.sql.parser.binder.metadata.column.ColumnMetaData;
 import org.apache.shardingsphere.sql.parser.binder.metadata.index.IndexMetaData;
@@ -29,12 +40,9 @@ import org.apache.shardingsphere.sql.parser.sql.statement.ddl.CreateTableStateme
 import org.apache.shardingsphere.sql.parser.sql.value.identifier.IdentifierValue;
 import org.junit.Test;
 
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.Optional;
-
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class CreateTableStatementMetaDataRefreshStrategyTest extends AbstractMetaDataRefreshStrategyTest {
     
@@ -47,5 +55,41 @@ public final class CreateTableStatementMetaDataRefreshStrategyTest extends Abstr
                 Collections.singletonList(new ColumnMetaData("order_id", 1, "String", true, false, false)),
                 Collections.singletonList(new IndexMetaData("index")))));
         assertTrue(getMetaData().getSchema().getConfiguredSchemaMetaData().containsTable("t_order_0"));
+    }
+    
+    @Test
+    public void assertRefreshMetaDataWithUnConfigured() throws SQLException {
+        MetaDataRefreshStrategy<CreateTableStatementContext> metaDataRefreshStrategy = new CreateTableStatementMetaDataRefreshStrategy();
+        CreateTableStatement createTableStatement = new CreateTableStatement(new SimpleTableSegment(new TableNameSegment(1, 3, new IdentifierValue("t_order_item"))));
+        CreateTableStatementContext createTableStatementContext = new CreateTableStatementContext(createTableStatement);
+        Map<String, DataSource> dataSourceSourceMap = new LinkedHashMap<>(1, 1);
+        dataSourceSourceMap.put("t_order_item", initDataSource());
+        metaDataRefreshStrategy.refreshMetaData(getMetaData(), new MySQLDatabaseType(), dataSourceSourceMap, createTableStatementContext,
+            tableName -> Optional.empty());
+        assertTrue(getMetaData().getSchema().getUnconfiguredSchemaMetaDataMap().containsKey("t_order_item"));
+    }
+    
+    private DataSource initDataSource() throws SQLException {
+        final String catalog = "catalog";
+        final String table = "t_order_item";
+        DataSource result = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        when(result.getConnection()).thenReturn(connection);
+        when(connection.getCatalog()).thenReturn(catalog);
+        when(connection.getSchema()).thenReturn("");
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        Statement statement = mock(Statement.class);
+        when(connection.createStatement()).thenReturn(statement);
+        ResultSet columnMetaDataResultSet = mock(ResultSet.class);
+        ResultSet primaryKeyResultSet = mock(ResultSet.class);
+        ResultSet tableResultSet = mock(ResultSet.class);
+        ResultSet indexMetaDataResultSet = mock(ResultSet.class);
+        when(databaseMetaData.getColumns(catalog, "", table, "%")).thenReturn(columnMetaDataResultSet);
+        when(databaseMetaData.getPrimaryKeys(catalog, "", table)).thenReturn(primaryKeyResultSet);
+        when(databaseMetaData.getTables(catalog, "", table, null)).thenReturn(tableResultSet);
+        when(databaseMetaData.getIndexInfo(catalog, "", table, false, false)).thenReturn(indexMetaDataResultSet);
+        when(tableResultSet.next()).thenReturn(true);
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #6716 .

Changes proposed in this pull request:
- Add test case for CreateTableStatementMetaDataRefreshStrategy with unconfigured meta data

