### PR TITLE
Refactor: overload the scaling MetaDataManager

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/splitter/InventoryDataTaskSplitter.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/splitter/InventoryDataTaskSplitter.java
@@ -92,7 +92,8 @@ public final class InventoryDataTaskSplitter {
     }
     
     private boolean isSpiltByPrimaryKeyRange(final InventoryDumperConfiguration inventoryDumperConfiguration, final MetaDataManager metaDataManager) {
-        TableMetaData tableMetaData = metaDataManager.getTableMetaData(inventoryDumperConfiguration.getTableName());
+        TableMetaData tableMetaData = metaDataManager.getTableMetaData(inventoryDumperConfiguration.getTableName(),
+                inventoryDumperConfiguration.getDataSourceConfiguration().getDatabaseType().getName());
         if (null == tableMetaData) {
             log.warn("Can't split range for table {}, reason: can not get table metadata ", inventoryDumperConfiguration.getTableName());
             return false;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManager.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManager.java
@@ -43,7 +43,7 @@ public final class MetaDataManager {
      * @return table meta data
      */
     public TableMetaData getTableMetaData(final String tableName) {
-        return getTableMetaData(tableName, null);
+        return getTableMetaData(tableName, "");
     }
     
     /**

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManager.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManager.java
@@ -43,9 +43,20 @@ public final class MetaDataManager {
      * @return table meta data
      */
     public TableMetaData getTableMetaData(final String tableName) {
+        return getTableMetaData(tableName, null);
+    }
+    
+    /**
+     * Get table meta data by table name.
+     * 
+     * @param tableName table name
+     * @param databaseType database type
+     * @return table meta data
+     */
+    public TableMetaData getTableMetaData(final String tableName, final String databaseType) {
         if (!tableMetaDataMap.containsKey(tableName)) {
             try {
-                TableMetaDataLoader.load(dataSource, tableName, "").ifPresent(tableMetaData -> tableMetaDataMap.put(tableName, tableMetaData));
+                TableMetaDataLoader.load(dataSource, tableName, databaseType).ifPresent(tableMetaData -> tableMetaDataMap.put(tableName, tableMetaData));
             } catch (final SQLException ex) {
                 throw new RuntimeException(String.format("Load metaData for table %s failed", tableName), ex);
             }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManagerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/metadata/MetaDataManagerTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -32,8 +34,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.List;
-
-import javax.sql.DataSource;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -107,6 +107,7 @@ public final class MetaDataManagerTest {
     public void assertGetTableMetaData() {
         MetaDataManager metaDataManager = new MetaDataManager(dataSource);
         assertColumnMetaData(metaDataManager.getTableMetaData(TEST_TABLE));
+        assertColumnMetaData(metaDataManager.getTableMetaData(TEST_TABLE, "MySQL"));
         assertPrimaryKeys(metaDataManager.getTableMetaData(TEST_TABLE).getPrimaryKeyColumns());
     }
     


### PR DESCRIPTION
Changes proposed in this pull request:
- overload the getTableMetaData because `TableMetaDataLoader.load` accept databaseType , then hard code an empty string is not a good way 


