### PR TITLE
更新shardingsphere的maven坐标

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/usage/sharding/spring-boot-starter.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/usage/sharding/spring-boot-starter.cn.md
@@ -8,7 +8,7 @@ weight = 3
 ```xml
 <dependency>
     <groupId>org.apache.shardingsphere</groupId>
-    <artifactId>shardingsphere-jdbc-spring-boot-starter</artifactId>
+    <artifactId>sharding-jdbc-spring-boot-starter</artifactId>
     <version>${shardingsphere.version}</version>
 </dependency>
 ```


### PR DESCRIPTION
		<dependency>
			<groupId>org.apache.shardingsphere</groupId>
			<artifactId>sharding-jdbc-spring-boot-starter</artifactId>
			<version>${shardingsphere.version}</version>
		</dependency>
原有maven依赖为
<dependency>
    <groupId>org.apache.shardingsphere</groupId>
    <artifactId>shardingsphere-jdbc-spring-boot-starter</artifactId>
    <version>${shardingsphere.version}</version>
</dependency>

shardingsphere在maven仓库中是找不到的

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
