### PR TITLE
GovernanceShardingSphereDataSourceFactoryTest added

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactoryTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactoryTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.governance.api;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.driver.governance.internal.datasource.GovernanceShardingSphereDataSource;
+import org.apache.shardingsphere.governance.repository.api.config.GovernanceCenterConfiguration;
+import org.apache.shardingsphere.governance.repository.api.config.GovernanceConfiguration;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class GovernanceShardingSphereDataSourceFactoryTest {
+    private static final String TABLE_TYPE = "TABLE";
+    
+    @SneakyThrows
+    @Test
+    public void assertCreateDataSourceWhenRuleConfigurationsNotEmpty() {
+        DataSource dataSource = GovernanceShardingSphereDataSourceFactory.createDataSource(createDataSourceMap(), Collections.singletonList(mock(RuleConfiguration.class)),
+                new Properties(), createGovernanceConfiguration());
+        assertTrue(dataSource instanceof GovernanceShardingSphereDataSource);
+    }
+    
+    @SneakyThrows
+    @Test
+    public void assertCreateDataSourceWithGivenDataSource() {
+        DataSource dataSource = GovernanceShardingSphereDataSourceFactory.createDataSource(createDataSource(), Collections.singletonList(mock(RuleConfiguration.class)),
+                new Properties(), createGovernanceConfiguration());
+        assertTrue(dataSource instanceof GovernanceShardingSphereDataSource);
+    }
+    
+    private Map<String, DataSource> createDataSourceMap() {
+        Map<String, DataSource> result = new HashMap<>();
+        result.put("dataSourceMapKey", createDataSource());
+        return result;
+    }
+    
+    @SneakyThrows
+    private DataSource createDataSource() {
+        DataSource result = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        when(connection.getMetaData()).thenReturn(databaseMetaData);
+        when(databaseMetaData.getURL()).thenReturn("jdbc:mysql://localhost:3306/mysql?serverTimezone=GMT%2B8");
+        ResultSet resultSet = mock(ResultSet.class);
+        when(databaseMetaData.getTables(null, null, null, new String[]{TABLE_TYPE})).thenReturn(resultSet);
+        when(result.getConnection()).thenReturn(connection);
+        return result;
+    }
+    
+    private GovernanceConfiguration createGovernanceConfiguration() {
+        GovernanceConfiguration result = mock(GovernanceConfiguration.class);
+        GovernanceCenterConfiguration governanceCenterConfiguration = mock(GovernanceCenterConfiguration.class);
+        when(result.getRegistryCenterConfiguration()).thenReturn(governanceCenterConfiguration);
+        when(governanceCenterConfiguration.getType()).thenReturn("REG_TEST");
+        return result;
+    }
+}
+

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactoryTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactoryTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class GovernanceShardingSphereDataSourceFactoryTest {
+    
     private static final String TABLE_TYPE = "TABLE";
     
     @SneakyThrows


### PR DESCRIPTION
Fixes #7099.

Since OrchestrationShardingSphereDataSourceFactory has been named to GovernanceShardingSphereDataSourceFactory,  pr of #7155 need to submit for master

assertCreateDataSourceWhenRuleConfigurationsNotEmpty and assertCreateDataSourceWithGivenDataSource added