### PR TITLE
refactor eventbus

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/DataSourcePersistEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/DataSourcePersistEvent.java
@@ -15,22 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus.event;
+package org.apache.shardingsphere.governance.core.event.persist;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.config.RuleConfiguration;
+import org.apache.shardingsphere.governance.core.event.GovernanceEvent;
+import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 
-import java.util.Collection;
+import java.util.Map;
 
 /**
- * Rule event.
+ * Data source event.
  */
 @RequiredArgsConstructor
 @Getter
-public final class RuleEvent {
+public final class DataSourcePersistEvent implements GovernanceEvent {
     
     private final String schemaName;
     
-    private final Collection<RuleConfiguration> ruleConfigurations;
+    private final Map<String, DataSourceConfiguration> dataSourceConfigurations;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/MetaDataPersistEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/MetaDataPersistEvent.java
@@ -15,19 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus.event;
+package org.apache.shardingsphere.governance.core.event.persist;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.governance.core.event.GovernanceEvent;
+import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
 
 /**
- * Schema name event.
+ * Meta data event.
  */
 @RequiredArgsConstructor
 @Getter
-public final class SchemaNameEvent {
+public final class MetaDataPersistEvent implements GovernanceEvent {
     
     private final String schemaName;
     
-    private final boolean isDrop; 
+    private final RuleSchemaMetaData metaData;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/RulePersistEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/RulePersistEvent.java
@@ -15,17 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus;
+package org.apache.shardingsphere.governance.core.event.persist;
 
-import org.junit.Test;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.governance.core.event.GovernanceEvent;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import java.util.Collection;
 
-public final class ShardingSphereEventBusTest {
+/**
+ * Rule event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class RulePersistEvent implements GovernanceEvent {
     
-    @Test
-    public void assertInstance() {
-        assertThat(ShardingSphereEventBus.getInstance(), is(ShardingSphereEventBus.getInstance()));
-    }
+    private final String schemaName;
+    
+    private final Collection<RuleConfiguration> ruleConfigurations;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/SchemaNamePersistEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/event/persist/SchemaNamePersistEvent.java
@@ -15,22 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus.event;
+package org.apache.shardingsphere.governance.core.event.persist;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
-
-import java.util.Map;
+import org.apache.shardingsphere.governance.core.event.GovernanceEvent;
 
 /**
- * Data source event.
+ * Schema name event.
  */
 @RequiredArgsConstructor
 @Getter
-public final class DataSourceEvent {
+public final class SchemaNamePersistEvent implements GovernanceEvent {
     
     private final String schemaName;
     
-    private final Map<String, DataSourceConfiguration> dataSourceConfigurations;
+    private final boolean isDrop; 
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/eventbus/ShardingSphereEventBus.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/eventbus/ShardingSphereEventBus.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus;
+package org.apache.shardingsphere.governance.core.eventbus;
 
 import com.google.common.eventbus.EventBus;
 import lombok.AccessLevel;

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/listener/PostGovernanceRepositoryEventListener.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/main/java/org/apache/shardingsphere/governance/core/listener/PostGovernanceRepositoryEventListener.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.governance.core.event.GovernanceEvent;
 import org.apache.shardingsphere.governance.repository.api.GovernanceRepository;
 import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEvent;
 import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEvent.ChangedType;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/test/java/org/apache/shardingsphere/governance/core/eventbus/ShardingSphereEventBusTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-common/src/test/java/org/apache/shardingsphere/governance/core/eventbus/ShardingSphereEventBusTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.eventbus;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class ShardingSphereEventBusTest {
+    
+    @Test
+    public void assertInstance() {
+        assertThat(ShardingSphereEventBus.getInstance(), is(ShardingSphereEventBus.getInstance()));
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-config/src/main/java/org/apache/shardingsphere/governance/core/config/ConfigCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-config/src/main/java/org/apache/shardingsphere/governance/core/config/ConfigCenter.java
@@ -32,10 +32,10 @@ import org.apache.shardingsphere.infra.auth.yaml.config.YamlAuthenticationConfig
 import org.apache.shardingsphere.infra.auth.yaml.swapper.AuthenticationYamlSwapper;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.eventbus.event.DataSourceEvent;
-import org.apache.shardingsphere.infra.eventbus.event.RuleEvent;
-import org.apache.shardingsphere.infra.eventbus.event.SchemaNameEvent;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.event.persist.DataSourcePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.RulePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.SchemaNamePersistEvent;
 import org.apache.shardingsphere.infra.yaml.config.YamlRootRuleConfigurations;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapperEngine;
@@ -104,7 +104,7 @@ public final class ConfigCenter {
      * @param event Data source event.
      */
     @Subscribe
-    public synchronized void renew(final DataSourceEvent event) {
+    public synchronized void renew(final DataSourcePersistEvent event) {
         persistDataSourceConfigurations(event.getSchemaName(), event.getDataSourceConfigurations());
     }
     
@@ -114,7 +114,7 @@ public final class ConfigCenter {
      * @param event Rule event.
      */
     @Subscribe
-    public synchronized void renew(final RuleEvent event) {
+    public synchronized void renew(final RulePersistEvent event) {
         persistRuleConfigurations(event.getSchemaName(), event.getRuleConfigurations());
     }
     
@@ -124,7 +124,7 @@ public final class ConfigCenter {
      * @param event Schema name event.
      */
     @Subscribe
-    public synchronized void renew(final SchemaNameEvent event) {
+    public synchronized void renew(final SchemaNamePersistEvent event) {
         persistSchema(event.getSchemaName(), event.isDrop());
     }
     

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-config/src/test/java/org/apache/shardingsphere/governance/core/config/ConfigCenterTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-config/src/test/java/org/apache/shardingsphere/governance/core/config/ConfigCenterTest.java
@@ -28,9 +28,9 @@ import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
-import org.apache.shardingsphere.infra.eventbus.event.DataSourceEvent;
-import org.apache.shardingsphere.infra.eventbus.event.RuleEvent;
-import org.apache.shardingsphere.infra.eventbus.event.SchemaNameEvent;
+import org.apache.shardingsphere.governance.core.event.persist.DataSourcePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.RulePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.SchemaNamePersistEvent;
 import org.apache.shardingsphere.infra.yaml.config.YamlRootRuleConfigurations;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapperEngine;
@@ -445,7 +445,7 @@ public final class ConfigCenterTest {
     
     @Test
     public void assertRenewDataSourceEvent() {
-        DataSourceEvent event = new DataSourceEvent("sharding_db", createDataSourceConfigurations());
+        DataSourcePersistEvent event = new DataSourcePersistEvent("sharding_db", createDataSourceConfigurations());
         ConfigCenter configCenter = new ConfigCenter(configurationRepository);
         configCenter.renew(event);
         verify(configurationRepository).persist(eq("/config/schema/sharding_db/datasource"), anyString());
@@ -453,7 +453,7 @@ public final class ConfigCenterTest {
     
     @Test
     public void assertRenewRuleEvent() {
-        RuleEvent event = new RuleEvent("sharding_db", createRuleConfigurations());
+        RulePersistEvent event = new RulePersistEvent("sharding_db", createRuleConfigurations());
         ConfigCenter configCenter = new ConfigCenter(configurationRepository);
         configCenter.renew(event);
         verify(configurationRepository).persist(eq("/config/schema/sharding_db/rule"), anyString());
@@ -461,7 +461,7 @@ public final class ConfigCenterTest {
     
     @Test
     public void assertRenewSchemaNameEventWithDrop() {
-        SchemaNameEvent event = new SchemaNameEvent("sharding_db", true);
+        SchemaNamePersistEvent event = new SchemaNamePersistEvent("sharding_db", true);
         when(configurationRepository.get("/config/schema")).thenReturn("sharding_db,master_slave_db");
         ConfigCenter configCenter = new ConfigCenter(configurationRepository);
         configCenter.renew(event);
@@ -470,7 +470,7 @@ public final class ConfigCenterTest {
     
     @Test
     public void assertRenewSchemaNameEventWithAdd() {
-        SchemaNameEvent event = new SchemaNameEvent("sharding_db", false);
+        SchemaNamePersistEvent event = new SchemaNamePersistEvent("sharding_db", false);
         when(configurationRepository.get("/config/schema")).thenReturn("master_slave_db");
         ConfigCenter configCenter = new ConfigCenter(configurationRepository);
         configCenter.renew(event);
@@ -479,7 +479,7 @@ public final class ConfigCenterTest {
     
     @Test
     public void assertRenewSchemaNameEventWithAddAndExist() {
-        SchemaNameEvent event = new SchemaNameEvent("sharding_db", false);
+        SchemaNamePersistEvent event = new SchemaNamePersistEvent("sharding_db", false);
         when(configurationRepository.get("/config/schema")).thenReturn("sharding_db,master_slave_db");
         ConfigCenter configCenter = new ConfigCenter(configurationRepository);
         configCenter.renew(event);

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/src/main/java/org/apache/shardingsphere/governance/context/schema/GovernanceSchemaContexts.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/src/main/java/org/apache/shardingsphere/governance/context/schema/GovernanceSchemaContexts.java
@@ -45,7 +45,7 @@ import org.apache.shardingsphere.infra.context.runtime.RuntimeContext;
 import org.apache.shardingsphere.infra.context.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypes;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.executor.kernel.ExecutorKernel;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/src/main/java/org/apache/shardingsphere/governance/context/transaction/GovernanceTransactionContexts.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/src/main/java/org/apache/shardingsphere/governance/context/transaction/GovernanceTransactionContexts.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.governance.context.transaction;
 
 import com.google.common.eventbus.Subscribe;
 import org.apache.shardingsphere.governance.core.event.datasource.DataSourceChangeCompletedEvent;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.transaction.ShardingTransactionManagerEngine;
 import org.apache.shardingsphere.transaction.context.TransactionContexts;
 

--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-metadata/src/main/java/org/apache/shardingsphere/governance/core/metadata/MetaDataCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-metadata/src/main/java/org/apache/shardingsphere/governance/core/metadata/MetaDataCenter.java
@@ -22,8 +22,8 @@ import com.google.common.eventbus.Subscribe;
 import org.apache.shardingsphere.governance.repository.api.GovernanceRepository;
 import org.apache.shardingsphere.governance.core.metadata.yaml.RuleSchemaMetaDataYamlSwapper;
 import org.apache.shardingsphere.governance.core.metadata.yaml.YamlRuleSchemaMetaData;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.eventbus.event.MetaDataEvent;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.event.persist.MetaDataPersistEvent;
 import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
@@ -74,7 +74,7 @@ public final class MetaDataCenter {
      * @param event Meta data event.
      */
     @Subscribe
-    public synchronized void renew(final MetaDataEvent event) {
+    public synchronized void renew(final MetaDataPersistEvent event) {
         persistMetaDataCenterNode(event.getSchemaName(), event.getMetaData());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/spi/RuleMetaDataNotifier.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/spi/RuleMetaDataNotifier.java
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.eventbus.event;
+package org.apache.shardingsphere.infra.metadata.schema.spi;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
+import org.apache.shardingsphere.infra.spi.type.TypedSPI;
 
 /**
- * Meta data event.
+ * Rule meta data notifier.
  */
-@RequiredArgsConstructor
-@Getter
-public final class MetaDataEvent {
+public interface RuleMetaDataNotifier extends TypedSPI {
     
-    private final String schemaName;
-    
-    private final RuleSchemaMetaData metaData;
+    /**
+     * Notify rule meta data changed.
+     * @param schemaName schema name
+     * @param metaData meta data
+     */
+    void notify(String schemaName, RuleSchemaMetaData metaData);
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/executor/PreparedStatementExecutor.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/executor/PreparedStatementExecutor.java
@@ -21,8 +21,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.context.SchemaContext;
 import org.apache.shardingsphere.infra.context.SchemaContexts;
 import org.apache.shardingsphere.infra.database.DefaultSchema;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.eventbus.event.MetaDataEvent;
 import org.apache.shardingsphere.infra.executor.kernel.InputGroup;
 import org.apache.shardingsphere.infra.executor.sql.ConnectionMode;
 import org.apache.shardingsphere.infra.executor.sql.QueryResult;
@@ -35,9 +33,13 @@ import org.apache.shardingsphere.infra.executor.sql.resourced.jdbc.queryresult.M
 import org.apache.shardingsphere.infra.executor.sql.resourced.jdbc.queryresult.StreamQueryResult;
 import org.apache.shardingsphere.infra.metadata.refresh.MetaDataRefreshStrategy;
 import org.apache.shardingsphere.infra.metadata.refresh.MetaDataRefreshStrategyFactory;
+import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaDataLoader;
+import org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataNotifier;
 import org.apache.shardingsphere.infra.rule.DataNodeRoutedRule;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.type.TypedSPIRegistry;
 import org.apache.shardingsphere.sql.parser.binder.statement.SQLStatementContext;
 
 import javax.sql.DataSource;
@@ -56,6 +58,10 @@ import java.util.stream.Collectors;
  */
 @RequiredArgsConstructor
 public final class PreparedStatementExecutor {
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleMetaDataNotifier.class);
+    }
     
     private final Map<String, DataSource> dataSourceMap;
     
@@ -172,7 +178,14 @@ public final class PreparedStatementExecutor {
             refreshStrategy.get().refreshMetaData(schemaContext.getSchema().getMetaData(), schemaContexts.getDatabaseType(),
                     dataSourceMap, sqlStatementContext, tableName -> metaDataLoader.load(schemaContexts.getDatabaseType(),
                             dataSourceMap, tableName, schemaContexts.getProps()));
-            ShardingSphereEventBus.getInstance().post(new MetaDataEvent(DefaultSchema.LOGIC_NAME, schemaContext.getSchema().getMetaData().getSchema()));
+            notifyPersistRuleMetaData(DefaultSchema.LOGIC_NAME, schemaContext.getSchema().getMetaData().getSchema());
+        }
+    }
+    
+    private void notifyPersistRuleMetaData(final String schemaName, final RuleSchemaMetaData metaData) {
+        RuleMetaDataNotifier notifier = TypedSPIRegistry.getRegisteredService(RuleMetaDataNotifier.class);
+        if (null != notifier) {
+            notifier.notify(schemaName, metaData);
         }
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/metadata/RuleSchemaMetaDataNotifier.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/metadata/RuleSchemaMetaDataNotifier.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.governance.internal.metadata;
+
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.event.persist.MetaDataPersistEvent;
+import org.apache.shardingsphere.infra.metadata.schema.RuleSchemaMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataNotifier;
+
+import java.util.Properties;
+
+/**
+ * Rule schema meta data notifier.
+ */
+public final class RuleSchemaMetaDataNotifier implements RuleMetaDataNotifier {
+    
+    @Override
+    public void notify(final String schemaName, final RuleSchemaMetaData metaData) {
+        ShardingSphereEventBus.getInstance().post(new MetaDataPersistEvent(schemaName, metaData));
+    }
+    
+    @Override
+    public String getType() {
+        return "metadata-notifier";
+    }
+    
+    @Override
+    public Properties getProps() {
+        return null;
+    }
+    
+    @Override
+    public void setProps(final Properties props) {
+    }
+}

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataNotifier
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.metadata.schema.spi.RuleMetaDataNotifier
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.driver.governance.internal.metadata.RuleSchemaMetaDataNotifier

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/JDBCDatabaseCommunicationEngine.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/JDBCDatabaseCommunicationEngine.java
@@ -21,8 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.config.exception.ShardingSphereConfigurationException;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.context.SchemaContext;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.eventbus.event.MetaDataEvent;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.event.persist.MetaDataPersistEvent;
 import org.apache.shardingsphere.infra.executor.sql.QueryResult;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.executor.sql.log.SQLLogger;
@@ -133,7 +133,7 @@ public final class JDBCDatabaseCommunicationEngine implements DatabaseCommunicat
         if (refreshStrategy.isPresent()) {
             refreshStrategy.get().refreshMetaData(schema.getSchema().getMetaData(), ProxySchemaContexts.getInstance().getSchemaContexts().getDatabaseType(),
                     schema.getSchema().getDataSources(), sqlStatementContext, this::loadTableMetaData);
-            ShardingSphereEventBus.getInstance().post(new MetaDataEvent(schema.getName(), schema.getSchema().getMetaData().getSchema()));
+            ShardingSphereEventBus.getInstance().post(new MetaDataPersistEvent(schema.getName(), schema.getSchema().getMetaData().getSchema()));
         }
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/RDLBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/RDLBackendHandler.java
@@ -22,10 +22,10 @@ import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.context.impl.StandardSchemaContexts;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.eventbus.event.DataSourceEvent;
-import org.apache.shardingsphere.infra.eventbus.event.RuleEvent;
-import org.apache.shardingsphere.infra.eventbus.event.SchemaNameEvent;
+import org.apache.shardingsphere.governance.core.eventbus.ShardingSphereEventBus;
+import org.apache.shardingsphere.governance.core.event.persist.DataSourcePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.RulePersistEvent;
+import org.apache.shardingsphere.governance.core.event.persist.SchemaNamePersistEvent;
 import org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapperEngine;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.BackendConnection;
 import org.apache.shardingsphere.proxy.backend.exception.DBCreateExistsException;
@@ -80,7 +80,7 @@ public final class RDLBackendHandler implements TextProtocolBackendHandler {
             return new ErrorResponse(new DBCreateExistsException(context.getSqlStatement().getDatabaseName()));
         }
         // TODO Need to get the executed feedback from registry center for returning.
-        ShardingSphereEventBus.getInstance().post(new SchemaNameEvent(context.getSqlStatement().getDatabaseName(), false));
+        ShardingSphereEventBus.getInstance().post(new SchemaNamePersistEvent(context.getSqlStatement().getDatabaseName(), false));
         UpdateResponse result = new UpdateResponse();
         result.setType("CREATE");
         return result;
@@ -91,7 +91,7 @@ public final class RDLBackendHandler implements TextProtocolBackendHandler {
             return new ErrorResponse(new DBCreateExistsException(context.getSqlStatement().getDatabaseName()));
         }
         // TODO Need to get the executed feedback from registry center for returning.
-        ShardingSphereEventBus.getInstance().post(new SchemaNameEvent(context.getSqlStatement().getDatabaseName(), true));
+        ShardingSphereEventBus.getInstance().post(new SchemaNamePersistEvent(context.getSqlStatement().getDatabaseName(), true));
         UpdateResponse result = new UpdateResponse();
         result.setType("DROP");
         return result;
@@ -102,7 +102,7 @@ public final class RDLBackendHandler implements TextProtocolBackendHandler {
         Map<String, DataSourceConfiguration> dataSources = DataSourceParameterConverter.getDataSourceConfigurationMap(
                 DataSourceParameterConverter.getDataSourceParameterMapFromYamlConfiguration(parameters));
         // TODO Need to get the executed feedback from registry center for returning.
-        ShardingSphereEventBus.getInstance().post(new DataSourceEvent(backendConnection.getSchema(), dataSources));
+        ShardingSphereEventBus.getInstance().post(new DataSourcePersistEvent(backendConnection.getSchema(), dataSources));
         UpdateResponse result = new UpdateResponse();
         result.setType("CREATE");
         return result;
@@ -112,7 +112,7 @@ public final class RDLBackendHandler implements TextProtocolBackendHandler {
         YamlShardingRuleConfiguration configurations = new CreateShardingRuleStatementContextConverter().convert(context);
         Collection<RuleConfiguration> rules = new YamlRuleConfigurationSwapperEngine().swapToRuleConfigurations(Collections.singleton(configurations));
         // TODO Need to get the executed feedback from registry center for returning.
-        ShardingSphereEventBus.getInstance().post(new RuleEvent(backendConnection.getSchema(), rules));
+        ShardingSphereEventBus.getInstance().post(new RulePersistEvent(backendConnection.getSchema(), rules));
         UpdateResponse result = new UpdateResponse();
         result.setType("CREATE");
         return result;


### PR DESCRIPTION
Fixes #7283.

refactor eventbus:
- move reventbut and event to governance module
- use SPI instead of event in jdbc-core
- rename 4 events to PersistEvent type
