### PR TITLE
enhance  DataSourceConnectionUrlUtil and add test case

### DIFF
--- a/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/main/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtil.java
+++ b/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/main/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtil.java
@@ -20,8 +20,7 @@ package org.apache.shardingsphere.rdl.parser.binder.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.*;
 import org.apache.shardingsphere.rdl.parser.statement.rdl.DataSourceConnectionSegment;
 
 /**
@@ -43,6 +42,12 @@ public final class DataSourceConnectionUrlUtil {
                 return getUrl(connectionSegment, new MySQLDatabaseType().getJdbcUrlPrefixes().iterator().next());
             case "PostgreSQL":
                 return getUrl(connectionSegment, new PostgreSQLDatabaseType().getJdbcUrlPrefixes().iterator().next());
+            case "MariaDB":
+                return getUrl(connectionSegment, new MariaDBDatabaseType().getJdbcUrlPrefixes().iterator().next());
+            case "Oracle":
+                return getUrl(connectionSegment, new OracleDatabaseType().getJdbcUrlPrefixes().iterator().next());
+            case "SQLServer":
+                return getUrl(connectionSegment, new SQLServerDatabaseType().getJdbcUrlPrefixes().iterator().next());
             default:
                 throw new UnsupportedOperationException(String.format("ShardingSphere can not get url from %s.", databaseType.getName()));
         }

--- a/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/main/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtil.java
+++ b/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/main/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtil.java
@@ -20,7 +20,12 @@ package org.apache.shardingsphere.rdl.parser.binder.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.*;
+
+import org.apache.shardingsphere.infra.database.type.dialect.MariaDBDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.OracleDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.SQLServerDatabaseType;
 import org.apache.shardingsphere.rdl.parser.statement.rdl.DataSourceConnectionSegment;
 
 /**

--- a/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/test/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtilTest.java
+++ b/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/test/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtilTest.java
@@ -17,7 +17,11 @@
 
 package org.apache.shardingsphere.rdl.parser.binder.util;
 
-import org.apache.shardingsphere.infra.database.type.dialect.*;
+import org.apache.shardingsphere.infra.database.type.dialect.MariaDBDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.OracleDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.SQLServerDatabaseType;
 import org.apache.shardingsphere.rdl.parser.statement.rdl.DataSourceConnectionSegment;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/test/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtilTest.java
+++ b/shardingsphere-rdl-parser/shardingsphere-rdl-parser-binder/src/test/java/org/apache/shardingsphere/rdl/parser/binder/util/DataSourceConnectionUrlUtilTest.java
@@ -17,8 +17,7 @@
 
 package org.apache.shardingsphere.rdl.parser.binder.util;
 
-import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.*;
 import org.apache.shardingsphere.rdl.parser.statement.rdl.DataSourceConnectionSegment;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +52,45 @@ public final class DataSourceConnectionUrlUtilTest {
         PostgreSQLDatabaseType databaseType = new PostgreSQLDatabaseType();
         String actual = DataSourceConnectionUrlUtil.getUrl(segment, databaseType);
         String expected = String.format("jdbc:postgresql://127.0.0.1:3306/test");
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void assertMariaDBGetUrl() {
+        DataSourceConnectionSegment segment = new DataSourceConnectionSegment();
+        segment.setHostName("127.0.0.1");
+        segment.setDb("test");
+        segment.setUser("root");
+        segment.setPort("3306");
+        MariaDBDatabaseType databaseType = new MariaDBDatabaseType();
+        String actual = DataSourceConnectionUrlUtil.getUrl(segment, databaseType);
+        String expected = String.format("jdbc:mariadb://127.0.0.1:3306/test");
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void assertOracleGetUrl() {
+        DataSourceConnectionSegment segment = new DataSourceConnectionSegment();
+        segment.setHostName("127.0.0.1");
+        segment.setDb("test");
+        segment.setUser("root");
+        segment.setPort("3306");
+        OracleDatabaseType databaseType = new OracleDatabaseType();
+        String actual = DataSourceConnectionUrlUtil.getUrl(segment, databaseType);
+        String expected = String.format("jdbc:oracle://127.0.0.1:3306/test");
+        assertThat(actual, is(expected));
+    }
+
+    @Test
+    public void assertSQLServerGetUrl() {
+        DataSourceConnectionSegment segment = new DataSourceConnectionSegment();
+        segment.setHostName("127.0.0.1");
+        segment.setDb("test");
+        segment.setUser("root");
+        segment.setPort("3306");
+        SQLServerDatabaseType databaseType = new SQLServerDatabaseType();
+        String actual = DataSourceConnectionUrlUtil.getUrl(segment, databaseType);
+        String expected = String.format("jdbc:microsoft:sqlserver://127.0.0.1:3306/test");
         assertThat(actual, is(expected));
     }
 }


### PR DESCRIPTION
Fixes #7849.

Changes proposed in this pull request:

enhance getUrl() method.
- add `switch case` for `Oracle`  in `DataSourceConnectionUrlUtil`.
- add `switch case` for `SQLServer `  in `DataSourceConnectionUrlUtil`.
- add `switch case` for `MariaDB `  in `DataSourceConnectionUrlUtil`.

add unit case.
- add unit case  for `Oracle` in `DataSourceConnectionUrlUtilTest `.
- add unit case  for `SQLServer` in `DataSourceConnectionUrlUtilTest `.
- add unit case  for `MariaDB` in `DataSourceConnectionUrlUtilTest `.