### PR TITLE
Optimize PostgreSQL g4 grammar, remove underline.

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -20,7 +20,7 @@ grammar BaseRule;
 import Keyword, PostgreSQLKeyword, Symbol, Literals;
 
 parameterMarker
-    : QUESTION_ literalsType_?
+    : QUESTION_ literalsType?
     ;
 
 reservedKeyword
@@ -104,22 +104,22 @@ reservedKeyword
     ;
 
 numberLiterals
-   : MINUS_? NUMBER_ literalsType_?
+   : MINUS_? NUMBER_ literalsType?
    ;
 
-literalsType_
+literalsType
     : TYPE_CAST_ IDENTIFIER_
     ;
 
 identifier
-    : unicodeEscapes_? IDENTIFIER_ uescape_? |  unreservedWord 
+    : unicodeEscapes? IDENTIFIER_ uescape? |  unreservedWord 
     ;
 
-unicodeEscapes_
+unicodeEscapes
     : ('U' | 'u') AMPERSAND_
     ;
 
-uescape_
+uescape
     : UESCAPE STRING_
     ;
     
@@ -1312,7 +1312,7 @@ selectWithParens
     ;
 
 dataType
-    : dataTypeName dataTypeLength? characterSet_? collateClause_? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet_? collateClause_?
+    : dataTypeName dataTypeLength? characterSet? collateClause_? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause_?
     ;
 
 dataTypeName
@@ -1326,20 +1326,20 @@ dataTypeLength
     : LP_ NUMBER_ (COMMA_ NUMBER_)? RP_
     ;
 
-characterSet_
-    : (CHARACTER | CHAR) SET EQ_? ignoredIdentifier_
+characterSet
+    : (CHARACTER | CHAR) SET EQ_? ignoredIdentifier
     ;
 
 collateClause_
-    : COLLATE EQ_? (STRING_ | ignoredIdentifier_)
+    : COLLATE EQ_? (STRING_ | ignoredIdentifier)
     ;
 
-ignoredIdentifier_
+ignoredIdentifier
     : identifier (DOT_ identifier)?
     ;
 
-ignoredIdentifiers_
-    : ignoredIdentifier_ (COMMA_ ignoredIdentifier_)*
+ignoredIdentifiers
+    : ignoredIdentifier (COMMA_ ignoredIdentifier)*
     ;
 
 signedIconst

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -1173,7 +1173,7 @@ tableFuncElement
     ;
 
 collateClause
-    : COLLATE anyName
+    : COLLATE EQ_? anyName
     ;
 
 anyName
@@ -1312,7 +1312,7 @@ selectWithParens
     ;
 
 dataType
-    : dataTypeName dataTypeLength? characterSet? collateClause_? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause_?
+    : dataTypeName dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
     ;
 
 dataTypeName
@@ -1328,10 +1328,6 @@ dataTypeLength
 
 characterSet
     : (CHARACTER | CHAR) SET EQ_? ignoredIdentifier
-    ;
-
-collateClause_
-    : COLLATE EQ_? (STRING_ | ignoredIdentifier)
     ;
 
 ignoredIdentifier

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -676,7 +676,50 @@ allOp
     ;
 
 op
-    : (AND_ | OR_ | NOT_ | TILDE_ | VERTICAL_BAR_ | AMPERSAND_ | SIGNED_LEFT_SHIFT_ | SIGNED_RIGHT_SHIFT_ | CARET_ | MOD_ | COLON_ | PLUS_ | MINUS_ | ASTERISK_ |   SLASH_ | BACKSLASH_ |   DOT_ | DOT_ASTERISK_ |  SAFE_EQ_ |   DEQ_ | EQ_ | CQ_ | NEQ_ | GT_ | GTE_ | LT_ | LTE_ | POUND_ | LP_ | RP_ | LBE_ | RBE_ | LBT_ | RBT_ | COMMA_ | DQ_ | SQ_ | BQ_ | QUESTION_ |   AT_ | SEMI_ | TILDE_TILDE_ |  NOT_TILDE_TILDE_ | TYPE_CAST_ )+
+    : (AND_
+    | OR_
+    | NOT_
+    | TILDE_
+    | VERTICAL_BAR_
+    | AMPERSAND_
+    | SIGNED_LEFT_SHIFT_
+    | SIGNED_RIGHT_SHIFT_
+    | CARET_
+    | MOD_
+    | COLON_
+    | PLUS_
+    | MINUS_
+    | ASTERISK_
+    | SLASH_
+    | BACKSLASH_
+    | DOT_
+    | DOT_ASTERISK_
+    | SAFE_EQ_
+    | DEQ_
+    | EQ_
+    | CQ_
+    | NEQ_
+    | GT_
+    | GTE_
+    | LT_
+    | LTE_
+    | POUND_
+    | LP_
+    | RP_
+    | LBE_
+    | RBE_
+    | LBT_
+    | RBT_
+    | COMMA_
+    | DQ_
+    | SQ_
+    | BQ_
+    | QUESTION_
+    | AT_
+    | SEMI_
+    | TILDE_TILDE_
+    | NOT_TILDE_TILDE_
+    | TYPE_CAST_ )+
     ;
 
 mathOperator

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DALStatement.g4
@@ -24,8 +24,8 @@ show
     ;
 
 set
-    : SET runtimeScope_?
-    (timeZoneClause_
+    : SET runtimeScope?
+    (timeZoneClause
     | configurationParameterClause
     | varName FROM CURRENT
     | TIME ZONE zoneValue
@@ -38,11 +38,11 @@ set
     | XML OPTION documentOrContent)
     ;
 
-runtimeScope_
+runtimeScope
     : SESSION | LOCAL
     ;
 
-timeZoneClause_
+timeZoneClause
     : TIME ZONE (numberLiterals | LOCAL | DEFAULT)
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
@@ -28,7 +28,7 @@ revoke
     ;
 
 privilegeClause
-    : privileges ON onObjectClause (FROM | TO) granteeList (WITH GRANT OPTION)?
+    : privilegeTypes ON onObjectClause (FROM | TO) granteeList (WITH GRANT OPTION)?
     ;
     
 roleClause
@@ -39,7 +39,7 @@ optionForClause
     : (GRANT | ADMIN) OPTION FOR
     ;
 
-privileges
+privilegeTypes
     : privilegeType columnNames? (COMMA_ privilegeType columnNames?)*
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
@@ -20,30 +20,30 @@ grammar DCLStatement;
 import Symbol, Keyword, PostgreSQLKeyword, Literals, BaseRule, DDLStatement;
 
 grant
-    : GRANT (privilegeClause | roleClause_)
+    : GRANT (privilegeClause | roleClause)
     ;
 
 revoke
-    : REVOKE optionForClause_? (privilegeClause | roleClause_) (CASCADE | RESTRICT)?
+    : REVOKE optionForClause? (privilegeClause | roleClause) (CASCADE | RESTRICT)?
     ;
 
 privilegeClause
-    : privileges_ ON onObjectClause (FROM | TO) granteeList (WITH GRANT OPTION)?
+    : privileges ON onObjectClause (FROM | TO) granteeList (WITH GRANT OPTION)?
     ;
     
-roleClause_
+roleClause
     : privilegeList (FROM | TO) roleList (WITH ADMIN OPTION)? (GRANTED BY roleSpec)?
     ;
 
-optionForClause_
+optionForClause
     : (GRANT | ADMIN) OPTION FOR
     ;
 
-privileges_
-    : privilegeType_ columnNames? (COMMA_ privilegeType_ columnNames?)*
+privileges
+    : privilegeType columnNames? (COMMA_ privilegeType columnNames?)*
     ;
 
-privilegeType_
+privilegeType
     : SELECT
     | INSERT
     | UPDATE

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -20,9 +20,9 @@ grammar DDLStatement;
 import Symbol, Keyword, PostgreSQLKeyword, Literals, BaseRule,DMLStatement;
 
 createTable
-    : CREATE createTableSpecification_ TABLE tableNotExistClause_? tableName
+    : CREATE createTableSpecification TABLE tableNotExistClause? tableName
       (createDefinitionClause | (OF anyName (LP_ typedTableElementList RP_)?) | (PARTITION OF qualifiedName (LP_ typedTableElementList RP_)? partitionBoundSpec))
-      inheritClause_ partitionSpec? tableAccessMethodClause? withOption? onCommitOption? tableSpace?
+      inheritClause partitionSpec? tableAccessMethodClause? withOption? onCommitOption? tableSpace?
       (AS select withData?)?
       (EXECUTE name executeParamClause withData?)?
     ;
@@ -88,7 +88,7 @@ accessMethod
     ;
 
 createIndex
-    : CREATE createIndexSpecification_ INDEX concurrentlyClause_ (indexNotExistClause_ indexName)? ON onlyClause_ tableName
+    : CREATE createIndexSpecification INDEX concurrentlyClause (indexNotExistClause indexName)? ON onlyClause tableName
       accessMethodClause? LP_ indexParams RP_ include? (WITH reloptions)? tableSpace? whereClause?
     ;
 
@@ -105,7 +105,7 @@ accessMethodClause
     ;
 
 createDatabase
-    : CREATE DATABASE name WITH? createDatabaseSpecification_*
+    : CREATE DATABASE name WITH? createDatabaseSpecification*
     ;
 
 createView
@@ -128,7 +128,7 @@ dropDatabase
     : DROP DATABASE (IF EXISTS)? name
     ;
 
-createDatabaseSpecification_
+createDatabaseSpecification
     :  createdbOptName EQ_? (signedIconst | booleanOrString | DEFAULT)
     ;
 
@@ -144,16 +144,16 @@ createdbOptName
 
 alterTable
     : ALTER TABLE
-    ( tableExistClause_ onlyClause_ tableNameClause alterDefinitionClause
+    ( tableExistClause onlyClause tableNameClause alterDefinitionClause
     | ALL IN TABLESPACE tableNameClause (OWNED BY roleList)? SET TABLESPACE name NOWAIT?)
     ;
 
 alterIndex
-    : ALTER INDEX (indexExistClause_ | ALL IN TABLESPACE) indexName alterIndexDefinitionClause_
+    : ALTER INDEX (indexExistClause | ALL IN TABLESPACE) indexName alterIndexDefinitionClause
     ;
 
 dropTable
-    : DROP TABLE tableExistClause_ tableNames dropTableOpt?
+    : DROP TABLE tableExistClause tableNames dropTableOpt?
     ;
 
 dropTableOpt
@@ -161,7 +161,7 @@ dropTableOpt
     ;
 
 dropIndex
-    : DROP INDEX concurrentlyClause_ indexExistClause_ indexNames dropIndexOpt?
+    : DROP INDEX concurrentlyClause indexExistClause indexNames dropIndexOpt?
     ;
 
 dropIndexOpt
@@ -169,7 +169,7 @@ dropIndexOpt
     ;
 
 truncateTable
-    : TRUNCATE TABLE? onlyClause_ tableNamesClause restartSeqs? dropTableOpt?
+    : TRUNCATE TABLE? onlyClause tableNamesClause restartSeqs? dropTableOpt?
     ;
 
 restartSeqs
@@ -177,11 +177,11 @@ restartSeqs
     | RESTART IDENTITY
     ;
 
-createTableSpecification_
+createTableSpecification
     : ((GLOBAL | LOCAL)? (TEMPORARY | TEMP) | UNLOGGED)?
     ;
 
-tableNotExistClause_
+tableNotExistClause
     : IF NOT EXISTS
     ;
 
@@ -284,7 +284,7 @@ exclusionConstraintElem
     | indexElem WITH OPERATOR LP_ anyOperator RP_
     ;
 
-inheritClause_
+inheritClause
     : (INHERITS tableNames)?
     ;
 
@@ -311,27 +311,27 @@ partStrategy
     | unreservedWord
     ;
 
-createIndexSpecification_
+createIndexSpecification
     : UNIQUE?
     ;
 
-concurrentlyClause_
+concurrentlyClause
     : CONCURRENTLY?
     ;
 
-indexNotExistClause_
+indexNotExistClause
     : (IF NOT EXISTS)?
     ;
 
-onlyClause_
+onlyClause
     : ONLY?
     ;
 
-tableExistClause_
+tableExistClause
     : (IF EXISTS)?
     ;
 
-asteriskClause_
+asteriskClause
     : ASTERISK_?
     ;
 
@@ -339,7 +339,7 @@ alterDefinitionClause
     : alterTableActions
     | renameColumnSpecification
     | renameConstraint
-    | renameTableSpecification_
+    | renameTableSpecification
     | SET SCHEMA name
     | partitionCmd
     ;
@@ -349,7 +349,7 @@ partitionCmd
     | DETACH PARTITION qualifiedName
     ;
 
-alterIndexDefinitionClause_
+alterIndexDefinitionClause
     : renameIndexSpecification | alterIndexDependsOnExtension | alterIndexSetTableSpace | alterTableCmds | indexPartitionCmd
     ;
 
@@ -388,7 +388,7 @@ alterTableAction
     | addConstraintSpecification
     | ALTER CONSTRAINT ignoredIdentifier_ constraintOptionalParam
     | VALIDATE CONSTRAINT ignoredIdentifier_
-    | DROP CONSTRAINT indexExistClause_ ignoredIdentifier_ (RESTRICT | CASCADE)?
+    | DROP CONSTRAINT indexExistClause ignoredIdentifier_ (RESTRICT | CASCADE)?
     | (DISABLE | ENABLE) TRIGGER (ignoredIdentifier_ | ALL | USER)?
     | ENABLE (REPLICA | ALWAYS) TRIGGER ignoredIdentifier_
     | (DISABLE | ENABLE) RULE ignoredIdentifier_
@@ -414,10 +414,10 @@ addColumnSpecification
     ;
 
 dropColumnSpecification
-    : DROP COLUMN? columnExistClause_ columnName (RESTRICT | CASCADE)?
+    : DROP COLUMN? columnExistClause columnName (RESTRICT | CASCADE)?
     ;
 
-columnExistClause_
+columnExistClause
     : (IF EXISTS)?
     ;
 
@@ -428,7 +428,7 @@ modifyColumnSpecification
     | modifyColumn (SET | DROP) NOT NULL
     | modifyColumn ADD GENERATED (ALWAYS | (BY DEFAULT)) AS IDENTITY (LP_ sequenceOptions RP_)?
     | modifyColumn alterColumnSetOption alterColumnSetOption*
-    | modifyColumn DROP IDENTITY columnExistClause_
+    | modifyColumn DROP IDENTITY columnExistClause
     | modifyColumn SET STATISTICS NUMBER_
     | modifyColumn SET LP_ attributeOptions RP_
     | modifyColumn RESET LP_ attributeOptions RP_
@@ -475,11 +475,11 @@ renameConstraint
     : RENAME CONSTRAINT ignoredIdentifier_ TO ignoredIdentifier_
     ;
 
-renameTableSpecification_
+renameTableSpecification
     : RENAME TO identifier
     ;
 
-indexExistClause_
+indexExistClause
     : (IF EXISTS)?
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -202,7 +202,7 @@ columnConstraint
     ;
 
 constraintClause
-    : CONSTRAINT ignoredIdentifier_
+    : CONSTRAINT ignoredIdentifier
     ;
 
 columnConstraintOption
@@ -242,7 +242,7 @@ sequenceOption
     ;
 
 indexParameters
-    : (USING INDEX TABLESPACE ignoredIdentifier_)?
+    : (USING INDEX TABLESPACE ignoredIdentifier)?
     | INCLUDE columnNames
     | WITH definition
     ;
@@ -267,7 +267,7 @@ tableConstraintOption
     : checkOption
     | UNIQUE columnNames indexParameters
     | primaryKey columnNames indexParameters
-    | EXCLUDE (USING ignoredIdentifier_)? LP_ exclusionConstraintList RP_ indexParameters exclusionWhereClause?
+    | EXCLUDE (USING ignoredIdentifier)? LP_ exclusionConstraintList RP_ indexParameters exclusionWhereClause?
     | FOREIGN KEY columnNames REFERENCES tableName columnNames? (MATCH FULL | MATCH PARTIAL | MATCH SIMPLE)? (ON (DELETE | UPDATE) action)*
     ;
 
@@ -362,11 +362,11 @@ renameIndexSpecification
     ;
 
 alterIndexDependsOnExtension
-    : DEPENDS ON EXTENSION ignoredIdentifier_
+    : DEPENDS ON EXTENSION ignoredIdentifier
     ;
 
 alterIndexSetTableSpace
-    : (OWNED BY ignoredIdentifiers_)? SET TABLESPACE name (NOWAIT)?
+    : (OWNED BY ignoredIdentifiers)? SET TABLESPACE name (NOWAIT)?
     ;
 
 tableNamesClause
@@ -386,18 +386,18 @@ alterTableAction
     | dropColumnSpecification
     | modifyColumnSpecification
     | addConstraintSpecification
-    | ALTER CONSTRAINT ignoredIdentifier_ constraintOptionalParam
-    | VALIDATE CONSTRAINT ignoredIdentifier_
-    | DROP CONSTRAINT indexExistClause ignoredIdentifier_ (RESTRICT | CASCADE)?
-    | (DISABLE | ENABLE) TRIGGER (ignoredIdentifier_ | ALL | USER)?
-    | ENABLE (REPLICA | ALWAYS) TRIGGER ignoredIdentifier_
-    | (DISABLE | ENABLE) RULE ignoredIdentifier_
-    | ENABLE (REPLICA | ALWAYS) RULE ignoredIdentifier_
+    | ALTER CONSTRAINT ignoredIdentifier constraintOptionalParam
+    | VALIDATE CONSTRAINT ignoredIdentifier
+    | DROP CONSTRAINT indexExistClause ignoredIdentifier (RESTRICT | CASCADE)?
+    | (DISABLE | ENABLE) TRIGGER (ignoredIdentifier | ALL | USER)?
+    | ENABLE (REPLICA | ALWAYS) TRIGGER ignoredIdentifier
+    | (DISABLE | ENABLE) RULE ignoredIdentifier
+    | ENABLE (REPLICA | ALWAYS) RULE ignoredIdentifier
     | (DISABLE | ENABLE | (NO? FORCE)) ROW LEVEL SECURITY
     | CLUSTER ON indexName
     | SET WITHOUT CLUSTER
     | SET (WITH | WITHOUT) OIDS
-    | SET TABLESPACE ignoredIdentifier_
+    | SET TABLESPACE ignoredIdentifier
     | SET (LOGGED | UNLOGGED)
     | SET LP_ storageParameterWithValue (COMMA_ storageParameterWithValue)* RP_
     | RESET LP_ storageParameter (COMMA_ storageParameter)* RP_
@@ -405,7 +405,7 @@ alterTableAction
     | NO INHERIT tableName
     | OF dataTypeName
     | NOT OF
-    | OWNER TO (ignoredIdentifier_ | CURRENT_USER | SESSION_USER)
+    | OWNER TO (ignoredIdentifier | CURRENT_USER | SESSION_USER)
     | REPLICA IDENTITY (DEFAULT | (USING INDEX indexName) | FULL | NOTHING)
     ;
 
@@ -456,7 +456,7 @@ addConstraintSpecification
     ;
 
 tableConstraintUsingIndex
-    : (CONSTRAINT ignoredIdentifier_)? (UNIQUE | primaryKey) USING INDEX indexName constraintOptionalParam
+    : (CONSTRAINT ignoredIdentifier)? (UNIQUE | primaryKey) USING INDEX indexName constraintOptionalParam
     ;
 
 storageParameterWithValue
@@ -472,7 +472,7 @@ renameColumnSpecification
     ;
 
 renameConstraint
-    : RENAME CONSTRAINT ignoredIdentifier_ TO ignoredIdentifier_
+    : RENAME CONSTRAINT ignoredIdentifier TO ignoredIdentifier
     ;
 
 renameTableSpecification
@@ -944,11 +944,11 @@ alterGroupClauses
     ;
 
 alterLanguage
-    : ALTER PROCEDURAL? LANGUAGE (colId RENAME TO colId | OWNER TO (ignoredIdentifier_ | CURRENT_USER | SESSION_USER))
+    : ALTER PROCEDURAL? LANGUAGE (colId RENAME TO colId | OWNER TO (ignoredIdentifier | CURRENT_USER | SESSION_USER))
     ;
 
 alterLargeObject
-    : ALTER LARGE OBJECT numericOnly OWNER TO (ignoredIdentifier_ | CURRENT_USER | SESSION_USER)
+    : ALTER LARGE OBJECT numericOnly OWNER TO (ignoredIdentifier | CURRENT_USER | SESSION_USER)
     ;
 
 alterMaterializedView

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -194,7 +194,7 @@ createDefinition
     ;
 
 columnDefinition
-    : columnName dataType collateClause_? columnConstraint*
+    : columnName dataType collateClause? columnConstraint*
     ;
 
 columnConstraint
@@ -422,7 +422,7 @@ columnExistClause
     ;
 
 modifyColumnSpecification
-    : modifyColumn (SET DATA)? TYPE dataType collateClause_? (USING aExpr)?
+    : modifyColumn (SET DATA)? TYPE dataType collateClause? (USING aExpr)?
     | modifyColumn SET DEFAULT aExpr
     | modifyColumn DROP DEFAULT
     | modifyColumn (SET | DROP) NOT NULL

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDALVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDALVisitor.java
@@ -51,8 +51,8 @@ public final class PostgreSQLDALVisitor extends PostgreSQLVisitor implements DAL
         Collection<VariableAssignSegment> variableAssigns = new LinkedList<>();
         if (null != ctx.configurationParameterClause()) {
             VariableAssignSegment variableAssignSegment = (VariableAssignSegment) visit(ctx.configurationParameterClause());
-            if (null != ctx.runtimeScope_()) {
-                variableAssignSegment.getVariable().setScope(ctx.runtimeScope_().getText());
+            if (null != ctx.runtimeScope()) {
+                variableAssignSegment.getVariable().setScope(ctx.runtimeScope().getText());
             }
             variableAssigns.add(variableAssignSegment);
             result.getVariableAssigns().addAll(variableAssigns);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDDLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/impl/PostgreSQLDDLVisitor.java
@@ -100,7 +100,7 @@ public final class PostgreSQLDDLVisitor extends PostgreSQLVisitor implements DDL
     public ASTNode visitCreateTable(final CreateTableContext ctx) {
         PostgreSQLCreateTableStatement result = new PostgreSQLCreateTableStatement();
         result.setTable((SimpleTableSegment) visit(ctx.tableName()));
-        result.setNotExisted(null != ctx.tableNotExistClause_());
+        result.setNotExisted(null != ctx.tableNotExistClause());
         if (null != ctx.createDefinitionClause()) {
             CollectionValue<CreateDefinitionSegment> createDefinitions = (CollectionValue<CreateDefinitionSegment>) visit(ctx.createDefinitionClause());
             for (CreateDefinitionSegment each : createDefinitions.getValue()) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/PostgreSQLParserParameterizedTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/PostgreSQLParserParameterizedTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sqlserver;
+package org.apache.shardingsphere.sql.parser.postgresql;
 
 import org.apache.shardingsphere.test.sql.parser.parameterized.engine.SQLParserParameterizedTest;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.sql.SQLCaseType;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/UnsupportedPostgreSQLParserParameterizedTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/UnsupportedPostgreSQLParserParameterizedTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sqlserver;
+package org.apache.shardingsphere.sql.parser.postgresql;
 
 import org.apache.shardingsphere.test.sql.parser.parameterized.engine.UnsupportedSQLParserParameterizedTest;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.sql.SQLCaseType;


### PR DESCRIPTION
For #7856 .

Changes proposed in this pull request:
- Optimize PostgreSQL DAL g4 grammar, remove underline.
- Optimize PostgreSQL DDL g4 grammar, remove underline.
- Optimize PostgreSQL DCL g4 grammar, remove underline.
- Optimize PostgreSQL BaseRule g4 grammar, remove underline.
