### PR TITLE
Update the sub class ShardingCTLExplainBackendHandler of TextProtocolBackendHandler

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandler.java
@@ -38,6 +38,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -91,9 +92,9 @@ public final class ShardingCTLExplainBackendHandler implements TextProtocolBacke
     }
     
     @Override
-    public List<Object> getRowData() {
+    public Collection<Object> getRowData() {
         ExecutionUnit executionUnit = executionUnits.next();
-        List<Object> row = new ArrayList<>(queryHeaders.size());
+        Collection<Object> row = new ArrayList<>(queryHeaders.size());
         row.add(executionUnit.getDataSourceName());
         row.add(executionUnit.getSqlUnit().getSql());
         return row;

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -74,6 +75,6 @@ public final class ShardingCTLExplainBackendHandlerTest {
     public void assertGetRowData() {
         handler.execute();
         assertTrue(handler.next());
-        assertThat(handler.getRowData().get(1), is("select 1"));
+        assertThat(((List) handler.getRowData()).get(1), is("select 1"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
@@ -21,7 +21,6 @@ import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/sctl/explain/ShardingCTLExplainBackendHandlerTest.java
@@ -20,11 +20,13 @@ import org.junit.Test;
 import javax.sql.DataSource;
 import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -75,6 +77,8 @@ public final class ShardingCTLExplainBackendHandlerTest {
     public void assertGetRowData() {
         handler.execute();
         assertTrue(handler.next());
-        assertThat(((List) handler.getRowData()).get(1), is("select 1"));
+        Iterator<Object> iterator = handler.getRowData().iterator();
+        assertNull(iterator.next());
+        assertThat(iterator.next(), is("select 1"));
     }
 }


### PR DESCRIPTION
Update ShardingCTLExplainBackendHandler's getRowData() return value to Collection type.

For #8241-4.

Changes proposed in this pull request:
- Update ShardingCTLExplainBackendHandler's getRowData() return value to Collection type.
