### PR TITLE
Support update sql table route，fix springboot version compatibility issues

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/algorithm/AESEncryptAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/algorithm/AESEncryptAlgorithm.java
@@ -44,6 +44,8 @@ public final class AESEncryptAlgorithm implements EncryptAlgorithm {
     
     private static final String AES_KEY = "aes.key.value";
     
+    private static final String AES_KEY_COMPATIBLE = "aes-key-value";
+    
     private Properties props = new Properties();
     
     private byte[] secretKey;
@@ -54,8 +56,13 @@ public final class AESEncryptAlgorithm implements EncryptAlgorithm {
     }
     
     private byte[] createSecretKey() {
-        Preconditions.checkArgument(props.containsKey(AES_KEY), String.format("%s can not be null.", AES_KEY));
-        return Arrays.copyOf(DigestUtils.sha1(props.getProperty(AES_KEY)), 16);
+        if (props.containsKey(AES_KEY)) {
+            Preconditions.checkArgument(true, String.format("%s can not be null.", AES_KEY));
+            return Arrays.copyOf(DigestUtils.sha1(props.getProperty(AES_KEY)), 16);
+        } else {
+            Preconditions.checkArgument(props.containsKey(AES_KEY_COMPATIBLE), String.format("%s can not be null.", AES_KEY));
+            return Arrays.copyOf(DigestUtils.sha1(props.getProperty(AES_KEY_COMPATIBLE)), 16);
+        }
     }
     
     @SneakyThrows

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/algorithm/RC4EncryptAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-common/src/main/java/org/apache/shardingsphere/encrypt/algorithm/RC4EncryptAlgorithm.java
@@ -36,6 +36,8 @@ public final class RC4EncryptAlgorithm implements EncryptAlgorithm {
     
     private static final String RC4_KEY = "rc4.key.value";
     
+    private static final String RC4_KEY_COMPATIBLE = "rc4-key-value";
+    
     private static final int SBOX_LENGTH = 256;
     
     private static final int KEY_MIN_LENGTH = 5;
@@ -52,7 +54,11 @@ public final class RC4EncryptAlgorithm implements EncryptAlgorithm {
     @SneakyThrows
     public void init() {
         reset();
-        setKey(StringUtils.getBytesUtf8(props.getProperty(RC4_KEY)));
+        if (props.containsKey(RC4_KEY)) {
+            setKey(StringUtils.getBytesUtf8(props.getProperty(RC4_KEY)));
+        } else {
+            setKey(StringUtils.getBytesUtf8(props.getProperty(RC4_KEY_COMPATIBLE)));
+        }
     }
     
     @Override
@@ -88,6 +94,7 @@ public final class RC4EncryptAlgorithm implements EncryptAlgorithm {
     
     /**
      * Crypt given byte array. Be aware, that you must init key, before using.
+     *
      * @param message array to be crypt
      * @return byte array
      * @see <a href="http://en.wikipedia.org/wiki/RC4#Pseudo-random_generation_algorithm_.28PRGA.29">Pseudo-random generation algorithm</a>

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/ShardingRouteDecorator.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/ShardingRouteDecorator.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.sharding.constant.ShardingOrder;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingConditions;
 import org.apache.shardingsphere.sharding.route.engine.condition.engine.InsertClauseShardingConditionEngine;
+import org.apache.shardingsphere.sharding.route.engine.condition.engine.UpdateClauseShardingConditionEngine;
 import org.apache.shardingsphere.sharding.route.engine.condition.engine.WhereClauseShardingConditionEngine;
 import org.apache.shardingsphere.sharding.route.engine.type.ShardingRouteEngine;
 import org.apache.shardingsphere.sharding.route.engine.type.ShardingRouteEngineFactory;
@@ -43,6 +44,7 @@ import org.apache.shardingsphere.sql.parser.binder.metadata.schema.SchemaMetaDat
 import org.apache.shardingsphere.sql.parser.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.sql.parser.binder.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.sql.parser.binder.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.sql.parser.binder.statement.dml.UpdateStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DMLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.util.SafeNumberOperationUtils;
@@ -75,12 +77,14 @@ public final class ShardingRouteDecorator implements RouteDecorator<ShardingRule
         shardingStatementValidator.ifPresent(validator -> validator.postValidate(sqlStatement, routeResult));
         return new RouteContext(sqlStatementContext, parameters, routeResult);
     }
-
+    
     private ShardingConditions getShardingConditions(final List<Object> parameters, final SQLStatementContext sqlStatementContext,
                                                      final SchemaMetaData schemaMetaData, final ShardingRule shardingRule) {
         if (sqlStatementContext.getSqlStatement() instanceof DMLStatement) {
             if (sqlStatementContext instanceof InsertStatementContext) {
                 return new ShardingConditions(new InsertClauseShardingConditionEngine(shardingRule, schemaMetaData).createShardingConditions((InsertStatementContext) sqlStatementContext, parameters));
+            } else if (sqlStatementContext instanceof UpdateStatementContext) {
+                return new ShardingConditions(new UpdateClauseShardingConditionEngine(shardingRule, schemaMetaData).createShardingConditions((UpdateStatementContext) sqlStatementContext, parameters));
             }
             return new ShardingConditions(new WhereClauseShardingConditionEngine(shardingRule, schemaMetaData).createShardingConditions(sqlStatementContext, parameters));
         }
@@ -137,7 +141,7 @@ public final class ShardingRouteDecorator implements RouteDecorator<ShardingRule
     }
     
     private boolean isSameRouteValue(final ShardingRule shardingRule, final ListRouteValue routeValue1, final ListRouteValue routeValue2) {
-        return isSameLogicTable(shardingRule, routeValue1, routeValue2) && routeValue1.getColumnName().equals(routeValue2.getColumnName()) 
+        return isSameLogicTable(shardingRule, routeValue1, routeValue2) && routeValue1.getColumnName().equals(routeValue2.getColumnName())
                 && SafeNumberOperationUtils.safeEquals(routeValue1.getValues(), routeValue2.getValues());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/UpdateClauseShardingConditionEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/UpdateClauseShardingConditionEngine.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.route.engine.condition.engine;
+
+import com.google.common.base.Preconditions;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.exception.ShardingSphereException;
+import org.apache.shardingsphere.sharding.route.engine.condition.ExpressionConditionUtils;
+import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
+import org.apache.shardingsphere.sharding.route.spi.SPITimeService;
+import org.apache.shardingsphere.sharding.rule.ShardingRule;
+import org.apache.shardingsphere.sharding.strategy.value.ListRouteValue;
+import org.apache.shardingsphere.sql.parser.binder.metadata.schema.SchemaMetaData;
+import org.apache.shardingsphere.sql.parser.binder.statement.dml.UpdateStatementContext;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.AssignmentSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.SimpleExpressionSegment;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class UpdateClauseShardingConditionEngine {
+    
+    private final ShardingRule shardingRule;
+    
+    private final SchemaMetaData schemaMetaData;
+    
+    /**
+     * Create sharding conditions.
+     *
+     * @param updateStatementContext Update statement context
+     * @param parameters             SQL parameters
+     * @return sharding conditions
+     */
+    public List<ShardingCondition> createShardingConditions(final UpdateStatementContext updateStatementContext, final List<Object> parameters) {
+        List<ShardingCondition> result = new LinkedList<>();
+        Collection<String> tableNames = updateStatementContext.getTablesContext().getTableNames();
+        
+        Collection<AssignmentSegment> assignments = updateStatementContext.getSqlStatement().getSetAssignment().getAssignments();
+        
+        for (String tableName : tableNames) {
+            for (AssignmentSegment assignment : assignments) {
+                String columnName = assignment.getColumn().getQualifiedName();
+                
+                if (shardingRule.isShardingColumn(columnName, tableName)) {
+                    result.add(createShardingCondition(tableName, columnName, assignment.getValue(), parameters));
+                }
+            }
+        }
+        
+        if (updateStatementContext.getWhere().isPresent()) {
+            result.addAll(new WhereClauseShardingConditionEngine(shardingRule, schemaMetaData).createShardingConditions(updateStatementContext, parameters));
+        }
+        
+        return result;
+    }
+    
+    private ShardingCondition createShardingCondition(final String tableName, final String columnName, final ExpressionSegment expressionSegment, final List<Object> parameters) {
+        ShardingCondition result = new ShardingCondition();
+        SPITimeService timeService = new SPITimeService();
+        
+        if (expressionSegment instanceof SimpleExpressionSegment) {
+            result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(getRouteValue((SimpleExpressionSegment) expressionSegment, parameters))));
+        } else if (ExpressionConditionUtils.isNowExpression(expressionSegment)) {
+            result.getRouteValues().add(new ListRouteValue<>(columnName, tableName, Collections.singletonList(timeService.getTime())));
+        } else if (ExpressionConditionUtils.isNullExpression(expressionSegment)) {
+            throw new ShardingSphereException("Insert clause sharding column can't be null.");
+        }
+        
+        return result;
+    }
+    
+    private Comparable<?> getRouteValue(final SimpleExpressionSegment expressionSegment, final List<Object> parameters) {
+        Object result;
+        if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
+            result = parameters.get(((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex());
+        } else {
+            result = ((LiteralExpressionSegment) expressionSegment).getLiterals();
+        }
+        Preconditions.checkArgument(result instanceof Comparable, "Sharding value must implements Comparable.");
+        return (Comparable) result;
+    }
+}

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidator.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.route.engine.validator.impl;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -45,6 +46,7 @@ import java.util.Optional;
 /**
  * Sharding update statement validator.
  */
+@Slf4j
 public final class ShardingUpdateStatementValidator implements ShardingStatementValidator<UpdateStatement> {
     
     @Override
@@ -67,7 +69,8 @@ public final class ShardingUpdateStatementValidator implements ShardingStatement
                 if (shardingColumnSetAssignmentValue.isPresent() && shardingValue.isPresent() && shardingColumnSetAssignmentValue.get().equals(shardingValue.get())) {
                     continue;
                 }
-                throw new ShardingSphereException("Can not update sharding key, logic table: [%s], column: [%s].", tableName, each);
+                log.warn("should not update sharding key, logic table: {}, column: {}", tableName, each);
+//                throw new ShardingSphereException("Can not update sharding key, logic table: [%s], column: [%s].", tableName, each);
             }
         }
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/impl/ShardingUpdateStatementValidatorTest.java
@@ -72,7 +72,7 @@ public final class ShardingUpdateStatementValidatorTest {
         new ShardingUpdateStatementValidator().preValidate(shardingRule, routeContext, mock(ShardingSphereMetaData.class));
     }
     
-    @Test(expected = ShardingSphereException.class)
+    @Test
     public void assertValidateUpdateWithShardingKey() {
         when(shardingRule.isShardingColumn("id", "user")).thenReturn(true);
         RouteContext routeContext = new RouteContext(new UpdateStatementContext(createUpdateStatement()), Collections.emptyList(), new RouteResult());
@@ -96,7 +96,7 @@ public final class ShardingUpdateStatementValidatorTest {
         new ShardingUpdateStatementValidator().preValidate(shardingRule, routeContext, mock(ShardingSphereMetaData.class));
     }
     
-    @Test(expected = ShardingSphereException.class)
+    @Test
     public void assertValidateUpdateWithShardingKeyAndShardingParameterNotEquals() {
         when(shardingRule.isShardingColumn("id", "user")).thenReturn(true);
         List<Object> parameters = Arrays.asList(1, 1);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/registry/AbstractAlgorithmProvidedBeanRegistry.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/registry/AbstractAlgorithmProvidedBeanRegistry.java
@@ -48,7 +48,9 @@ public abstract class AbstractAlgorithmProvidedBeanRegistry implements BeanDefin
     @SuppressWarnings("all")
     protected void registerBean(final String preFix, final Class clazz, final BeanDefinitionRegistry registry) {
         Map<String, Object> paramMap = PropertyUtil.handle(environment, preFix, Map.class);
-        Set<String> keySet = paramMap.keySet().stream().map(key -> key.substring(0, key.indexOf("."))).collect(Collectors.toSet());
+        Set<String> keySet = paramMap.keySet().stream().map(key -> {
+            return key.contains(".") ? key.substring(0, key.indexOf(".")) : key;
+        }).collect(Collectors.toSet());
         Map<String, YamlShardingSphereAlgorithmConfiguration> shardingAlgorithmMap = new LinkedHashMap<>();
         keySet.forEach(key -> {
             String type = environment.getProperty(preFix + key + ".type");


### PR DESCRIPTION
Support #6918.
Fixes #7163

Changes proposed in this pull request:
- Support table route for update sql.
- Allow update sharding key in sql.
- Compatible fix property read for springboot after 2.0.0M1.
- Fix property read if property not has '.' , cause by springboot version
