### PR TITLE
Keep PostgreSQL CURRENT_USER password unchanged (#6943)

### DIFF
--- a/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dcl/dcl-integrate-test-cases.xml
+++ b/shardingsphere-integration-test/shardingsphere-test-suite/src/test/resources/integrate/cases/dcl/dcl-integrate-test-cases.xml
@@ -41,7 +41,6 @@
     <dcl-test-case sql="ALTER USER user_dev WITH PASSWORD 'passwd_dev'" db-types="PostgreSQL"/>
     <dcl-test-case sql="ALTER USER user_dev WITH PASSWORD 'passwd_dev'" db-types="PostgreSQL"/>
     <dcl-test-case sql="ALTER ROLE role_dev_bak DROP MEMBER member1" db-types="SQLServer"/>
-    <dcl-test-case sql="ALTER USER CURRENT_USER WITH ENCRYPTED PASSWORD 'password'" db-types="PostgreSQL"/>
     <dcl-test-case sql="ALTER ROLE role_dev IDENTIFIED EXTERNALLY"  db-types="Oracle"/>
     <dcl-test-case sql="ALTER USER user_dev IDENTIFIED EXTERNALLY" db-types="Oracle"/>
     <dcl-test-case sql="ALTER ROLE role_dev IDENTIFIED GLOBALLY"  db-types="Oracle"/>


### PR DESCRIPTION
Fixes #6943.

Changes proposed in this pull request:
- Keep PostgreSQL CURRENT_USER password unchanged when running DCL integration test
