### PR TITLE
Add test case for DatabaseProtocolFrontendEngineFactory when newInstance success (#7012)

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/util/DataSourceConverterTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/util/DataSourceConverterTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.config.DataSourceConfiguration;
 import org.apache.shardingsphere.kernel.context.schema.DataSourceParameter;
 import org.junit.Test;
 
+import javax.sql.DataSource;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,8 +30,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-
-import javax.sql.DataSource;
 
 public final class DataSourceConverterTest {
     

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/DatabaseProtocolFrontendEngineFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/DatabaseProtocolFrontendEngineFactoryTest.java
@@ -18,12 +18,27 @@
 package org.apache.shardingsphere.proxy.frontend;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseTypes;
+import org.apache.shardingsphere.proxy.frontend.mysql.MockMySQLProtocolFrontendEngine;
+import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine;
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 public final class DatabaseProtocolFrontendEngineFactoryTest {
     
     @Test(expected = UnsupportedOperationException.class)
     public void assertNewInstanceWhenUnsupported() {
         DatabaseProtocolFrontendEngineFactory.newInstance(DatabaseTypes.getActualDatabaseType("Oracle"));
+    }
+    
+    @Test
+    public void assertNewInstanceWhenSupported() {
+        DatabaseProtocolFrontendEngine actual = DatabaseProtocolFrontendEngineFactory.newInstance(DatabaseTypes.getActualDatabaseType("MySQL"));
+        assertNotNull(actual);
+        assertThat(actual, instanceOf(MockMySQLProtocolFrontendEngine.class));
+        assertThat(actual.getDatabaseType(), is("MySQL"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/DatabaseProtocolFrontendEngineFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/DatabaseProtocolFrontendEngineFactoryTest.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.proxy.frontend;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseTypes;
-import org.apache.shardingsphere.proxy.frontend.mysql.MockMySQLProtocolFrontendEngine;
 import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine;
+import org.apache.shardingsphere.proxy.frontend.spi.MockProtocolFrontendEngine;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -38,7 +38,7 @@ public final class DatabaseProtocolFrontendEngineFactoryTest {
     public void assertNewInstanceWhenSupported() {
         DatabaseProtocolFrontendEngine actual = DatabaseProtocolFrontendEngineFactory.newInstance(DatabaseTypes.getActualDatabaseType("MySQL"));
         assertNotNull(actual);
-        assertThat(actual, instanceOf(MockMySQLProtocolFrontendEngine.class));
+        assertThat(actual, instanceOf(MockProtocolFrontendEngine.class));
         assertThat(actual.getDatabaseType(), is("MySQL"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MockMySQLProtocolFrontendEngine.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MockMySQLProtocolFrontendEngine.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.mysql;
+
+import org.apache.shardingsphere.db.protocol.codec.DatabasePacketCodecEngine;
+import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.BackendConnection;
+import org.apache.shardingsphere.proxy.frontend.context.FrontendContext;
+import org.apache.shardingsphere.proxy.frontend.engine.AuthenticationEngine;
+import org.apache.shardingsphere.proxy.frontend.engine.CommandExecuteEngine;
+import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine;
+
+public final class MockMySQLProtocolFrontendEngine implements DatabaseProtocolFrontendEngine {
+    
+    @Override
+    public FrontendContext getFrontendContext() {
+        return null;
+    }
+    
+    @Override
+    public DatabasePacketCodecEngine getCodecEngine() {
+        return null;
+    }
+    
+    @Override
+    public AuthenticationEngine getAuthEngine() {
+        return null;
+    }
+    
+    @Override
+    public CommandExecuteEngine getCommandExecuteEngine() {
+        return null;
+    }
+    
+    @Override
+    public void release(final BackendConnection backendConnection) {
+
+    }
+    
+    @Override
+    public String getDatabaseType() {
+        return "MySQL";
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/spi/MockProtocolFrontendEngine.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/spi/MockProtocolFrontendEngine.java
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.proxy.frontend.mysql;
+package org.apache.shardingsphere.proxy.frontend.spi;
 
 import org.apache.shardingsphere.db.protocol.codec.DatabasePacketCodecEngine;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.BackendConnection;
 import org.apache.shardingsphere.proxy.frontend.context.FrontendContext;
 import org.apache.shardingsphere.proxy.frontend.engine.AuthenticationEngine;
 import org.apache.shardingsphere.proxy.frontend.engine.CommandExecuteEngine;
-import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine;
 
-public final class MockMySQLProtocolFrontendEngine implements DatabaseProtocolFrontendEngine {
+public final class MockProtocolFrontendEngine implements DatabaseProtocolFrontendEngine {
     
     @Override
     public FrontendContext getFrontendContext() {

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/resources/META-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/resources/META-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.proxy.frontend.mysql.MockMySQLProtocolFrontendEngine
+org.apache.shardingsphere.proxy.frontend.spi.MockProtocolFrontendEngine

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/resources/META-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/resources/META-INF/services/org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngine
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.proxy.frontend.mysql.MockMySQLProtocolFrontendEngine


### PR DESCRIPTION
Add test case for DatabaseProtocolFrontendEngineFactory when newInstance success (#7012)

Fixes #7012.

Changes proposed in this pull request:
- Reorganize imports of DataSourceConverterTest.java.
- Add test case for DatabaseProtocolFrontendEngineFactory when newInstance success, using spi mock class.