### PR TITLE
For #6985 :  Add unit test cases & study PostgreSQL wire protocol

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/PostgreSQLComStartupPacket.java
@@ -36,7 +36,7 @@ public final class PostgreSQLComStartupPacket implements PostgreSQLPacket {
     
     public PostgreSQLComStartupPacket(final PostgreSQLPacketPayload payload) {
         payload.skipReserved(8);
-        while (0 != payload.bytesBeforeZero()) {
+        while (payload.bytesBeforeZero() > 0) {
             parametersMap.put(payload.readStringNul(), payload.readStringNul());
         }
     }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/ByteBufTestUtils.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/ByteBufTestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+
+public final class ByteBufTestUtils {
+    
+    /**
+     * Creates a new buffer with a newly allocated byte array, fixed capacity.
+     *
+     * @param capacity the fixed capacity of the underlying byte array
+     * @return ByteBuf
+     */
+    public static ByteBuf createByteBuf(final int capacity) {
+        return createByteBuf(capacity, capacity);
+    }
+    
+    /**
+     * Creates a new buffer with a newly allocated byte array.
+     *
+     * @param initialCapacity the initial capacity of the underlying byte array
+     * @param maxCapacity     the max capacity of the underlying byte array
+     * @return ByteBuf
+     */
+    public static ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
+        UnpooledByteBufAllocator byteBufAllocator = UnpooledByteBufAllocator.DEFAULT;
+        return new UnpooledHeapByteBuf(byteBufAllocator, initialCapacity, maxCapacity);
+    }
+    
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLUnspecifiedBinaryProtocolValueTest.java
@@ -18,9 +18,8 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.binary.bind.protocol;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.buffer.UnpooledHeapByteBuf;
 import java.nio.charset.StandardCharsets;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.binary.bind.PostgreSQLTypeUnspecifiedSQLParameter;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
@@ -41,17 +40,17 @@ public final class PostgreSQLUnspecifiedBinaryProtocolValueTest {
     @Test
     public void assertRead() {
         String timestampStr = "2020-08-23 15:57:03+08";
-        PooledByteBufAllocator byteBufAllocator = new PooledByteBufAllocator();
-        ByteBuf byteBuf = new UnpooledHeapByteBuf(byteBufAllocator, 4 + timestampStr.length(), 64);
+        int expectedLength = 4 + timestampStr.length();
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
         byteBuf.writeInt(timestampStr.length());
         byteBuf.writeCharSequence(timestampStr, StandardCharsets.ISO_8859_1);
         byteBuf.readInt();
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
         Object result = new PostgreSQLUnspecifiedBinaryProtocolValue().read(payload);
-        byteBuf.release();
         assertNotNull(result);
         assertTrue(result instanceof PostgreSQLTypeUnspecifiedSQLParameter);
         assertThat(result.toString(), is(timestampStr));
+        assertThat(byteBuf.readerIndex(), is(expectedLength));
     }
     
     @Test(expected = UnsupportedOperationException.class)

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLAuthenticationOKPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLAuthenticationOKPacketTest.java
@@ -17,27 +17,36 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationOKPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class PostgreSQLCommandCompletePacketTest {
+public final class PostgreSQLAuthenticationOKPacketTest {
     
     @Test
-    public void assertReadWrite() {
-        String sqlCommand = "SELECT * FROM t_order LIMIT 1";
-        long rowCount = 1;
-        String expectedString = sqlCommand + " " + rowCount;
-        int expectedStringLength = expectedString.length();
-        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(ByteBufTestUtils.createByteBuf(expectedStringLength + 1));
-        PostgreSQLCommandCompletePacket packet = new PostgreSQLCommandCompletePacket(sqlCommand, rowCount);
-        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.COMMAND_COMPLETE.getValue()));
+    public void assertSuccessTrue() {
+        assertReadWrite(true);
+    }
+    
+    @Test
+    public void assertSuccessFalse() {
+        assertReadWrite(false);
+    }
+    
+    private void assertReadWrite(final boolean isSuccess) {
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(4);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLAuthenticationOKPacket packet = new PostgreSQLAuthenticationOKPacket(isSuccess);
+        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.AUTHENTICATION_OK.getValue()));
         packet.write(payload);
-        assertThat(payload.readStringNul(), is(expectedString));
+        assertThat(byteBuf.writerIndex(), is(4));
+        assertThat(byteBuf.readInt(), is(isSuccess ? 0 : 1));
     }
     
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComStartupPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComStartupPacketTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
+
+import io.netty.buffer.ByteBuf;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLComStartupPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class PostgreSQLComStartupPacketTest {
+    
+    @Test
+    public void assertReadWrite() {
+        Map<String, String> expectedParametersMap = new LinkedHashMap<>();
+        expectedParametersMap.put("user", "postgres");
+        expectedParametersMap.put("database", "postgres");
+        int expectedLength = 4 + 4;
+        for (Map.Entry<String, String> each : expectedParametersMap.entrySet()) {
+            expectedLength += each.getKey().length() + 1;
+            expectedLength += each.getValue().length() + 1;
+        }
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        payload.writeInt4(expectedLength);
+        payload.writeInt4(196608);
+        for (Map.Entry<String, String> each : expectedParametersMap.entrySet()) {
+            payload.writeStringNul(each.getKey());
+            payload.writeStringNul(each.getValue());
+        }
+        PostgreSQLComStartupPacket packet = new PostgreSQLComStartupPacket(payload);
+        assertThat(packet.getMessageType(), is('\0'));
+        Map<String, String> actualParametersMap = packet.getParametersMap();
+        assertThat(actualParametersMap, is(expectedParametersMap));
+        
+        packet.write(payload);
+        assertThat(byteBuf.writerIndex(), is(expectedLength));
+    }
+    
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComTerminationPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComTerminationPacketTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class PostgreSQLComTerminationPacketTest {
+    
+    @Test
+    public void assertReadWrite() {
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(4);
+        byteBuf.writeInt(1);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLComTerminationPacket packet = new PostgreSQLComTerminationPacket(payload);
+        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.TERMINATE.getValue()));
+        assertThat(byteBuf.readerIndex(), is(4));
+        packet.write(payload);
+        assertThat(byteBuf.writerIndex(), is(4));
+    }
+    
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLCommandCompletePacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLCommandCompletePacketTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.Charset;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class PostgreSQLCommandCompletePacketTest {
+    
+    @Test
+    public void assertReadWrite() {
+        String sqlCommand = "SELECT * FROM t_order LIMIT 1";
+        long rowCount = 1;
+        int expectedStringLength = sqlCommand.length() + 1 + String.valueOf(rowCount).length();
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedStringLength + 1);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLCommandCompletePacket packet = new PostgreSQLCommandCompletePacket(sqlCommand, rowCount);
+        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.COMMAND_COMPLETE.getValue()));
+        packet.write(payload);
+        assertThat(byteBuf.writerIndex(), is(expectedStringLength + 1));
+        assertThat(byteBuf.readCharSequence(expectedStringLength, Charset.defaultCharset()), is(sqlCommand + " " + rowCount));
+        assertThat(byteBuf.readByte(), is((byte) 0));
+    }
+    
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLParameterStatusPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLParameterStatusPacketTest.java
@@ -17,27 +17,31 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class PostgreSQLCommandCompletePacketTest {
+public final class PostgreSQLParameterStatusPacketTest {
     
     @Test
     public void assertReadWrite() {
-        String sqlCommand = "SELECT * FROM t_order LIMIT 1";
-        long rowCount = 1;
-        String expectedString = sqlCommand + " " + rowCount;
-        int expectedStringLength = expectedString.length();
-        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(ByteBufTestUtils.createByteBuf(expectedStringLength + 1));
-        PostgreSQLCommandCompletePacket packet = new PostgreSQLCommandCompletePacket(sqlCommand, rowCount);
-        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.COMMAND_COMPLETE.getValue()));
+        String key = "key1";
+        String value = "value1";
+        int expectedLength = key.length() + 1 + value.length() + 1;
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLParameterStatusPacket packet = new PostgreSQLParameterStatusPacket(key, value);
+        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.PARAMETER_STATUS.getValue()));
         packet.write(payload);
-        assertThat(payload.readStringNul(), is(expectedString));
+        assertThat(byteBuf.writerIndex(), is(expectedLength));
+        assertThat(payload.readStringNul(), is(key));
+        assertThat(payload.readStringNul(), is(value));
     }
     
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLReadyForQueryPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLReadyForQueryPacketTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
@@ -25,19 +26,17 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class PostgreSQLCommandCompletePacketTest {
+public final class PostgreSQLReadyForQueryPacketTest {
     
     @Test
     public void assertReadWrite() {
-        String sqlCommand = "SELECT * FROM t_order LIMIT 1";
-        long rowCount = 1;
-        String expectedString = sqlCommand + " " + rowCount;
-        int expectedStringLength = expectedString.length();
-        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(ByteBufTestUtils.createByteBuf(expectedStringLength + 1));
-        PostgreSQLCommandCompletePacket packet = new PostgreSQLCommandCompletePacket(sqlCommand, rowCount);
-        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.COMMAND_COMPLETE.getValue()));
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(1);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLReadyForQueryPacket packet = new PostgreSQLReadyForQueryPacket();
+        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.READY_FOR_QUERY.getValue()));
         packet.write(payload);
-        assertThat(payload.readStringNul(), is(expectedString));
+        assertThat(byteBuf.writerIndex(), is(1));
+        assertThat(byteBuf.readByte(), is((byte) 'I'));
     }
     
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLSSLNegativePacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLSSLNegativePacketTest.java
@@ -17,27 +17,26 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 
+import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
-import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLSSLNegativePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class PostgreSQLCommandCompletePacketTest {
+public final class PostgreSQLSSLNegativePacketTest {
     
     @Test
     public void assertReadWrite() {
-        String sqlCommand = "SELECT * FROM t_order LIMIT 1";
-        long rowCount = 1;
-        String expectedString = sqlCommand + " " + rowCount;
-        int expectedStringLength = expectedString.length();
-        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(ByteBufTestUtils.createByteBuf(expectedStringLength + 1));
-        PostgreSQLCommandCompletePacket packet = new PostgreSQLCommandCompletePacket(sqlCommand, rowCount);
-        assertThat(packet.getMessageType(), is(PostgreSQLCommandPacketType.COMMAND_COMPLETE.getValue()));
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(1);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        PostgreSQLSSLNegativePacket packet = new PostgreSQLSSLNegativePacket();
+        assertThat(packet.getMessageType(), is('\0'));
         packet.write(payload);
-        assertThat(payload.readStringNul(), is(expectedString));
+        assertThat(byteBuf.writerIndex(), is(1));
+        assertThat(payload.readInt1(), is((int) 'N'));
     }
     
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/PostgreSQLRandomGeneratorTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/PostgreSQLRandomGeneratorTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertThat;
 public class PostgreSQLRandomGeneratorTest {
     
     @Test
-    public void t() {
+    public void assertGenerateRandomBytes() {
         PostgreSQLRandomGenerator generator = PostgreSQLRandomGenerator.getInstance();
         for (int i = 1; i < 13; i++) {
             assertThat(generator.generateRandomBytes(i).length, is(i));

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayloadTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayloadTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.payload;
+
+import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PostgreSQLPacketPayloadTest {
+    
+    @Test
+    public void assertReadWrite() {
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(16, 128);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        
+        byte expectedInt1 = (byte) 'i';
+        payload.writeInt1(expectedInt1);
+        assertThat(payload.readInt1(), is((int) expectedInt1));
+        short expectedInt2 = Short.MAX_VALUE;
+        payload.writeInt2(expectedInt2);
+        assertThat(payload.readInt2(), is((int) expectedInt2));
+        int expectedInt4 = Integer.MAX_VALUE;
+        payload.writeInt4(expectedInt4);
+        assertThat(payload.readInt4(), is(expectedInt4));
+        long expectedInt8 = Long.MAX_VALUE;
+        payload.writeInt8(expectedInt8);
+        assertThat(payload.readInt8(), is(expectedInt8));
+        
+        payload.writeInt4(1);
+        payload.skipReserved(4);
+        
+        String expectedString = "user";
+        payload.writeStringEOF(expectedString);
+        assertThat(byteBuf.readCharSequence(expectedString.length(), StandardCharsets.ISO_8859_1).toString(), is(expectedString));
+        payload.writeStringNul(expectedString);
+        assertThat(payload.bytesBeforeZero(), is(expectedString.length()));
+        assertThat(payload.readStringNul(), is(expectedString));
+        
+        assertThat(payload.getByteBuf(), is(byteBuf));
+        payload.close();
+    }
+    
+}


### PR DESCRIPTION
Fixes #6985 .

Changes proposed in this pull request:
- Following unit test cases
```
PostgreSQLComTerminationPacket.java
PostgreSQLCommandCompletePacket.java
PostgreSQLErrorResponsePacket.java
PostgreSQLReadyForQueryPacket.java
PostgreSQLAuthenticationMD5PasswordPacket.java
PostgreSQLAuthenticationOKPacket.java
PostgreSQLComStartupPacket.java
PostgreSQLParameterStatusPacket.java
PostgreSQLPasswordMessagePacket.java
PostgreSQLRandomGenerator.java
PostgreSQLSSLNegativePacket.java
PostgreSQLPacketPayload.java
```

