### PR TITLE
Fix parse problem in delete multi table statement and select into sta…

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
@@ -105,11 +105,7 @@ singleTableClause
     ;
 
 multipleTablesClause
-    : multipleTableNames FROM tableReferences | FROM multipleTableNames USING tableReferences
-    ;
-
-multipleTableNames
-    : tableIdentOptWild (COMMA_ tableIdentOptWild)*
+    : tableAliasRefList FROM tableReferences | FROM tableAliasRefList USING tableReferences
     ;
 
 select
@@ -374,5 +370,5 @@ tableIdentOptWild
     ;
 
 tableAliasRefList
-    : tableIdentOptWild+
+    : tableIdentOptWild (COMMA_ tableIdentOptWild)*
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DMLStatement.g4
@@ -105,11 +105,11 @@ singleTableClause
     ;
 
 multipleTablesClause
-    : tableAliasRefList FROM tableReferences | FROM tableAliasRefList USING tableReferences
+    : multipleTableNames FROM tableReferences | FROM multipleTableNames USING tableReferences
     ;
 
 multipleTableNames
-    : tableName DOT_ASTERISK_? (COMMA_ tableName DOT_ASTERISK_?)*
+    : tableIdentOptWild (COMMA_ tableIdentOptWild)*
     ;
 
 select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -1012,11 +1012,11 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
         DeleteMultiTableSegment result = new DeleteMultiTableSegment();
         TableSegment relateTableSource = (TableSegment) visit(ctx.tableReferences());
         result.setRelationTable(relateTableSource);
-        result.setActualDeleteTables(generateTablesFromTableMultipleTableNames(ctx.multipleTableNames()));
+        result.setActualDeleteTables(generateTablesFromTableAliasRefList(ctx.tableAliasRefList()));
         return result;
     }
     
-    private List<SimpleTableSegment> generateTablesFromTableMultipleTableNames(final MySQLStatementParser.MultipleTableNamesContext ctx) {
+    private List<SimpleTableSegment> generateTablesFromTableAliasRefList(final MySQLStatementParser.TableAliasRefListContext ctx) {
         List<SimpleTableSegment> result = new LinkedList<>();
         for (MySQLStatementParser.TableIdentOptWildContext each : ctx.tableIdentOptWild()) {
             result.add((SimpleTableSegment) visit(each.tableName()));

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
@@ -297,4 +297,51 @@
             </and-predicate>
         </where>
     </delete>
+
+    <delete sql-case-id="delete_multi_tables" parameters="1">
+        <where start-index="56" stop-index="124">
+            <and-predicate>
+                <predicate start-index="62" stop-index="101">
+                    <column-left-value name="order_id" start-index="62" stop-index="77">
+                        <owner name="t_order" start-index="62" stop-index="68"/>
+                    </column-left-value>
+                    <operator type="="/>
+                    <column-right-value name="order_id" start-index="62" stop-index="77">
+                        <owner name="t_order" start-index="62" stop-index="68"/>
+                    </column-right-value>
+                </predicate>
+                <predicate start-index="107" stop-index="124">
+                    <column-left-value name="status" start-index="107" stop-index="120">
+                        <owner name="t_order" start-index="107" stop-index="113"/>
+                    </column-left-value>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="124" stop-index="124"/>
+                        <literal-expression value="1" start-index="124" stop-index="124"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+        <table name="t_order" start-index="7" stop-index="13"/>
+        <table name="t_order_item" start-index="16" stop-index="27"/>
+    </delete>
+
+    <delete sql-case-id="delete_multi_tables_with_using" parameters="1">
+        <where start-index="115" stop-index="138">
+            <and-predicate>
+                <predicate start-index="121" stop-index="138">
+                    <column-left-value name="status" start-index="121" stop-index="134">
+                        <owner name="t_order" start-index="121" stop-index="127"/>
+                    </column-left-value>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="138" stop-index="138"/>
+                        <literal-expression value="1" start-index="138" stop-index="138"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+        <table name="t_order" start-index="12" stop-index="18"/>
+        <table name="t_order_item" start-index="21" stop-index="32"/>
+    </delete>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-into.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-into.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <select sql-case-id="select_into_before_from" parameters="1">
+        <from start-index="30" stop-index="36">
+            <simple-table name="t_order" start-index="30" stop-index="36"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="12">
+            <column-projection name="status" start-index="7" stop-index="12"/>
+        </projections>
+        <where start-index="38" stop-index="55">
+            <and-predicate>
+                <predicate start-index="44" stop-index="55">
+                    <column-left-value name="order_id" start-index="44" stop-index="51"/>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="55" stop-index="55"/>
+                        <literal-expression value="1" start-index="55" stop-index="55"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+    </select>
+
+    <select sql-case-id="select_into_after_from" parameters="1">
+        <from start-index="19" stop-index="25">
+            <simple-table name="t_order" start-index="19" stop-index="25"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="12">
+            <column-projection name="status" start-index="7" stop-index="12"/>
+        </projections>
+        <where start-index="27" stop-index="44">
+            <and-predicate>
+                <predicate start-index="33" stop-index="44">
+                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
+                        <literal-expression value="1" start-index="44" stop-index="44"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+    </select>
+
+    <select sql-case-id="select_into_multi_variable" parameters="1">
+        <from start-index="28" stop-index="34">
+            <simple-table name="t_order" start-index="28" stop-index="34"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="21">
+            <column-projection name="user_id" start-index="7" stop-index="13"/>
+            <column-projection name="status" start-index="16" stop-index="21"/>
+        </projections>
+        <where start-index="36" stop-index="53">
+            <and-predicate>
+                <predicate start-index="42" stop-index="53">
+                    <column-left-value name="order_id" start-index="42" stop-index="49"/>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="53" stop-index="53"/>
+                        <literal-expression value="1" start-index="53" stop-index="53"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+    </select>
+
+    <select sql-case-id="select_into_out_file" parameters="2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <limit start-index="22" stop-index="28">
+            <row-count value="2" parameter-index="0" start-index="28" stop-index="28"/>
+        </limit>
+    </select>
+
+    <select sql-case-id="select_into_out_file_with_charset" parameters="2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <limit start-index="22" stop-index="28">
+            <row-count value="2" parameter-index="0" start-index="28" stop-index="28"/>
+        </limit>
+    </select>
+
+    <select sql-case-id="select_into_out_file_with_fields" parameters="2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <limit start-index="22" stop-index="28">
+            <row-count value="2" parameter-index="0" start-index="28" stop-index="28"/>
+        </limit>
+    </select>
+
+    <select sql-case-id="select_into_out_file_with_fields_and_escaped" parameters="2">
+        <from start-index="28" stop-index="34">
+            <simple-table name="t_order" start-index="28" stop-index="34"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="21">
+            <column-projection name="user_id" start-index="7" stop-index="13"/>
+            <column-projection name="status" start-index="16" stop-index="21"/>
+        </projections>
+        <limit start-index="36" stop-index="42">
+            <row-count value="2" parameter-index="0" start-index="42" stop-index="42"/>
+        </limit>
+    </select>
+
+    <select sql-case-id="select_into_out_file_with_lines" parameters="2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <limit start-index="22" stop-index="28">
+            <row-count value="2" parameter-index="0" start-index="28" stop-index="28"/>
+        </limit>
+    </select>
+
+    <select sql-case-id="select_into_with_lock_after_into" parameters="1">
+        <from start-index="19" stop-index="25">
+            <simple-table name="t_order" start-index="19" stop-index="25"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="12">
+            <column-projection name="status" start-index="7" stop-index="12"/>
+        </projections>
+        <where start-index="27" stop-index="44">
+            <and-predicate>
+                <predicate start-index="33" stop-index="44">
+                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
+                        <literal-expression value="1" start-index="44" stop-index="44"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+    </select>
+
+    <select sql-case-id="select_into_with_lock_before_into" parameters="1">
+        <from start-index="19" stop-index="25">
+            <simple-table name="t_order" start-index="19" stop-index="25"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="12">
+            <column-projection name="status" start-index="7" stop-index="12"/>
+        </projections>
+        <where start-index="27" stop-index="44">
+            <and-predicate>
+                <predicate start-index="33" stop-index="44">
+                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
+                    <operator type="="/>
+                    <compare-right-value>
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
+                        <literal-expression value="1" start-index="44" stop-index="44"/>
+                    </compare-right-value>
+                </predicate>
+            </and-predicate>
+        </where>
+    </select>
+</sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/delete.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/delete.xml
@@ -30,4 +30,6 @@
     <sql-case id="delete_with_output_clause_column_shorthand" value="DELETE FROM t_order OUTPUT DELETED.* WHERE order_id = ?" db-types="SQLServer" />
     <sql-case id="delete_with_top" value="DELETE TOP(10) FROM t_order WHERE order_id = ?" db-types="SQLServer" />
     <sql-case id="delete_with_top_percent" value="DELETE TOP(10) PERCENT FROM t_order WHERE order_id = ?" db-types="SQLServer" />
+    <sql-case id="delete_multi_tables" value="DELETE t_order, t_order_item from t_order, t_order_item where t_order.order_id = t_order_item.order_id and t_order.status = ?" db-types="MySQL"/>
+    <sql-case id="delete_multi_tables_with_using" value="DELETE from t_order, t_order_item using t_order left join t_order_item on t_order.order_id = t_order_item.order_id where t_order.status = ?" db-types="MySQL"/>
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-into.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-into.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="select_into_before_from" value="SELECT status INTO @var1 FROM t_order WHERE order_id = ?" db-types="MySQL"/>
+    <sql-case id="select_into_after_from" value="SELECT status FROM t_order WHERE order_id = ? INTO @var1" db-types="MySQL"/>
+    <sql-case id="select_into_multi_variable" value="SELECT user_id, status FROM t_order WHERE order_id = ? INTO @var1, @var2" db-types="MySQL"/>
+    <sql-case id="select_into_out_file" value="SELECT * FROM t_order LIMIT ? INTO OUTFILE '/tmp/tmp.txt'" db-types="MySQL"/>
+    <sql-case id="select_into_out_file_with_charset" value="SELECT * FROM t_order LIMIT ? INTO OUTFILE '/tmp/tmp.txt' CHARACTER SET utf8" db-types="MySQL"/>
+    <sql-case id="select_into_out_file_with_fields" value="SELECT * FROM t_order LIMIT ? INTO OUTFILE '/tmp/tmp.txt'  FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '&quot;'" db-types="MySQL"/>
+    <sql-case id="select_into_out_file_with_fields_and_escaped" value="SELECT user_id, status FROM t_order LIMIT ? INTO OUTFILE '/tmp/tmp.txt'  FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '&quot;', ESCAPED BY '\'" db-types="MySQL"/>
+    <sql-case id="select_into_out_file_with_lines" value="SELECT * FROM t_order LIMIT ? INTO OUTFILE '/tmp/tmp.txt'  LINES TERMINATED BY '\n'" db-types="MySQL"/>
+    <sql-case id="select_into_with_lock_after_into" value="SELECT status FROM t_order WHERE order_id = ? INTO @var1 FOR UPDATE " db-types="MySQL" lock-clause="true"/>
+    <sql-case id="select_into_with_lock_before_into" value="SELECT status FROM t_order WHERE order_id = ? FOR UPDATE INTO @var1" db-types="MySQL" lock-clause="true"/>
+</sql-cases>


### PR DESCRIPTION
Fixes #7978.
* Fix parse problem in delete multi table statement and select into statement
  * Added missing logic for selectWithInto when visit select.
  * Added test cases for select-into statements; case 'select_into_out_file_with_fields_and_escaped' and 
    'select_into_with_lock_before_into' are supported in MySQL 8.0 but not in MySQL 5.7.
  * Table names should split with COMMA_ (',') in multipleTablesClause.
  * Added test cases for delete multi table statements.
