### PR TITLE
Support oracle connect descriptor url

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
@@ -33,13 +33,13 @@ public final class OracleDataSourceMetaData implements DataSourceMetaData {
     
     private static final int DEFAULT_PORT = 1521;
     
-    private String hostName;
+    private final String hostName;
     
-    private int port;
+    private final int port;
     
-    private String catalog;
+    private final String catalog;
     
-    private String schema;
+    private final String schema;
     
     private final Pattern thinUrlPattern = Pattern.compile("jdbc:oracle:(thin|oci|kprb):@(//)?([\\w\\-\\.]+):?([0-9]*)[:/]([\\w\\-]+)", Pattern.CASE_INSENSITIVE);
     
@@ -49,23 +49,19 @@ public final class OracleDataSourceMetaData implements DataSourceMetaData {
     public OracleDataSourceMetaData(final String url, final String username) {
         Matcher matcher = thinUrlPattern.matcher(url);
         if (!matcher.find()) {
-            matchWithConnectDescriptorPattern(url, username);
+            matcher = connectDescriptorUrlPattern.matcher(url);
+            if (!matcher.find()) {
+                throw new UnrecognizedDatabaseURLException(url, connectDescriptorUrlPattern.pattern());
+            }
+            hostName = matcher.group(2);
+            port = Integer.parseInt(matcher.group(7));
+            catalog = matcher.group(8);
+            schema = username;
             return;
         }
         hostName = matcher.group(3);
         port = Strings.isNullOrEmpty(matcher.group(4)) ? DEFAULT_PORT : Integer.parseInt(matcher.group(4));
         catalog = matcher.group(5);
-        schema = username;
-    }
-    
-    private void matchWithConnectDescriptorPattern(final String url, final String username) {
-        Matcher matcher = connectDescriptorUrlPattern.matcher(url);
-        if (!matcher.find()) {
-            throw new UnrecognizedDatabaseURLException(url, connectDescriptorUrlPattern.pattern());
-        }
-        hostName = matcher.group(2);
-        port = Integer.parseInt(matcher.group(7));
-        catalog = matcher.group(8);
         schema = username;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
@@ -22,6 +22,9 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
 import org.apache.shardingsphere.infra.database.metadata.UnrecognizedDatabaseURLException;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +35,8 @@ import java.util.regex.Pattern;
 public final class OracleDataSourceMetaData implements DataSourceMetaData {
     
     private static final int DEFAULT_PORT = 1521;
+    
+    private static final int THIN_MATCH_GROUP_COUNT = 5;
     
     private final String hostName;
     
@@ -47,21 +52,23 @@ public final class OracleDataSourceMetaData implements DataSourceMetaData {
             + "((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}).*PORT\\s*=\\s*(\\d+).*SERVICE_NAME\\s*=\\s*(\\w+)\\)");
     
     public OracleDataSourceMetaData(final String url, final String username) {
-        Matcher matcher = thinUrlPattern.matcher(url);
-        if (!matcher.find()) {
-            matcher = connectDescriptorUrlPattern.matcher(url);
-            if (!matcher.find()) {
-                throw new UnrecognizedDatabaseURLException(url, connectDescriptorUrlPattern.pattern());
-            }
+        List<Matcher> matcherList = Arrays.asList(thinUrlPattern.matcher(url), connectDescriptorUrlPattern.matcher(url));
+        Optional<Matcher> matcherOptional = matcherList.stream().filter(matcher -> matcher.find()).findAny();
+        if (!matcherOptional.isPresent()) {
+            throw new UnrecognizedDatabaseURLException(url, thinUrlPattern.pattern());
+        }
+        Matcher matcher = matcherOptional.get();
+        int groupCount = matcher.groupCount();
+        if (groupCount == THIN_MATCH_GROUP_COUNT) {
+            hostName = matcher.group(3);
+            port = Strings.isNullOrEmpty(matcher.group(4)) ? DEFAULT_PORT : Integer.parseInt(matcher.group(4));
+            catalog = matcher.group(5);
+            schema = username;
+        } else {
             hostName = matcher.group(2);
             port = Integer.parseInt(matcher.group(7));
             catalog = matcher.group(8);
             schema = username;
-            return;
         }
-        hostName = matcher.group(3);
-        port = Strings.isNullOrEmpty(matcher.group(4)) ? DEFAULT_PORT : Integer.parseInt(matcher.group(4));
-        catalog = matcher.group(5);
-        schema = username;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaData.java
@@ -33,24 +33,39 @@ public final class OracleDataSourceMetaData implements DataSourceMetaData {
     
     private static final int DEFAULT_PORT = 1521;
     
-    private final String hostName;
+    private String hostName;
     
-    private final int port;
+    private int port;
     
-    private final String catalog;
+    private String catalog;
     
-    private final String schema;
+    private String schema;
     
-    private final Pattern pattern = Pattern.compile("jdbc:oracle:(thin|oci|kprb):@(//)?([\\w\\-\\.]+):?([0-9]*)[:/]([\\w\\-]+)", Pattern.CASE_INSENSITIVE);
+    private final Pattern thinUrlPattern = Pattern.compile("jdbc:oracle:(thin|oci|kprb):@(//)?([\\w\\-\\.]+):?([0-9]*)[:/]([\\w\\-]+)", Pattern.CASE_INSENSITIVE);
+    
+    private final Pattern connectDescriptorUrlPattern = Pattern.compile("jdbc:oracle:(thin|oci|kprb):@[(\\w\\s=)]+HOST\\s*=\\s*(\\d+(\\."
+            + "((2(5[0-5]|[0-4]\\d))|[0-1]?\\d{1,2})){3}).*PORT\\s*=\\s*(\\d+).*SERVICE_NAME\\s*=\\s*(\\w+)\\)");
     
     public OracleDataSourceMetaData(final String url, final String username) {
-        Matcher matcher = pattern.matcher(url);
+        Matcher matcher = thinUrlPattern.matcher(url);
         if (!matcher.find()) {
-            throw new UnrecognizedDatabaseURLException(url, pattern.pattern());
+            matchWithConnectDescriptorPattern(url, username);
+            return;
         }
         hostName = matcher.group(3);
         port = Strings.isNullOrEmpty(matcher.group(4)) ? DEFAULT_PORT : Integer.parseInt(matcher.group(4));
         catalog = matcher.group(5);
+        schema = username;
+    }
+    
+    private void matchWithConnectDescriptorPattern(final String url, final String username) {
+        Matcher matcher = connectDescriptorUrlPattern.matcher(url);
+        if (!matcher.find()) {
+            throw new UnrecognizedDatabaseURLException(url, connectDescriptorUrlPattern.pattern());
+        }
+        hostName = matcher.group(2);
+        port = Integer.parseInt(matcher.group(7));
+        catalog = matcher.group(8);
         schema = username;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/OracleDataSourceMetaDataTest.java
@@ -42,6 +42,17 @@ public final class OracleDataSourceMetaDataTest {
         assertThat(actual.getSchema(), is("test"));
     }
     
+    @Test
+    public void assertNewConstructorWithConnectDescriptorUrl() {
+        OracleDataSourceMetaData actual = new OracleDataSourceMetaData("jdbc:oracle:thin:@(DESCRIPTION =(ADDRESS = (PROTOCOL = TCP)(HOST = 172.16.0.12)(PORT = 1521))(ADDRESS = (PROTOCOL = TCP)"
+                + "(HOST = 172.16.0.22)(PORT = 1521))(LOAD_BALANCE = yes)(FAILOVER = ON)(CONNECT_DATA =(SERVER = DEDICATED)"
+                + "(SERVICE_NAME = rac)(FAILOVER_MODE=(TYPE = SELECT)(METHOD = BASIC)(RETIRES = 20)(DELAY = 15))))", "test");
+        assertThat(actual.getHostName(), is("172.16.0.12"));
+        assertThat(actual.getPort(), is(1521));
+        assertThat(actual.getCatalog(), is("rac"));
+        assertThat(actual.getSchema(), is("test"));
+    }
+    
     @Test(expected = UnrecognizedDatabaseURLException.class)
     public void assertNewConstructorFailure() {
         new OracleDataSourceMetaData("jdbc:oracle:xxxxxxxx", "test");


### PR DESCRIPTION
Fixes #7195 

Changes proposed in this pull request:
- support oracle rac (connect descriptor url style) see [detail](https://docs.oracle.com/en/database/oracle/oracle-database/18/netag/identifying-and-accessing-database.html#GUID-2BDF9E52-4147-4F46-84E2-A5AE1018A373)

