### PR TITLE
change mysql parser rule name from XXX_ to XXX

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -57,7 +57,7 @@ literals
     ;
 
 stringLiterals
-    : characterSetName_? STRING_ collateClause_?
+    : characterSetName? STRING_ collateClause?
     ;
 
 numberLiterals
@@ -70,11 +70,11 @@ dateTimeLiterals
     ;
 
 hexadecimalLiterals
-    : characterSetName_? HEX_DIGIT_ collateClause_?
+    : characterSetName? HEX_DIGIT_ collateClause?
     ;
 
 bitValueLiterals
-    : characterSetName_? BIT_NUM_ collateClause_?
+    : characterSetName? BIT_NUM_ collateClause?
     ;
 
 booleanLiterals
@@ -85,7 +85,7 @@ nullValueLiterals
     : NULL
     ;
 
-characterSetName_
+characterSetName
     : IDENTIFIER_
     ;
 
@@ -150,11 +150,21 @@ unreservedWord
     ;
 
 variable
-    : (AT_? AT_)? scope? DOT_? identifier
+    : (AT_? AT_)? scope? DOT_? internalVariableName
     ;
 
 scope
-    : GLOBAL | PERSIST | PERSIST_ONLY | SESSION | LOCAL | NEW
+    : GLOBAL | PERSIST | PERSIST_ONLY | SESSION | LOCAL
+    ;
+
+internalVariableName
+    : identifier
+    | DEFAULT DOT_ identifier
+    | identifier DOT_ identifier
+    ;
+
+setExprOrDefault
+    : expr | DEFAULT | ALL | BINARY | ROW | SYSTEM
     ;
 
 schemaName
@@ -317,14 +327,14 @@ expr
     : booleanPrimary
     | expr logicalOperator expr
     | expr XOR expr
-    | notOperator_ expr
+    | notOperator expr
     ;
 
 logicalOperator
     : OR | OR_ | AND | AND_
     ;
 
-notOperator_
+notOperator
     : NOT | NOT_
     ;
 
@@ -376,12 +386,12 @@ simpleExpr
     | simpleExpr COLLATE (STRING_ | identifier)
     | variable
     | simpleExpr OR_ simpleExpr
-    | (PLUS_ | MINUS_ | TILDE_ | notOperator_ | BINARY) simpleExpr
+    | (PLUS_ | MINUS_ | TILDE_ | notOperator | BINARY) simpleExpr
     | ROW? LP_ expr (COMMA_ expr)* RP_
     | EXISTS? subquery
     | LBE_ identifier expr RBE_
     | identifier (JSON_SEPARATOR | JSON_UNQUOTED_SEPARATOR) STRING_
-    | matchExpression_
+    | matchExpression
     | caseExpression
     | intervalExpression
     ;
@@ -391,7 +401,7 @@ functionCall
     ;
 
 aggregationFunction
-    : aggregationFunctionName LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? RP_ overClause_?
+    : aggregationFunctionName LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? RP_ overClause?
     ;
 
 aggregationFunctionName
@@ -402,37 +412,37 @@ distinct
     : DISTINCT
     ;
 
-overClause_
-    : OVER (LP_ windowSpecification_ RP_ | identifier)
+overClause
+    : OVER (LP_ windowSpecification RP_ | identifier)
     ;
 
-windowSpecification_
-    : identifier? partitionClause_? orderByClause? frameClause_?
+windowSpecification
+    : identifier? partitionClause? orderByClause? frameClause?
     ;
 
-partitionClause_
+partitionClause
     : PARTITION BY expr (COMMA_ expr)*
     ;
 
-frameClause_
-    : (ROWS | RANGE) (frameStart_ | frameBetween_)
+frameClause
+    : (ROWS | RANGE) (frameStart | frameBetween)
     ;
 
-frameStart_
+frameStart
     : CURRENT ROW | UNBOUNDED PRECEDING | UNBOUNDED FOLLOWING | expr PRECEDING | expr FOLLOWING
     ;
 
-frameEnd_
-    : frameStart_
+frameEnd
+    : frameStart
     ;
 
-frameBetween_
-    : BETWEEN frameStart_ AND frameEnd_
+frameBetween
+    : BETWEEN frameStart AND frameEnd
     ;
 
 specialFunction
     : groupConcatFunction | windowFunction | castFunction | convertFunction | positionFunction | substringFunction | extractFunction 
-    | charFunction | trimFunction_ | weightStringFunction | valuesFunction_ | currentUserFunction
+    | charFunction | trimFunction | weightStringFunction | valuesFunction | currentUserFunction
     ;
 
 currentUserFunction
@@ -444,7 +454,7 @@ groupConcatFunction
     ;
 
 windowFunction
-    : identifier LP_ expr (COMMA_ expr)* RP_ overClause_
+    : identifier LP_ expr (COMMA_ expr)* RP_ overClause
     ;
 
 castFunction
@@ -470,26 +480,26 @@ extractFunction
     ;
 
 charFunction
-    : CHAR LP_ expr (COMMA_ expr)* (USING ignoredIdentifier_)? RP_
+    : CHAR LP_ expr (COMMA_ expr)* (USING ignoredIdentifier)? RP_
     ;
 
-trimFunction_
+trimFunction
     : TRIM LP_ (LEADING | BOTH | TRAILING) STRING_ FROM STRING_ RP_
     ;
 
-valuesFunction_
+valuesFunction
     : VALUES LP_ columnName RP_
     ;
 
 weightStringFunction
-    : WEIGHT_STRING LP_ expr (AS dataType)? levelClause_? RP_
+    : WEIGHT_STRING LP_ expr (AS dataType)? levelClause? RP_
     ;
 
-levelClause_
-    : LEVEL (levelInWeightListElement_ (COMMA_ levelInWeightListElement_)* | NUMBER_ MINUS_ NUMBER_)
+levelClause
+    : LEVEL (levelInWeightListElement (COMMA_ levelInWeightListElement)* | NUMBER_ MINUS_ NUMBER_)
     ;
 
-levelInWeightListElement_
+levelInWeightListElement
     : NUMBER_ (ASC | DESC)? REVERSE?
     ;
 
@@ -503,26 +513,26 @@ shorthandRegularFunction
     ;
   
 completeRegularFunction
-    : regularFunctionName_ (LP_ (expr (COMMA_ expr)* | ASTERISK_)? RP_)
+    : regularFunctionName (LP_ (expr (COMMA_ expr)* | ASTERISK_)? RP_)
     ;
     
-regularFunctionName_
+regularFunctionName
     : IF | LOCALTIME | LOCALTIMESTAMP | REPLACE | INTERVAL | MOD
     | DATABASE | LEFT | RIGHT | DATE | DAY | GEOMCOLLECTION | GEOMETRYCOLLECTION
     | LINESTRING | MULTILINESTRING | MULTIPOINT | MULTIPOLYGON | POINT | POLYGON
     | TIME | TIMESTAMP | TIMESTAMPADD | TIMESTAMPDIFF | DATE | CURRENT_TIMESTAMP | identifier
     ;
 
-matchExpression_
-    : MATCH columnNames AGAINST LP_ expr matchSearchModifier_? RP_
+matchExpression
+    : MATCH columnNames AGAINST LP_ expr matchSearchModifier? RP_
     ;
 
-matchSearchModifier_
+matchSearchModifier
     : IN NATURAL LANGUAGE MODE | IN NATURAL LANGUAGE MODE WITH QUERY EXPANSION | IN BOOLEAN MODE | WITH QUERY EXPANSION
     ;
 
 caseExpression
-    : CASE simpleExpr? caseWhen_+ caseElse_? END
+    : CASE simpleExpr? caseWhen+ caseElse? END
     ;
 
 datetimeExpr
@@ -533,11 +543,11 @@ binaryLogFileIndexNumber
     : NUMBER_
     ;
 
-caseWhen_
+caseWhen
     : WHEN expr THEN expr
     ;
 
-caseElse_
+caseElse
     : ELSE expr
     ;
 
@@ -546,10 +556,10 @@ intervalExpression
     ;
     
 intervalValue
-    : expr intervalUnit_
+    : expr intervalUnit
     ;
 
-intervalUnit_
+intervalUnit
     : MICROSECOND | SECOND | MINUTE | HOUR | DAY | WEEK | MONTH
     | QUARTER | YEAR | SECOND_MICROSECOND | MINUTE_MICROSECOND | MINUTE_SECOND | HOUR_MICROSECOND | HOUR_SECOND
     | HOUR_MINUTE | DAY_MICROSECOND | DAY_SECOND | DAY_MINUTE | DAY_HOUR | YEAR_MONTH
@@ -568,7 +578,7 @@ orderByItem
     ;
 
 dataType
-    : dataTypeName dataTypeLength? characterSet_? collateClause_? (UNSIGNED | SIGNED)? ZEROFILL? | dataTypeName collectionOptions characterSet_? collateClause_?
+    : dataTypeName dataTypeLength? characterSet? collateClause? (UNSIGNED | SIGNED)? ZEROFILL? | dataTypeName collectionOptions characterSet? collateClause?
     ;
 
 dataTypeName
@@ -587,31 +597,31 @@ collectionOptions
     : LP_ STRING_ (COMMA_ STRING_)* RP_
     ;
 
-characterSet_
-    : (CHARSET | CHAR SET | CHARACTER SET) EQ_? ignoredIdentifier_
+characterSet
+    : (CHARSET | CHAR SET | CHARACTER SET) EQ_? ignoredIdentifier
     ;
 
-collateClause_
-    : COLLATE EQ_? (STRING_ | ignoredIdentifier_)
+collateClause
+    : COLLATE EQ_? (STRING_ | ignoredIdentifier)
     ;
 
-ignoredIdentifier_
+ignoredIdentifier
     : identifier (DOT_ identifier)?
     ;
 
 ignoredIdentifiers_
-    : ignoredIdentifier_ (COMMA_ ignoredIdentifier_)*
+    : ignoredIdentifier (COMMA_ ignoredIdentifier)*
     ;
 
 fieldOrVarSpec
     : LP_ (identifier (COMMA_ identifier)*)? RP_
     ;
 
-notExistClause_
+notExistClause
     : IF NOT EXISTS
     ;
 
-existClause_
+existClause
     : IF EXISTS
     ;
 
@@ -619,7 +629,7 @@ pattern
     : STRING_
     ;
 
-connectionId_
+connectionId
     : NUMBER_
     ;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -30,7 +30,7 @@ help
 explain
     : (DESC | DESCRIBE | EXPLAIN)
     (tableName (columnName | pattern)?
-    | explainType? (explainableStatement | FOR CONNECTION connectionId_)
+    | explainType? (explainableStatement | FOR CONNECTION connectionId)
     | ANALYZE select)
     ;
 
@@ -47,11 +47,11 @@ showTableStatus
     ;
 
 showColumns
-    : SHOW EXTENDED? FULL? (COLUMNS | FIELDS) fromTable fromSchema? (showColumnLike_ | showWhereClause_)?
+    : SHOW EXTENDED? FULL? (COLUMNS | FIELDS) fromTable fromSchema? (showColumnLike | showWhereClause)?
     ;
 
 showIndex
-    : SHOW EXTENDED? (INDEX | INDEXES | KEYS) fromTable fromSchema? showWhereClause_?
+    : SHOW EXTENDED? (INDEX | INDEXES | KEYS) fromTable fromSchema? showWhereClause?
     ;
 
 showCreateTable
@@ -74,16 +74,16 @@ showLike
     : LIKE stringLiterals
     ;
 
-showColumnLike_
+showColumnLike
     : LIKE stringLiterals
     ;
 
-showWhereClause_
+showWhereClause
     : WHERE expr
     ;
 
 showFilter
-    : showLike | showWhereClause_
+    : showLike | showWhereClause
     ;
 
 showProfileType
@@ -95,7 +95,7 @@ setVariable
     ;
 
 variableAssign
-    : variable EQ_ expr
+    : variable EQ_? setExprOrDefault
     ;
 
 showBinaryLogs
@@ -115,7 +115,7 @@ showCollation
     ;
 
 showCreateDatabase
-    : SHOW CREATE (DATABASE | SCHEMA) notExistClause_? schemaName
+    : SHOW CREATE (DATABASE | SCHEMA) notExistClause? schemaName
     ;
 
 showCreateEvent
@@ -235,18 +235,18 @@ showWarnings
     ;
 
 setCharacter
-    : SET (CHARACTER SET | CHARSET) (characterSetName_ | DEFAULT)
+    : SET (CHARACTER SET | CHARSET) (characterSetName | DEFAULT)
     ;
 
 setName
-    : SET NAMES (characterSetName_ (COLLATE collationName_)? | DEFAULT)
+    : SET NAMES (characterSetName (COLLATE collationName_)? | DEFAULT)
     ;
 
 clone
-    : CLONE cloneAction_
+    : CLONE cloneAction
     ;
 
-cloneAction_
+cloneAction
     : LOCAL DATA DIRECTORY EQ_? cloneDir SEMI_
     | INSTANCE FROM cloneInstance IDENTIFIED BY STRING_ (DATA DIRECTORY EQ_? cloneDir)? (REQUIRE NO? SSL)?
     ;
@@ -278,10 +278,10 @@ analyzeTable
     ;
 
 checkTable
-    : CHECK TABLE tableNames checkTableOption_
+    : CHECK TABLE tableNames checkTableOption
     ;
 
-checkTableOption_
+checkTableOption
     : FOR UPGRADE | QUICK | FAST | MEDIUM | EXTENDED | CHANGE
     ;
 
@@ -297,16 +297,16 @@ repairTable
     ;
 
 alterResourceGroup
-    : ALTER RESOURCE GROUP groupName (VCPU EQ_? vcpuSpec_ (COMMA_ vcpuSpec_)*)? (THREAD_PRIORITY EQ_? NUMBER_)?
+    : ALTER RESOURCE GROUP groupName (VCPU EQ_? vcpuSpec (COMMA_ vcpuSpec)*)? (THREAD_PRIORITY EQ_? NUMBER_)?
     (ENABLE | DISABLE FORCE?)?
     ;
 
-vcpuSpec_
+vcpuSpec
     : NUMBER_ | NUMBER_ MINUS_ NUMBER_
     ;
 
 createResourceGroup
-    : CREATE RESOURCE GROUP groupName TYPE EQ_ (SYSTEM | USER) (VCPU EQ_? vcpuSpec_ (COMMA_ vcpuSpec_)*)? 
+    : CREATE RESOURCE GROUP groupName TYPE EQ_ (SYSTEM | USER) (VCPU EQ_? vcpuSpec (COMMA_ vcpuSpec)*)?
     (THREAD_PRIORITY EQ_? NUMBER_)? (ENABLE | DISABLE )?
     ;
 
@@ -335,15 +335,15 @@ partitionList
     ;
 
 flush
-    : FLUSH (NO_WRITE_TO_BINLOG | LOCAL)? (flushOption_ (COMMA_ flushOption_)* | tablesOption_)
+    : FLUSH (NO_WRITE_TO_BINLOG | LOCAL)? (flushOption (COMMA_ flushOption)* | tablesOption)
     ;
 
-flushOption_
+flushOption
     : BINARY LOGS | ENGINE LOGS | ERROR LOGS | GENERAL LOGS | HOSTS | LOGS | PRIVILEGES | OPTIMIZER_COSTS
     | RELAY LOGS (FOR CHANNEL channelName)? | SLOW LOGS | STATUS | USER_RESOURCES 
     ;
 
-tablesOption_
+tablesOption
     : TABLES |TABLES tableName (COMMA_ tableName)* | TABLES WITH READ LOCK | TABLES tableName (COMMA_ tableName)* WITH READ LOCK
     | TABLES tableName (COMMA_ tableName)* FOR EXPORT
     ;
@@ -357,15 +357,15 @@ loadIndexInfo
     ;
 
 resetStatement
-    : RESET resetOption_ (COMMA_ resetOption_)*
+    : RESET resetOption (COMMA_ resetOption)*
     ;
 
-resetOption_
+resetOption
     : MASTER | SLAVE | QUERY CACHE
     ;
 
 resetPersist
-    : RESET PERSIST (existClause_? IDENTIFIER_)
+    : RESET PERSIST (existClause? IDENTIFIER_)
     ;
 
 restart

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
@@ -20,34 +20,34 @@ grammar DCLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule;
 
 grant
-    : GRANT (proxyClause_ | privilegeClause | roleClause_)
+    : GRANT (proxyClause | privilegeClause | roleClause)
     ;
 
 revoke
-    : REVOKE (proxyClause_ | privilegeClause | allClause_ | roleClause_)
+    : REVOKE (proxyClause | privilegeClause | allClause | roleClause)
     ;
 
-proxyClause_
-    : PROXY ON userOrRole TO userOrRoles_ withGrantOption_?
+proxyClause
+    : PROXY ON userOrRole TO userOrRoles withGrantOption?
     ;
 
 privilegeClause
-    : privileges_ ON onObjectClause (TO | FROM) userOrRoles_ withGrantOption_? grantOption_?
+    : privileges ON onObjectClause (TO | FROM) userOrRoles withGrantOption? grantOption?
     ;
 
-roleClause_
-    : roles_ ( TO| FROM) userOrRoles_ withGrantOption_?
+roleClause
+    : roles ( TO| FROM) userOrRoles withGrantOption?
     ;
 
-allClause_
-    : ALL PRIVILEGES? COMMA_ GRANT OPTION FROM userOrRoles_
+allClause
+    : ALL PRIVILEGES? COMMA_ GRANT OPTION FROM userOrRoles
     ;
 
-privileges_
-    : privilegeType_ columnNames? (COMMA_ privilegeType_ columnNames?)*
+privileges
+    : privilegeType columnNames? (COMMA_ privilegeType columnNames?)*
     ;
 
-privilegeType_
+privilegeType
     : ALL PRIVILEGES?
     | ALTER ROUTINE?
     | CREATE
@@ -84,10 +84,10 @@ privilegeType_
     ;
 
 onObjectClause
-    : objectType_? privilegeLevel
+    : objectType? privilegeLevel
     ;
 
-objectType_
+objectType
     : TABLE | FUNCTION | PROCEDURE
     ;
 
@@ -96,7 +96,7 @@ privilegeLevel
     ;
 
 createUser
-    : CREATE USER (IF NOT EXISTS)? userName userAuthOption_? (COMMA_ userName userAuthOption_?)*
+    : CREATE USER (IF NOT EXISTS)? userName userAuthOption? (COMMA_ userName userAuthOption?)*
     defaultRoleClause? requireClause? connectOption? accountLockPasswordExpireOptions?
     ;
 
@@ -105,11 +105,11 @@ defaultRoleClause
     ;
 
 requireClause
-    : REQUIRE (NONE | tlsOption_ (AND? tlsOption_)*)
+    : REQUIRE (NONE | tlsOption (AND? tlsOption)*)
     ;
 
 connectOption
-    : WITH resourceOption_ resourceOption_*
+    : WITH resourceOption resourceOption*
     ;
 
 accountLockPasswordExpireOptions
@@ -117,13 +117,13 @@ accountLockPasswordExpireOptions
     ;
 
 accountLockPasswordExpireOption
-    : passwordOption_ | lockOption_
+    : passwordOption | lockOption
     ;
 
 alterUser
-    : ALTER USER (IF EXISTS)? userName userAuthOption_? (COMMA_ userName userAuthOption_?)*
-    (REQUIRE (NONE | tlsOption_ (AND? tlsOption_)*))? (WITH resourceOption_ resourceOption_*)? (passwordOption_ | lockOption_)*
-    | ALTER USER (IF EXISTS)? USER LP_ RP_ userFuncAuthOption_
+    : ALTER USER (IF EXISTS)? userName userAuthOption? (COMMA_ userName userAuthOption?)*
+    (REQUIRE (NONE | tlsOption (AND? tlsOption)*))? (WITH resourceOption resourceOption*)? (passwordOption | lockOption)*
+    | ALTER USER (IF EXISTS)? USER LP_ RP_ userFuncAuthOption
     | ALTER USER (IF EXISTS)? userName DEFAULT ROLE (NONE | ALL | roleName (COMMA_ roleName)*)
     ;
 
@@ -148,54 +148,54 @@ setDefaultRole
     ;
 
 setRole
-    : SET ROLE (DEFAULT | NONE | ALL | ALL EXCEPT roles_ | roles_)
+    : SET ROLE (DEFAULT | NONE | ALL | ALL EXCEPT roles | roles)
     ;
 
 setPassword
-    : SET PASSWORD (FOR userName)? authOption_ (REPLACE STRING_)? (RETAIN CURRENT PASSWORD)?
+    : SET PASSWORD (FOR userName)? authOption (REPLACE STRING_)? (RETAIN CURRENT PASSWORD)?
     ;
 
-authOption_
+authOption
     : EQ_ stringLiterals | TO RANDOM
     ;
 
-withGrantOption_
+withGrantOption
     : WITH GRANT OPTION
     ;
 
-userOrRoles_
+userOrRoles
     : userOrRole (COMMA_ userOrRole)*
     ;
 
-roles_
+roles
     : roleName (COMMA_ roleName)*
     ;
 
-grantOption_
-    : AS userName (WITH ROLE DEFAULT | NONE | ALL | ALL EXCEPT roles_ | roles_ )?
+grantOption
+    : AS userName (WITH ROLE DEFAULT | NONE | ALL | ALL EXCEPT roles | roles )?
     ;
 
-userAuthOption_
-    : identifiedBy_
-    | identifiedWith_
+userAuthOption
+    : identifiedBy
+    | identifiedWith
     | DISCARD OLD PASSWORD
     ;
 
-identifiedBy_
+identifiedBy
     : IDENTIFIED BY (STRING_ | RANDOM PASSWORD) (REPLACE STRING_)? (RETAIN CURRENT PASSWORD)?
     ;
 
-identifiedWith_
+identifiedWith
     : IDENTIFIED WITH pluginName (BY |AS) (STRING_ | RANDOM PASSWORD)
       (REPLACE stringLiterals)? (RETAIN CURRENT PASSWORD)?
     ;
 
-lockOption_
+lockOption
     : ACCOUNT LOCK | ACCOUNT UNLOCK
     ;
 
 
-passwordOption_
+passwordOption
     : PASSWORD EXPIRE (DEFAULT | NEVER | INTERVAL NUMBER_ DAY)?
     | PASSWORD HISTORY (DEFAULT | NUMBER_)
     | PASSWORD REUSE INTERVAL (DEFAULT | NUMBER_ DAY)
@@ -204,17 +204,17 @@ passwordOption_
     | PASSWORD_LOCK_TIME (NUMBER_ | UNBOUNDED)
     ;
 
-resourceOption_
+resourceOption
     : MAX_QUERIES_PER_HOUR NUMBER_
     | MAX_UPDATES_PER_HOUR NUMBER_
     | MAX_CONNECTIONS_PER_HOUR NUMBER_
     | MAX_USER_CONNECTIONS NUMBER_
     ;
 
-tlsOption_
+tlsOption
     : SSL | X509 | CIPHER STRING_ | ISSUER STRING_ | SUBJECT STRING_
     ;
 
-userFuncAuthOption_
-    : identifiedBy_ | DISCARD OLD PASSWORD
+userFuncAuthOption
+    : identifiedBy | DISCARD OLD PASSWORD
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -20,11 +20,11 @@ grammar DDLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule, DMLStatement, DALStatement;
 
 createTable
-    : CREATE TEMPORARY? TABLE notExistClause_? tableName (createDefinitionClause? tableOptions_? partitionClause? duplicateAsQueryExpression? | createLikeClause)
+    : CREATE TEMPORARY? TABLE notExistClause? tableName (createDefinitionClause? tableOptions? partitionClause? duplicateAsQueryExpression? | createLikeClause)
     ;
 
 partitionClause
-    : PARTITION BY partitionTypeDef (PARTITIONS NUMBER_)? subPartitions? partitionDefinitions_?
+    : PARTITION BY partitionTypeDef (PARTITIONS NUMBER_)? subPartitions? partitionDefinitions?
     ;
 
 partitionTypeDef
@@ -54,13 +54,13 @@ partitionOptions
     ;
 
 partitionOption
-    : ADD PARTITION LP_ partitionDefinition_ RP_
+    : ADD PARTITION LP_ partitionDefinition RP_
     | DROP PARTITION partitionNames
     | DISCARD PARTITION (partitionNames | ALL) TABLESPACE
     | IMPORT PARTITION (partitionNames | ALL) TABLESPACE
     | TRUNCATE PARTITION (partitionNames | ALL)
     | COALESCE PARTITION NUMBER_
-    | REORGANIZE PARTITION partitionNames INTO LP_ partitionDefinitions_ RP_
+    | REORGANIZE PARTITION partitionNames INTO LP_ partitionDefinitions RP_
     | EXCHANGE PARTITION partitionName WITH TABLE tableName ((WITH | WITHOUT) VALIDATION)
     | ANALYZE PARTITION (partitionNames | ALL)
     | CHECK PARTITION (partitionNames | ALL)
@@ -76,7 +76,7 @@ partitionNames
     ;
 
 dropTable
-    : DROP dropTableSpecification_ TABLE existClause_? tableNames (RESTRICT | CASCADE)?
+    : DROP dropTableSpecification TABLE existClause? tableNames (RESTRICT | CASCADE)?
     ;
 
 dropIndex
@@ -97,12 +97,12 @@ truncateTable
     ;
 
 createIndex
-    : CREATE createIndexSpecification_ INDEX indexName indexType_? ON tableName keyParts_ indexOption_? 
+    : CREATE createIndexSpecification INDEX indexName indexType? ON tableName keyParts indexOption?
     (algorithmOption | lockOption)*
     ;
 
 createDatabase
-    : CREATE (DATABASE | SCHEMA) notExistClause_? schemaName createDatabaseSpecification_*
+    : CREATE (DATABASE | SCHEMA) notExistClause? schemaName createDatabaseSpecification_*
     ;
 
 alterDatabase
@@ -110,7 +110,7 @@ alterDatabase
     ;
 
 createDatabaseSpecification_
-    : DEFAULT? (CHARACTER SET | CHARSET) EQ_? characterSetName_
+    : DEFAULT? (CHARACTER SET | CHARSET) EQ_? characterSetName
     | DEFAULT? COLLATE EQ_? collationName_
     | DEFAULT? ENCRYPTION EQ_? y_or_n=STRING_
     ;
@@ -121,7 +121,7 @@ alterDatabaseSpecification_
     ;
 
 dropDatabase
-    : DROP (DATABASE | SCHEMA) existClause_? schemaName
+    : DROP (DATABASE | SCHEMA) existClause? schemaName
     ;
 
 alterInstance
@@ -140,8 +140,8 @@ channel
     ;
 
 createEvent
-    : CREATE ownerStatement? EVENT notExistClause_? eventName
-      ON SCHEDULE scheduleExpression_
+    : CREATE ownerStatement? EVENT notExistClause? eventName
+      ON SCHEDULE scheduleExpression
       (ON COMPLETION NOT? PRESERVE)? 
       (ENABLE | DISABLE | DISABLE ON SLAVE)?
       (COMMENT STRING_)?
@@ -150,7 +150,7 @@ createEvent
 
 alterEvent
     : ALTER ownerStatement? EVENT eventName
-      (ON SCHEDULE scheduleExpression_)?
+      (ON SCHEDULE scheduleExpression)?
       (ON COMPLETION NOT? PRESERVE)?
       (RENAME TO eventName)? (ENABLE | DISABLE | DISABLE ON SLAVE)?
       (COMMENT STRING_)?
@@ -158,53 +158,53 @@ alterEvent
     ;
 
 dropEvent
-    :  DROP EVENT existClause_? eventName
+    :  DROP EVENT existClause? eventName
     ;
 
 createFunction
     : CREATE ownerStatement?
       FUNCTION functionName LP_ (identifier dataType)? (COMMA_ identifier dataType)* RP_
       RETURNS dataType
-      routineOption_*
+      routineOption*
       routineBody
     ;
 
 alterFunction
-    : ALTER FUNCTION functionName routineOption_*
+    : ALTER FUNCTION functionName routineOption*
     ;
 
 dropFunction
-    : DROP FUNCTION existClause_? functionName
+    : DROP FUNCTION existClause? functionName
     ;
 
 createProcedure
     : CREATE ownerStatement?
-      PROCEDURE functionName LP_ procedureParameter_? (COMMA_ procedureParameter_)* RP_
-      routineOption_*
+      PROCEDURE functionName LP_ procedureParameter? (COMMA_ procedureParameter)* RP_
+      routineOption*
       routineBody
     ;
 
 alterProcedure
-    : ALTER PROCEDURE functionName routineOption_*
+    : ALTER PROCEDURE functionName routineOption*
     ;
 
 dropProcedure
-    : DROP PROCEDURE existClause_? functionName
+    : DROP PROCEDURE existClause? functionName
     ;
 
 createServer
     : CREATE SERVER serverName
       FOREIGN DATA WRAPPER wrapperName
-      OPTIONS LP_ serverOption_ (COMMA_ serverOption_)* RP_
+      OPTIONS LP_ serverOption (COMMA_ serverOption)* RP_
     ;
 
 alterServer
     : ALTER SERVER serverName OPTIONS
-      LP_ serverOption_ (COMMA_ serverOption_)* RP_
+      LP_ serverOption (COMMA_ serverOption)* RP_
     ;
 
 dropServer
-    : DROP SERVER existClause_? serverName
+    : DROP SERVER existClause? serverName
     ;
 
 createView
@@ -227,13 +227,13 @@ alterView
     ;
 
 dropView
-    : DROP VIEW existClause_? viewName (COMMA_ viewName)* (RESTRICT | CASCADE)?
+    : DROP VIEW existClause? viewName (COMMA_ viewName)* (RESTRICT | CASCADE)?
     ;
 
 createTablespaceInnodb
     : CREATE (UNDO)? TABLESPACE identifier
       ADD DATAFILE STRING_
-      (FILE_BLOCK_SIZE EQ_ fileSizeLiteral_)?
+      (FILE_BLOCK_SIZE EQ_ fileSizeLiteral)?
       (ENCRYPTION EQ_ y_or_n=STRING_)?
       (ENGINE EQ_? STRING_)?
     ;
@@ -242,10 +242,10 @@ createTablespaceNdb
     : CREATE ( UNDO )? TABLESPACE identifier
       ADD DATAFILE STRING_
       USE LOGFILE GROUP identifier
-      (EXTENT_SIZE EQ_? fileSizeLiteral_)?
-      (INITIAL_SIZE EQ_? fileSizeLiteral_)?
-      (AUTOEXTEND_SIZE EQ_? fileSizeLiteral_)?
-      (MAX_SIZE EQ_? fileSizeLiteral_)?
+      (EXTENT_SIZE EQ_? fileSizeLiteral)?
+      (INITIAL_SIZE EQ_? fileSizeLiteral)?
+      (AUTOEXTEND_SIZE EQ_? fileSizeLiteral)?
+      (MAX_SIZE EQ_? fileSizeLiteral)?
       (NODEGROUP EQ_? identifier)?
       WAIT?
       (COMMENT EQ_? STRING_)?
@@ -255,7 +255,7 @@ createTablespaceNdb
 alterTablespaceNdb
     : ALTER UNDO? TABLESPACE identifier
       (ADD | DROP) DATAFILE STRING_
-      (INITIAL_SIZE EQ_ fileSizeLiteral_)?
+      (INITIAL_SIZE EQ_ fileSizeLiteral)?
       WAIT? (RENAME TO identifier)?
       (ENGINE EQ_? identifier)?
     ;
@@ -274,9 +274,9 @@ dropTablespace
 createLogfileGroup
     : CREATE LOGFILE GROUP identifier
       ADD UNDOFILE STRING_
-      (INITIAL_SIZE EQ_? fileSizeLiteral_)?
-      (UNDO_BUFFER_SIZE EQ_? fileSizeLiteral_)?
-      (REDO_BUFFER_SIZE EQ_? fileSizeLiteral_)?
+      (INITIAL_SIZE EQ_? fileSizeLiteral)?
+      (UNDO_BUFFER_SIZE EQ_? fileSizeLiteral)?
+      (REDO_BUFFER_SIZE EQ_? fileSizeLiteral)?
       (NODEGROUP EQ_? identifier)?
       WAIT?
       (COMMENT EQ_? STRING_)?
@@ -286,7 +286,7 @@ createLogfileGroup
 alterLogfileGroup
     : ALTER LOGFILE GROUP identifier
       ADD UNDOFILE STRING_
-      (INITIAL_SIZE EQ_? fileSizeLiteral_)?
+      (INITIAL_SIZE EQ_? fileSizeLiteral)?
       WAIT? 
       (ENGINE EQ_? identifier)?
     ;
@@ -300,7 +300,7 @@ createTrigger
     ;
 
 dropTrigger
-    : DROP TRIGGER existClause_? (schemaName DOT_)? triggerName
+    : DROP TRIGGER existClause? (schemaName DOT_)? triggerName
     ;
 
 renameTable
@@ -312,7 +312,7 @@ createDefinitionClause
     ;
 
 createDefinition
-    : columnDefinition | indexDefinition_ | constraintDefinition | checkConstraintDefinition
+    : columnDefinition | indexDefinition | constraintDefinition | checkConstraintDefinition
     ;
 
 columnDefinition
@@ -334,60 +334,60 @@ generatedOption
     ;
 
 dataTypeGenericOption
-    : primaryKey | UNIQUE KEY? | NOT? NULL | collateClause_ | checkConstraintDefinition | referenceDefinition 
+    : primaryKey | UNIQUE KEY? | NOT? NULL | collateClause | checkConstraintDefinition | referenceDefinition
     | COMMENT STRING_ | ON UPDATE CURRENT_TIMESTAMP (LP_ NUMBER_ RP_)*
     ;
 
 checkConstraintDefinition
-    : (CONSTRAINT ignoredIdentifier_?)? CHECK LP_ expr RP_ (NOT? ENFORCED)?
+    : (CONSTRAINT ignoredIdentifier?)? CHECK LP_ expr RP_ (NOT? ENFORCED)?
     ;
 
 referenceDefinition
-    : REFERENCES tableName keyParts_ (MATCH FULL | MATCH PARTIAL | MATCH SIMPLE)? (ON (UPDATE | DELETE) referenceOption_)*
+    : REFERENCES tableName keyParts (MATCH FULL | MATCH PARTIAL | MATCH SIMPLE)? (ON (UPDATE | DELETE) referenceOption)*
     ;
 
-referenceOption_
+referenceOption
     : RESTRICT | CASCADE | SET NULL | NO ACTION | SET DEFAULT
     ;
 
-indexDefinition_
-    : (FULLTEXT | SPATIAL)? (INDEX | KEY)? indexName? indexType_? keyParts_ indexOption_*
+indexDefinition
+    : (FULLTEXT | SPATIAL)? (INDEX | KEY)? indexName? indexType? keyParts indexOption*
     ;
 
-indexType_
+indexType
     : USING (BTREE | HASH)
     ;
 
-keyParts_
-    : LP_ keyPart_ (COMMA_ keyPart_)* RP_
+keyParts
+    : LP_ keyPart (COMMA_ keyPart)* RP_
     ;
 
-keyPart_
+keyPart
     : (columnName (LP_ NUMBER_ RP_)? | expr) (ASC | DESC)?
     ;
 
-indexOption_
+indexOption
     : KEY_BLOCK_SIZE EQ_? NUMBER_ 
-    | indexType_ 
+    | indexType
     | WITH PARSER identifier 
     | COMMENT STRING_ 
     | (VISIBLE | INVISIBLE)
     ;
 
 constraintDefinition
-    : (CONSTRAINT ignoredIdentifier_?)? (primaryKeyOption | uniqueOption_ | foreignKeyOption)
+    : (CONSTRAINT ignoredIdentifier?)? (primaryKeyOption | uniqueOption | foreignKeyOption)
     ;
 
 primaryKeyOption
-    : primaryKey indexType_? keyParts_ indexOption_*
+    : primaryKey indexType? keyParts indexOption*
     ;
 
 primaryKey
     : PRIMARY? KEY
     ;
 
-uniqueOption_
-    : UNIQUE (INDEX | KEY)? indexName? indexType_? keyParts_ indexOption_*
+uniqueOption
+    : UNIQUE (INDEX | KEY)? indexName? indexType? keyParts indexOption*
     ;
 
 foreignKeyOption
@@ -398,7 +398,7 @@ createLikeClause
     : LP_? LIKE tableName RP_?
     ;
 
-createIndexSpecification_
+createIndexSpecification
     : (UNIQUE | FULLTEXT | SPATIAL)?
     ;
 
@@ -407,26 +407,26 @@ alterDefinitionClause
     ;
 
 alterSpecification
-    : tableOptions_
+    : tableOptions
     | addColumnSpecification
     | addIndexSpecification
     | addConstraintSpecification
     | ADD checkConstraintDefinition
-    | DROP CHECK ignoredIdentifier_
-    | ALTER CHECK ignoredIdentifier_ NOT? ENFORCED
+    | DROP CHECK ignoredIdentifier
+    | ALTER CHECK ignoredIdentifier NOT? ENFORCED
     | ALGORITHM EQ_? (DEFAULT | INSTANT | INPLACE | COPY)
     | ALTER COLUMN? columnName (SET DEFAULT expr | DROP DEFAULT)
     | ALTER INDEX indexName (VISIBLE | INVISIBLE)
     | changeColumnSpecification
     | modifyColumnSpecification
-    | DEFAULT? characterSet_ collateClause_?
-    | CONVERT TO characterSet_ collateClause_?
+    | DEFAULT? characterSet collateClause?
+    | CONVERT TO characterSet collateClause?
     | (DISABLE | ENABLE) KEYS
     | (DISCARD | IMPORT) TABLESPACE
     | dropColumnSpecification
     | dropIndexSpecification
     | dropPrimaryKeySpecification
-    | DROP FOREIGN KEY ignoredIdentifier_
+    | DROP FOREIGN KEY ignoredIdentifier
     | FORCE
     | lockOption
     // TODO investigate ORDER BY col_name [, col_name] ...
@@ -435,14 +435,14 @@ alterSpecification
     | renameIndexSpecification
     | renameTableSpecification
     | (WITHOUT | WITH) VALIDATION
-    | ADD PARTITION LP_ partitionDefinition_ RP_
+    | ADD PARTITION LP_ partitionDefinition RP_
     | DROP PARTITION ignoredIdentifiers_
     | DISCARD PARTITION (ignoredIdentifiers_ | ALL) TABLESPACE
     | IMPORT PARTITION (ignoredIdentifiers_ | ALL) TABLESPACE
     | TRUNCATE PARTITION (ignoredIdentifiers_ | ALL)
     | COALESCE PARTITION NUMBER_
-    | REORGANIZE PARTITION ignoredIdentifiers_ INTO partitionDefinitions_
-    | EXCHANGE PARTITION ignoredIdentifier_ WITH TABLE tableName ((WITH | WITHOUT) VALIDATION)?
+    | REORGANIZE PARTITION ignoredIdentifiers_ INTO partitionDefinitions
+    | EXCHANGE PARTITION ignoredIdentifier WITH TABLE tableName ((WITH | WITHOUT) VALIDATION)?
     | ANALYZE PARTITION (ignoredIdentifiers_ | ALL)
     | CHECK PARTITION (ignoredIdentifiers_ | ALL)
     | OPTIMIZE PARTITION (ignoredIdentifiers_ | ALL)
@@ -452,14 +452,14 @@ alterSpecification
     | UPGRADE PARTITIONING
     ;
 
-tableOptions_
-    : tableOption_ (COMMA_? tableOption_)*
+tableOptions
+    : tableOption (COMMA_? tableOption)*
     ;
 
-tableOption_
+tableOption
     : AUTO_INCREMENT EQ_? NUMBER_
     | AVG_ROW_LENGTH EQ_? NUMBER_
-    | DEFAULT? (characterSet_ | collateClause_)
+    | DEFAULT? (characterSet | collateClause)
     | CHECKSUM EQ_? NUMBER_
     | COMMENT EQ_? STRING_
     | COMPRESSION EQ_? STRING_
@@ -467,7 +467,7 @@ tableOption_
     | (DATA | INDEX) DIRECTORY EQ_? STRING_
     | DELAY_KEY_WRITE EQ_? NUMBER_
     | ENCRYPTION EQ_? STRING_
-    | ENGINE EQ_? ignoredIdentifier_
+    | ENGINE EQ_? ignoredIdentifier
     | INSERT_METHOD EQ_? (NO | FIRST | LAST)
     | KEY_BLOCK_SIZE EQ_? NUMBER_
     | MAX_ROWS EQ_? NUMBER_
@@ -481,7 +481,7 @@ tableOption_
     | STATS_PERSISTENT EQ_? (DEFAULT | NUMBER_)
     | STATS_SAMPLE_PAGES EQ_? (NUMBER_ | DEFAULT)
     | TABLE_CHECKSUM EQ_ NUMBER_
-    | TABLESPACE ignoredIdentifier_ (STORAGE (DISK | MEMORY | DEFAULT))?
+    | TABLESPACE ignoredIdentifier (STORAGE (DISK | MEMORY | DEFAULT))?
     | UNION EQ_? LP_ tableName (COMMA_ tableName)* RP_
     ;
 
@@ -494,7 +494,7 @@ firstOrAfterColumn
     ;
 
 addIndexSpecification
-    : ADD indexDefinition_
+    : ADD indexDefinition
     ;
 
 addConstraintSpecification
@@ -534,26 +534,26 @@ renameTableSpecification
     : RENAME (TO | AS)? identifier
     ;
 
-partitionDefinitions_
-    : LP_ partitionDefinition_ (COMMA_ partitionDefinition_)* RP_
+partitionDefinitions
+    : LP_ partitionDefinition (COMMA_ partitionDefinition)* RP_
     ;
 
-partitionDefinition_
+partitionDefinition
     : PARTITION partitionName
-    (VALUES (LESS THAN partitionLessThanValue_ | IN LP_ partitionValueList_ RP_))?
-    partitionDefinitionOption_* 
-    (LP_ subpartitionDefinition_ (COMMA_ subpartitionDefinition_)* RP_)?
+    (VALUES (LESS THAN partitionLessThanValue | IN LP_ partitionValueList RP_))?
+    partitionDefinitionOption*
+    (LP_ subpartitionDefinition (COMMA_ subpartitionDefinition)* RP_)?
     ;
 
-partitionLessThanValue_
-    : LP_ (expr | partitionValueList_) RP_ | MAXVALUE
+partitionLessThanValue
+    : LP_ (expr | partitionValueList) RP_ | MAXVALUE
     ;
 
-partitionValueList_
+partitionValueList
     : expr (COMMA_ expr)*
     ;
 
-partitionDefinitionOption_
+partitionDefinitionOption
     : STORAGE? ENGINE EQ_? identifier
     | COMMENT EQ_? STRING_
     | DATA DIRECTORY EQ_? STRING_
@@ -563,11 +563,11 @@ partitionDefinitionOption_
     | TABLESPACE EQ_? identifier
     ;
 
-subpartitionDefinition_
-    : SUBPARTITION identifier partitionDefinitionOption_*
+subpartitionDefinition
+    : SUBPARTITION identifier partitionDefinitionOption*
     ;
 
-dropTableSpecification_
+dropTableSpecification
     : TEMPORARY?
     ;
 
@@ -575,7 +575,7 @@ ownerStatement
     : DEFINER EQ_ (userName | CURRENT_USER ( '(' ')')?)
     ;
 
-scheduleExpression_
+scheduleExpression
     : AT timestampValue (PLUS_ intervalExpression)*
     | EVERY intervalValue
       (STARTS timestampValue (PLUS_ intervalExpression)*)?
@@ -590,7 +590,7 @@ routineBody
     : simpleStatement | compoundStatement
     ;
 
-serverOption_
+serverOption
     : HOST STRING_
     | DATABASE STRING_
     | USER STRING_
@@ -600,7 +600,7 @@ serverOption_
     | PORT numberLiterals 
     ;
 
-routineOption_
+routineOption
     : COMMENT STRING_                                       
     | LANGUAGE SQL                                              
     | NOT? DETERMINISTIC                                          
@@ -608,11 +608,11 @@ routineOption_
     | SQL SECURITY (DEFINER | INVOKER)                    
     ;
 
-procedureParameter_
+procedureParameter
     : (IN | OUT | INOUT)? identifier dataType
     ;
 
-fileSizeLiteral_
+fileSizeLiteral
     : FILESIZE_LITERAL | numberLiterals
     ; 
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
@@ -20,51 +20,51 @@ grammar DMLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule;
 
 insert
-    : INSERT insertSpecification_ INTO? tableName partitionNames_? (insertValuesClause | setAssignmentsClause | insertSelectClause) onDuplicateKeyClause?
+    : INSERT insertSpecification INTO? tableName partitionNames? (insertValuesClause | setAssignmentsClause | insertSelectClause) onDuplicateKeyClause?
     ;
 
-insertSpecification_
+insertSpecification
     : (LOW_PRIORITY | DELAYED | HIGH_PRIORITY)? IGNORE?
     ;
 
 insertValuesClause
-    : columnNames? (VALUES | VALUE) (assignmentValues (COMMA_ assignmentValues)* | rowConstructorList) valueReference_?
+    : columnNames? (VALUES | VALUE) (assignmentValues (COMMA_ assignmentValues)* | rowConstructorList) valueReference?
     ;
 
 insertSelectClause
-    : valueReference_? columnNames? select
+    : valueReference? columnNames? select
     ;
 
 onDuplicateKeyClause
     : ON DUPLICATE KEY UPDATE assignment (COMMA_ assignment)*
     ;
 
-valueReference_
-    : AS alias derivedColumns_?
+valueReference
+    : AS alias derivedColumns?
     ;
 
-derivedColumns_
+derivedColumns
     : LP_ alias (COMMA_ alias)* RP_
     ;
 
 replace
-    : REPLACE replaceSpecification_? INTO? tableName partitionNames_? (replaceValuesClause | setAssignmentsClause | replaceSelectClause)
+    : REPLACE replaceSpecification? INTO? tableName partitionNames? (replaceValuesClause | setAssignmentsClause | replaceSelectClause)
     ;
 
-replaceSpecification_
+replaceSpecification
     : LOW_PRIORITY | DELAYED
     ;
 
 replaceValuesClause
-    : columnNames? (VALUES | VALUE) (assignmentValues (COMMA_ assignmentValues)* | rowConstructorList) valueReference_?
+    : columnNames? (VALUES | VALUE) (assignmentValues (COMMA_ assignmentValues)* | rowConstructorList) valueReference?
     ;
 
 replaceSelectClause
-    : valueReference_? columnNames? select
+    : valueReference? columnNames? select
     ;
 
 update
-    : withClause_? UPDATE updateSpecification_ tableReferences setAssignmentsClause whereClause? orderByClause? limitClause?
+    : withClause? UPDATE updateSpecification_ tableReferences setAssignmentsClause whereClause? orderByClause? limitClause?
     ;
 
 updateSpecification_
@@ -76,7 +76,7 @@ assignment
     ;
 
 setAssignmentsClause
-    : valueReference_? SET assignment (COMMA_ assignment)*
+    : valueReference? SET assignment (COMMA_ assignment)*
     ;
 
 assignmentValues
@@ -93,15 +93,15 @@ blobValue
     ;
 
 delete
-    : DELETE deleteSpecification_ (singleTableClause | multipleTablesClause) whereClause? orderByClause? limitClause?
+    : DELETE deleteSpecification (singleTableClause | multipleTablesClause) whereClause? orderByClause? limitClause?
     ;
 
-deleteSpecification_
+deleteSpecification
     : LOW_PRIORITY? QUICK? IGNORE?
     ;
 
 singleTableClause
-    : FROM tableName (AS? alias)? partitionNames_?
+    : FROM tableName (AS? alias)? partitionNames?
     ;
 
 multipleTablesClause
@@ -113,7 +113,7 @@ multipleTableNames
     ;
 
 select 
-    : withClause_? unionClause
+    : withClause? unionClause
     ;
 
 call
@@ -155,10 +155,10 @@ loadDataStatement
       (LOW_PRIORITY | CONCURRENT)? LOCAL? 
       INFILE STRING_
       (REPLACE | IGNORE)?
-      INTO TABLE tableName partitionNames_?
+      INTO TABLE tableName partitionNames?
       (CHARACTER SET identifier)?
-      ((FIELDS | COLUMNS) selectFieldsInto_+ )?
-      ( LINES selectLinesInto_+ )?
+      ((FIELDS | COLUMNS) selectFieldsInto+ )?
+      ( LINES selectLinesInto+ )?
       ( IGNORE numberLiterals (LINES | ROWS) )?
       fieldOrVarSpec?
       (setAssignmentsClause)?
@@ -193,12 +193,12 @@ rowConstructorList
     : ROW assignmentValues (COMMA_ ROW assignmentValues)*
     ;
 
-withClause_
-    : WITH RECURSIVE? cteClause_ (COMMA_ cteClause_)*
+withClause
+    : WITH RECURSIVE? cteClause (COMMA_ cteClause)*
     ;
 
-cteClause_
-    : ignoredIdentifier_ columnNames? AS subquery
+cteClause
+    : ignoredIdentifier columnNames? AS subquery
     ;
 
 unionClause
@@ -206,7 +206,7 @@ unionClause
     ;
 
 selectClause
-    : LP_? SELECT selectSpecification* projections selectIntoExpression_? fromClause? whereClause? groupByClause? havingClause? windowClause_? orderByClause? limitClause? selectIntoExpression_? lockClause? RP_?
+    : LP_? SELECT selectSpecification* projections selectIntoExpression? fromClause? whereClause? groupByClause? havingClause? windowClause? orderByClause? limitClause? selectIntoExpression? lockClause? RP_?
     ;
 
 selectSpecification
@@ -250,18 +250,18 @@ tableReference
     ;
 
 tableFactor
-    : tableName partitionNames_? (AS? alias)? indexHintList_? | subquery AS? alias columnNames? | LP_ tableReferences RP_
+    : tableName partitionNames? (AS? alias)? indexHintList? | subquery AS? alias columnNames? | LP_ tableReferences RP_
     ;
 
-partitionNames_ 
+partitionNames
     : PARTITION LP_ identifier (COMMA_ identifier)* RP_
     ;
 
-indexHintList_
-    : indexHint_ (COMMA_ indexHint_)*
+indexHintList
+    : indexHint (COMMA_ indexHint)*
     ;
 
-indexHint_
+indexHint
     : (USE | IGNORE | FORCE) (INDEX | KEY) (FOR (JOIN | ORDER BY | GROUP BY))? LP_ indexName (COMMA_ indexName)* RP_
     ;
 
@@ -299,29 +299,29 @@ limitOffset
     : numberLiterals | parameterMarker
     ;
 
-windowClause_
-    : WINDOW windowItem_ (COMMA_ windowItem_)*
+windowClause
+    : WINDOW windowItem (COMMA_ windowItem)*
     ;
 
-windowItem_
-    : ignoredIdentifier_ AS LP_ windowSpecification_ RP_
+windowItem
+    : ignoredIdentifier AS LP_ windowSpecification RP_
     ;
 
 subquery
     : LP_ unionClause RP_
     ;
 
-selectLinesInto_
+selectLinesInto
     : STARTING BY STRING_ | TERMINATED BY STRING_
     ;
 
-selectFieldsInto_
+selectFieldsInto
     : TERMINATED BY STRING_ | OPTIONALLY? ENCLOSED BY STRING_ | ESCAPED BY STRING_
     ;
 
-selectIntoExpression_
+selectIntoExpression
     : INTO variable (COMMA_ variable )* | INTO DUMPFILE STRING_
-    | (INTO OUTFILE STRING_ (CHARACTER SET IDENTIFIER_)?((FIELDS | COLUMNS) selectFieldsInto_+)? (LINES selectLinesInto_+)?)
+    | (INTO OUTFILE STRING_ (CHARACTER SET IDENTIFIER_)?((FIELDS | COLUMNS) selectFieldsInto+)? (LINES selectLinesInto+)?)
     ;
 
 lockClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/RLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/RLStatement.g4
@@ -20,19 +20,19 @@ grammar RLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule;
 
 changeMasterTo
-    : CHANGE MASTER TO masterDefs  channelOption_?
+    : CHANGE MASTER TO masterDefs  channelOption?
     ;
 
 changeReplicationFilter
-    : CHANGE REPLICATION FILTER filterDefs channelOption_?
+    : CHANGE REPLICATION FILTER filterDefs channelOption?
     ;
 
 startSlave
-    : START SLAVE threadTypes_? utilOption_? connectionOptions_ channelOption_?
+    : START SLAVE threadTypes? utilOption? connectionOptions channelOption?
     ;
 
 stopSlave
-    : STOP SLAVE threadTypes_ channelOption_*
+    : STOP SLAVE threadTypes channelOption*
     ;
 
 startGroupReplication
@@ -52,29 +52,29 @@ resetMaster
     ;
 
 resetSlave
-    : RESET SLAVE ALL? channelOption_?
+    : RESET SLAVE ALL? channelOption?
     ;
 
-threadTypes_
-    : threadType_+
+threadTypes
+    : threadType+
     ;
 
-threadType_
+threadType
     : IO_THREAD | SQL_THREAD
     ;
 
-utilOption_
+utilOption
     : UNTIL ((SQL_BEFORE_GTIDS | SQL_AFTER_GTIDS) EQ_ identifier
     | MASTER_LOG_FILE EQ_ identifier COMMA_ MASTER_LOG_POS EQ_ identifier
     | RELAY_LOG_FILE EQ_ identifier COMMA_ RELAY_LOG_POS  EQ_ identifier
     | SQL_AFTER_MTS_GAPS)
     ;
 
-connectionOptions_
+connectionOptions
     : (USER EQ_ identifier)? (PASSWORD EQ_ identifier)? (DEFAULT_AUTH EQ_ identifier)? (PLUGIN_DIR EQ_ identifier)?
     ;
 
-channelOption_
+channelOption
     : FOR CHANNEL identifier
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/TCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/TCLStatement.g4
@@ -20,16 +20,11 @@ grammar TCLStatement;
 import Symbol, Keyword, MySQLKeyword, Literals, BaseRule;
 
 setTransaction
-    : SET scope_? TRANSACTION transactionCharacteristic (COMMA_ transactionCharacteristic)*
+    : SET scope? TRANSACTION transactionCharacteristic (COMMA_ transactionCharacteristic)*
     ;
 
 setAutoCommit
-    : SET scope_? AUTOCOMMIT EQ_ autoCommitValue
-    ;
-
-scope_
-    : (GLOBAL | PERSIST | PERSIST_ONLY | SESSION)
-    | AT_ AT_ (GLOBAL | PERSIST | PERSIST_ONLY | SESSION) DOT_
+    : SET (AT_? AT_)? scope? DOT_? AUTOCOMMIT EQ_ autoCommitValue
     ;
 
 autoCommitValue
@@ -78,14 +73,14 @@ xa
     ;
 
 transactionCharacteristic
-   : ISOLATION LEVEL level_ | accessMode_ | WITH CONSISTENT SNAPSHOT
+   : ISOLATION LEVEL level | accessMode | WITH CONSISTENT SNAPSHOT
    ;
 
-level_
+level
    : REPEATABLE READ | READ COMMITTED | READ UNCOMMITTED | SERIALIZABLE
    ;
 
-accessMode_
+accessMode
    : READ (WRITE | ONLY)
    ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/MySQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/MySQLVisitor.java
@@ -47,7 +47,7 @@ import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.Identif
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.IndexNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.IntervalExpressionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.LiteralsContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.MatchExpression_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.MatchExpressionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.NullValueLiteralsContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.NumberLiteralsContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.OrderByClauseContext;
@@ -458,10 +458,10 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
         if (null != ctx.columnName()) {
             return visit(ctx.columnName());
         }
-        if (null != ctx.matchExpression_()) {
-            return visit(ctx.matchExpression_());
+        if (null != ctx.matchExpression()) {
+            return visit(ctx.matchExpression());
         }
-        if (null != ctx.notOperator_()) {
+        if (null != ctx.notOperator()) {
             ASTNode expression = visit(ctx.simpleExpr(0));
             if (expression instanceof ExistsSubqueryExpression) {
                 ((ExistsSubqueryExpression) expression).setNot(true);
@@ -647,7 +647,7 @@ public abstract class MySQLVisitor extends MySQLStatementBaseVisitor<ASTNode> {
     }
     
     @Override
-    public final ASTNode visitMatchExpression_(final MatchExpression_Context ctx) {
+    public final ASTNode visitMatchExpression(final MatchExpressionContext ctx) {
         visit(ctx.expr());
         String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
         return new CommonExpressionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), text);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDALVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDALVisitor.java
@@ -302,12 +302,12 @@ public final class MySQLDALVisitor extends MySQLVisitor implements DALVisitor {
     @Override
     public ASTNode visitSetName(final SetNameContext ctx) {
         MySQLSetStatement result = new MySQLSetStatement();
-        if (null != ctx.characterSetName_() || null != ctx.DEFAULT()) {
+        if (null != ctx.characterSetName() || null != ctx.DEFAULT()) {
             VariableAssignSegment characterSet = new VariableAssignSegment();
             VariableSegment variable = new VariableSegment();
             variable.setVariable("charset");
             characterSet.setVariable(variable);
-            String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.characterSetName_().getText();
+            String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.characterSetName().getText();
             characterSet.setAssignValue(assignValue);
         }
         if (null != ctx.collationName_()) {
@@ -327,7 +327,7 @@ public final class MySQLDALVisitor extends MySQLVisitor implements DALVisitor {
         VariableSegment variable = new VariableSegment();
         String variableName = (null != ctx.CHARSET()) ? ctx.CHARSET().getText() : "charset";
         variable.setVariable(variableName);
-        String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.characterSetName_().getText();
+        String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.characterSetName().getText();
         characterSet.setAssignValue(assignValue);
         return result;
     }
@@ -338,7 +338,7 @@ public final class MySQLDALVisitor extends MySQLVisitor implements DALVisitor {
         result.setStartIndex(ctx.start.getStartIndex());
         result.setStopIndex(ctx.stop.getStopIndex());
         result.setVariable((VariableSegment) visit(ctx.variable()));
-        result.setAssignValue(ctx.expr().getText());
+        result.setAssignValue(ctx.setExprOrDefault().getText());
         return result;
     }
     
@@ -350,10 +350,10 @@ public final class MySQLDALVisitor extends MySQLVisitor implements DALVisitor {
         if (null != ctx.scope()) {
             result.setScope(ctx.scope().getText());
         }
-        result.setVariable(ctx.identifier().getText());
+        result.setVariable(ctx.internalVariableName().getText());
         return result;
     }
-    
+
     @Override
     public ASTNode visitFromSchema(final FromSchemaContext ctx) {
         return new FromSchemaSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLDDLVisitor.java
@@ -70,9 +70,9 @@ import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.FlowCon
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ForeignKeyOptionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.GeneratedOptionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.IfStatementContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.IndexDefinition_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.KeyPart_Context;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.KeyParts_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.IndexDefinitionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.KeyPartContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.KeyPartsContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.LoopStatementContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ModifyColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ReferenceDefinitionContext;
@@ -201,7 +201,7 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
     public ASTNode visitCreateTable(final CreateTableContext ctx) {
         MySQLCreateTableStatement result = new MySQLCreateTableStatement();
         result.setTable((SimpleTableSegment) visit(ctx.tableName()));
-        result.setNotExisted(null != ctx.notExistClause_());
+        result.setNotExisted(null != ctx.notExistClause());
         if (null != ctx.createDefinitionClause()) {
             CollectionValue<CreateDefinitionSegment> createDefinitions = (CollectionValue<CreateDefinitionSegment>) visit(ctx.createDefinitionClause());
             for (CreateDefinitionSegment each : createDefinitions.getValue()) {
@@ -228,17 +228,17 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
             if (null != each.checkConstraintDefinition()) {
                 result.getValue().add((ConstraintDefinitionSegment) visit(each.checkConstraintDefinition()));
             }
-            if (null != each.indexDefinition_()) {
-                result.getValue().add((ConstraintDefinitionSegment) visit(each.indexDefinition_()));
+            if (null != each.indexDefinition()) {
+                result.getValue().add((ConstraintDefinitionSegment) visit(each.indexDefinition()));
             }
         }
         return result;
     }
     
     @Override
-    public ASTNode visitIndexDefinition_(final IndexDefinition_Context ctx) {
+    public ASTNode visitIndexDefinition(final IndexDefinitionContext ctx) {
         ConstraintDefinitionSegment result = new ConstraintDefinitionSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex());
-        CollectionValue<ColumnSegment> columnSegments = (CollectionValue<ColumnSegment>) visit(ctx.keyParts_());
+        CollectionValue<ColumnSegment> columnSegments = (CollectionValue<ColumnSegment>) visit(ctx.keyParts());
         result.getIndexColumns().addAll(columnSegments.getValue());
         if (null != ctx.indexName()) {
             result.setIndexName((IndexSegment) visit(ctx.indexName()));
@@ -366,17 +366,17 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
     public ASTNode visitConstraintDefinition(final ConstraintDefinitionContext ctx) {
         ConstraintDefinitionSegment result = new ConstraintDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex());
         if (null != ctx.primaryKeyOption()) {
-            result.getPrimaryKeyColumns().addAll(((CollectionValue<ColumnSegment>) visit(ctx.primaryKeyOption().keyParts_())).getValue());
+            result.getPrimaryKeyColumns().addAll(((CollectionValue<ColumnSegment>) visit(ctx.primaryKeyOption().keyParts())).getValue());
         }
         if (null != ctx.foreignKeyOption()) {
             result.setReferencedTable((SimpleTableSegment) visit(ctx.foreignKeyOption()));
         }
-        if (null != ctx.uniqueOption_()) {
-            CollectionValue<ColumnSegment> columnSegments = (CollectionValue<ColumnSegment>) visit(ctx.uniqueOption_().keyParts_());
+        if (null != ctx.uniqueOption()) {
+            CollectionValue<ColumnSegment> columnSegments = (CollectionValue<ColumnSegment>) visit(ctx.uniqueOption().keyParts());
             result.getIndexColumns().addAll(columnSegments.getValue());
-            if (null != ctx.uniqueOption_().indexName()) {
-                result.setIndexName(new IndexSegment(ctx.uniqueOption_().indexName().start.getStartIndex(), ctx.uniqueOption_().indexName().stop.getStopIndex(),
-                        (IdentifierValue) visit(ctx.uniqueOption_().indexName())));
+            if (null != ctx.uniqueOption().indexName()) {
+                result.setIndexName(new IndexSegment(ctx.uniqueOption().indexName().start.getStartIndex(), ctx.uniqueOption().indexName().stop.getStopIndex(),
+                        (IdentifierValue) visit(ctx.uniqueOption().indexName())));
             }
         }
         return result;
@@ -480,10 +480,10 @@ public final class MySQLDDLVisitor extends MySQLVisitor implements DDLVisitor {
     }
     
     @Override
-    public ASTNode visitKeyParts_(final KeyParts_Context ctx) {
+    public ASTNode visitKeyParts(final KeyPartsContext ctx) {
         CollectionValue<ColumnSegment> result = new CollectionValue<>();
-        List<KeyPart_Context> keyParts = ctx.keyPart_();
-        for (KeyPart_Context each : keyParts) {
+        List<KeyPartContext> keyParts = ctx.keyPart();
+        for (KeyPartContext each : keyParts) {
             if (null != each.columnName()) {
                 result.getValue().add((ColumnSegment) visit(each.columnName()));
             }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLTCLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/impl/MySQLTCLVisitor.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.sql.parser.mysql.visitor.impl;
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.statement.TCLVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.TransactionCharacteristicContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.Scope_Context;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ScopeContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AutoCommitValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.BeginTransactionContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CommitContext;
@@ -45,8 +45,8 @@ public final class MySQLTCLVisitor extends MySQLVisitor implements TCLVisitor {
     @Override
     public ASTNode visitSetTransaction(final SetTransactionContext ctx) {
         MySQLSetTransactionStatement result = new MySQLSetTransactionStatement();
-        if (null != ctx.scope_()) {
-            Scope_Context scopeContext = ctx.scope_();
+        if (null != ctx.scope()) {
+            ScopeContext scopeContext = ctx.scope();
             if (null != scopeContext.GLOBAL()) {
                 result.setScope(scopeContext.GLOBAL().getText());
             } else if (null != scopeContext.SESSION()) {
@@ -55,11 +55,11 @@ public final class MySQLTCLVisitor extends MySQLVisitor implements TCLVisitor {
         }
         if (null != ctx.transactionCharacteristic()) {
             for (TransactionCharacteristicContext each : ctx.transactionCharacteristic()) {
-                if (null != each.level_()) {
-                    result.setIsolationLevel(each.level_().getText());
+                if (null != each.level()) {
+                    result.setIsolationLevel(each.level().getText());
                 }
-                if (null != each.accessMode_()) {
-                    result.setAccessMode(each.accessMode_().getText());
+                if (null != each.accessMode()) {
+                    result.setAccessMode(each.accessMode().getText());
                 }
             }
         }


### PR DESCRIPTION
### What is the purpose of the change
The SQL parser should be used by the user separately. If there is an attribute name in the ast with the_ ", unfriendly

### Changes in this pull request:
- change mysql parser rule name from XXX_ to XXX
- Merge scope_ And scope 

