### PR TITLE
test cases added for MySQLErrPacketFactory

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -19,11 +19,13 @@ package org.apache.shardingsphere.proxy.frontend.mysql;
 
 import org.apache.shardingsphere.db.protocol.mysql.packet.generic.MySQLErrPacket;
 import org.apache.shardingsphere.proxy.backend.exception.DBCreateExistsException;
+import org.apache.shardingsphere.proxy.backend.exception.DBDropExistsException;
 import org.apache.shardingsphere.proxy.backend.exception.NoDatabaseSelectedException;
 import org.apache.shardingsphere.proxy.backend.exception.TableModifyInTransactionException;
 import org.apache.shardingsphere.proxy.backend.exception.UnknownDatabaseException;
 import org.apache.shardingsphere.proxy.backend.text.sctl.exception.InvalidShardingCTLFormatException;
 import org.apache.shardingsphere.proxy.backend.text.sctl.exception.UnsupportedShardingCTLTypeException;
+import org.apache.shardingsphere.sharding.route.engine.exception.TableExistsException;
 import org.junit.Test;
 
 import java.sql.SQLException;
@@ -124,5 +126,23 @@ public final class MySQLErrPacketFactoryTest {
         assertThat(actual.getErrorCode(), is(1007));
         assertThat(actual.getSqlState(), is("HY000"));
         assertThat(actual.getErrorMessage(), is("Can't create database 'No reason'; database exists"));
+    }
+    
+    @Test
+    public void assertNewInstanceWithDBDropExistsException() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new DBDropExistsException("No reason"));
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(1008));
+        assertThat(actual.getSqlState(), is("HY000"));
+        assertThat(actual.getErrorMessage(), is("Can't drop database 'No reason'; database doesn't exist"));
+    }
+    
+    @Test
+    public void assertNewInstanceWithTableExistsException() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new TableExistsException("table_name"));
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(1050));
+        assertThat(actual.getSqlState(), is("42S01"));
+        assertThat(actual.getErrorMessage(), is("Table 'table_name' already exists"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.frontend.mysql;
 
 import org.apache.shardingsphere.db.protocol.mysql.packet.generic.MySQLErrPacket;
+import org.apache.shardingsphere.proxy.backend.exception.DBCreateExistsException;
 import org.apache.shardingsphere.proxy.backend.exception.NoDatabaseSelectedException;
 import org.apache.shardingsphere.proxy.backend.exception.TableModifyInTransactionException;
 import org.apache.shardingsphere.proxy.backend.exception.UnknownDatabaseException;
@@ -114,5 +115,14 @@ public final class MySQLErrPacketFactoryTest {
         assertThat(actual.getErrorCode(), is(10002));
         assertThat(actual.getSqlState(), is("C10002"));
         assertThat(actual.getErrorMessage(), is("Unknown exception: [No reason]"));
+    }
+    
+    @Test
+    public void assertNewInstanceWithDBCreateExistsException() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new DBCreateExistsException("No reason"));
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(1007));
+        assertThat(actual.getSqlState(), is("HY000"));
+        assertThat(actual.getErrorMessage(), is("Can't create database 'No reason'; database exists"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -27,6 +27,8 @@ import org.apache.shardingsphere.proxy.backend.exception.TableModifyInTransactio
 import org.apache.shardingsphere.proxy.backend.exception.UnknownDatabaseException;
 import org.apache.shardingsphere.proxy.backend.text.sctl.exception.InvalidShardingCTLFormatException;
 import org.apache.shardingsphere.proxy.backend.text.sctl.exception.UnsupportedShardingCTLTypeException;
+import org.apache.shardingsphere.proxy.frontend.exception.UnsupportedCommandException;
+import org.apache.shardingsphere.proxy.frontend.exception.UnsupportedPreparedStatementException;
 import org.apache.shardingsphere.sharding.route.engine.exception.TableExistsException;
 import org.apache.shardingsphere.sql.parser.exception.SQLParsingException;
 import org.junit.Test;
@@ -166,6 +168,24 @@ public final class MySQLErrPacketFactoryTest {
     @Test
     public void assertNewInstanceWithSQLParsingException() {
         assertCommonException(MySQLErrPacketFactory.newInstance(new SQLParsingException("No reason")));
+    }
+    
+    @Test
+    public void assertNewInstanceWithUnsupportedCommandException() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new UnsupportedCommandException("No reason"));
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(10001));
+        assertThat(actual.getSqlState(), is("C10001"));
+        assertThat(actual.getErrorMessage(), is("Unsupported command: [No reason]"));
+    }
+    
+    @Test
+    public void assertNewInstanceWithUnsupportedPreparedStatementException() {
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new UnsupportedPreparedStatementException());
+        assertThat(actual.getSequenceId(), is(1));
+        assertThat(actual.getErrorCode(), is(1295));
+        assertThat(actual.getSqlState(), is("HY000"));
+        assertThat(actual.getErrorMessage(), is("This command is not supported in the prepared statement protocol yet"));
     }
     
     private void assertCommonException(final MySQLErrPacket actual) {

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -160,14 +160,12 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithShardingSphereConfigurationException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new ShardingSphereConfigurationException("No reason"));
-        assertCommonException(actual);
+        assertCommonException(MySQLErrPacketFactory.newInstance(1, new ShardingSphereConfigurationException("No reason")));
     }
     
     @Test
     public void assertNewInstanceWithSQLParsingException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new SQLParsingException("No reason"));
-        assertCommonException(actual);
+        assertCommonException(MySQLErrPacketFactory.newInstance(1, new SQLParsingException("No reason")));
     }
     
     private void assertCommonException(final MySQLErrPacket actual) {

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/MySQLErrPacketFactoryTest.java
@@ -124,7 +124,7 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithDBCreateExistsException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new DBCreateExistsException("No reason"));
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new DBCreateExistsException("No reason"));
         assertThat(actual.getSequenceId(), is(1));
         assertThat(actual.getErrorCode(), is(1007));
         assertThat(actual.getSqlState(), is("HY000"));
@@ -133,7 +133,7 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithDBDropExistsException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new DBDropExistsException("No reason"));
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new DBDropExistsException("No reason"));
         assertThat(actual.getSequenceId(), is(1));
         assertThat(actual.getErrorCode(), is(1008));
         assertThat(actual.getSqlState(), is("HY000"));
@@ -142,7 +142,7 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithTableExistsException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new TableExistsException("table_name"));
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new TableExistsException("table_name"));
         assertThat(actual.getSequenceId(), is(1));
         assertThat(actual.getErrorCode(), is(1050));
         assertThat(actual.getSqlState(), is("42S01"));
@@ -151,7 +151,7 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithCircuitBreakException() {
-        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(1, new CircuitBreakException());
+        MySQLErrPacket actual = MySQLErrPacketFactory.newInstance(new CircuitBreakException());
         assertThat(actual.getSequenceId(), is(1));
         assertThat(actual.getErrorCode(), is(10000));
         assertThat(actual.getSqlState(), is("C10000"));
@@ -160,12 +160,12 @@ public final class MySQLErrPacketFactoryTest {
     
     @Test
     public void assertNewInstanceWithShardingSphereConfigurationException() {
-        assertCommonException(MySQLErrPacketFactory.newInstance(1, new ShardingSphereConfigurationException("No reason")));
+        assertCommonException(MySQLErrPacketFactory.newInstance(new ShardingSphereConfigurationException("No reason")));
     }
     
     @Test
     public void assertNewInstanceWithSQLParsingException() {
-        assertCommonException(MySQLErrPacketFactory.newInstance(1, new SQLParsingException("No reason")));
+        assertCommonException(MySQLErrPacketFactory.newInstance(new SQLParsingException("No reason")));
     }
     
     private void assertCommonException(final MySQLErrPacket actual) {


### PR DESCRIPTION
Fixes #7483.

Changes proposed in this pull request:
-assertNewInstanceWithDBCreateExistsException
-assertNewInstanceWithDBDropExistsException
-assertNewInstanceWithTableExistsException
-assertNewInstanceWithCircuitBreakException
-assertNewInstanceWithShardingSphereConfigurationException
-assertNewInstanceWithSQLParsingException
-assertNewInstanceWithUnsupportedCommandException
-assertNewInstanceWithUnsupportedPreparedStatementException