### PR TITLE
fix problem：Statement setFetchDirection not supported #6661

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractStatementAdapter.java
@@ -39,6 +39,8 @@ public abstract class AbstractStatementAdapter extends AbstractUnsupportedOperat
     private boolean poolable;
     
     private int fetchSize;
+
+    private int fecthDirection;
     
     private final ForceExecuteTemplate<Statement> forceExecuteTemplate = new ForceExecuteTemplate<>();
     
@@ -82,6 +84,18 @@ public abstract class AbstractStatementAdapter extends AbstractUnsupportedOperat
         fetchSize = rows;
         recordMethodInvocation(targetClass, "setFetchSize", new Class[] {int.class}, new Object[] {rows});
         forceExecuteTemplate.execute((Collection) getRoutedStatements(), statement -> statement.setFetchSize(rows));
+    }
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return fecthDirection;
+    }
+
+    @Override
+    public void setFetchDirection(final int direction) throws SQLException {
+        this.fecthDirection = direction;
+        recordMethodInvocation(targetClass, "setFetchDirection", new Class[] {int.class}, new Object[] {direction});
+        forceExecuteTemplate.execute((Collection) getRoutedStatements(), statement -> statement.setFetchDirection(direction));
     }
     
     @SuppressWarnings("unchecked")

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationStatement.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationStatement.java
@@ -27,17 +27,7 @@ import java.sql.Statement;
  * Unsupported {@code Statement} methods.
  */
 public abstract class AbstractUnsupportedOperationStatement extends WrapperAdapter implements Statement {
-    
-    @Override
-    public final int getFetchDirection() throws SQLException {
-        throw new SQLFeatureNotSupportedException("getFetchDirection");
-    }
-    
-    @Override
-    public final void setFetchDirection(final int direction) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setFetchDirection");
-    }
-    
+
     @Override
     public final void addBatch(final String sql) throws SQLException {
         throw new SQLFeatureNotSupportedException("addBatch sql");

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
@@ -121,7 +121,26 @@ public final class StatementAdapterTest extends AbstractShardingSphereDataSource
             assertThat(each.getFetchSize(), is(fetchSize));
         }
     }
-    
+
+    @Test
+    public void assertSetFetchDirection() throws SQLException {
+        for (Statement each : statements.values()) {
+            each.setFetchDirection(ResultSet.FETCH_FORWARD);
+            each.executeQuery(sql);
+            assertFetchDirection((ShardingSphereStatement) each, ResultSet.FETCH_FORWARD);
+            each.setFetchDirection(ResultSet.FETCH_REVERSE);
+            assertFetchDirection((ShardingSphereStatement) each, ResultSet.FETCH_REVERSE);
+        }
+    }
+
+    private void assertFetchDirection(final ShardingSphereStatement actual, final int fetchDirection) throws SQLException {
+        assertThat(actual.getFetchDirection(), is(fetchDirection));
+        for (Statement each : actual.getRoutedStatements()) {
+            // H2,MySQL getFetchDirection() always return ResultSet.FETCH_FORWARD
+            assertThat(each.getFetchDirection(), is(ResultSet.FETCH_FORWARD));
+        }
+    }
+
     @Test
     public void assertSetEscapeProcessing() throws SQLException {
         for (Statement each : statements.values()) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
@@ -54,20 +54,6 @@ public final class UnsupportedOperationStatementTest extends AbstractShardingSph
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertGetFetchDirection() throws SQLException {
-        for (Statement each : statements) {
-            each.getFetchDirection();
-        }
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertSetFetchDirection() throws SQLException {
-        for (Statement each : statements) {
-            each.setFetchDirection(ResultSet.FETCH_UNKNOWN);
-        }
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertAddBatch() throws SQLException {
         for (Statement each : statements) {
             each.addBatch("");

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
@@ -23,7 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
@@ -52,7 +51,7 @@ public final class UnsupportedOperationStatementTest extends AbstractShardingSph
             each.close();
         }
     }
-    
+
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertAddBatch() throws SQLException {
         for (Statement each : statements) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/statement/CircuitBreakerStatement.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/statement/CircuitBreakerStatement.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.driver.governance.internal.circuit.connection.C
 
 import java.sql.Connection;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.SQLWarning;
 
 /**
@@ -97,7 +98,16 @@ public final class CircuitBreakerStatement extends AbstractUnsupportedOperationS
     public int getFetchSize() {
         return 0;
     }
-    
+
+    @Override
+    public int getFetchDirection() throws SQLException {
+        return ResultSet.FETCH_FORWARD;
+    }
+
+    @Override
+    public void setFetchDirection(final int direction) throws SQLException {
+    }
+
     @Override
     public int getResultSetConcurrency() {
         return ResultSet.CONCUR_READ_ONLY;


### PR DESCRIPTION
Fixes #6661 

Changes proposed in this pull request:
- **AbstractUnsupportedOperationStatement:** delete `getFetchDirection` and `setFetchDirection` method
- **AbstractStatementAdapter:**  add field `fecthDirection`; add the implementation of `getFetchDirection` and `setFetchDirection` method.
 The setting of the `setFetchDirection` are invalid for many DB drivers,such as MySQL,H2，`getFetchDirection` always return 1000. Instead of returning directly the `getFetchDirection` result of the first underlying Statement, I think adding a field  named `fecthDirection` is a better choice , which ensures that the getter and setter of `fetchDirection`are consistent in  ShardingSphere.
- **CircuitBreakerStatement:** add the implementation of `getFetchDirection` and `setFetchDirection` method.
- **UnsupportedOperationStatementTest:** delete `assertGetFetchDirection` and `assertSetFetchDirection`
- **StatementAdapterTest:** add the `assertSetFetchDirection` and `assertFetchDirection` method
This PR is to solve the problem in issue 6661.