### PR TITLE
Rename return variable to "result"

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-bootstrap/src/main/java/org/apache/shardingsphere/scaling/Bootstrap.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-bootstrap/src/main/java/org/apache/shardingsphere/scaling/Bootstrap.java
@@ -57,7 +57,6 @@ public final class Bootstrap {
      * @throws InterruptedException Interrupted exception
      */
     public static void main(final String[] args) throws IOException, InterruptedException {
-        log.info("Init server config");
         initServerConfig();
         log.info("ShardingScaling Startup");
         EventLoopGroup bossGroup = new NioEventLoopGroup(1);
@@ -80,6 +79,7 @@ public final class Bootstrap {
     }
     
     private static void initServerConfig() throws IOException {
+        log.info("Init server config");
         File yamlFile = new File(Resources.getResource(DEFAULT_CONFIG_PATH + DEFAULT_CONFIG_FILE_NAME).getPath());
         ServerConfiguration serverConfiguration = YamlEngine.unmarshal(yamlFile, ServerConfiguration.class);
         Preconditions.checkNotNull(serverConfiguration, "Server configuration file `%s` is invalid.", yamlFile.getName());

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/execute/executor/channel/MemoryChannel.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/execute/executor/channel/MemoryChannel.java
@@ -49,7 +49,7 @@ public final class MemoryChannel implements Channel {
     
     @Override
     public List<Record> fetchRecords(final int batchSize, final int timeout) {
-        List<Record> records = new ArrayList<>(batchSize);
+        List<Record> result = new ArrayList<>(batchSize);
         long start = System.currentTimeMillis();
         while (batchSize > queue.size()) {
             if (timeout * 1000L <= System.currentTimeMillis() - start) {
@@ -57,9 +57,9 @@ public final class MemoryChannel implements Channel {
             }
             ThreadUtil.sleep(100L);
         }
-        queue.drainTo(records, batchSize);
-        toBeAcknowledgeRecords.addAll(records);
-        return records;
+        queue.drainTo(result, batchSize);
+        toBeAcknowledgeRecords.addAll(result);
+        return result;
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ShardingScalingJobPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ShardingScalingJobPreparer.java
@@ -109,8 +109,8 @@ public final class ShardingScalingJobPreparer {
     }
     
     private PositionManager<? extends IncrementalPosition> instancePositionManager(final String databaseType, final DataSource dataSource) {
-        PositionManager<? extends IncrementalPosition> positionManager = PositionManagerFactory.newInstance(databaseType, dataSource);
-        positionManager.getPosition();
-        return positionManager;
+        PositionManager<? extends IncrementalPosition> result = PositionManagerFactory.newInstance(databaseType, dataSource);
+        result.getPosition();
+        return result;
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/resumer/SyncPositionResumer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/resumer/SyncPositionResumer.java
@@ -79,17 +79,17 @@ public final class SyncPositionResumer {
         return result;
     }
     
-    private InventoryDumperConfiguration newInventoryDumperConfiguration(final DumperConfiguration dumperConfiguration, final MetaDataManager metaDataManager,
-                                                                final Entry<String, PositionManager<InventoryPosition>> entry) {
+    private InventoryDumperConfiguration newInventoryDumperConfiguration(
+            final DumperConfiguration dumperConfiguration, final MetaDataManager metaDataManager, final Entry<String, PositionManager<InventoryPosition>> entry) {
         String[] splitTable = entry.getKey().split("#");
-        InventoryDumperConfiguration splitDumperConfig = new InventoryDumperConfiguration(dumperConfiguration);
-        splitDumperConfig.setTableName(splitTable[0].split("\\.")[1]);
-        splitDumperConfig.setPositionManager(entry.getValue());
+        InventoryDumperConfiguration result = new InventoryDumperConfiguration(dumperConfiguration);
+        result.setTableName(splitTable[0].split("\\.")[1]);
+        result.setPositionManager(entry.getValue());
         if (2 == splitTable.length) {
-            splitDumperConfig.setSpiltNum(Integer.parseInt(splitTable[1]));
+            result.setSpiltNum(Integer.parseInt(splitTable[1]));
         }
-        splitDumperConfig.setPrimaryKey(metaDataManager.getTableMetaData(splitDumperConfig.getTableName()).getPrimaryKeyColumns().get(0));
-        return splitDumperConfig;
+        result.setPrimaryKey(metaDataManager.getTableMetaData(result.getTableName()).getPrimaryKeyColumns().get(0));
+        return result;
     }
     
     private Map<String, PositionManager<InventoryPosition>> getInventoryPositionMap(

--- a/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLBinlogDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLBinlogDumperTest.java
@@ -73,14 +73,12 @@ public final class MySQLBinlogDumperTest {
     }
     
     private DumperConfiguration mockDumperConfiguration() {
-        JDBCDataSourceConfiguration jdbcDataSourceConfiguration =
-                new JDBCDataSourceConfiguration(URL, "root", "root");
-        DumperConfiguration dumperConfiguration = new DumperConfiguration();
-        dumperConfiguration.setDataSourceConfiguration(jdbcDataSourceConfiguration);
+        DumperConfiguration result = new DumperConfiguration();
+        result.setDataSourceConfiguration(new JDBCDataSourceConfiguration(URL, "root", "root"));
         Map<String, String> tableNameMap = new HashedMap<>(1);
         tableNameMap.put("t_order", "t_order");
-        dumperConfiguration.setTableNameMap(tableNameMap);
-        return dumperConfiguration;
+        result.setTableNameMap(tableNameMap);
+        return result;
     }
     
     @SneakyThrows(SQLException.class)

--- a/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLJdbcDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLJdbcDumperTest.java
@@ -61,10 +61,10 @@ public final class MySQLJdbcDumperTest {
     }
     
     private DumperConfiguration mockDumperConfiguration() {
-        DumperConfiguration dumperConfiguration = new DumperConfiguration();
-        dumperConfiguration.setDataSourceConfiguration(
+        DumperConfiguration result = new DumperConfiguration();
+        result.setDataSourceConfiguration(
                 new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL", "root", "root"));
-        return dumperConfiguration;
+        return result;
     }
     
     @SneakyThrows(SQLException.class)

--- a/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLJdbcDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/MySQLJdbcDumperTest.java
@@ -62,8 +62,7 @@ public final class MySQLJdbcDumperTest {
     
     private DumperConfiguration mockDumperConfiguration() {
         DumperConfiguration result = new DumperConfiguration();
-        result.setDataSourceConfiguration(
-                new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL", "root", "root"));
+        result.setDataSourceConfiguration(new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL", "root", "root"));
         return result;
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/main/java/org/apache/shardingsphere/scaling/postgresql/wal/WalEventConverter.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/main/java/org/apache/shardingsphere/scaling/postgresql/wal/WalEventConverter.java
@@ -92,28 +92,28 @@ public final class WalEventConverter {
     }
     
     private DataRecord handleWriteRowsEvent(final WriteRowEvent writeRowEvent) {
-        DataRecord record = createDataRecord(writeRowEvent, writeRowEvent.getAfterRow().size());
-        record.setType(ScalingConstant.INSERT);
-        putColumnsIntoDataRecord(record, metaDataManager.getTableMetaData(writeRowEvent.getTableName()), writeRowEvent.getAfterRow());
-        return record;
+        DataRecord result = createDataRecord(writeRowEvent, writeRowEvent.getAfterRow().size());
+        result.setType(ScalingConstant.INSERT);
+        putColumnsIntoDataRecord(result, metaDataManager.getTableMetaData(writeRowEvent.getTableName()), writeRowEvent.getAfterRow());
+        return result;
     }
     
     private DataRecord handleUpdateRowsEvent(final UpdateRowEvent updateRowEvent) {
-        DataRecord record = createDataRecord(updateRowEvent, updateRowEvent.getAfterRow().size());
-        record.setType(ScalingConstant.UPDATE);
-        putColumnsIntoDataRecord(record, metaDataManager.getTableMetaData(updateRowEvent.getTableName()), updateRowEvent.getAfterRow());
-        return record;
+        DataRecord result = createDataRecord(updateRowEvent, updateRowEvent.getAfterRow().size());
+        result.setType(ScalingConstant.UPDATE);
+        putColumnsIntoDataRecord(result, metaDataManager.getTableMetaData(updateRowEvent.getTableName()), updateRowEvent.getAfterRow());
+        return result;
     }
     
     private DataRecord handleDeleteRowsEvent(final DeleteRowEvent event) {
         //TODO completion columns
-        DataRecord record = createDataRecord(event, event.getPrimaryKeys().size());
-        record.setType(ScalingConstant.DELETE);
+        DataRecord result = createDataRecord(event, event.getPrimaryKeys().size());
+        result.setType(ScalingConstant.DELETE);
         List<String> primaryKeyColumns = metaDataManager.getTableMetaData(event.getTableName()).getPrimaryKeyColumns();
         for (int i = 0; i < event.getPrimaryKeys().size(); i++) {
-            record.addColumn(new Column(primaryKeyColumns.get(i), event.getPrimaryKeys().get(i), true, true));
+            result.addColumn(new Column(primaryKeyColumns.get(i), event.getPrimaryKeys().get(i), true, true));
         }
-        return record;
+        return result;
     }
     
     private DataRecord createDataRecord(final AbstractRowEvent rowsEvent, final int columnCount) {

--- a/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/main/java/org/apache/shardingsphere/scaling/postgresql/wal/decode/TestDecodingPlugin.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/main/java/org/apache/shardingsphere/scaling/postgresql/wal/decode/TestDecodingPlugin.java
@@ -85,14 +85,14 @@ public final class TestDecodingPlugin implements DecodingPlugin {
     }
     
     private AbstractRowEvent readWriteRowEvent(final ByteBuffer data) {
-        WriteRowEvent writeRowEvent = new WriteRowEvent();
+        WriteRowEvent result = new WriteRowEvent();
         List<Object> afterColumns = new LinkedList<>();
         
         while (data.hasRemaining()) {
             afterColumns.add(readColumn(data));
         }
-        writeRowEvent.setAfterRow(afterColumns);
-        return writeRowEvent;
+        result.setAfterRow(afterColumns);
+        return result;
     }
     
     private AbstractRowEvent readUpdateRowEvent(final ByteBuffer data) {

--- a/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLJdbcDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLJdbcDumperTest.java
@@ -77,8 +77,7 @@ public final class PostgreSQLJdbcDumperTest {
     
     private DumperConfiguration mockDumperConfiguration() {
         DumperConfiguration result = new DumperConfiguration();
-        result.setDataSourceConfiguration(
-                new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=PostgreSQL", "root", "root"));
+        result.setDataSourceConfiguration(new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=PostgreSQL", "root", "root"));
         return result;
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLJdbcDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLJdbcDumperTest.java
@@ -76,9 +76,9 @@ public final class PostgreSQLJdbcDumperTest {
     }
     
     private DumperConfiguration mockDumperConfiguration() {
-        DumperConfiguration dumperConfiguration = new DumperConfiguration();
-        dumperConfiguration.setDataSourceConfiguration(
+        DumperConfiguration result = new DumperConfiguration();
+        result.setDataSourceConfiguration(
                 new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=PostgreSQL", "root", "root"));
-        return dumperConfiguration;
+        return result;
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLWalDumperTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/PostgreSQLWalDumperTest.java
@@ -75,9 +75,9 @@ public final class PostgreSQLWalDumperTest {
     
     private DumperConfiguration mockDumperConfiguration() {
         jdbcDataSourceConfiguration = new JDBCDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=PostgreSQL", "root", "root");
-        DumperConfiguration dumperConfiguration = new DumperConfiguration();
-        dumperConfiguration.setDataSourceConfiguration(jdbcDataSourceConfiguration);
-        return dumperConfiguration;
+        DumperConfiguration result = new DumperConfiguration();
+        result.setDataSourceConfiguration(jdbcDataSourceConfiguration);
+        return result;
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:
- Rename return variable to "result"
- remove useless linefeed