### PR TITLE
fix wrong project url in document 

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-ui/usage/build.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-ui/usage/build.cn.md
@@ -5,7 +5,7 @@ weight = 1
 
 ## 二进制运行
 
-1. `git clone https://github.com/apache/shardingsphere.git`；
+1. `git clone https://github.com/apache/shardingsphere-ui.git`；
 1. 运行 `mvn clean install -Prelease`；
 1. 获取安装包 `/shardingsphere-ui/shardingsphere-ui-distribution/target/apache-shardingsphere-${latest.release.version}-shardingsphere-ui-bin.tar.gz`；
 1. 解压缩后运行`bin/start.sh`；

--- a/docs/document/content/user-manual/shardingsphere-ui/usage/build.en.md
+++ b/docs/document/content/user-manual/shardingsphere-ui/usage/build.en.md
@@ -5,7 +5,7 @@ weight = 1
 
 ## Binary Run
 
-1. `git clone https://github.com/apache/shardingsphere.git`;
+1. `git clone https://github.com/apache/shardingsphere-ui.git`;
 1. Run `mvn clean install -Prelease`;
 1. Get the package in `/shardingsphere-ui/shardingsphere-ui-distribution/target/apache-shardingsphere-${latest.release.version}-shardingsphere-ui-bin.tar.gz`;
 1. After the decompression, run `bin/start.sh`;


### PR DESCRIPTION
fix document error,

https://shardingsphere.apache.org/document/current/cn/user-manual/shardingsphere-ui/usage/build/

git clone https://github.com/apache/shardingsphere.git
改为
git clone https://github.com/apache/shardingsphere-ui.git

