### PR TITLE
Add scope for shardingsphere-test in pom.xml

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/pom.xml
+++ b/shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/pom.xml
@@ -54,6 +54,7 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/pom.xml
@@ -117,6 +117,7 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
Fixes #8142 .

Changes proposed in this pull request:
-  Add `scope` for shardingsphere-test in `shardingsphere-governance/shardingsphere-governance-core/shardingsphere-governance-core-context/pom.xml`
-  Add `scope` for shardingsphere-test in `shardingsphere-proxy/shardingsphere-proxy-backend/pom.xml`
