### PR TITLE
fix mysql create table column character set parse error

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -588,7 +588,7 @@ collectionOptions
     ;
 
 characterSet_
-    : (CHARSET | CHAR SET) EQ_? ignoredIdentifier_
+    : (CHARSET | CHAR SET | CHARACTER SET) EQ_? ignoredIdentifier_
     ;
 
 collateClause_

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
@@ -1437,4 +1437,14 @@
             <column name="num" />
         </column-definition>
     </create-table>
+
+    <create-table sql-case-id="create_table_with_enum_and_character_set">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="INT" primary-key="true" start-index="22" stop-index="45">
+            <column name="order_id" />
+        </column-definition>
+        <column-definition type="ENUM" start-index="48" stop-index="87">
+            <column name="status" />
+        </column-definition>
+    </create-table>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
@@ -203,4 +203,5 @@
     <sql-case id="create_table_with_on_update_current_timestamp" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, create_time DATETIME DEFAULT CURRENT_TIMESTAMP, modify_time DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP)" db-types="MySQL" />
     <sql-case id="create_table_with_on_update_current_timestamp_and_fsp" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, create_time DATETIME DEFAULT CURRENT_TIMESTAMP, modify_time DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6))" db-types="MySQL" />
     <sql-case id="create_table_with_on_other_vendor_data_type" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, num MIDDLEINT(10))" db-types="MySQL" />
+    <sql-case id="create_table_with_enum_and_character_set" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, status ENUM('0', '1') CHARACTER SET UTF8)" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #7696.

Changes proposed in this pull request:
- fix mysql create table column character set parse error
