### PR TITLE
Add ExpressionAssert for WhereClause, IdentifierValueAssert for ExpectedOwner and TableAssert for UpdateStatementAssert.

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/column/ColumnAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/column/ColumnAssert.java
@@ -20,16 +20,13 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.owner.OwnerAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
 
-import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -46,17 +43,13 @@ public final class ColumnAssert {
      * @param expected expected column
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnSegment actual, final ExpectedColumn expected) {
-        assertThat(assertContext.getText("Column name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getIdentifier(), expected, "Column");
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());
-            // TODO OwnerAssert is needed.
-            OwnerSegment owner = actual.getOwner().get();
-            TableAssert.assertOwner(assertContext, new SimpleTableSegment(owner.getStartIndex(), owner.getStopIndex(), owner.getIdentifier()), expected.getOwner());
+            OwnerAssert.assertIs(assertContext, actual.getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getOwner().isPresent());
         }
-        assertThat(assertContext.getText("Column start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Column end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
@@ -56,6 +56,7 @@ import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -73,9 +74,13 @@ public final class ExpressionAssert {
      */
     public static void assertParameterMarkerExpression(final SQLCaseAssertContext assertContext,
                                                         final ParameterMarkerExpressionSegment actual, final ExpectedParameterMarkerExpression expected) {
-        assertNotNull(assertContext.getText("Expected parameter marker expression should exist."), expected);
-        assertThat(assertContext.getText("Parameter marker index assertion error: "), actual.getParameterMarkerIndex(), is(expected.getValue()));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual parameter marker expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual parameter marker expression should exist."), actual);
+            assertThat(assertContext.getText("Parameter marker index assertion error: "), actual.getParameterMarkerIndex(), is(expected.getValue()));
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
     
     /**
@@ -87,9 +92,13 @@ public final class ExpressionAssert {
      */
     public static void assertLiteralExpression(final SQLCaseAssertContext assertContext,
                                                 final LiteralExpressionSegment actual, final ExpectedLiteralExpression expected) {
-        assertNotNull(assertContext.getText("Expected literal expression should exist."), expected);
-        assertThat(assertContext.getText("Literal assertion error: "), actual.getLiterals().toString(), is(expected.getValue()));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual literal expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual literal expression should exist."), actual);
+            assertThat(assertContext.getText("Literal assertion error: "), actual.getLiterals().toString(), is(expected.getValue()));
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
     
     /**
@@ -101,10 +110,14 @@ public final class ExpressionAssert {
      */
     public static void assertCommonExpression(final SQLCaseAssertContext assertContext,
                                                final ComplexExpressionSegment actual, final ExpectedCommonExpression expected) {
-        assertNotNull(assertContext.getText("Expected common expression should exist."), expected);
-        String expectedText = SQLCaseType.Literal == assertContext.getSqlCaseType() && null != expected.getLiteralText() ? expected.getLiteralText() : expected.getText();
-        assertThat(assertContext.getText("Common expression text assertion error: "), actual.getText(), is(expectedText));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual common expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual common expression should exist."), actual);
+            String expectedText = SQLCaseType.Literal == assertContext.getSqlCaseType() && null != expected.getLiteralText() ? expected.getLiteralText() : expected.getText();
+            assertThat(assertContext.getText("Common expression text assertion error: "), actual.getText(), is(expectedText));
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
     
     /**
@@ -115,8 +128,12 @@ public final class ExpressionAssert {
      * @param expected expected subquery expression
      */
     public static void assertSubqueryExpression(final SQLCaseAssertContext assertContext, final SubqueryExpressionSegment actual, final ExpectedSubquery expected) {
-        assertNotNull(assertContext.getText("Expected subquery expression should exist."), expected);
-        assertSubquery(assertContext, actual.getSubquery(), expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual subquery expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual subquery expression should exist."), actual);
+            assertSubquery(assertContext, actual.getSubquery(), expected);
+        }
     }
 
     /**
@@ -128,9 +145,13 @@ public final class ExpressionAssert {
      */
     public static void assertSubquery(final SQLCaseAssertContext assertContext,
                                       final SubquerySegment actual, final ExpectedSubquery expected) {
-        assertNotNull(assertContext.getText("Expected subquery should exist."), expected);
-        SelectStatementAssert.assertIs(assertContext, actual.getSelect(), expected.getSelectTestCases());
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual subquery should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual subquery should exist."), actual);
+            SelectStatementAssert.assertIs(assertContext, actual.getSelect(), expected.getSelectTestCases());
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**
@@ -142,11 +163,15 @@ public final class ExpressionAssert {
      */
     public static void assertExistsSubqueryExpression(final SQLCaseAssertContext assertContext,
                                                       final ExistsSubqueryExpression actual, final ExpectedExistsSubquery expected) {
-        assertNotNull(assertContext.getText("Expected exists subquery expression should exist."), expected);
-        assertSubquery(assertContext, actual.getSubquery(), expected.getSubquery());
-        assertThat(assertContext.getText("Exists subquery expression not value assert error."),
-                actual.isNot(), is(expected.isNot()));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual exists subquery should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual exists subquery should exist."), actual);
+            assertSubquery(assertContext, actual.getSubquery(), expected.getSubquery());
+            assertThat(assertContext.getText("Exists subquery expression not value assert error."),
+                    actual.isNot(), is(expected.isNot()));
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**
@@ -158,12 +183,16 @@ public final class ExpressionAssert {
     public static void assertBinaryOperationExpression(final SQLCaseAssertContext assertContext,
                                                        final BinaryOperationExpression actual,
                                                        final ExpectedBinaryOperationExpression expected) {
-        assertNotNull(assertContext.getText("Expected binary operation expression should exist."), expected);
-        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
-        assertThat(assertContext.getText("Binary operation expression operator assert error."),
-                actual.getOperator(), is(expected.getOperator()));
-        assertExpression(assertContext, actual.getRight(), expected.getRight());
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual binary operation expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual binary operation expression should exist."), actual);
+            assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+            assertThat(assertContext.getText("Binary operation expression operator assert error."),
+                    actual.getOperator(), is(expected.getOperator()));
+            assertExpression(assertContext, actual.getRight(), expected.getRight());
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**
@@ -174,12 +203,16 @@ public final class ExpressionAssert {
      */
     public static void assertInExpression(final SQLCaseAssertContext assertContext,
                                           final InExpression actual, final ExpectedInExpression expected) {
-        assertNotNull(assertContext.getText("Expected in expression should exist."), expected);
-        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
-        assertThat(assertContext.getText("In expression not value assert error."),
-                actual.isNot(), is(expected.isNot()));
-        assertExpression(assertContext, actual.getRight(), expected.getRight());
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual in expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual in expression should exist."), actual);
+            assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+            assertThat(assertContext.getText("In expression not value assert error."),
+                    actual.isNot(), is(expected.isNot()));
+            assertExpression(assertContext, actual.getRight(), expected.getRight());
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**
@@ -190,8 +223,13 @@ public final class ExpressionAssert {
      */
     public static void assertNotExpression(final SQLCaseAssertContext assertContext,
                                            final NotExpression actual, final ExpectedNotExpression expected) {
-        assertExpression(assertContext, actual.getExpression(), expected.getExpr());
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual not expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual not expression should exist."), actual);
+            assertExpression(assertContext, actual.getExpression(), expected.getExpr());
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**
@@ -202,16 +240,20 @@ public final class ExpressionAssert {
      */
     public static void assertListExpression(final SQLCaseAssertContext assertContext,
                                            final ListExpression actual, final ExpectedListExpression expected) {
-        assertNotNull(assertContext.getText("Expected list expression should exist."), expected);
-        assertThat(assertContext.getText("List expression item size assert error."),
-                actual.getItems().size(), is(expected.getItems().size()));
-        Iterator<ExpressionSegment> actualItems = actual.getItems().iterator();
-        Iterator<ExpectedExpression> expectedItems = expected.getItems().iterator();
-        while (actualItems.hasNext()) {
-            assertExpression(assertContext, actualItems.next(), expectedItems.next());
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual list expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual list expression should exist."), actual);
+            assertThat(assertContext.getText("List expression item size assert error."),
+                    actual.getItems().size(), is(expected.getItems().size()));
+            Iterator<ExpressionSegment> actualItems = actual.getItems().iterator();
+            Iterator<ExpectedExpression> expectedItems = expected.getItems().iterator();
+            while (actualItems.hasNext()) {
+                assertExpression(assertContext, actualItems.next(), expectedItems.next());
+            }
+            //TODO PostgreSQL list expression start index was incorrect.
+//            SQLSegmentAssert.assertIs(assertContext, actual, expected);
         }
-        //TODO PostgreSQL list expression start index was incorrect.
-//        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 
     /**
@@ -222,13 +264,17 @@ public final class ExpressionAssert {
      */
     public static void assertBetweenExpression(final SQLCaseAssertContext assertContext,
                                            final BetweenExpression actual, final ExpectedBetweenExpression expected) {
-        assertNotNull(assertContext.getText("Expected between expression should exist."), expected);
-        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
-        assertExpression(assertContext, actual.getBetweenExpr(), expected.getBetweenExpr());
-        assertExpression(assertContext, actual.getAndExpr(), expected.getAndExpr());
-        assertThat(assertContext.getText("Between expression not value assert error."),
-                actual.isNot(), is(expected.isNot()));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual between expression should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual between expression should exist."), actual);
+            assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+            assertExpression(assertContext, actual.getBetweenExpr(), expected.getBetweenExpr());
+            assertExpression(assertContext, actual.getAndExpr(), expected.getAndExpr());
+            assertThat(assertContext.getText("Between expression not value assert error."),
+                    actual.isNot(), is(expected.isNot()));
+            SQLSegmentAssert.assertIs(assertContext, actual, expected);
+        }
     }
 
     /**

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
@@ -19,18 +19,40 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BetweenExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExistsSubqueryExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.NotExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.column.ColumnAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.projection.ProjectionAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dml.impl.SelectStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedBetweenExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedBinaryOperationExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedExistsSubquery;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedInExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedListExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedNotExpression;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.complex.ExpectedCommonExpression;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedLiteralExpression;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedParameterMarkerExpression;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedSubquery;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.sql.SQLCaseType;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
+
+import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
@@ -65,7 +87,7 @@ public final class ExpressionAssert {
      */
     public static void assertLiteralExpression(final SQLCaseAssertContext assertContext,
                                                 final LiteralExpressionSegment actual, final ExpectedLiteralExpression expected) {
-        assertNotNull(assertContext.getText("Expected literal expression should exist."));
+        assertNotNull(assertContext.getText("Expected literal expression should exist."), expected);
         assertThat(assertContext.getText("Literal assertion error: "), actual.getLiterals().toString(), is(expected.getValue()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
@@ -79,7 +101,7 @@ public final class ExpressionAssert {
      */
     public static void assertCommonExpression(final SQLCaseAssertContext assertContext,
                                                final ComplexExpressionSegment actual, final ExpectedCommonExpression expected) {
-        assertNotNull(assertContext.getText("Expected common expression should exist."));
+        assertNotNull(assertContext.getText("Expected common expression should exist."), expected);
         String expectedText = SQLCaseType.Literal == assertContext.getSqlCaseType() && null != expected.getLiteralText() ? expected.getLiteralText() : expected.getText();
         assertThat(assertContext.getText("Common expression text assertion error: "), actual.getText(), is(expectedText));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
@@ -89,11 +111,176 @@ public final class ExpressionAssert {
      * Assert subquery expression.
      *
      * @param assertContext assert context
-     * @param actual actual subquery segment
+     * @param actual actual subquery expression segment
      * @param expected expected subquery expression
      */
     public static void assertSubqueryExpression(final SQLCaseAssertContext assertContext, final SubqueryExpressionSegment actual, final ExpectedSubquery expected) {
-        SelectStatementAssert.assertIs(assertContext, actual.getSubquery().getSelect(), expected.getSelectTestCases());
+        assertNotNull(assertContext.getText("Expected subquery expression should exist."), expected);
+        assertSubquery(assertContext, actual.getSubquery(), expected);
+    }
+
+    /**
+     * Assert subquery.
+     *
+     * @param assertContext assert context
+     * @param actual actual subquery segment
+     * @param expected expected subquery expression
+     */
+    public static void assertSubquery(final SQLCaseAssertContext assertContext,
+                                      final SubquerySegment actual, final ExpectedSubquery expected) {
+        assertNotNull(assertContext.getText("Expected subquery should exist."), expected);
+        SelectStatementAssert.assertIs(assertContext, actual.getSelect(), expected.getSelectTestCases());
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert exists subquery expression.
+     *
+     * @param assertContext assert context
+     * @param actual actual exists subquery expression
+     * @param expected expected exists subquery expression
+     */
+    public static void assertExistsSubqueryExpression(final SQLCaseAssertContext assertContext,
+                                                      final ExistsSubqueryExpression actual, final ExpectedExistsSubquery expected) {
+        assertNotNull(assertContext.getText("Expected exists subquery expression should exist."), expected);
+        assertSubquery(assertContext, actual.getSubquery(), expected.getSubquery());
+        assertThat(assertContext.getText("Exists subquery expression not value assert error."),
+                actual.isNot(), is(expected.isNot()));
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert binary operation expression.
+     * @param assertContext assert context
+     * @param actual actual binary operation expression
+     * @param expected expected binary operation expression
+     */
+    public static void assertBinaryOperationExpression(final SQLCaseAssertContext assertContext,
+                                                       final BinaryOperationExpression actual,
+                                                       final ExpectedBinaryOperationExpression expected) {
+        assertNotNull(assertContext.getText("Expected binary operation expression should exist."), expected);
+        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+        assertThat(assertContext.getText("Binary operation expression operator assert error."),
+                actual.getOperator(), is(expected.getOperator()));
+        assertExpression(assertContext, actual.getRight(), expected.getRight());
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert in operation expression.
+     * @param assertContext assert context
+     * @param actual actual in operation expression
+     * @param expected expected in operation expression
+     */
+    public static void assertInExpression(final SQLCaseAssertContext assertContext,
+                                          final InExpression actual, final ExpectedInExpression expected) {
+        assertNotNull(assertContext.getText("Expected in expression should exist."), expected);
+        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+        assertThat(assertContext.getText("In expression not value assert error."),
+                actual.isNot(), is(expected.isNot()));
+        assertExpression(assertContext, actual.getRight(), expected.getRight());
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert not operation expression.
+     * @param assertContext assert context
+     * @param actual actual not operation expression
+     * @param expected expected not operation expression
+     */
+    public static void assertNotExpression(final SQLCaseAssertContext assertContext,
+                                           final NotExpression actual, final ExpectedNotExpression expected) {
+        assertExpression(assertContext, actual.getExpression(), expected.getExpr());
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert list operation expression.
+     * @param assertContext assert context
+     * @param actual actual list operation expression
+     * @param expected expected list operation expression
+     */
+    public static void assertListExpression(final SQLCaseAssertContext assertContext,
+                                           final ListExpression actual, final ExpectedListExpression expected) {
+        assertNotNull(assertContext.getText("Expected list expression should exist."), expected);
+        assertThat(assertContext.getText("List expression item size assert error."),
+                actual.getItems().size(), is(expected.getItems().size()));
+        Iterator<ExpressionSegment> actualItems = actual.getItems().iterator();
+        Iterator<ExpectedExpression> expectedItems = expected.getItems().iterator();
+        while (actualItems.hasNext()) {
+            assertExpression(assertContext, actualItems.next(), expectedItems.next());
+        }
+        //TODO PostgreSQL list expression start index was incorrect.
+//        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert between operation expression.
+     * @param assertContext assert context
+     * @param actual actual between operation expression
+     * @param expected expected between operation expression
+     */
+    public static void assertBetweenExpression(final SQLCaseAssertContext assertContext,
+                                           final BetweenExpression actual, final ExpectedBetweenExpression expected) {
+        assertNotNull(assertContext.getText("Expected between expression should exist."), expected);
+        assertExpression(assertContext, actual.getLeft(), expected.getLeft());
+        assertExpression(assertContext, actual.getBetweenExpr(), expected.getBetweenExpr());
+        assertExpression(assertContext, actual.getAndExpr(), expected.getAndExpr());
+        assertThat(assertContext.getText("Between expression not value assert error."),
+                actual.isNot(), is(expected.isNot()));
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
+    }
+
+    /**
+     * Assert expression by actual expression segment class type.
+     * @param assertContext assert context
+     * @param actual actual expression segment
+     * @param expected expected expression
+     *
+     * @throws UnsupportedOperationException When expression segment class type is not supported.
+     */
+    public static void assertExpression(final SQLCaseAssertContext assertContext,
+                                        final ExpressionSegment actual, final ExpectedExpression expected) {
+        assertNotNull(assertContext.getText("Expected expression should exist."), expected);
+        if (actual instanceof BinaryOperationExpression) {
+            assertBinaryOperationExpression(assertContext,
+                    (BinaryOperationExpression) actual, expected.getBinaryOperationExpression());
+        } else if (actual instanceof SubqueryExpressionSegment) {
+            assertSubqueryExpression(assertContext,
+                    (SubqueryExpressionSegment) actual, expected.getSubquery());
+        } else if (actual instanceof ColumnSegment) {
+            ColumnAssert.assertIs(assertContext,
+                    (ColumnSegment) actual, expected.getColumn());
+        } else if (actual instanceof LiteralExpressionSegment) {
+            assertLiteralExpression(assertContext,
+                    (LiteralExpressionSegment) actual, expected.getLiteralExpression());
+        } else if (actual instanceof ParameterMarkerExpressionSegment) {
+            assertParameterMarkerExpression(assertContext,
+                    (ParameterMarkerExpressionSegment) actual, expected.getParameterMarkerExpression());
+        } else if (actual instanceof ExistsSubqueryExpression) {
+            assertExistsSubqueryExpression(assertContext,
+                    (ExistsSubqueryExpression) actual, expected.getExistsSubquery());
+        } else if (actual instanceof CommonExpressionSegment) {
+            assertCommonExpression(assertContext,
+                    (ComplexExpressionSegment) actual, expected.getCommonExpression());
+        } else if (actual instanceof InExpression) {
+            assertInExpression(assertContext,
+                    (InExpression) actual, expected.getInExpression());
+        } else if (actual instanceof NotExpression) {
+            assertNotExpression(assertContext,
+                    (NotExpression) actual, expected.getNotExpression());
+        } else if (actual instanceof ListExpression) {
+            assertListExpression(assertContext,
+                    (ListExpression) actual, expected.getListExpression());
+        } else if (actual instanceof BetweenExpression) {
+            assertBetweenExpression(assertContext,
+                    (BetweenExpression) actual, expected.getBetweenExpression());
+        } else if (actual instanceof ExpressionProjectionSegment) {
+            ProjectionAssert.assertProjection(assertContext,
+                    (ExpressionProjectionSegment) actual, expected.getExpressionProjection());
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format("Unsupported expression  : %s.", actual.getClass().getName()));
+        }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
@@ -73,7 +73,7 @@ public final class ExpressionAssert {
      * @param expected expected parameter marker expression
      */
     public static void assertParameterMarkerExpression(final SQLCaseAssertContext assertContext,
-                                                        final ParameterMarkerExpressionSegment actual, final ExpectedParameterMarkerExpression expected) {
+                                                       final ParameterMarkerExpressionSegment actual, final ExpectedParameterMarkerExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual parameter marker expression should not exist."), actual);
         } else {
@@ -91,7 +91,7 @@ public final class ExpressionAssert {
      * @param expected expected literal expression
      */
     public static void assertLiteralExpression(final SQLCaseAssertContext assertContext,
-                                                final LiteralExpressionSegment actual, final ExpectedLiteralExpression expected) {
+                                               final LiteralExpressionSegment actual, final ExpectedLiteralExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual literal expression should not exist."), actual);
         } else {
@@ -109,7 +109,7 @@ public final class ExpressionAssert {
      * @param expected expected common expression
      */
     public static void assertCommonExpression(final SQLCaseAssertContext assertContext,
-                                               final ComplexExpressionSegment actual, final ExpectedCommonExpression expected) {
+                                              final ComplexExpressionSegment actual, final ExpectedCommonExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual common expression should not exist."), actual);
         } else {
@@ -127,7 +127,8 @@ public final class ExpressionAssert {
      * @param actual actual subquery expression segment
      * @param expected expected subquery expression
      */
-    public static void assertSubqueryExpression(final SQLCaseAssertContext assertContext, final SubqueryExpressionSegment actual, final ExpectedSubquery expected) {
+    public static void assertSubqueryExpression(final SQLCaseAssertContext assertContext,
+                                                final SubqueryExpressionSegment actual, final ExpectedSubquery expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual subquery expression should not exist."), actual);
         } else {
@@ -181,8 +182,7 @@ public final class ExpressionAssert {
      * @param expected expected binary operation expression
      */
     public static void assertBinaryOperationExpression(final SQLCaseAssertContext assertContext,
-                                                       final BinaryOperationExpression actual,
-                                                       final ExpectedBinaryOperationExpression expected) {
+                                                       final BinaryOperationExpression actual, final ExpectedBinaryOperationExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual binary operation expression should not exist."), actual);
         } else {
@@ -239,7 +239,7 @@ public final class ExpressionAssert {
      * @param expected expected list operation expression
      */
     public static void assertListExpression(final SQLCaseAssertContext assertContext,
-                                           final ListExpression actual, final ExpectedListExpression expected) {
+                                            final ListExpression actual, final ExpectedListExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual list expression should not exist."), actual);
         } else {
@@ -263,7 +263,7 @@ public final class ExpressionAssert {
      * @param expected expected between operation expression
      */
     public static void assertBetweenExpression(final SQLCaseAssertContext assertContext,
-                                           final BetweenExpression actual, final ExpectedBetweenExpression expected) {
+                                               final BetweenExpression actual, final ExpectedBetweenExpression expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual between expression should not exist."), actual);
         } else {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/orderby/OrderByItemAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/orderby/OrderByItemAssert.java
@@ -21,7 +21,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.owner.OwnerAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.item.ExpectedOrderByItem;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.item.impl.ExpectedColumnOrderByItem;
@@ -31,8 +32,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.Co
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.ExpressionOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.IndexOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.OrderByItemSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 
 import java.util.Collection;
 
@@ -91,12 +90,10 @@ public final class OrderByItemAssert {
     
     private static void assertColumnOrderByItem(final SQLCaseAssertContext assertContext,
                                                 final ColumnOrderByItemSegment actual, final ExpectedColumnOrderByItem expected, final String type) {
-        assertThat(assertContext.getText(String.format("%s item column name assertion error: ", type)), actual.getColumn().getIdentifier().getValue(), is(expected.getName()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getColumn().getIdentifier(), expected, String.format("%s item", type));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getColumn().getOwner().isPresent());
-            // TODO OwnerAssert is needed.
-            OwnerSegment owner = actual.getColumn().getOwner().get();
-            TableAssert.assertOwner(assertContext, new SimpleTableSegment(owner.getStartIndex(), owner.getStopIndex(), owner.getIdentifier()), expected.getOwner());
+            OwnerAssert.assertIs(assertContext, actual.getColumn().getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getColumn().getOwner().isPresent());
         }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/output/OutputClauseAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/output/OutputClauseAssert.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnPr
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OutputSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.output.ExpectedOutputClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.column.ExpectedColumnProjection;
 
@@ -69,8 +70,7 @@ public final class OutputClauseAssert {
     }
     
     private static void assertOutputColumnSegment(final SQLCaseAssertContext assertContext, final ColumnProjectionSegment actual, final ExpectedColumnProjection expected) { 
-        assertThat(assertContext.getText("Output column name assertion error: "), 
-                actual.getColumn().getIdentifier().getValue(), is(expected.getName()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getColumn().getIdentifier(), expected, "Output column");
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/owner/OwnerAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/owner/OwnerAssert.java
@@ -15,34 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.owner;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index.ExpectedIndex;
-
-import static org.junit.Assert.assertNotNull;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedOwner;
 
 /**
- * Index assert.
+ * Owner assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class IndexAssert {
+public final class OwnerAssert {
     
     /**
-     * Assert actual column segment is correct with expected column.
+     * Assert actual owner segment is correct with expected owner.
      *
      * @param assertContext assert context
-     * @param actual actual index segment
-     * @param expected expected index
+     * @param actual actual owner segment
+     * @param expected expected owner
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final IndexSegment actual, final ExpectedIndex expected) {
-        assertNotNull(assertContext.getText("Index should exist."), expected);
-        IdentifierValueAssert.assertIs(assertContext, actual.getIdentifier(), expected, "Index");
+    public static void assertIs(final SQLCaseAssertContext assertContext, final OwnerSegment actual, final ExpectedOwner expected) {
+        IdentifierValueAssert.assertIs(assertContext, actual.getIdentifier(), expected, "Owner");
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/projection/ProjectionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/projection/ProjectionAssert.java
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.Shorthan
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.rownum.NumberLiteralRowNumberValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.rownum.ParameterMarkerRowNumberValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.top.TopProjectionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.sql.SQLCaseType;
 
 import java.util.List;
 
@@ -139,8 +140,10 @@ public final class ProjectionAssert {
     private static void assertExpressionProjection(final SQLCaseAssertContext assertContext, final ExpressionProjectionSegment actual, final ExpectedExpressionProjection expected) {
         assertThat(assertContext.getText("Expression projection alias assertion error: "),
                 actual.getAlias().orElse(null), is(expected.getAlias()));
+        String expectedText = SQLCaseType.Literal == assertContext.getSqlCaseType() && null != expected.getLiteralText()
+                ? expected.getLiteralText() : expected.getText();
         assertThat(assertContext.getText("Expression projection text assertion error: "),
-                actual.getText(), is(expected.getText()));
+                actual.getText(), is(expectedText));
     }
     
     private static void assertTopProjection(final SQLCaseAssertContext assertContext, final TopProjectionSegment actual, final ExpectedTopProjection expected) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/projection/ProjectionAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/projection/ProjectionAssert.java
@@ -21,7 +21,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.owner.OwnerAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.ExpectedProjection;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.ExpectedProjections;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.aggregation.ExpectedAggregationDistinctProjection;
@@ -40,8 +41,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.Shorthan
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.rownum.NumberLiteralRowNumberValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.rownum.ParameterMarkerRowNumberValueSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.top.TopProjectionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 
 import java.util.List;
 
@@ -79,8 +78,14 @@ public final class ProjectionAssert {
         assertThat(assertContext.getText("Projections distinct row assertion error: "), actual.isDistinctRow(), is(expected.isDistinctRow()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
-    
-    private static void assertProjection(final SQLCaseAssertContext assertContext, final ProjectionSegment actual, final ExpectedProjection expected) {
+
+    /**
+     * Assert actual projection segment is correct with expected projection.
+     * @param assertContext assert context
+     * @param actual actual projection
+     * @param expected expected projection
+     */
+    public static void assertProjection(final SQLCaseAssertContext assertContext, final ProjectionSegment actual, final ExpectedProjection expected) {
         if (actual instanceof ShorthandProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, instanceOf(ExpectedShorthandProjection.class));
             assertShorthandProjection(assertContext, (ShorthandProjectionSegment) actual, (ExpectedShorthandProjection) expected);
@@ -103,25 +108,18 @@ public final class ProjectionAssert {
     private static void assertShorthandProjection(final SQLCaseAssertContext assertContext, final ShorthandProjectionSegment actual, final ExpectedShorthandProjection expected) {
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());
-            OwnerSegment owner = actual.getOwner().get();
-            TableAssert.assertOwner(assertContext, new SimpleTableSegment(owner.getStartIndex(), owner.getStopIndex(), owner.getIdentifier()), expected.getOwner());
+            OwnerAssert.assertIs(assertContext, actual.getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getOwner().isPresent());
         }
     }
     
     private static void assertColumnProjection(final SQLCaseAssertContext assertContext, final ColumnProjectionSegment actual, final ExpectedColumnProjection expected) {
-        assertThat(assertContext.getText("Column projection name assertion error: "), actual.getColumn().getIdentifier().getValue(), is(expected.getName()));
-        assertThat(assertContext.getText("Column projection start delimiter assertion error: "), 
-                actual.getColumn().getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Column projection end delimiter assertion error: "), 
-                actual.getColumn().getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getColumn().getIdentifier(), expected, "Column projection");
         assertThat(assertContext.getText("Column projection alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getColumn().getOwner().isPresent());
-            // TODO OwnerAssert is needed.
-            OwnerSegment owner = actual.getColumn().getOwner().get();
-            TableAssert.assertOwner(assertContext, new SimpleTableSegment(owner.getStartIndex(), owner.getStopIndex(), owner.getIdentifier()), expected.getOwner());
+            OwnerAssert.assertIs(assertContext, actual.getColumn().getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getColumn().getOwner().isPresent());
         }
@@ -139,7 +137,10 @@ public final class ProjectionAssert {
     }
     
     private static void assertExpressionProjection(final SQLCaseAssertContext assertContext, final ExpressionProjectionSegment actual, final ExpectedExpressionProjection expected) {
-        assertThat(assertContext.getText("Expression projection alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Expression projection alias assertion error: "),
+                actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Expression projection text assertion error: "),
+                actual.getText(), is(expected.getText()));
     }
     
     private static void assertTopProjection(final SQLCaseAssertContext assertContext, final TopProjectionSegment actual, final ExpectedTopProjection expected) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/schema/SchemaAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/schema/SchemaAssert.java
@@ -22,10 +22,8 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.schema.ExpectedSchema;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 
 /**
  * Schema assert.
@@ -41,9 +39,7 @@ public final class SchemaAssert {
      * @param expected expected schema
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SchemaSegment actual, final ExpectedSchema expected) {
-        assertThat(assertContext.getText("Owner name assertion error: "), actual.getIdentifier().getValue(), is(expected.getName()));
-        assertThat(assertContext.getText("Owner start delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Owner end delimiter assertion error: "), actual.getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getIdentifier(), expected, "Schema");
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/table/TableAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/table/TableAssert.java
@@ -19,21 +19,19 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.schema.SchemaAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.owner.OwnerAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dml.impl.SelectStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedJoinTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSubqueryTable;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTableOwner;
 
 import java.util.Collection;
 import java.util.List;
@@ -77,18 +75,14 @@ public final class TableAssert {
      * @param expected expected table
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SimpleTableSegment actual, final ExpectedSimpleTable expected) {
-        assertThat(assertContext.getText("Table name assertion error: "), actual.getTableName().getIdentifier().getValue(), is(expected.getName()));
+        IdentifierValueAssert.assertIs(assertContext, actual.getTableName().getIdentifier(), expected, "Table");
         assertThat(assertContext.getText("Table alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
         if (null != expected.getOwner()) {
             assertTrue(assertContext.getText("Actual owner should exist."), actual.getOwner().isPresent());
-            // TODO OwnerAssert is necessary.
-            OwnerSegment owner = actual.getOwner().get();
-            SchemaAssert.assertIs(assertContext, new SchemaSegment(owner.getStartIndex(), owner.getStopIndex(), owner.getIdentifier()), expected.getOwner());
+            OwnerAssert.assertIs(assertContext, actual.getOwner().get(), expected.getOwner());
         } else {
             assertFalse(assertContext.getText("Actual owner should not exist."), actual.getOwner().isPresent());
         }
-        assertThat(assertContext.getText("Table start delimiter assertion error: "), actual.getTableName().getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Table end delimiter assertion error: "), actual.getTableName().getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
         SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 
@@ -145,21 +139,6 @@ public final class TableAssert {
         for (int i = 0; i < actualTables.size(); i++) {
             assertIs(assertContext, actualTables.get(i), expectedTables.get(i));
         }
-    }
-
-    /**
-     * Assert actual table segment is correct with expected table owner.
-     *
-     * @param assertContext assert context
-     * @param actual actual table segment
-     * @param expected expected table owner
-     */
-    public static void assertOwner(final SQLCaseAssertContext assertContext, final SimpleTableSegment actual, final ExpectedSimpleTableOwner expected) {
-        assertThat(assertContext.getText("Owner name assertion error: "), actual.getTableName().getIdentifier().getValue(), is(expected.getName()));
-        assertThat(assertContext.getText("Owner name start delimiter assertion error: "),
-                actual.getTableName().getIdentifier().getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
-        assertThat(assertContext.getText("Owner name end delimiter assertion error: "), actual.getTableName().getIdentifier().getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
-        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/where/WhereClauseAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/where/WhereClauseAssert.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.expression.ExpressionAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.predicate.ExpectedWhereClause;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.WhereSegment;
 
@@ -37,6 +39,7 @@ public final class WhereClauseAssert {
      * @param expected expected where clause
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final WhereSegment actual, final ExpectedWhereClause expected) {
-//        TODO support expr in where assert
+        ExpressionAssert.assertExpression(assertContext, actual.getExpr(), expected.getExpr());
+        SQLSegmentAssert.assertIs(assertContext, actual, expected);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/SelectStatementAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/SelectStatementAssert.java
@@ -60,7 +60,6 @@ public final class SelectStatementAssert {
         assertLimitClause(assertContext, actual, expected);
         assertTable(assertContext, actual, expected);
         assertLockClause(assertContext, actual, expected);
-//        TODO support table assert
     }
     
     private static void assertProjection(final SQLCaseAssertContext assertContext, final SelectStatement actual, final SelectStatementTestCase expected) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/UpdateStatementAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/UpdateStatementAssert.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.S
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.limit.LimitClauseAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.orderby.OrderByClauseAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.set.SetClauseAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.where.WhereClauseAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.UpdateStatementTestCase;
 
@@ -58,7 +59,11 @@ public final class UpdateStatementAssert {
     }
     
     private static void assertTable(final SQLCaseAssertContext assertContext, final UpdateStatement actual, final UpdateStatementTestCase expected) {
-//        TODO to support table assert
+        if (null != expected.getTable()) {
+            TableAssert.assertIs(assertContext, actual.getTableSegment(), expected.getTable());
+        } else {
+            assertFalse(assertContext.getText("Actual from should not exist."), null != actual.getTableSegment());
+        }
     }
     
     private static void assertSetClause(final SQLCaseAssertContext assertContext, final UpdateStatement actual, final UpdateStatementTestCase expected) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/value/IdentifierValueAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/value/IdentifierValueAssert.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.value;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.ExpectedIdentifierSQLSegment;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Identifier value assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class IdentifierValueAssert {
+    
+    /**
+     * Assert actual identifier value is correct with expected identifier.
+     *
+     * @param assertContext assert context
+     * @param actual actual identifier value
+     * @param expected expected identifier
+     * @param type assert identifier value type
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final IdentifierValue actual,
+                                final ExpectedIdentifierSQLSegment expected, final String type) {
+        assertThat(assertContext.getText(String.format("%s name assertion error: ", type)),
+                actual.getValue(), is(expected.getName()));
+        assertThat(assertContext.getText(String.format("%s start delimiter assertion error: ", type)),
+                actual.getQuoteCharacter().getStartDelimiter(), is(expected.getStartDelimiter()));
+        assertThat(assertContext.getText(String.format("%s end delimiter assertion error: ", type)),
+                actual.getQuoteCharacter().getEndDelimiter(), is(expected.getEndDelimiter()));
+    }
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/AbstractExpectedDelimiterSQLSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/AbstractExpectedDelimiterSQLSegment.java
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 @Getter
 @Setter
 public abstract class AbstractExpectedDelimiterSQLSegment extends AbstractExpectedSQLSegment implements ExpectedDelimiterSQLSegment {
-    
+
     @XmlAttribute(name = "start-delimiter")
     private String startDelimiter = "";
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/AbstractExpectedIdentifierSQLSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/AbstractExpectedIdentifierSQLSegment.java
@@ -15,21 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedDelimiterSQLSegment;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * Expected simple table owner.
+ * Abstract expected delimiter SQL segment.
  */
 @Getter
 @Setter
-public final class ExpectedSimpleTableOwner extends AbstractExpectedDelimiterSQLSegment {
-    
+public abstract class AbstractExpectedIdentifierSQLSegment extends AbstractExpectedDelimiterSQLSegment implements ExpectedIdentifierSQLSegment {
+
     @XmlAttribute
     private String name;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/ExpectedIdentifierSQLSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/ExpectedIdentifierSQLSegment.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
-
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment;
 
 /**
- * Expected index.
+ * Expected Identifier SQL segment.
  */
-@Getter
-@Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+public interface ExpectedIdentifierSQLSegment extends ExpectedDelimiterSQLSegment {
+    
+    /**
+     * Get name.
+     *
+     * @return name
+     */
+    String getName();
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/column/ExpectedColumn.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/column/ExpectedColumn.java
@@ -19,10 +19,10 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedDelimiterSQLSegment;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTableOwner;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedExpressionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedOwner;
 
-import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
@@ -30,11 +30,8 @@ import javax.xml.bind.annotation.XmlElement;
  */
 @Getter
 @Setter
-public final class ExpectedColumn extends AbstractExpectedDelimiterSQLSegment {
-    
-    @XmlAttribute
-    private String name;
+public final class ExpectedColumn extends AbstractExpectedIdentifierSQLSegment implements ExpectedExpressionSegment {
     
     @XmlElement
-    private ExpectedSimpleTableOwner owner;
+    private ExpectedOwner owner;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedBetweenExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedBetweenExpression.java
@@ -15,16 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedBetweenExpression extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+    @XmlElement(name = "not")
+    private boolean not;
+
+    @XmlElement(name = "left")
+    private ExpectedExpression left;
+
+    @XmlElement(name = "between-expr")
+    private ExpectedExpression betweenExpr;
+
+    @XmlElement(name = "and-expr")
+    private ExpectedExpression andExpr;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedBinaryOperationExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedBinaryOperationExpression.java
@@ -15,16 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedBinaryOperationExpression extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+    @XmlElement(name = "left")
+    private ExpectedExpression left;
+
+    @XmlElement(name = "operator")
+    private String operator;
+
+    @XmlElement(name = "right")
+    private ExpectedExpression right;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExistsSubquery.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExistsSubquery.java
@@ -15,16 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedSubquery;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedExistsSubquery extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+    @XmlElement(name = "not")
+    private boolean not;
+
+    @XmlElement(name = "subquery")
+    private ExpectedSubquery subquery;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExpression.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.complex.ExpectedCommonExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedLiteralExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedParameterMarkerExpression;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedSubquery;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.expression.ExpectedExpressionProjection;
+
+import javax.xml.bind.annotation.XmlElement;
+
+@Getter
+@Setter
+public class ExpectedExpression extends AbstractExpectedSQLSegment {
+
+    @XmlElement(name = "between-expression")
+    private ExpectedBetweenExpression betweenExpression;
+
+    @XmlElement(name = "binary-operation-expression")
+    private ExpectedBinaryOperationExpression binaryOperationExpression;
+
+    @XmlElement(name = "column")
+    private ExpectedColumn column;
+
+    @XmlElement(name = "common-expression")
+    private ExpectedCommonExpression commonExpression;
+
+    @XmlElement(name = "exists-subquery")
+    private ExpectedExistsSubquery existsSubquery;
+
+    @XmlElement(name = "expression-projection")
+    private ExpectedExpressionProjection expressionProjection;
+
+    @XmlElement(name = "in-expression")
+    private ExpectedInExpression inExpression;
+
+    @XmlElement(name = "list-expression")
+    private ExpectedListExpression listExpression;
+
+    @XmlElement(name = "literal-expression")
+    private ExpectedLiteralExpression literalExpression;
+
+    @XmlElement(name = "not-expression")
+    private ExpectedNotExpression notExpression;
+
+    @XmlElement(name = "parameter-marker-expression")
+    private ExpectedParameterMarkerExpression parameterMarkerExpression;
+
+    @XmlElement(name = "subquery")
+    private ExpectedSubquery subquery;
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedInExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedInExpression.java
@@ -15,16 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedInExpression extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+    @XmlElement(name = "not")
+    private boolean not;
+
+    @XmlElement(name = "left")
+    private ExpectedExpression left;
+
+    @XmlElement(name = "right")
+    private ExpectedExpression right;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedListExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedListExpression.java
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedListExpression extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+
+    @XmlElement(name = "items")
+    private List<ExpectedExpression> items = new LinkedList<>();
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedNotExpression.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedNotExpression.java
@@ -15,16 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-/**
- * Expected index.
- */
-@Getter
+import javax.xml.bind.annotation.XmlElement;
+
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+@Getter
+public class ExpectedNotExpression extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+
+    @XmlElement(name = "expr")
+    private ExpectedExpression expr;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/orderby/item/impl/ExpectedColumnOrderByItem.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/orderby/item/impl/ExpectedColumnOrderByItem.java
@@ -19,8 +19,9 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.ExpectedIdentifierSQLSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.item.ExpectedOrderByItem;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTableOwner;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedOwner;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -30,11 +31,11 @@ import javax.xml.bind.annotation.XmlElement;
  */
 @Getter
 @Setter
-public final class ExpectedColumnOrderByItem extends ExpectedOrderByItem {
+public final class ExpectedColumnOrderByItem extends ExpectedOrderByItem implements ExpectedIdentifierSQLSegment {
     
     @XmlAttribute
     private String name;
     
     @XmlElement
-    private ExpectedSimpleTableOwner owner;
+    private ExpectedOwner owner;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/predicate/ExpectedWhereClause.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/predicate/ExpectedWhereClause.java
@@ -20,12 +20,11 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.ExpectedExpression;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Expected where clause.
@@ -34,7 +33,7 @@ import java.util.List;
 @Setter
 @XmlAccessorType(XmlAccessType.FIELD)
 public final class ExpectedWhereClause extends AbstractExpectedSQLSegment {
-    
-    @XmlElement(name = "and-predicate")
-    private final List<ExpectedAndPredicate> andPredicates = new LinkedList<>();
+
+    @XmlElement(name = "expr")
+    private ExpectedExpression expr;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/column/ExpectedColumnProjection.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/column/ExpectedColumnProjection.java
@@ -19,23 +19,20 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedDelimiterSQLSegment;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTableOwner;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.ExpectedProjection;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedOwner;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 @Getter
 @Setter
-public final class ExpectedColumnProjection extends AbstractExpectedDelimiterSQLSegment implements ExpectedProjection {
-    
-    @XmlAttribute
-    private String name;
+public final class ExpectedColumnProjection extends AbstractExpectedIdentifierSQLSegment implements ExpectedProjection {
     
     @XmlAttribute
     private String alias;
     
     @XmlElement
-    private ExpectedSimpleTableOwner owner;
+    private ExpectedOwner owner;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/expression/ExpectedExpressionProjection.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/expression/ExpectedExpressionProjection.java
@@ -20,14 +20,18 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.complex.ExpectedComplexExpressionSegment;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.ExpectedProjection;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
 @Getter
 @Setter
-public final class ExpectedExpressionProjection extends AbstractExpectedSQLSegment implements ExpectedProjection {
-    
-    @XmlAttribute
+public final class ExpectedExpressionProjection extends AbstractExpectedSQLSegment implements ExpectedProjection, ExpectedComplexExpressionSegment {
+
+    @XmlAttribute(name = "text")
+    private String text;
+
+    @XmlAttribute(name = "alias")
     private String alias;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/expression/ExpectedExpressionProjection.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/expression/ExpectedExpressionProjection.java
@@ -32,6 +32,9 @@ public final class ExpectedExpressionProjection extends AbstractExpectedSQLSegme
     @XmlAttribute(name = "text")
     private String text;
 
+    @XmlAttribute(name = "literal-text")
+    private String literalText;
+
     @XmlAttribute(name = "alias")
     private String alias;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/shorthand/ExpectedShorthandProjection.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/projection/impl/shorthand/ExpectedShorthandProjection.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTableOwner;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedOwner;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.ExpectedProjection;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -30,5 +30,5 @@ import javax.xml.bind.annotation.XmlElement;
 public final class ExpectedShorthandProjection extends AbstractExpectedSQLSegment implements ExpectedProjection {
     
     @XmlElement
-    private ExpectedSimpleTableOwner owner;
+    private ExpectedOwner owner;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/schema/ExpectedSchema.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/schema/ExpectedSchema.java
@@ -19,17 +19,12 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedDelimiterSQLSegment;
-
-import javax.xml.bind.annotation.XmlAttribute;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
 
 /**
  * Expected schema.
  */
 @Getter
 @Setter
-public final class ExpectedSchema extends AbstractExpectedDelimiterSQLSegment {
-    
-    @XmlAttribute
-    private String name;
+public final class ExpectedSchema extends AbstractExpectedIdentifierSQLSegment {
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/table/ExpectedOwner.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/table/ExpectedOwner.java
@@ -15,16 +15,16 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table;
 
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
 
 /**
- * Expected index.
+ * Expected owner.
  */
 @Getter
 @Setter
-public final class ExpectedIndex extends AbstractExpectedIdentifierSQLSegment {
+public final class ExpectedOwner extends AbstractExpectedIdentifierSQLSegment {
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/table/ExpectedSimpleTable.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/table/ExpectedSimpleTable.java
@@ -19,8 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedDelimiterSQLSegment;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.schema.ExpectedSchema;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedIdentifierSQLSegment;
 
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
@@ -30,14 +29,11 @@ import javax.xml.bind.annotation.XmlElement;
  */
 @Getter
 @Setter
-public final class ExpectedSimpleTable extends AbstractExpectedDelimiterSQLSegment {
-    
-    @XmlAttribute
-    private String name;
+public final class ExpectedSimpleTable extends AbstractExpectedIdentifierSQLSegment {
     
     @XmlAttribute
     private String alias;
     
     @XmlElement
-    private ExpectedSchema owner;
+    private ExpectedOwner owner;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/UpdateStatementTestCase.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/UpdateStatementTestCase.java
@@ -23,12 +23,10 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.predicate.ExpectedWhereClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.set.ExpectedSetClause;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Update statement test case.
@@ -38,7 +36,7 @@ import java.util.List;
 public final class UpdateStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "table")
-    private final List<ExpectedSimpleTable> tables = new LinkedList<>();
+    private ExpectedTable table;
     
     @XmlElement(name = "set")
     private ExpectedSetClause setClause;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/sql/loader/SQLCasesLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/sql/loader/SQLCasesLoader.java
@@ -117,7 +117,7 @@ public final class SQLCasesLoader {
         if (null == parameters || parameters.isEmpty()) {
             return sql;
         }
-        return String.format(sql.replace("%", "$").replace("?", "%s"), parameters.toArray()).replace("$", "%").replace("%%", "%").replace("'%'", "'%%'");
+        return String.format(sql.replace("%", "$$").replace("?", "%s"), parameters.toArray()).replace("$$", "%").replace("%%", "%").replace("'%'", "'%%'");
     }
     
     /**

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/sql/loader/SQLCasesLoader.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/sql/loader/SQLCasesLoader.java
@@ -39,6 +39,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * SQL test cases loader.
@@ -110,14 +112,14 @@ public final class SQLCasesLoader {
     }
     
     private String getPlaceholderSQL(final String sql) {
-        return sql.replace("%%", "%").replace("'%'", "'%%'");
+        return sql;
     }
     
     private String getLiteralSQL(final String sql, final List<?> parameters) {
         if (null == parameters || parameters.isEmpty()) {
             return sql;
         }
-        return String.format(sql.replace("%", "$$").replace("?", "%s"), parameters.toArray()).replace("$$", "%").replace("%%", "%").replace("'%'", "'%%'");
+        return replace(sql, "?", parameters.toArray());
     }
     
     /**
@@ -162,6 +164,35 @@ public final class SQLCasesLoader {
     
     private static Collection<String> getAllDatabaseTypes() {
         return Arrays.asList("H2", "MySQL", "PostgreSQL", "Oracle", "SQLServer", "SQL92");
+    }
+
+    /**
+     * Replaces each substring of this string that matches the literal target sequence with
+     * literal replacements one by one.
+     *
+     * @param source The source string need to be replaced
+     * @param target The sequence of char values to be replaced
+     * @param replacements Array of replacement
+     * @return  The resulting string
+     * @throws IllegalArgumentException When replacements is not enough to replace found target.
+     */
+    private static String replace(final String source, final CharSequence target, final Object... replacements) {
+        if (null == source || null == replacements) {
+            return source;
+        }
+        Matcher matcher = Pattern.compile(target.toString(), Pattern.LITERAL).matcher(source);
+        int found = 0;
+        StringBuffer sb = new StringBuffer();
+        while (matcher.find()) {
+            found++;
+            if (found > replacements.length) {
+                throw new IllegalArgumentException(
+                        String.format("Missing replacement for '%s' at [%s].", target, found));
+            }
+            matcher.appendReplacement(sb, Matcher.quoteReplacement(replacements[found - 1].toString()));
+        }
+        matcher.appendTail(sb);
+        return sb.toString();
     }
     
     /**

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
@@ -20,141 +20,191 @@
     <delete sql-case-id="delete_with_sharding_value" parameters="1000, 1001, 'init'">
         <table name="t_order" start-index="12" stop-index="18" />
         <where start-index="20" stop-index="66" literal-stop-index="77">
-            <and-predicate>
-                <predicate start-index="26" stop-index="37" literal-stop-index="40">
-                    <column-left-value name="order_id" start-index="26" stop-index="33" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
-                        <literal-expression value="1000" start-index="37" stop-index="40" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="43" stop-index="53" literal-start-index="46" literal-stop-index="59">
-                    <column-left-value name="user_id" start-index="43" stop-index="49" literal-start-index="46" literal-stop-index="52" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
-                        <literal-expression value="1001" start-index="56" stop-index="59" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="59" stop-index="66" literal-start-index="65" literal-stop-index="77">
-                    <column-left-value name="status" start-index="59" stop-index="64" literal-start-index="65" literal-stop-index="70" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="66" stop-index="66" />
-                        <literal-expression value="init" start-index="72" stop-index="77" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="26" stop-index="66" literal-stop-index="77">
+                    <left>
+                        <binary-operation-expression start-index="26" stop-index="53" literal-stop-index="59">
+                            <left>
+                                <binary-operation-expression start-index="26" stop-index="37" literal-stop-index="40">
+                                    <left>
+                                        <column name="order_id" start-index="26" stop-index="33" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1000" start-index="37" stop-index="40" />
+                                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="43" stop-index="53" literal-start-index="46" literal-stop-index="59">
+                                    <left>
+                                        <column name="user_id" start-index="43" stop-index="49" literal-start-index="46" literal-stop-index="52" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1001" start-index="56" stop-index="59" />
+                                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="59" stop-index="66" literal-start-index="65" literal-stop-index="77">
+                            <left>
+                                <column name="status" start-index="59" stop-index="64" literal-start-index="65" literal-stop-index="70" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="72" stop-index="77" />
+                                <parameter-marker-expression value="2" start-index="66" stop-index="66" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_without_sharding_value" parameters="'init'">
         <table name="t_order" start-index="12" stop-index="18" />
         <where start-index="20" stop-index="33" literal-stop-index="38">
-            <and-predicate>
-                <predicate start-index="26" stop-index="33" literal-stop-index="38">
-                    <column-left-value name="status" start-index="26" stop-index="31" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="33" stop-index="33" />
+            <expr>
+                <binary-operation-expression start-index="26" stop-index="33" literal-stop-index="38">
+                    <left>
+                        <column name="status" start-index="26" stop-index="31" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="init" start-index="33" stop-index="38" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="33" stop-index="33" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_special_character_without_sharding_value">
         <table name="t_order" start-delimiter="`" end-delimiter="`" start-index="12" stop-index="20" />
         <where start-index="22" stop-index="42">
-            <and-predicate>
-                <predicate start-index="28" stop-index="42">
-                    <column-left-value name="status" start-delimiter="`" end-delimiter="`" start-index="28" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression value="init" start-index="37" stop-index="42"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="42">
+                    <left>
+                        <column name="status" start-delimiter="`" end-delimiter="`" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="init" start-index="37" stop-index="42" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_special_comments_return_without_sharding_value">
         <table name="t_order" start-index="33" stop-index="39" />
         <where start-index="41" stop-index="54">
-            <and-predicate>
-                <predicate start-index="47" stop-index="54">
-                    <column-left-value name="status" start-index="47" stop-index="52" />
-                    <operator type="=" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="47" stop-index="54">
+                    <left>
+                        <column name="status" start-index="47" stop-index="52" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="54" stop-index="54" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_special_comments_returning_without_sharding_value">
         <table name="t_order" start-index="34" stop-index="40" />
         <where start-index="43" stop-index="56">
-            <and-predicate>
-                <predicate start-index="49" stop-index="56">
-                    <column-left-value name="status" start-index="49" stop-index="54" />
-                    <operator type="=" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="49" stop-index="56">
+                    <left>
+                        <column name="status" start-index="49" stop-index="54" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="56" stop-index="56" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_alias" parameters="'init'">
         <table name="t_order" alias="o" start-index="12" stop-index="23" />
-        <where start-index="25" stop-index="38" literal-stop-index="44">
-            <and-predicate>
-                <predicate start-index="31" stop-index="38" literal-stop-index="43">
-                    <column-left-value name="status" start-index="31" stop-index="36" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="38" stop-index="38" />
+        <where start-index="25" stop-index="38" literal-stop-index="43">
+            <expr>
+                <binary-operation-expression start-index="31" stop-index="38" literal-stop-index="43">
+                    <left>
+                        <column name="status" start-index="31" stop-index="36" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="init" start-index="38" stop-index="43" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="38" stop-index="38" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_order_by_row_count" parameters="1000, 1001, 'init', 10">
         <table name="t_order" start-index="12" stop-index="18" />
         <where start-index="20" stop-index="66" literal-stop-index="77">
-            <and-predicate>
-                <predicate start-index="26" stop-index="37" literal-stop-index="40">
-                    <column-left-value name="order_id" start-index="26" stop-index="33" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
-                        <literal-expression value="1000" start-index="37" stop-index="40" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="43" stop-index="53" literal-start-index="46" literal-stop-index="59">
-                    <column-left-value name="user_id" start-index="43" stop-index="49" literal-start-index="46" literal-stop-index="52" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
-                        <literal-expression value="1001" start-index="56" stop-index="59" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="59" stop-index="66" literal-start-index="65" literal-stop-index="77">
-                    <column-left-value name="status" start-index="59" stop-index="64" literal-start-index="65" literal-stop-index="70" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="66" stop-index="66" />
-                        <literal-expression value="init" start-index="72" stop-index="77" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="26" stop-index="66" literal-stop-index="77">
+                    <left>
+                        <binary-operation-expression start-index="26" stop-index="53" literal-stop-index="59">
+                            <left>
+                                <binary-operation-expression start-index="26" stop-index="37" literal-stop-index="40">
+                                    <left>
+                                        <column name="order_id" start-index="26" stop-index="33" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1000" start-index="37" stop-index="40" />
+                                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="43" stop-index="53" literal-start-index="46" literal-stop-index="59">
+                                    <left>
+                                        <column name="user_id" start-index="43" stop-index="49" literal-start-index="46" literal-stop-index="52" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1001" start-index="56" stop-index="59" />
+                                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="59" stop-index="66" literal-start-index="65" literal-stop-index="77">
+                            <left>
+                                <column name="status" start-index="59" stop-index="64" literal-start-index="65" literal-stop-index="70" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="72" stop-index="77" />
+                                <parameter-marker-expression value="2" start-index="66" stop-index="66" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="77" stop-index="84" literal-start-index="88" literal-stop-index="95" />
@@ -182,16 +232,18 @@
             </output-table-columns>
         </output>
         <where start-index="108" stop-index="125" literal-stop-index="128">
-            <and-predicate>
-                <predicate start-index="114" stop-index="125" literal-stop-index="128">
-                    <column-left-value name="order_id" start-index="114" stop-index="121" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
+            <expr>
+                <binary-operation-expression start-index="114" stop-index="125" literal-stop-index="128">
+                    <left>
+                        <column name="order_id" start-index="114" stop-index="121" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="125" stop-index="128" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
@@ -209,16 +261,18 @@
             <output-table name="@MyTableVar" start-index="66" stop-index="76"/>
         </output>
         <where start-index="78" stop-index="95" literal-stop-index="98">
-            <and-predicate>
-                <predicate start-index="84" stop-index="95" literal-stop-index="98">
-                    <column-left-value name="order_id" start-index="84" stop-index="91" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="95" stop-index="95" />
+            <expr>
+                <binary-operation-expression start-index="84" stop-index="95" literal-stop-index="98">
+                    <left>
+                        <column name="order_id" start-index="84" stop-index="91" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="95" stop-index="98" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="95" stop-index="95" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
@@ -235,16 +289,18 @@
             </output-columns>
         </output>
         <where start-index="61" stop-index="78" literal-stop-index="81">
-            <and-predicate>
-                <predicate start-index="67" stop-index="74" literal-stop-index="81">
-                    <column-left-value name="order_id" start-index="67" stop-index="74" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="78" stop-index="78" />
+            <expr>
+                <binary-operation-expression start-index="67" stop-index="78" literal-stop-index="81">
+                    <left>
+                        <column name="order_id" start-index="67" stop-index="74" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="78" stop-index="81" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="78" stop-index="78" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
@@ -252,48 +308,54 @@
         <table name="t_order" start-index="12" stop-index="18" />
         <output start-index="20" stop-index="35"/>
         <where start-index="37" stop-index="54" literal-stop-index="57">
-            <and-predicate>
-                <predicate start-index="43" stop-index="50" literal-stop-index="54">
-                    <column-left-value name="order_id" start-index="43" stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="54" stop-index="54" />
+            <expr>
+                <binary-operation-expression start-index="43" stop-index="54" literal-stop-index="57">
+                    <left>
+                        <column name="order_id" start-index="43" stop-index="50" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="54" stop-index="57" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="54" stop-index="54" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_top" parameters="1000">
         <table name="t_order" start-index="20" stop-index="26" />
         <where start-index="28" stop-index="45" literal-stop-index="48">
-            <and-predicate>
-                <predicate start-index="34" stop-index="45" literal-stop-index="48">
-                    <column-left-value name="order_id" start-index="34" stop-index="41" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="45" stop-index="45" />
+            <expr>
+                <binary-operation-expression start-index="34" stop-index="45" literal-stop-index="48">
+                    <left>
+                        <column name="order_id" start-index="34" stop-index="41" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="45" stop-index="48" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="45" stop-index="45" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_with_top_percent" parameters="1000">
         <table name="t_order" start-index="28" stop-index="34" />
         <where start-index="36" stop-index="53" literal-stop-index="56">
-            <and-predicate>
-                <predicate start-index="42" stop-index="53" literal-stop-index="56">
-                    <column-left-value name="order_id" start-index="42" stop-index="49" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="53" stop-index="53" />
+            <expr>
+                <binary-operation-expression start-index="42" stop-index="53" literal-stop-index="56">
+                    <left>
+                        <column name="order_id" start-index="42" stop-index="49" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="53" stop-index="56" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="53" stop-index="53" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
@@ -319,13 +381,21 @@
         </with>
         <table name="t_order" start-index="79" stop-index="85" />
         <where start-index="96" stop-index="132">
-            <and-predicate>
-                <predicate start-index="96" stop-index="132">
-                    <column-left-value owner="t_order" name="order_id" start-index="110" stop-index="117" />
-                    <operator type="=" />
-                    <column-right-value owner="cte" name="order_id" start-index="125" stop-index="132" />
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="102" stop-index="132">
+                    <left>
+                        <column name="order_id" start-index="102" stop-index="117">
+                            <owner name="t_order" start-index="102" stop-index="108" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="121" stop-index="132">
+                            <owner name="cte" start-index="121" stop-index="123" />
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
@@ -347,39 +417,60 @@
         </with>
         <table name="t_order" start-index="59" stop-index="65" />
         <where start-index="76" stop-index="112">
-            <and-predicate>
-                <predicate start-index="82" stop-index="112">
-                    <column-left-value owner="t_order" name="order_id" start-index="90" stop-index="97" />
-                    <operator type="=" />
-                    <column-right-value owner="cte" name="order_id" start-index="105" stop-index="112" />
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="82" stop-index="112">
+                    <left>
+                        <column name="order_id" start-index="82" stop-index="97">
+                            <owner name="t_order" start-index="82" stop-index="88" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="101" stop-index="112">
+                            <owner name="cte" start-index="101" stop-index="103" />
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 
     <delete sql-case-id="delete_multi_tables" parameters="1">
         <where start-index="56" stop-index="124">
-            <and-predicate>
-                <predicate start-index="62" stop-index="101">
-                    <column-left-value name="order_id" start-index="62" stop-index="77">
-                        <owner name="t_order" start-index="62" stop-index="68"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <column-right-value name="order_id" start-index="62" stop-index="77">
-                        <owner name="t_order" start-index="62" stop-index="68"/>
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="107" stop-index="124">
-                    <column-left-value name="status" start-index="107" stop-index="120">
-                        <owner name="t_order" start-index="107" stop-index="113"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="124" stop-index="124"/>
-                        <literal-expression value="1" start-index="124" stop-index="124"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="62" stop-index="124">
+                    <left>
+                        <binary-operation-expression start-index="62" stop-index="101">
+                            <left>
+                                <column name="order_id" start-index="62" stop-index="77">
+                                    <owner name="t_order" start-index="62" stop-index="68" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="81" stop-index="101">
+                                    <owner name="t_order_item" start-index="81" stop-index="92" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>and</operator>
+                    <right>
+                        <binary-operation-expression start-index="107" stop-index="124">
+                            <left>
+                                <column name="status" start-index="107" stop-index="120">
+                                    <owner name="t_order" start-index="107" stop-index="113" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="124" stop-index="124" />
+                                <parameter-marker-expression value="0" start-index="124" stop-index="124" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <table name="t_order" start-index="7" stop-index="13"/>
         <table name="t_order_item" start-index="16" stop-index="27"/>
@@ -387,18 +478,20 @@
 
     <delete sql-case-id="delete_multi_tables_with_using" parameters="1">
         <where start-index="115" stop-index="138">
-            <and-predicate>
-                <predicate start-index="121" stop-index="138">
-                    <column-left-value name="status" start-index="121" stop-index="134">
-                        <owner name="t_order" start-index="121" stop-index="127"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="138" stop-index="138"/>
-                        <literal-expression value="1" start-index="138" stop-index="138"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="121" stop-index="138">
+                    <left>
+                        <column name="status" start-index="121" stop-index="134">
+                            <owner name="t_order" start-index="121" stop-index="127" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="138" stop-index="138" />
+                        <parameter-marker-expression value="0" start-index="138" stop-index="138" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <table name="t_order" start-index="12" stop-index="18"/>
         <table name="t_order_item" start-index="21" stop-index="32"/>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/delete.xml
@@ -500,16 +500,18 @@
     <delete sql-case-id="delete_with_query_hint" parameters="1000">
         <table name="t_order" start-index="12" stop-index="18" />
         <where start-index="20" stop-index="37" literal-stop-index="40">
-            <and-predicate>
-                <predicate start-index="26" stop-index="37" literal-stop-index="40">
-                    <column-left-value name="order_id" start-index="26" stop-index="33" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
+            <expr>
+                <binary-operation-expression start-index="26" stop-index="37" literal-stop-index="40">
+                    <left>
+                        <column name="order_id" start-index="26" stop-index="33" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="37" stop-index="40" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="37" stop-index="37" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </delete>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/insert.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/insert.xml
@@ -679,7 +679,7 @@
     </insert>
 
     <insert sql-case-id="insert_with_batch_and_composite_expression" parameters="1, 1, 'init', 2, 2, 'init'">
-            <table name="t_order" start-index="12" stop-index="18" />
+        <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="46">
             <column name="order_id" start-index="21" stop-index="28" />
             <column name="user_id" start-index="31" stop-index="37" />
@@ -1165,17 +1165,19 @@
                 <column-projection name="user_id" start-index="65" stop-index="71" />
                 <column-projection name="status" start-index="74" stop-index="79" />
             </projections>
-            <where start-index="94" stop-index="111">
-                <and-predicate>
-                    <predicate start-index="100" stop-index="111" literal-stop-index="113">
-                        <column-left-value name="order_id" start-index="100" stop-index="107" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="111" stop-index="111" />
+            <where start-index="94" stop-index="111" literal-stop-index="113">
+                <expr>
+                    <binary-operation-expression start-index="100" stop-index="111" literal-stop-index="113">
+                        <left>
+                            <column name="order_id" start-index="100" stop-index="107" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="111" stop-index="113" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="111" stop-index="111" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -1192,17 +1194,19 @@
                 <column-projection name="user_id" start-index="37" stop-index="43" />
                 <column-projection name="status" start-index="46" stop-index="51" />
             </projections>
-            <where start-index="66" stop-index="83">
-                <and-predicate>
-                    <predicate start-index="72" stop-index="83" literal-stop-index="85">
-                        <column-left-value name="order_id" start-index="72" stop-index="79" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="83" stop-index="83" />
+            <where start-index="66" stop-index="83" literal-stop-index="85">
+                <expr>
+                    <binary-operation-expression start-index="72" stop-index="83" literal-stop-index="85">
+                        <left>
+                            <column name="order_id" start-index="72" stop-index="79" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="83" stop-index="85" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="83" stop-index="83" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -1224,20 +1228,22 @@
                 <column-projection name="item_id" start-index="83" stop-index="89" />
                 <column-projection name="order_id" start-index="92" stop-index="99" />
                 <column-projection name="user_id" start-index="102" stop-index="108" />
-                <expression-projection start-index="111" stop-index="118" />
-                <expression-projection start-index="121" stop-index="132" />
+                <expression-projection text="insert" start-index="111" stop-index="118" />
+                <expression-projection text="2017-08-08" start-index="121" stop-index="132" />
             </projections>
-            <where start-index="152" stop-index="168">
-                <and-predicate>
-                    <predicate start-index="158" stop-index="168" literal-stop-index="170">
-                        <column-left-value name="item_id" start-index="158" stop-index="164" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="168" stop-index="168" />
+            <where start-index="152" stop-index="168" literal-stop-index="170">
+                <expr>
+                    <binary-operation-expression start-index="158" stop-index="168" literal-stop-index="170">
+                        <left>
+                            <column name="item_id" start-index="158" stop-index="164" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="168" stop-index="170" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="168" stop-index="168" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -1257,20 +1263,22 @@
             <projections start-index="74" stop-index="114">
                 <column-projection name="order_id" start-index="74" stop-index="81" />
                 <column-projection name="user_id" start-index="84" stop-index="90" />
-                <expression-projection start-index="93" stop-index="100" />
-                <expression-projection start-index="103" stop-index="114" />
+                <expression-projection text="insert" start-index="93" stop-index="100" />
+                <expression-projection text="2017-08-08" start-index="103" stop-index="114" />
             </projections>
-            <where start-index="134" stop-index="151">
-                <and-predicate>
-                    <predicate start-index="140" stop-index="151" literal-stop-index="153">
-                        <column-left-value name="order_id" start-index="140" stop-index="147" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="151" stop-index="151" />
+            <where start-index="134" stop-index="151" literal-stop-index="153">
+                <expr>
+                    <binary-operation-expression start-index="140" stop-index="151" literal-stop-index="153">
+                        <left>
+                            <column name="order_id" start-index="140" stop-index="147" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="151" stop-index="153" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="151" stop-index="151" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -1291,17 +1299,19 @@
                 <column-projection name="user_id" start-index="64" stop-index="70" />
                 <column-projection name="status" start-index="73" stop-index="78" />
             </projections>
-            <where start-index="93" stop-index="110">
-                <and-predicate>
-                    <predicate start-index="99" stop-index="110" literal-stop-index="112">
-                        <column-left-value name="order_id" start-index="99" stop-index="106" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="110" stop-index="110" literal-stop-index="112" />
+            <where start-index="93" stop-index="110" literal-stop-index="112">
+                <expr>
+                    <binary-operation-expression start-index="99" stop-index="110" literal-stop-index="112">
+                        <left>
+                            <column name="order_id" start-index="99" stop-index="106" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="110" stop-index="112" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="110" stop-index="110" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
         <on-duplicate-key-columns start-index="112" stop-index="158" literal-start-index="114" literal-stop-index="160">
@@ -1328,7 +1338,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_digit_literals_value">
         <table name="digit_literals_value_test" start-index="12" stop-index="36" />
         <columns start-index="37" stop-index="42">
@@ -1342,7 +1352,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_with_clause">
         <with start-index="0" stop-index="70">
             <common-table-expression name = "cte" start-index="5" stop-index="70">
@@ -1378,7 +1388,7 @@
             </projections>
         </select>
     </insert>
-    
+
     <insert sql-case-id="insert_without_columns_with_with_clause">
         <with start-index="0" stop-index="50">
             <common-table-expression name="cte" start-index="5" stop-index="50">
@@ -1410,7 +1420,7 @@
             </projections>
         </select>
     </insert>
-    
+
     <insert sql-case-id="insert_without_into_keyword" parameters="1, 1, 'init'">
         <table name="t_order" start-index="7" stop-index="13" />
         <columns start-index="15" stop-index="41">
@@ -1435,7 +1445,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_default_values">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="46">
@@ -1444,12 +1454,12 @@
             <column name="status" start-index="40" stop-index="45" />
         </columns>
     </insert>
-    
+
     <insert sql-case-id="insert_without_columns_with_default_values">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="19" stop-index="19" />
     </insert>
-    
+
     <insert sql-case-id="insert_with_top">
         <table name="t_order" start-index="15" stop-index="21" />
         <columns start-index="23" stop-index="41">
@@ -1466,7 +1476,7 @@
             </projections>
         </select>
     </insert>
-    
+
     <insert sql-case-id="insert_with_top_percent">
         <table name="t_order" start-index="23" stop-index="29" />
         <columns start-index="31" stop-index="49">
@@ -1483,7 +1493,7 @@
             </projections>
         </select>
     </insert>
-    
+
     <insert sql-case-id="insert_with_output_clause" parameters="1, 1">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="38">
@@ -1518,7 +1528,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_output_clause_without_output_table_columns" parameters="1, 1">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="38">
@@ -1549,7 +1559,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_output_clause_without_output_table" parameters="1, 1">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="38">
@@ -1579,7 +1589,7 @@
             </value>
         </values>
     </insert>
-    
+
     <insert sql-case-id="insert_with_output_clause_column_shorthand" parameters="1, 1">
         <table name="t_order" start-index="12" stop-index="18" />
         <columns start-index="20" stop-index="38">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/replace.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/replace.xml
@@ -849,17 +849,19 @@
                 <column-projection name="user_id" start-index="66" stop-index="72" />
                 <column-projection name="status" start-index="75" stop-index="80" />
             </projections>
-            <where start-index="95" stop-index="112">
-                <and-predicate>
-                    <predicate start-index="101" stop-index="112" literal-stop-index="114">
-                        <column-left-value name="order_id" start-index="101" stop-index="108" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+            <where start-index="95" stop-index="112" literal-stop-index="114">
+                <expr>
+                    <binary-operation-expression start-index="101" stop-index="112" literal-stop-index="114">
+                        <left>
+                            <column name="order_id" start-index="101" stop-index="108" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="112" stop-index="114" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -876,17 +878,19 @@
                 <column-projection name="user_id" start-index="38" stop-index="44" />
                 <column-projection name="status" start-index="47" stop-index="52" />
             </projections>
-            <where start-index="67" stop-index="84">
-                <and-predicate>
-                    <predicate start-index="73" stop-index="84" literal-stop-index="86">
-                        <column-left-value name="order_id" start-index="73" stop-index="80" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="84" stop-index="84" />
+            <where start-index="67" stop-index="84" literal-stop-index="86">
+                <expr>
+                    <binary-operation-expression start-index="73" stop-index="84" literal-stop-index="86">
+                        <left>
+                            <column name="order_id" start-index="73" stop-index="80" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="84" stop-index="86" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="84" stop-index="84" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -901,11 +905,6 @@
             <column name="creation_date" start-index="62" stop-index="74" />
         </columns>
         <select>
-<!--            <table-reference>-->
-<!--                <table-factor>-->
-<!--                    <table name="t_order_item" start-index="140" stop-index="151" />-->
-<!--                </table-factor>-->
-<!--            </table-reference>-->
             <from>
                 <simple-table name="t_order_item" start-index="140" stop-index="151" />
             </from>
@@ -913,20 +912,22 @@
                 <column-projection name="item_id" start-index="84" stop-index="90" />
                 <column-projection name="order_id" start-index="93" stop-index="100" />
                 <column-projection name="user_id" start-index="103" stop-index="109" />
-                <expression-projection start-index="112" stop-index="119" />
-                <expression-projection start-index="122" stop-index="133" />
+                <expression-projection text="insert" start-index="112" stop-index="119" />
+                <expression-projection text="2017-08-08" start-index="122" stop-index="133" />
             </projections>
-            <where start-index="153" stop-index="169">
-                <and-predicate>
-                    <predicate start-index="159" stop-index="169" literal-stop-index="171">
-                        <column-left-value name="item_id" start-index="159" stop-index="165" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="169" stop-index="169" />
+            <where start-index="153" stop-index="169" literal-stop-index="171">
+                <expr>
+                    <binary-operation-expression start-index="159" stop-index="169" literal-stop-index="171">
+                        <left>
+                            <column name="item_id" start-index="159" stop-index="165" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="169" stop-index="171" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="169" stop-index="169" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>
@@ -946,20 +947,22 @@
             <projections start-index="75" stop-index="115">
                 <column-projection name="order_id" start-index="75" stop-index="82" />
                 <column-projection name="user_id" start-index="85" stop-index="91" />
-                <expression-projection start-index="94" stop-index="101" />
-                <expression-projection start-index="104" stop-index="115" />
+                <expression-projection text="insert" start-index="94" stop-index="101" />
+                <expression-projection text="2017-08-08" start-index="104" stop-index="115" />
             </projections>
-            <where start-index="135" stop-index="152">
-                <and-predicate>
-                    <predicate start-index="141" stop-index="152" literal-stop-index="154">
-                        <column-left-value name="order_id" start-index="141" stop-index="148" />
-                        <operator type="=" />
-                        <compare-right-value>
-                            <parameter-marker-expression value="0" start-index="152" stop-index="152" />
+            <where start-index="135" stop-index="152" literal-stop-index="154">
+                <expr>
+                    <binary-operation-expression start-index="141" stop-index="152" literal-stop-index="154">
+                        <left>
+                            <column name="order_id" start-index="141" stop-index="148" />
+                        </left>
+                        <operator>=</operator>
+                        <right>
                             <literal-expression value="100" start-index="152" stop-index="154" />
-                        </compare-right-value>
-                    </predicate>
-                </and-predicate>
+                            <parameter-marker-expression value="0" start-index="152" stop-index="152" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
             </where>
         </select>
     </insert>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-aggregate.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-aggregate.xml
@@ -43,15 +43,26 @@
             <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="45" stop-index="64">
-            <and-predicate>
-                <predicate start-index="51" stop-index="64">
-                    <column-left-value name="order_id" start-index="51" stop-index="58" />
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <common-expression text="1-1" start-index="62" stop-index="64" literal-start-index="62" literal-stop-index="64" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="51" stop-index="64">
+                    <left>
+                        <column name="order_id" start-index="51" stop-index="58" />
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <binary-operation-expression start-index="62" stop-index="64">
+                            <left>
+                                <literal-expression value="1" start-index="62" stop-index="62" />
+                            </left>
+                            <operator>-</operator>
+                            <right>
+                                <literal-expression value="1" start-index="64" stop-index="64" />
+                            </right>
+                        </binary-operation-expression>
+                        <common-expression text="1-1" start-index="62" stop-index="64" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -63,15 +74,26 @@
             <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="45" stop-index="66">
-            <and-predicate>
-                <predicate start-index="51" stop-index="66">
-                    <column-left-value name="order_id" start-index="51" stop-index="58" />
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <common-expression text="1 - 1" start-index="62" stop-index="66" literal-start-index="62" literal-stop-index="66"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="51" stop-index="66">
+                    <left>
+                        <column name="order_id" start-index="51" stop-index="58" />
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <binary-operation-expression start-index="62" stop-index="66">
+                            <left>
+                                <literal-expression value="1" start-index="62" stop-index="62" />
+                            </left>
+                            <operator>-</operator>
+                            <right>
+                                <literal-expression value="1" start-index="66" stop-index="66" />
+                            </right>
+                        </binary-operation-expression>
+                        <common-expression text="1 - 1" start-index="62" stop-index="66" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -117,46 +139,91 @@
             <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="62" stop-index="171" literal-stop-index="172">
-            <and-predicate>
-                <predicate start-index="68" stop-index="88">
-                    <column-left-value name="user_id" start-index="68" stop-index="76">
-                        <owner name="o" start-index="68" stop-index="68" />
-                    </column-left-value>
-                    <column-right-value name="user_id" start-index="80" stop-index="88">
-                        <owner name="i" start-index="80" stop-index="80" />
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="94" stop-index="116">
-                    <column-left-value name="order_id" start-index="94" stop-index="103">
-                        <owner name="o" start-index="94" stop-index="94" />
-                    </column-left-value>
-                    <column-right-value name="order_id" start-index="107" stop-index="116">
-                        <owner name="i" start-index="107" stop-index="107" />
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="122" stop-index="140">
-                    <column-left-value name="user_id" start-index="122" stop-index="130">
-                        <owner name="o" start-index="122" stop-index="122" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="136" stop-index="136" />
-                        <parameter-marker-expression value="1" start-index="139" stop-index="139" />
-                        <literal-expression value="1" start-index="136" stop-index="136" />
-                        <literal-expression value="2" start-index="139" stop-index="139" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="146" stop-index="171" literal-stop-index="172">
-                    <column-left-value name="order_id" start-index="146" stop-index="155">
-                        <owner name="o" start-index="146" stop-index="146" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="165" stop-index="165" />
-                        <between-literal-expression value="9" start-index="165" stop-index="165" />
-                        <and-parameter-marker-expression value="3" start-index="171" stop-index="171" />
-                        <and-literal-expression value="10" start-index="171" stop-index="172" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="68" stop-index="171" literal-stop-index="172">
+                    <left>
+                        <binary-operation-expression start-index="68" stop-index="140">
+                            <left>
+                                <binary-operation-expression start-index="68" stop-index="116">
+                                    <left>
+                                        <binary-operation-expression start-index="68" stop-index="88">
+                                            <left>
+                                                <column name="user_id" start-index="68" stop-index="76">
+                                                    <owner name="o" start-index="68" stop-index="68" />
+                                                </column>
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <column name="user_id" start-index="80" stop-index="88">
+                                                    <owner name="i" start-index="80" stop-index="80" />
+                                                </column>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="94" stop-index="116">
+                                            <left>
+                                                <column name="order_id" start-index="94" stop-index="103">
+                                                    <owner name="o" start-index="94" stop-index="94" />
+                                                </column>
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <column name="order_id" start-index="107" stop-index="116">
+                                                    <owner name="i" start-index="107" stop-index="107" />
+                                                </column>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <in-expression start-index="122" stop-index="140">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="122" stop-index="130">
+                                            <owner name="o" start-index="122" stop-index="122" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="135" stop-index="140">
+                                            <items>
+                                                <literal-expression value="1" start-index="136" stop-index="136" />
+                                                <parameter-marker-expression value="0" start-index="136" stop-index="136" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="139" stop-index="139" />
+                                                <parameter-marker-expression value="1" start-index="139" stop-index="139" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="146" stop-index="171" literal-stop-index="172">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="146" stop-index="155">
+                                    <owner name="o" start-index="146" stop-index="146" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="165" stop-index="165" />
+                                <parameter-marker-expression value="2" start-index="165" stop-index="165" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="171" stop-index="172" />
+                                <parameter-marker-expression value="3" start-index="171" stop-index="171" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -195,30 +262,51 @@
             <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="119" stop-index="174" literal-stop-index="175">
-            <and-predicate>
-                <predicate start-index="125" stop-index="143">
-                    <column-left-value name="user_id" start-index="125" stop-index="133">
-                        <owner name="o" start-index="125" stop-index="125" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="139" stop-index="139" />
-                        <parameter-marker-expression value="1" start-index="142" stop-index="142" />
-                        <literal-expression value="1" start-index="139" stop-index="139" />
-                        <literal-expression value="2" start-index="142" stop-index="142" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="149" stop-index="174" literal-stop-index="175">
-                    <column-left-value name="order_id" start-index="149" stop-index="158">
-                        <owner name="o" start-index="149" stop-index="149" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="168" stop-index="168" />
-                        <between-literal-expression value="9" start-index="168" stop-index="168" />
-                        <and-parameter-marker-expression value="3" start-index="174" stop-index="174" />
-                        <and-literal-expression value="10" start-index="174" stop-index="175" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="125" stop-index="174" literal-stop-index="175">
+                    <left>
+                        <in-expression start-index="125" stop-index="143">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="125" stop-index="133">
+                                    <owner name="o" start-index="125" stop-index="125" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="138" stop-index="143">
+                                    <items>
+                                        <literal-expression value="1" start-index="139" stop-index="139" />
+                                        <parameter-marker-expression value="0" start-index="139" stop-index="139" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="142" stop-index="142" />
+                                        <parameter-marker-expression value="1" start-index="142" stop-index="142" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="149" stop-index="174" literal-stop-index="175">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="149" stop-index="158">
+                                    <owner name="o" start-index="149" stop-index="149" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="168" stop-index="168" />
+                                <parameter-marker-expression value="2" start-index="168" stop-index="168" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="174" stop-index="175" />
+                                <parameter-marker-expression value="3" start-index="174" stop-index="174" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
@@ -37,6 +37,7 @@
             <simple-table name="t_order" alias="o" start-index="38" stop-index="49"/>
         </from>
         <projections start-index="7" stop-index="31">
+            <!-- 'text' is different from other database -->
             <expression-projection text="o.order_id+1*2" alias="exp" start-index="7" stop-index="31"/>
         </projections>
         <order-by>
@@ -48,15 +49,13 @@
 
     <select sql-case-id="select_with_date_function">
         <from>
-            <simple-table name="t_order_item" alias="i" start-delimiter="`" end-delimiter="`"
-                          start-index="51" stop-index="69"/>
+            <simple-table name="t_order_item" alias="i" start-delimiter="`" end-delimiter="`" start-index="51" stop-index="69"/>
         </from>
         <projections start-index="7" stop-index="44">
             <expression-projection text="DATE(i.creation_date)" alias="creation_date" start-index="7" stop-index="44"/>
         </projections>
         <order-by>
-            <expression-item expression="DATE(i.creation_date)" order-direction="DESC"
-                             start-index="80" stop-index="100"/>
+            <expression-item expression="DATE(i.creation_date)" order-direction="DESC" start-index="80" stop-index="100"/>
         </order-by>
     </select>
 
@@ -69,11 +68,9 @@
         </projections>
         <where start-index="29" stop-index="75" literal-stop-index="80">
             <expr>
-                <binary-operation-expression start-index="35" stop-index="75"
-                                             literal-stop-index="80">
+                <binary-operation-expression start-index="35" stop-index="75" literal-stop-index="80">
                     <left>
-                        <binary-operation-expression start-index="35" stop-index="51"
-                                                     literal-stop-index="56">
+                        <binary-operation-expression start-index="35" stop-index="51" literal-stop-index="56">
                             <left>
                                 <column name="status" start-index="35" stop-index="42">
                                     <owner name="t" start-index="35" stop-index="35"/>
@@ -82,37 +79,28 @@
                             <operator>REGEXP</operator>
                             <right>
                                 <literal-expression value="init" start-index="51" stop-index="56"/>
-                                <parameter-marker-expression value="0" start-index="51"
-                                                             stop-index="51"/>
+                                <parameter-marker-expression value="0" start-index="51" stop-index="51"/>
                             </right>
                         </binary-operation-expression>
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <in-expression start-index="57" stop-index="75" literal-start-index="62"
-                                       literal-stop-index="80">
+                        <in-expression start-index="57" stop-index="75" literal-start-index="62" literal-stop-index="80">
                             <not>false</not>
                             <left>
-                                <column name="item_id" start-index="57" stop-index="65"
-                                        literal-start-index="62" literal-stop-index="70">
-                                    <owner name="t" start-index="57" stop-index="57"
-                                           literal-start-index="62" literal-stop-index="62"/>
+                                <column name="item_id" start-index="57" stop-index="65" literal-start-index="62" literal-stop-index="70">
+                                    <owner name="t" start-index="57" stop-index="57" literal-start-index="62" literal-stop-index="62"/>
                                 </column>
                             </left>
                             <right>
-                                <list-expression start-index="70" stop-index="75"
-                                                 literal-start-index="75" literal-stop-index="80">
+                                <list-expression start-index="70" stop-index="75" literal-start-index="75" literal-stop-index="80">
                                     <items>
-                                        <literal-expression value="1" start-index="76"
-                                                            stop-index="76"/>
-                                        <parameter-marker-expression value="1" start-index="71"
-                                                                     stop-index="71"/>
+                                        <literal-expression value="1" start-index="76" stop-index="76"/>
+                                        <parameter-marker-expression value="1" start-index="71" stop-index="71"/>
                                     </items>
                                     <items>
-                                        <literal-expression value="2" start-index="79"
-                                                            stop-index="79"/>
-                                        <parameter-marker-expression value="2" start-index="74"
-                                                                     stop-index="74"/>
+                                        <literal-expression value="2" start-index="79" stop-index="79"/>
+                                        <parameter-marker-expression value="2" start-index="74" stop-index="74"/>
                                     </items>
                                 </list-expression>
                             </right>
@@ -213,6 +201,40 @@
                                 </column>
                             </right>
                         </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_or_sign" parameters="1, 2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20" />
+        </from>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <where start-index="22" stop-index="71">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="71">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="52">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="43">
+                                    <owner name="t_order" start-index="28" stop-index="34" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <common-expression text="? || ?" literal-text="1 || 2" start-index="47" stop-index="52" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="56" stop-index="71">
+                            <owner name="t_order" start-index="56" stop-index="62" />
+                        </column>
                     </right>
                 </binary-operation-expression>
             </expr>
@@ -1357,22 +1379,22 @@
         </where>
     </select>
 
-    <select sql-case-id="select_where_with_simple_expr_with_row">
+    <select sql-case-id="select_where_with_simple_expr_with_row" parameters="'abc'">
         <from start-index="14" stop-index="20">
-            <simple-table name="t_order" start-index="14" stop-index="20"/>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
-        <projections distinct-row="false" start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7"/>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="65">
+        <where start-index="22" stop-index="61" literal-stop-index="65">
             <expr>
-                <binary-operation-expression start-index="28" stop-index="65">
+                <binary-operation-expression start-index="28" stop-index="61" literal-stop-index="65">
                     <left>
-                        <common-expression text="ROW('abc', now())" start-index="28" stop-index="44"/>
+                        <common-expression text="ROW(?, now())" literal-text="ROW('abc', now())" start-index="28" stop-index="40" literal-stop-index="44"/>
                     </left>
                     <operator>=</operator>
                     <right>
-                        <common-expression text="(order_id, status)" start-index="48" stop-index="65"/>
+                        <common-expression text="(order_id, status)" start-index="44" stop-index="61" literal-start-index="48" literal-stop-index="65"/>
                     </right>
                 </binary-operation-expression>
             </expr>
@@ -1456,16 +1478,16 @@
         </where>
     </select>
 
-    <select sql-case-id="select_where_with_simple_expr_with_odbc_escape_syntax">
+    <select sql-case-id="select_where_with_simple_expr_with_odbc_escape_syntax" parameters="'1994-02-04 12:23:00'">
         <from start-index="14" stop-index="20">
-            <simple-table name="t_order" start-index="14" stop-index="20"/>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
-        <projections distinct-row="false" start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7"/>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="53">
+        <where start-index="22" stop-index="33" literal-stop-index="53">
             <expr>
-                <common-expression text="{ts '1994-02-04 12:23:00'}" start-index="28" stop-index="53"/>
+                <common-expression text="{ts ?}" literal-text="{ts '1994-02-04 12:23:00'}" start-index="28" stop-index="33" literal-stop-index="53"/>
             </expr>
         </where>
     </select>
@@ -1498,30 +1520,34 @@
         </where>
     </select>
 
-    <select sql-case-id="select_where_with_simple_expr_with_match">
+    <select sql-case-id="select_where_with_simple_expr_with_match" parameters="'keyword'">
         <from start-index="14" stop-index="20">
-            <simple-table name="t_order" start-index="14" stop-index="20"/>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
-        <projections distinct-row="false" start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7"/>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="88">
+        <where start-index="22" stop-index="80" literal-stop-index="88">
             <expr>
-                <common-expression text="MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" start-index="28" stop-index="88"/>
+                <common-expression text="MATCH (order_id) AGAINST (? IN NATURAL LANGUAGE MODE)"
+                                   literal-text="MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)"
+                                   start-index="28" stop-index="80" literal-stop-index="88"/>
             </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_where_with_simple_expr_with_case">
+    <select sql-case-id="select_where_with_simple_expr_with_case" parameters="1,'true','false'">
         <from start-index="14" stop-index="20">
-            <simple-table name="t_order" start-index="14" stop-index="20"/>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
-        <projections distinct-row="false" start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7"/>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="78">
+        <where start-index="22" stop-index="67" literal-stop-index="78">
             <expr>
-                <common-expression text="CASE WHEN order_id &gt; 2 THEN 'true' ELSE 'false' END" start-index="28" stop-index="78"/>
+                <common-expression text="CASE WHEN order_id &gt; ? THEN ? ELSE ? END"
+                                   literal-text="CASE WHEN order_id > 1 THEN 'true' ELSE 'false' END"
+                                   start-index="28" stop-index="67" literal-stop-index="78" />
             </expr>
         </where>
     </select>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
@@ -19,58 +19,107 @@
 <sql-parser-test-cases>
     <select sql-case-id="select_with_expression">
         <from>
-            <simple-table name="t_order" alias="o" start-index="38" stop-index="49" />
+            <simple-table name="t_order" alias="o" start-index="38" stop-index="49"/>
         </from>
         <projections start-index="7" stop-index="31">
             <!-- TODO check expression-projection's stop-index whether include alias -->
-            <expression-projection alias="exp" start-index="7" stop-index="31" />
+            <expression-projection text="o.order_id + 1 * 2" alias="exp" start-index="7" stop-index="31"/>
         </projections>
         <order-by>
-            <column-item name="order_id" start-index="60" stop-index="69" >
-                <owner name="o" start-index="60" stop-index="60" />
+            <column-item name="order_id" start-index="60" stop-index="69">
+                <owner name="o" start-index="60" stop-index="60"/>
+            </column-item>
+        </order-by>
+    </select>
+
+    <select sql-case-id="select_with_expression_for_postgresql">
+        <from>
+            <simple-table name="t_order" alias="o" start-index="38" stop-index="49"/>
+        </from>
+        <projections start-index="7" stop-index="31">
+            <expression-projection text="o.order_id+1*2" alias="exp" start-index="7" stop-index="31"/>
+        </projections>
+        <order-by>
+            <column-item name="order_id" start-index="60" stop-index="69">
+                <owner name="o" start-index="60" stop-index="60"/>
             </column-item>
         </order-by>
     </select>
 
     <select sql-case-id="select_with_date_function">
         <from>
-            <simple-table name="t_order_item" alias="i" start-delimiter="`" end-delimiter="`" start-index="51" stop-index="69" />
+            <simple-table name="t_order_item" alias="i" start-delimiter="`" end-delimiter="`"
+                          start-index="51" stop-index="69"/>
         </from>
         <projections start-index="7" stop-index="44">
-            <expression-projection alias="creation_date" start-index="7" stop-index="44" />
+            <expression-projection text="DATE(i.creation_date)" alias="creation_date" start-index="7" stop-index="44"/>
         </projections>
         <order-by>
-            <expression-item expression="DATE(i.creation_date)" order-direction="DESC" start-index="80" stop-index="100" />
+            <expression-item expression="DATE(i.creation_date)" order-direction="DESC"
+                             start-index="80" stop-index="100"/>
         </order-by>
     </select>
 
     <select sql-case-id="select_with_regexp" parameters="'init', 1, 2">
         <from>
-            <simple-table name="t_order_item" alias="t" start-index="14" stop-index="27" />
+            <simple-table name="t_order_item" alias="t" start-index="14" stop-index="27"/>
         </from>
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <where start-index="29" stop-index="75" literal-stop-index="80">
-            <and-predicate>
-                <!-- FIXME cannot parse REGEXP -->
-                <!--<predicate start-index="35" stop-index="51" literal-stop-index="56">-->
-                    <!--<column-left-value name="status" start-index="35" stop-index="51" literal-stop-index="56">-->
-                        <!--<owner name="t" start-index="35" stop-index="35" />-->
-                    <!--</column-left-value>-->
-                <!--</predicate>-->
-                <predicate start-index="57" stop-index="75"  literal-start-index="62" literal-stop-index="80">
-                    <column-left-value name="item_id" start-index="57" stop-index="65" literal-start-index="62" literal-stop-index="70">
-                        <owner name="t" start-index="57" stop-index="57" literal-start-index="62" literal-stop-index="62" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="1" start-index="71" stop-index="71" />
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="1" start-index="76" stop-index="76" />
-                        <literal-expression value="2" start-index="79" stop-index="79" />
-                    </in-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="35" stop-index="75"
+                                             literal-stop-index="80">
+                    <left>
+                        <binary-operation-expression start-index="35" stop-index="51"
+                                                     literal-stop-index="56">
+                            <left>
+                                <column name="status" start-index="35" stop-index="42">
+                                    <owner name="t" start-index="35" stop-index="35"/>
+                                </column>
+                            </left>
+                            <operator>REGEXP</operator>
+                            <right>
+                                <literal-expression value="init" start-index="51" stop-index="56"/>
+                                <parameter-marker-expression value="0" start-index="51"
+                                                             stop-index="51"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <in-expression start-index="57" stop-index="75" literal-start-index="62"
+                                       literal-stop-index="80">
+                            <not>false</not>
+                            <left>
+                                <column name="item_id" start-index="57" stop-index="65"
+                                        literal-start-index="62" literal-stop-index="70">
+                                    <owner name="t" start-index="57" stop-index="57"
+                                           literal-start-index="62" literal-stop-index="62"/>
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="70" stop-index="75"
+                                                 literal-start-index="75" literal-stop-index="80">
+                                    <items>
+                                        <literal-expression value="1" start-index="76"
+                                                            stop-index="76"/>
+                                        <parameter-marker-expression value="1" start-index="71"
+                                                                     stop-index="71"/>
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="79"
+                                                            stop-index="79"/>
+                                        <parameter-marker-expression value="2" start-index="74"
+                                                                     stop-index="74"/>
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -82,45 +131,1398 @@
             <column-projection start-index="11" stop-index="19" name="item_id" alias="item_id">
                 <owner start-index="11" stop-index="11" name="o"/>
             </column-projection>
-            <expression-projection start-index="33" stop-index="124" alias="stateName" />
+            <expression-projection text="case when t.status = 'init' then '已启用' when t.status = 'failed' then '已停用' end" start-index="33" stop-index="124" alias="stateName"/>
         </projections>
         <from>
             <join-table>
                 <left>
-                    <simple-table start-index="135" stop-index="143" name="t_order" alias="t" />
+                    <simple-table start-index="135" stop-index="143" name="t_order" alias="t"/>
                 </left>
                 <right>
-                    <simple-table start-index="155" stop-index="171" name="t_order_item" alias="o" />
+                    <simple-table start-index="155" stop-index="171" name="t_order_item" alias="o"/>
                 </right>
                 <joinSpecification>
                     <and-predicate>
                         <predicate start-index="176" stop-index="197">
                             <column-left-value name="order_id" start-index="176" stop-index="185">
-                                <owner name="o" start-index="176" stop-index="176" />
+                                <owner name="o" start-index="176" stop-index="176"/>
                             </column-left-value>
                             <column-right-value name="order_id" start-index="188" stop-index="197">
-                                <owner name="t" start-index="188" stop-index="188" />
+                                <owner name="t" start-index="188" stop-index="188"/>
                             </column-right-value>
                         </predicate>
                     </and-predicate>
                 </joinSpecification>
             </join-table>
         </from>
-        <where start-index="198" stop-index="219">
-            <and-predicate>
-                <predicate start-index="205" stop-index="219" >
-                    <operator type="=" />
-                    <column-left-value name="order_id" start-index="205" stop-index="214">
-                        <owner name="t" start-index="205" stop-index="205" />
-                    </column-left-value>
-                    <compare-right-value operator="=">
-                        <literal-expression value="1000" start-index="216" stop-index="219" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="199" stop-index="219">
+            <expr>
+                <binary-operation-expression start-index="205" stop-index="219">
+                    <left>
+                        <column name="order_id" start-index="205" stop-index="214">
+                            <owner name="t" start-index="205" stop-index="205"/>
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1000" start-index="216" stop-index="219"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <limit start-index="221" stop-index="227">
-            <row-count value="1" start-index="227" stop-index="227" />
+            <row-count value="1" start-index="227" stop-index="227"/>
         </limit>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_or" parameters="1,2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="71">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="71">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="43">
+                                    <owner name="t_order" start-index="28" stop-index="34"/>
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="47" stop-index="47"/>
+                                <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>OR</operator>
+                    <right>
+                        <binary-operation-expression start-index="52" stop-index="71">
+                            <left>
+                                <literal-expression value="2" start-index="52" stop-index="52"/>
+                                <parameter-marker-expression value="1" start-index="52" stop-index="52"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="56" stop-index="71">
+                                    <owner name="t_order" start-index="56" stop-index="62"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_xor" parameters="1,2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="72">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="72">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="43">
+                                    <owner name="t_order" start-index="28" stop-index="34"/>
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="47" stop-index="47"/>
+                                <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>XOR</operator>
+                    <right>
+                        <binary-operation-expression start-index="53" stop-index="72">
+                            <left>
+                                <literal-expression value="2" start-index="53" stop-index="53"/>
+                                <parameter-marker-expression value="1" start-index="53" stop-index="53"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="57" stop-index="72">
+                                    <owner name="t_order" start-index="57" stop-index="63"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_and" parameters="1,2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="72">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="72">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="43">
+                                    <owner name="t_order" start-index="28" stop-index="34"/>
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="47" stop-index="47"/>
+                                <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="53" stop-index="72">
+                            <left>
+                                <literal-expression value="2" start-index="53" stop-index="53"/>
+                                <parameter-marker-expression value="1" start-index="53" stop-index="53"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="57" stop-index="72">
+                                    <owner name="t_order" start-index="57" stop-index="63"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_and_sign" parameters="1,2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="71">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="71">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="43">
+                                    <owner name="t_order" start-index="28" stop-index="34"/>
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="47" stop-index="47"/>
+                                <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>&amp;&amp;</operator>
+                    <right>
+                        <binary-operation-expression start-index="52" stop-index="71">
+                            <left>
+                                <literal-expression value="2" start-index="52" stop-index="52"/>
+                                <parameter-marker-expression value="1" start-index="52" stop-index="52"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="56" stop-index="71">
+                                    <owner name="t_order" start-index="56" stop-index="62"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_not" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="53">
+            <expr>
+                <not-expression start-index="28" stop-index="53">
+                    <expr>
+                        <binary-operation-expression start-index="33" stop-index="52">
+                            <left>
+                                <literal-expression value="1" start-index="33" stop-index="33"/>
+                                <parameter-marker-expression value="0" start-index="33" stop-index="33"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="37" stop-index="52">
+                                    <owner name="t_order" start-index="37" stop-index="43"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </expr>
+                </not-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_not_sign" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="52">
+            <expr>
+                <not-expression start-index="28" stop-index="52">
+                    <expr>
+                        <binary-operation-expression start-index="32" stop-index="51">
+                            <left>
+                                <literal-expression value="1" start-index="32" stop-index="32"/>
+                                <parameter-marker-expression value="0" start-index="32" stop-index="32"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="36" stop-index="51">
+                                    <owner name="t_order" start-index="36" stop-index="42"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </expr>
+                </not-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_is" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="56">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="56">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <literal-expression value="1" start-index="28" stop-index="28"/>
+                                <parameter-marker-expression value="0" start-index="28" stop-index="28"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="32" stop-index="47">
+                                    <owner name="t_order" start-index="32" stop-index="38"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>IS</operator>
+                    <right>
+                        <literal-expression value="51..56" start-index="51" stop-index="56"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_expr_with_is_not" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="60">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="60">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="47">
+                            <left>
+                                <literal-expression value="1" start-index="28" stop-index="28"/>
+                                <parameter-marker-expression value="0" start-index="28" stop-index="28"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="32" stop-index="47">
+                                    <owner name="t_order" start-index="32" stop-index="38"/>
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>IS</operator>
+                    <right>
+                        <literal-expression value="51..60" start-index="51" stop-index="60"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_boolean_primary_with_is">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="49">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="49">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>IS</operator>
+                    <right>
+                        <literal-expression value="45..49" start-index="45" stop-index="49"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_boolean_primary_with_is_not">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="53">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="53">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>IS</operator>
+                    <right>
+                        <literal-expression value="45..53" start-index="45" stop-index="53"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_boolean_primary_with_null_safe">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="62">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="62">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&lt;=&gt;</operator>
+                    <right>
+                        <column name="order_id" start-index="47" stop-index="62">
+                            <owner name="t_order" start-index="47" stop-index="53"/>
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_boolean_primary_with_comparison_predicate">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="61">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="61">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&gt;=</operator>
+                    <right>
+                        <column name="order_id" start-index="46" stop-index="61">
+                            <owner name="t_order" start-index="46" stop-index="52"/>
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_boolean_primary_with_comparison_subquery" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="98">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="98">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <subquery start-index="49" stop-index="98">
+                            <select>
+                                <from start-index="69" stop-index="80">
+                                    <simple-table name="t_order_item" start-index="69" stop-index="80"/>
+                                </from>
+                                <projections distinct-row="false" start-index="57" stop-index="62">
+                                    <column-projection name="status" start-index="57" stop-index="62"/>
+                                </projections>
+                                <where start-index="82" stop-index="97">
+                                    <expr>
+                                        <binary-operation-expression start-index="88" stop-index="97">
+                                            <left>
+                                                <column name="status" start-index="88" stop-index="93"/>
+                                            </left>
+                                            <operator>&gt;</operator>
+                                            <right>
+                                                <literal-expression value="1" start-index="97" stop-index="97"/>
+                                                <parameter-marker-expression value="0" start-index="97" stop-index="97"/>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </select>
+                        </subquery>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_in_subquery" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="103">
+            <expr>
+                <in-expression start-index="28" stop-index="103">
+                    <not>true</not>
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <right>
+                        <subquery start-index="52" stop-index="103">
+                            <select>
+                                <from start-index="74" stop-index="85">
+                                    <simple-table name="t_order_item" start-index="74" stop-index="85"/>
+                                </from>
+                                <projections distinct-row="false" start-index="60" stop-index="67">
+                                    <column-projection name="order_id" start-index="60" stop-index="67"/>
+                                </projections>
+                                <where start-index="87" stop-index="102">
+                                    <expr>
+                                        <binary-operation-expression start-index="93" stop-index="102">
+                                            <left>
+                                                <column name="status" start-index="93" stop-index="98"/>
+                                            </left>
+                                            <operator>&gt;</operator>
+                                            <right>
+                                                <literal-expression value="1" start-index="102" stop-index="102"/>
+                                                <parameter-marker-expression value="0" start-index="102" stop-index="102"/>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </select>
+                        </subquery>
+                    </right>
+                </in-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_in_expr" parameters="1,2,3">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="56">
+            <expr>
+                <in-expression start-index="28" stop-index="56">
+                    <not>false</not>
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <right>
+                        <list-expression start-index="48" stop-index="56">
+                            <items>
+                                <literal-expression value="1" start-index="49" stop-index="49"/>
+                                <parameter-marker-expression value="0" start-index="49" stop-index="49"/>
+                            </items>
+                            <items>
+                                <literal-expression value="2" start-index="52" stop-index="52"/>
+                                <parameter-marker-expression value="1" start-index="52" stop-index="52"/>
+                            </items>
+                            <items>
+                                <literal-expression value="3" start-index="55" stop-index="55"/>
+                                <parameter-marker-expression value="2" start-index="55" stop-index="55"/>
+                            </items>
+                        </list-expression>
+                    </right>
+                </in-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_between" parameters="1,2">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="59">
+            <expr>
+                <between-expression start-index="28" stop-index="59">
+                    <not>false</not>
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <between-expr>
+                        <literal-expression value="1" start-index="53" stop-index="53"/>
+                        <parameter-marker-expression value="0" start-index="53" stop-index="53"/>
+                    </between-expr>
+                    <and-expr>
+                        <literal-expression value="2" start-index="59" stop-index="59"/>
+                        <parameter-marker-expression value="1" start-index="59" stop-index="59"/>
+                    </and-expr>
+                </between-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_sounds_like">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="60">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="60">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>SOUNDS LIKE</operator>
+                    <right>
+                        <literal-expression value="1%" start-index="57" stop-index="60"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_like">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="68">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="68">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>NOT LIKE</operator>
+                    <right>
+                        <list-expression start-index="54" stop-index="68">
+                            <items>
+                                <literal-expression value="1%" start-index="54" stop-index="57"/>
+                            </items>
+                            <items>
+                                <literal-expression value="$" start-index="66" stop-index="68"/>
+                            </items>
+                        </list-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_predicate_with_regexp">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="62">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="62">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>NOT REGEXP</operator>
+                    <right>
+                        <literal-expression value="[123]" start-index="56" stop-index="62"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_vertical_bar" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>|</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_ampersand" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&amp;</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_signed_left_shift" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="48">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="48">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&lt;&lt;</operator>
+                    <right>
+                        <literal-expression value="1" start-index="48" stop-index="48"/>
+                        <parameter-marker-expression value="0" start-index="48" stop-index="48"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_signed_right_shift" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="48">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="48">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>&gt;&gt;</operator>
+                    <right>
+                        <literal-expression value="1" start-index="48" stop-index="48"/>
+                        <parameter-marker-expression value="0" start-index="48" stop-index="48"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_plus" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>+</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_minus" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>-</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_asterisk" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>*</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_slash" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>/</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_div" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="49">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="49">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>DIV</operator>
+                    <right>
+                        <literal-expression value="1" start-index="49" stop-index="49"/>
+                        <parameter-marker-expression value="0" start-index="49" stop-index="49"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_mod" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="49">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="49">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>MOD</operator>
+                    <right>
+                        <literal-expression value="1" start-index="49" stop-index="49"/>
+                        <parameter-marker-expression value="0" start-index="49" stop-index="49"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_mod_sign" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>%</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_caret" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>^</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47"/>
+                        <parameter-marker-expression value="0" start-index="47" stop-index="47"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_plus_interval">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="63">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="63">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>+</operator>
+                    <right>
+                        <expression-projection text="INTERVAL1SECOND" start-index="47" stop-index="63" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_bit_expr_with_minus_interval">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="63">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="63">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>-</operator>
+                    <right>
+                        <expression-projection text="INTERVAL1SECOND" start-index="47" stop-index="63" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_literals" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="39">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <literal-expression value="1" start-index="28" stop-index="28"/>
+                        <parameter-marker-expression value="0" start-index="28" stop-index="28"/>
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
+                        <column name="order_id" start-index="32" stop-index="39"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_column">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="43">
+            <expr>
+                <column name="order_id" start-index="28" stop-index="43">
+                    <owner name="t_order" start-index="28" stop-index="34"/>
+                </column>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_function_call">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="43">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="43">
+                    <left>
+                        <expression-projection text="now()" start-index="28" stop-index="32" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
+                        <column name="order_id" start-index="36" stop-index="43"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_collate">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="64">
+            <expr>
+                <common-expression text="order_id collate 'utf8mb4_0900_ai_ci'" start-index="28" stop-index="64"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_variable">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="55">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="55">
+                    <left>
+                        <common-expression text="@@max_connections" start-index="28" stop-index="44"/>
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
+                        <column name="order_id" start-index="48" stop-index="55"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_plus" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <literal-expression value="1" start-index="28" stop-index="28"/>
+                        <parameter-marker-expression value="0" start-index="28" stop-index="28"/>
+                    </left>
+                    <operator>+</operator>
+                    <right>
+                        <column name="order_id" start-index="32" stop-index="47">
+                            <owner name="t_order" start-index="32" stop-index="38"/>
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_minus" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="47">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <literal-expression value="1" start-index="28" stop-index="28"/>
+                        <parameter-marker-expression value="0" start-index="28" stop-index="28"/>
+                    </left>
+                    <operator>-</operator>
+                    <right>
+                        <column name="order_id" start-index="32" stop-index="47">
+                            <owner name="t_order" start-index="32" stop-index="38"/>
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_tilde">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="44">
+            <expr>
+                <common-expression text="~t_order.order_id" start-index="28" stop-index="44"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_not">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="44">
+            <expr>
+                <not-expression start-index="28" stop-index="44">
+                    <expr>
+                        <column name="order_id" start-index="29" stop-index="44">
+                            <owner name="t_order" start-index="29" stop-index="35"/>
+                        </column>
+                    </expr>
+                </not-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_binary">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="50">
+            <expr>
+                <common-expression text="BINARY t_order.order_id" start-index="28" stop-index="50"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_row">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="65">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="65">
+                    <left>
+                        <common-expression text="ROW('abc', now())" start-index="28" stop-index="44"/>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <common-expression text="(order_id, status)" start-index="48" stop-index="65"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_subquery" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="79">
+            <expr>
+                <subquery start-index="28" stop-index="79">
+                    <select>
+                        <from start-index="50" stop-index="61">
+                            <simple-table name="t_order_item" start-index="50" stop-index="61"/>
+                        </from>
+                        <projections distinct-row="false" start-index="36" stop-index="43">
+                            <column-projection name="order_id" start-index="36" stop-index="43"/>
+                        </projections>
+                        <where start-index="63" stop-index="78">
+                            <expr>
+                                <binary-operation-expression start-index="69" stop-index="78">
+                                    <left>
+                                        <column name="status" start-index="69" stop-index="74"/>
+                                    </left>
+                                    <operator>&gt;</operator>
+                                    <right>
+                                        <literal-expression value="1" start-index="78" stop-index="78"/>
+                                        <parameter-marker-expression value="0" start-index="78" stop-index="78"/>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
+                        </where>
+                    </select>
+                </subquery>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_exists_subquery" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="87">
+            <expr>
+                <exists-subquery start-index="28" stop-index="87">
+                    <not>false</not>
+                    <subquery start-index="35" stop-index="87">
+                        <select>
+                            <from start-index="57" stop-index="68">
+                                <simple-table name="t_order_item" start-index="57" stop-index="68"/>
+                            </from>
+                            <projections distinct-row="false" start-index="43" stop-index="50">
+                                <column-projection name="order_id" start-index="43" stop-index="50"/>
+                            </projections>
+                            <where start-index="70" stop-index="85">
+                                <expr>
+                                    <binary-operation-expression start-index="76" stop-index="85">
+                                        <left>
+                                            <column name="status" start-index="76" stop-index="81"/>
+                                        </left>
+                                        <operator>&gt;</operator>
+                                        <right>
+                                            <literal-expression value="1" start-index="85" stop-index="85"/>
+                                            <parameter-marker-expression value="0" start-index="85" stop-index="85"/>
+                                        </right>
+                                    </binary-operation-expression>
+                                </expr>
+                            </where>
+                        </select>
+                    </subquery>
+                </exists-subquery>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_odbc_escape_syntax">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="53">
+            <expr>
+                <common-expression text="{ts '1994-02-04 12:23:00'}" start-index="28" stop-index="53"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_json_extract_sign">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="44">
+            <expr>
+                <common-expression text="order_id -&gt;&quot;$[1]&quot;" start-index="28" stop-index="44"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_json_unquote_extract_sign">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="46">
+            <expr>
+                <common-expression text="order_id -&gt;&gt; &quot;$[1]&quot;" start-index="28" stop-index="46"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_match">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="88">
+            <expr>
+                <common-expression text="MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" start-index="28" stop-index="88"/>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_case">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="78">
+            <expr>
+                <common-expression text="CASE WHEN order_id &gt; 2 THEN 'true' ELSE 'false' END" start-index="28" stop-index="78"/>
+            </expr>
+        </where>
     </select>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-expression.xml
@@ -1529,9 +1529,7 @@
         </projections>
         <where start-index="22" stop-index="80" literal-stop-index="88">
             <expr>
-                <common-expression text="MATCH (order_id) AGAINST (? IN NATURAL LANGUAGE MODE)"
-                                   literal-text="MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)"
-                                   start-index="28" stop-index="80" literal-stop-index="88"/>
+                <common-expression text="MATCH (order_id) AGAINST (? IN NATURAL LANGUAGE MODE)" literal-text="MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" start-index="28" stop-index="80" literal-stop-index="88"/>
             </expr>
         </where>
     </select>
@@ -1545,9 +1543,7 @@
         </projections>
         <where start-index="22" stop-index="67" literal-stop-index="78">
             <expr>
-                <common-expression text="CASE WHEN order_id &gt; ? THEN ? ELSE ? END"
-                                   literal-text="CASE WHEN order_id > 1 THEN 'true' ELSE 'false' END"
-                                   start-index="28" stop-index="67" literal-stop-index="78" />
+                <common-expression text="CASE WHEN order_id &gt; ? THEN ? ELSE ? END" literal-text="CASE WHEN order_id > 1 THEN 'true' ELSE 'false' END" start-index="28" stop-index="67" literal-stop-index="78" />
             </expr>
         </where>
     </select>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-group-by.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-group-by.xml
@@ -148,30 +148,51 @@
             <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="119" stop-index="174" literal-stop-index="175">
-            <and-predicate>
-                <predicate start-index="125" stop-index="143">
-                    <column-left-value name="user_id" start-index="125" stop-index="133">
-                        <owner name="o" start-index="125" stop-index="125" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="139" stop-index="139" />
-                        <parameter-marker-expression value="1" start-index="142" stop-index="142" />
-                        <literal-expression value="1" start-index="139" stop-index="139" />
-                        <literal-expression value="2" start-index="142" stop-index="142" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="149" stop-index="174" literal-stop-index="175">
-                    <column-left-value name="order_id" start-index="149" stop-index="158">
-                        <owner name="o" start-index="149" stop-index="149" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="168" stop-index="168" />
-                        <between-literal-expression value="9" start-index="168" stop-index="168" />
-                        <and-parameter-marker-expression value="3" start-index="174" stop-index="174" />
-                        <and-literal-expression value="10" start-index="174" stop-index="175" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="125" stop-index="174" literal-stop-index="175">
+                    <left>
+                        <in-expression start-index="125" stop-index="143">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="125" stop-index="133">
+                                    <owner name="o" start-index="125" stop-index="125" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="138" stop-index="143">
+                                    <items>
+                                        <literal-expression value="1" start-index="139" stop-index="139" />
+                                        <parameter-marker-expression value="0" start-index="139" stop-index="139" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="142" stop-index="142" />
+                                        <parameter-marker-expression value="1" start-index="142" stop-index="142" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="149" stop-index="174" literal-stop-index="175">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="149" stop-index="158">
+                                    <owner name="o" start-index="149" stop-index="149" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="168" stop-index="168" />
+                                <parameter-marker-expression value="2" start-index="168" stop-index="168" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="174" stop-index="175" />
+                                <parameter-marker-expression value="3" start-index="174" stop-index="174" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <group-by>
             <column-item name="user_id" start-index="185" stop-index="193" literal-start-index="186" literal-stop-index="194">
@@ -243,21 +264,30 @@
             <simple-table  name="t_order_item" start-delimiter="`" end-delimiter="`" start-index="91" stop-index="104" />
         </from>
         <projections start-index="7" stop-index="84">
-            <expression-projection alias="creation_date" start-index="7" stop-index="62" />
+            <expression-projection text="date_format(creation_date,  '%y-%m-%d')" alias="creation_date" start-index="7" stop-index="62" />
             <aggregation-projection type="COUNT" inner-expression="(*)" alias="c_number" start-index="65" stop-index="72" />
         </projections>
-        <where start-index="106" stop-index="130" literal-stop-index="135">
-            <and-predicate>
-                <predicate start-index="112" stop-index="129" literal-stop-index="135">
-                    <column-left-value name="order_id" start-index="112" stop-index="119" />
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
-                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
-                        <literal-expression value="1000" start-index="125" stop-index="128" />
-                        <literal-expression value="1100" start-index="131" stop-index="134" />
-                    </in-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="106" stop-index="129" literal-stop-index="135">
+            <expr>
+                <in-expression start-index="112" stop-index="129" literal-stop-index="135">
+                    <not>false</not>
+                    <left>
+                        <column name="order_id" start-index="112" stop-index="119" />
+                    </left>
+                    <right>
+                        <list-expression start-index="124" stop-index="129" literal-stop-index="135">
+                            <items>
+                                <literal-expression value="1000" start-index="125" stop-index="128" />
+                                <parameter-marker-expression value="0" start-index="125" stop-index="125" />
+                            </items>
+                            <items>
+                                <literal-expression value="1100" start-index="131" stop-index="134" />
+                                <parameter-marker-expression value="1" start-index="128" stop-index="128" />
+                            </items>
+                        </list-expression>
+                    </right>
+                </in-expression>
+            </expr>
         </where>
         <group-by>
             <expression-item expression="date_format(creation_date,'%y-%m-%d')" start-index="140" stop-index="177" literal-start-index="146" literal-stop-index="183" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-into.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-into.xml
@@ -25,16 +25,18 @@
             <column-projection name="status" start-index="7" stop-index="12"/>
         </projections>
         <where start-index="38" stop-index="55">
-            <and-predicate>
-                <predicate start-index="44" stop-index="55">
-                    <column-left-value name="order_id" start-index="44" stop-index="51"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="55" stop-index="55"/>
-                        <literal-expression value="1" start-index="55" stop-index="55"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="44" stop-index="55">
+                    <left>
+                        <column name="order_id" start-index="44" stop-index="51" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="55" stop-index="55" />
+                        <parameter-marker-expression value="0" start-index="55" stop-index="55" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -46,16 +48,18 @@
             <column-projection name="status" start-index="7" stop-index="12"/>
         </projections>
         <where start-index="27" stop-index="44">
-            <and-predicate>
-                <predicate start-index="33" stop-index="44">
-                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
-                        <literal-expression value="1" start-index="44" stop-index="44"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="44">
+                    <left>
+                        <column name="order_id" start-index="33" stop-index="40" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="44" stop-index="44" />
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -68,16 +72,18 @@
             <column-projection name="status" start-index="16" stop-index="21"/>
         </projections>
         <where start-index="36" stop-index="53">
-            <and-predicate>
-                <predicate start-index="42" stop-index="53">
-                    <column-left-value name="order_id" start-index="42" stop-index="49"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="53" stop-index="53"/>
-                        <literal-expression value="1" start-index="53" stop-index="53"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="42" stop-index="53">
+                    <left>
+                        <column name="order_id" start-index="42" stop-index="49" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="53" stop-index="53" />
+                        <parameter-marker-expression value="0" start-index="53" stop-index="53" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -150,16 +156,18 @@
             <column-projection name="status" start-index="7" stop-index="12"/>
         </projections>
         <where start-index="27" stop-index="44">
-            <and-predicate>
-                <predicate start-index="33" stop-index="44">
-                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
-                        <literal-expression value="1" start-index="44" stop-index="44"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="44">
+                    <left>
+                        <column name="order_id" start-index="33" stop-index="40" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="44" stop-index="44" />
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <lock start-index="57" stop-index="66"/>
     </select>
@@ -172,16 +180,18 @@
             <column-projection name="status" start-index="7" stop-index="12"/>
         </projections>
         <where start-index="27" stop-index="44">
-            <and-predicate>
-                <predicate start-index="33" stop-index="44">
-                    <column-left-value name="order_id" start-index="33" stop-index="40"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="44" stop-index="44"/>
-                        <literal-expression value="1" start-index="44" stop-index="44"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="44">
+                    <left>
+                        <column name="order_id" start-index="33" stop-index="40" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="44" stop-index="44" />
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <lock start-index="46" stop-index="55"/>
     </select>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-join.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-join.xml
@@ -46,18 +46,20 @@
             </shorthand-projection>
         </projections>
         <where start-index="79" stop-index="98" literal-stop-index="101">
-            <and-predicate>
-                <predicate start-index="85" stop-index="98" literal-stop-index="101">
-                    <column-left-value name="order_id" start-index="85" stop-index="94">
-                        <owner name="o" start-index="85" stop-index="85" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="98" stop-index="98" />
+            <expr>
+                <binary-operation-expression start-index="85" stop-index="98" literal-stop-index="101">
+                    <left>
+                        <column name="order_id" start-index="85" stop-index="94">
+                            <owner name="o" start-index="85" stop-index="85" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="98" stop-index="101" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="98" stop-index="98" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -90,18 +92,20 @@
             </shorthand-projection>
         </projections>
         <where start-index="97" stop-index="122" literal-stop-index="125">
-            <and-predicate>
-                <predicate start-index="103" stop-index="122" literal-stop-index="125">
-                    <column-left-value name="order_id" start-index="103" stop-index="118">
-                        <owner name="t_order" start-index="103" stop-index="109" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="122" stop-index="122" />
+            <expr>
+                <binary-operation-expression start-index="103" stop-index="122" literal-stop-index="125">
+                    <left>
+                        <column name="order_id" start-index="103" stop-index="118">
+                            <owner name="t_order" start-index="103" stop-index="109" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="122" stop-index="125" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="122" stop-index="122" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -122,18 +126,20 @@
             </shorthand-projection>
         </projections>
         <where start-index="62" stop-index="81" literal-stop-index="84">
-            <and-predicate>
-                <predicate start-index="68" stop-index="81" literal-stop-index="84">
-                    <column-left-value name="order_id" start-index="68" stop-index="77">
-                        <owner name="o" start-index="68" stop-index="68" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="81" stop-index="81" />
+            <expr>
+                <binary-operation-expression start-index="68" stop-index="81" literal-stop-index="84">
+                    <left>
+                        <column name="order_id" start-index="68" stop-index="77">
+                            <owner name="o" start-index="68" stop-index="68" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="81" stop-index="84" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="81" stop-index="81" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-lock.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-lock.xml
@@ -19,16 +19,18 @@
 <sql-parser-test-cases>
     <select sql-case-id="select_lock_with_lock_in" parameters="1">
         <where start-index="22" stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39"/>
-                        <literal-expression value="1" start-index="39" stop-index="39"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="39" stop-index="39" />
+                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>
@@ -41,16 +43,18 @@
 
     <select sql-case-id="select_lock_with_for_update" parameters="1">
         <where start-index="22" stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39"/>
-                        <literal-expression value="1" start-index="39" stop-index="39"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="39" stop-index="39" />
+                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>
@@ -63,16 +67,18 @@
 
     <select sql-case-id="select_lock_with_for_share" parameters="1">
         <where start-index="22" stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39"/>
-                        <literal-expression value="1" start-index="39" stop-index="39"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="39" stop-index="39" />
+                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>
@@ -85,16 +91,18 @@
 
     <select sql-case-id="select_lock_with_nowait" parameters="1">
         <where start-index="22" stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39"/>
-                        <literal-expression value="1" start-index="39" stop-index="39"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="39" stop-index="39" />
+                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>
@@ -107,16 +115,18 @@
 
     <select sql-case-id="select_lock_with_skip_locked" parameters="1">
         <where start-index="22" stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35"/>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39"/>
-                        <literal-expression value="1" start-index="39" stop-index="39"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="39">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="39" stop-index="39" />
+                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>
@@ -129,27 +139,40 @@
 
     <select sql-case-id="select_lock_with_of" parameters="1">
         <where start-index="36" stop-index="106">
-            <and-predicate>
-                <predicate start-index="42" stop-index="81">
-                    <column-left-value name="order_id" start-index="42" stop-index="57">
-                        <owner name="t_order" start-index="42" stop-index="48"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <column-right-value name="order_id" start-index="42" stop-index="57">
-                        <owner name="t_order" start-index="42" stop-index="48"/>
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="87" stop-index="106">
-                    <column-left-value name="order_id" start-index="87" stop-index="102">
-                        <owner name="t_order" start-index="87" stop-index="93"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="106" stop-index="106"/>
-                        <literal-expression value="1" start-index="106" stop-index="106"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="42" stop-index="106">
+                    <left>
+                        <binary-operation-expression start-index="42" stop-index="81">
+                            <left>
+                                <column name="order_id" start-index="42" stop-index="57">
+                                    <owner name="t_order" start-index="42" stop-index="48" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="61" stop-index="81">
+                                    <owner name="t_order_item" start-index="61" stop-index="72" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="87" stop-index="106">
+                            <left>
+                                <column name="order_id" start-index="87" stop-index="102">
+                                    <owner name="t_order" start-index="87" stop-index="93" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="106" stop-index="106" />
+                                <parameter-marker-expression value="0" start-index="106" stop-index="106" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="34">
             <join-table start-index="14" stop-index="34">
@@ -172,36 +195,60 @@
 
     <select sql-case-id="select_lock_with_of_multi_tables" parameters="1">
         <where start-index="44" stop-index="151">
-            <and-predicate>
-                <predicate start-index="50" stop-index="89">
-                    <column-left-value name="order_id" start-index="50" stop-index="65">
-                        <owner name="t_order" start-index="50" stop-index="56"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <column-right-value name="order_id" start-index="50" stop-index="65">
-                        <owner name="t_order" start-index="50" stop-index="56"/>
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="95" stop-index="126">
-                    <column-left-value name="user_id" start-index="95" stop-index="109">
-                        <owner name="t_order" start-index="95" stop-index="101"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <column-right-value name="user_id" start-index="95" stop-index="109">
-                        <owner name="t_order" start-index="95" stop-index="101"/>
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="132" stop-index="151">
-                    <column-left-value name="order_id" start-index="132" stop-index="147">
-                        <owner name="t_order" start-index="132" stop-index="138"/>
-                    </column-left-value>
-                    <operator type="="/>
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="151" stop-index="151"/>
-                        <literal-expression value="1" start-index="151" stop-index="151"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="50" stop-index="151">
+                    <left>
+                        <binary-operation-expression start-index="50" stop-index="126">
+                            <left>
+                                <binary-operation-expression start-index="50" stop-index="89">
+                                    <left>
+                                        <column name="order_id" start-index="50" stop-index="65">
+                                            <owner name="t_order" start-index="50" stop-index="56" />
+                                        </column>
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <column name="order_id" start-index="69" stop-index="89">
+                                            <owner name="t_order_item" start-index="69" stop-index="80" />
+                                        </column>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="95" stop-index="126">
+                                    <left>
+                                        <column name="user_id" start-index="95" stop-index="109">
+                                            <owner name="t_order" start-index="95" stop-index="101" />
+                                        </column>
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <column name="user_id" start-index="113" stop-index="126">
+                                            <owner name="t_user" start-index="113" stop-index="118" />
+                                        </column>
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="132" stop-index="151">
+                            <left>
+                                <column name="order_id" start-index="132" stop-index="147">
+                                    <owner name="t_order" start-index="132" stop-index="138" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="151" stop-index="151" />
+                                <parameter-marker-expression value="0" start-index="151" stop-index="151" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <from start-index="14" stop-index="42">
             <join-table start-index="14" stop-index="42">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-or.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-or.xml
@@ -25,26 +25,35 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="55">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="1" start-index="39" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="44" stop-index="55">
-                    <column-left-value name="order_id" start-index="44" stop-index="51" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="55" stop-index="55" />
-                        <literal-expression value="2" start-index="55" stop-index="55" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="55">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="39">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="35" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="39" stop-index="39" />
+                                <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>OR</operator>
+                    <right>
+                        <binary-operation-expression start-index="44" stop-index="55">
+                            <left>
+                                <column name="order_id" start-index="44" stop-index="51" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="55" stop-index="55" />
+                                <parameter-marker-expression value="1" start-index="55" stop-index="55" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -56,26 +65,35 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="54">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="1" start-index="39" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="44" stop-index="54">
-                    <column-left-value name="user_id" start-index="44" stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="54" stop-index="54" />
-                        <literal-expression value="2" start-index="54" stop-index="54" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="54">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="39">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="35" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="39" stop-index="39" />
+                                <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>OR</operator>
+                    <right>
+                        <binary-operation-expression start-index="44" stop-index="54">
+                            <left>
+                                <column name="user_id" start-index="44" stop-index="50" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="54" stop-index="54" />
+                                <parameter-marker-expression value="1" start-index="54" stop-index="54" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -87,26 +105,35 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="53" literal-stop-index="58">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="1" start-index="39" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="44" stop-index="53" literal-stop-index="58">
-                    <column-left-value name="status" start-index="44" stop-index="49" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
-                        <literal-expression value="init" start-index="53" stop-index="58" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="53" literal-stop-index="58">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="39">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="35" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="39" stop-index="39" />
+                                <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>OR</operator>
+                    <right>
+                        <binary-operation-expression start-index="44" stop-index="53" literal-stop-index="58">
+                            <left>
+                                <column name="status" start-index="44" stop-index="49" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="53" stop-index="58" />
+                                <parameter-marker-expression value="1" start-index="53" stop-index="53" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -118,42 +145,52 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="71" literal-stop-index="76">
-            <and-predicate>
-                <predicate start-index="29" stop-index="40">
-                    <column-left-value name="order_id" start-index="29" stop-index="36" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="40" stop-index="40" />
-                        <literal-expression value="1" start-index="40" stop-index="40" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="61" stop-index="71" literal-start-index="66" literal-stop-index="76">
-                    <column-left-value name="user_id" start-index="61" stop-index="67" literal-start-index="66" literal-stop-index="72" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="71" stop-index="71" />
-                        <literal-expression value="3" start-index="76" stop-index="76" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="45" stop-index="54" literal-stop-index="59">
-                    <column-left-value name="status" start-index="45" stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="54" stop-index="54" />
-                        <literal-expression value="init" start-index="54" stop-index="59" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="61" stop-index="71" literal-start-index="66" literal-stop-index="76">
-                    <column-left-value name="user_id" start-index="61" stop-index="67" literal-start-index="66" literal-stop-index="72" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="71" stop-index="71" />
-                        <literal-expression value="3" start-index="76" stop-index="76" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="71" literal-stop-index="76">
+                    <left>
+                        <binary-operation-expression start-index="29" stop-index="54" literal-stop-index="59">
+                            <left>
+                                <binary-operation-expression start-index="29" stop-index="40">
+                                    <left>
+                                        <column name="order_id" start-index="29" stop-index="36" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1" start-index="40" stop-index="40" />
+                                        <parameter-marker-expression value="0" start-index="40" stop-index="40" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>OR</operator>
+                            <right>
+                                <binary-operation-expression start-index="45" stop-index="54" literal-stop-index="59">
+                                    <left>
+                                        <column name="status" start-index="45" stop-index="50" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="init" start-index="54" stop-index="59" />
+                                        <parameter-marker-expression value="1" start-index="54" stop-index="54" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="61" stop-index="71" literal-start-index="66" literal-stop-index="76">
+                            <left>
+                                <column name="user_id" start-index="61" stop-index="67" literal-start-index="66" literal-stop-index="72" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="3" start-index="76" stop-index="76" />
+                                <parameter-marker-expression value="2" start-index="71" stop-index="71" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -165,110 +202,86 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="113" literal-stop-index="118">
-            <and-predicate>
-                <predicate start-index="30" stop-index="39" literal-stop-index="44">
-                    <column-left-value name="status" start-index="30" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="init" start-index="39" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="46" stop-index="57" literal-start-index="51" literal-stop-index="62">
-                    <column-left-value name="order_id" start-index="46" stop-index="53" literal-start-index="51" literal-stop-index="58" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="57" stop-index="57" />
-                        <literal-expression value="1" start-index="62" stop-index="62" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="83" stop-index="93" literal-start-index="88" literal-stop-index="98">
-                    <column-left-value name="user_id" start-index="83" stop-index="89" literal-start-index="88" literal-stop-index="94" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="93" stop-index="93" />
-                        <literal-expression value="3" start-index="98" stop-index="98" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="30" stop-index="39" literal-stop-index="44">
-                    <column-left-value name="status" start-index="30" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="init" start-index="39" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="46" stop-index="57" literal-start-index="51" literal-stop-index="62">
-                    <column-left-value name="order_id" start-index="46" stop-index="53" literal-start-index="51" literal-stop-index="58" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="57" stop-index="57" />
-                        <literal-expression value="1" start-index="62" stop-index="62" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="99" stop-index="109" literal-start-index="104" literal-stop-index="114">
-                    <column-left-value name="user_id" start-index="99" stop-index="105" literal-start-index="104" literal-stop-index="110" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="109" stop-index="109" />
-                        <literal-expression value="4" start-index="114" stop-index="114" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="30" stop-index="39" literal-stop-index="44">
-                    <column-left-value name="status" start-index="30" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="init" start-index="39" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="63" stop-index="74" literal-start-index="68" literal-stop-index="79">
-                    <column-left-value name="order_id" start-index="63" stop-index="70" literal-start-index="68" literal-stop-index="75" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="2" start-index="79" stop-index="79" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="83" stop-index="93" literal-start-index="88" literal-stop-index="98">
-                    <column-left-value name="user_id" start-index="83" stop-index="89" literal-start-index="88" literal-stop-index="94" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="93" stop-index="93" />
-                        <literal-expression value="3" start-index="98" stop-index="98" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="30" stop-index="39" literal-stop-index="44">
-                    <column-left-value name="status" start-index="30" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="init" start-index="39" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="63" stop-index="74" literal-start-index="68" literal-stop-index="79">
-                    <column-left-value name="order_id" start-index="63" stop-index="70" literal-start-index="68" literal-stop-index="75" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="2" start-index="79" stop-index="79" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="99" stop-index="109" literal-start-index="104" literal-stop-index="114">
-                    <column-left-value name="user_id" start-index="99" stop-index="105" literal-start-index="104" literal-stop-index="110" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="109" stop-index="109" />
-                        <literal-expression value="4" start-index="114" stop-index="114" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="30" stop-index="111" literal-stop-index="116">
+                    <left>
+                        <binary-operation-expression start-index="30" stop-index="76" literal-stop-index="81">
+                            <left>
+                                <binary-operation-expression start-index="30" stop-index="39" literal-stop-index="44">
+                                    <left>
+                                        <column name="status" start-index="30" stop-index="35" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="init" start-index="39" stop-index="44" />
+                                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="46" stop-index="75" literal-start-index="51" literal-stop-index="80">
+                                    <left>
+                                        <binary-operation-expression start-index="46" stop-index="57" literal-start-index="51" literal-stop-index="62">
+                                            <left>
+                                                <column name="order_id" start-index="46" stop-index="53" literal-start-index="51" literal-stop-index="58" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <literal-expression value="1" start-index="62" stop-index="62" />
+                                                <parameter-marker-expression value="1" start-index="57" stop-index="57" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </left>
+                                    <operator>OR</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="63" stop-index="74" literal-start-index="68" literal-stop-index="79">
+                                            <left>
+                                                <column name="order_id" start-index="63" stop-index="70" literal-start-index="68" literal-stop-index="75" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <literal-expression value="2" start-index="79" stop-index="79" />
+                                                <parameter-marker-expression value="2" start-index="74" stop-index="74" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="83" stop-index="110" literal-start-index="88" literal-stop-index="115">
+                            <left>
+                                <binary-operation-expression start-index="83" stop-index="93" literal-start-index="88" literal-stop-index="98">
+                                    <left>
+                                        <column name="user_id" start-index="83" stop-index="89" literal-start-index="88" literal-stop-index="94" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="3" start-index="98" stop-index="98" />
+                                        <parameter-marker-expression value="3" start-index="93" stop-index="93" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>OR</operator>
+                            <right>
+                                <binary-operation-expression start-index="99" stop-index="109" literal-start-index="104" literal-stop-index="114">
+                                    <left>
+                                        <column name="user_id" start-index="99" stop-index="105" literal-start-index="104" literal-stop-index="110" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="4" start-index="114" stop-index="114" />
+                                        <parameter-marker-expression value="4" start-index="109" stop-index="109" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -309,50 +322,58 @@
             </shorthand-projection>
         </projections>
         <where start-index="99" stop-index="156">
-            <and-predicate>
-                <predicate start-index="106" stop-index="119">
-                    <column-left-value name="order_id" start-index="106" stop-index="115">
-                        <owner name="o" start-index="106" stop-index="106" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="144" stop-index="156">
-                    <column-left-value name="user_id" start-index="144" stop-index="152">
-                        <owner name="o" start-index="144" stop-index="144" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="156" stop-index="156" />
-                        <literal-expression value="3" start-index="156" stop-index="156" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="124" stop-index="137">
-                    <column-left-value name="order_id" start-index="124" stop-index="133">
-                        <owner name="o" start-index="124" stop-index="124" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="137" stop-index="137" />
-                        <literal-expression value="2" start-index="137" stop-index="137" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="144" stop-index="156">
-                    <column-left-value name="user_id" start-index="144" stop-index="152">
-                        <owner name="o" start-index="144" stop-index="144" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="156" stop-index="156" />
-                        <literal-expression value="3" start-index="156" stop-index="156" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="156">
+                    <left>
+                        <binary-operation-expression start-index="106" stop-index="137">
+                            <left>
+                                <binary-operation-expression start-index="106" stop-index="119">
+                                    <left>
+                                        <column name="order_id" start-index="106" stop-index="115">
+                                            <owner name="o" start-index="106" stop-index="106" />
+                                        </column>
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>OR</operator>
+                            <right>
+                                <binary-operation-expression start-index="124" stop-index="137">
+                                    <left>
+                                        <column name="order_id" start-index="124" stop-index="133">
+                                            <owner name="o" start-index="124" stop-index="124" />
+                                        </column>
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="2" start-index="137" stop-index="137" />
+                                        <parameter-marker-expression value="1" start-index="137" stop-index="137" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="144" stop-index="156">
+                            <left>
+                                <column name="user_id" start-index="144" stop-index="152">
+                                    <owner name="o" start-index="144" stop-index="144" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="3" start-index="156" stop-index="156" />
+                                <parameter-marker-expression value="2" start-index="156" stop-index="156" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -412,70 +433,77 @@
             </shorthand-projection>
         </projections>
         <where start-index="147" stop-index="221" literal-stop-index="226">
-            <and-predicate>
-                <predicate start-index="154" stop-index="167">
-                    <column-left-value name="order_id" start-index="154" stop-index="163">
-                        <owner name="o" start-index="154" stop-index="154" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="167" stop-index="167" />
-                        <literal-expression value="1" start-index="167" stop-index="167" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="192" stop-index="204">
-                    <column-left-value name="user_id" start-index="192" stop-index="200">
-                        <owner name="o" start-index="192" stop-index="192" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="204" stop-index="204" />
-                        <literal-expression value="3" start-index="204" stop-index="204" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="210" stop-index="221" literal-stop-index="226">
-                    <column-left-value name="status" start-index="210" stop-index="217">
-                        <owner name="o" start-index="210" stop-index="210" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="221" stop-index="221" />
-                        <literal-expression value="init" start-index="221" stop-index="226" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="172" stop-index="185">
-                    <column-left-value name="order_id" start-index="172" stop-index="181">
-                        <owner name="o" start-index="172" stop-index="172" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="185" stop-index="185" />
-                        <literal-expression value="2" start-index="185" stop-index="185" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="192" stop-index="204">
-                    <column-left-value name="user_id" start-index="192" stop-index="200">
-                        <owner name="o" start-index="192" stop-index="192" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="204" stop-index="204" />
-                        <literal-expression value="3" start-index="204" stop-index="204" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="210" stop-index="221" literal-stop-index="226">
-                    <column-left-value name="status" start-index="210" stop-index="217">
-                        <owner name="o" start-index="210" stop-index="210" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="221" stop-index="221" />
-                        <literal-expression value="init" start-index="221" stop-index="226" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="153" stop-index="221" literal-stop-index="226">
+                    <left>
+                        <binary-operation-expression start-index="153" stop-index="204">
+                            <left>
+                                <binary-operation-expression start-index="154" stop-index="185">
+                                    <left>
+                                        <binary-operation-expression start-index="154" stop-index="167">
+                                            <left>
+                                                <column name="order_id" start-index="154" stop-index="163">
+                                                    <owner name="o" start-index="154" stop-index="154" />
+                                                </column>
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <literal-expression value="1" start-index="167" stop-index="167" />
+                                                <parameter-marker-expression value="0" start-index="167" stop-index="167" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </left>
+                                    <operator>OR</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="172" stop-index="185">
+                                            <left>
+                                                <column name="order_id" start-index="172" stop-index="181">
+                                                    <owner name="o" start-index="172" stop-index="172" />
+                                                </column>
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <literal-expression value="2" start-index="185" stop-index="185" />
+                                                <parameter-marker-expression value="1" start-index="185" stop-index="185" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="192" stop-index="204">
+                                    <left>
+                                        <column name="user_id" start-index="192" stop-index="200">
+                                            <owner name="o" start-index="192" stop-index="192" />
+                                        </column>
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="3" start-index="204" stop-index="204" />
+                                        <parameter-marker-expression value="2" start-index="204" stop-index="204" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="210" stop-index="221" literal-stop-index="226">
+                            <left>
+                                <column name="status" start-index="210" stop-index="217">
+                                    <owner name="o" start-index="210" stop-index="210" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="221" stop-index="226" />
+                                <parameter-marker-expression value="3" start-index="221" stop-index="221" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-order-by.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-order-by.xml
@@ -49,27 +49,39 @@
             </shorthand-projection>
         </projections>
         <where start-index="42" stop-index="92">
-            <and-predicate>
-                <predicate start-index="48" stop-index="70">
-                    <column-left-value name="order_id" start-index="48" stop-index="57">
-                        <owner name="o" start-index="48" stop-index="48" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <column-right-value name="order_id" start-index="61" stop-index="70">
-                        <owner name="i" start-index="61" stop-index="61" />
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="76" stop-index="92">
-                    <column-left-value name="status" start-index="76" stop-index="83">
-                        <owner name="o" start-index="76" stop-index="76" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" />
-                        <literal-expression value="init" start-index="87" stop-index="92" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="48" stop-index="92">
+                    <left>
+                        <binary-operation-expression start-index="48" stop-index="70">
+                            <left>
+                                <column name="order_id" start-index="48" stop-index="57">
+                                    <owner name="o" start-index="48" stop-index="48" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="61" stop-index="70">
+                                    <owner name="i" start-index="61" stop-index="61" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="76" stop-index="92">
+                            <left>
+                                <column name="status" start-index="76" stop-index="83">
+                                    <owner name="o" start-index="76" stop-index="76" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="87" stop-index="92" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" order-direction="DESC" start-index="103" stop-index="112">
@@ -112,26 +124,39 @@
             </shorthand-projection>
         </projections>
         <where start-index="42" stop-index="92">
-            <and-predicate>
-                <predicate start-index="48" stop-index="70">
-                    <column-left-value name="order_id" start-index="48" stop-index="57">
-                        <owner name="o" start-index="48" stop-index="48" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <column-right-value name="order_id" start-index="61" stop-index="70">
-                        <owner name="i" start-index="61" stop-index="61" />
-                    </column-right-value>
-                </predicate>
-                <predicate start-index="76" stop-index="92">
-                    <column-left-value name="status" start-index="76" stop-index="83">
-                        <owner name="o" start-index="76" stop-index="76" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression value="init" start-index="87" stop-index="92" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="48" stop-index="92">
+                    <left>
+                        <binary-operation-expression start-index="48" stop-index="70">
+                            <left>
+                                <column name="order_id" start-index="48" stop-index="57">
+                                    <owner name="o" start-index="48" stop-index="48" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="61" stop-index="70">
+                                    <owner name="i" start-index="61" stop-index="61" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="76" stop-index="92">
+                            <left>
+                                <column name="status" start-index="76" stop-index="83">
+                                    <owner name="o" start-index="76" stop-index="76" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="87" stop-index="92" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="creation_date" order-direction="DESC" start-index="103" stop-index="117">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with
@@ -17,8 +16,7 @@
   -->
 
 <sql-parser-test-cases>
-    <select sql-case-id="select_pagination_with_group_by_and_order_by"
-            parameters="1, 2, 9, 10, 5, 3">
+    <select sql-case-id="select_pagination_with_group_by_and_order_by" parameters="1, 2, 9, 10, 5, 3">
         <from>
             <join-table>
                 <left>
@@ -56,8 +54,7 @@
         </projections>
         <where start-index="105" stop-index="160" literal-stop-index="161">
             <expr>
-                <binary-operation-expression start-index="111" stop-index="160"
-                                             literal-stop-index="161">
+                <binary-operation-expression start-index="111" stop-index="160" literal-stop-index="161">
                     <left>
                         <in-expression start-index="111" stop-index="129">
                             <not>false</not>
@@ -69,16 +66,12 @@
                             <right>
                                 <list-expression start-index="124" stop-index="129">
                                     <items>
-                                        <literal-expression value="1" start-index="125"
-                                                            stop-index="125"/>
-                                        <parameter-marker-expression value="0" start-index="125"
-                                                                     stop-index="125"/>
+                                        <literal-expression value="1" start-index="125" stop-index="125"/>
+                                        <parameter-marker-expression value="0" start-index="125" stop-index="125"/>
                                     </items>
                                     <items>
-                                        <literal-expression value="2" start-index="128"
-                                                            stop-index="128"/>
-                                        <parameter-marker-expression value="1" start-index="128"
-                                                                     stop-index="128"/>
+                                        <literal-expression value="2" start-index="128" stop-index="128"/>
+                                        <parameter-marker-expression value="1" start-index="128" stop-index="128"/>
                                     </items>
                                 </list-expression>
                             </right>
@@ -86,8 +79,7 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <between-expression start-index="135" stop-index="160"
-                                            literal-stop-index="161">
+                        <between-expression start-index="135" stop-index="160" literal-stop-index="161">
                             <not>false</not>
                             <left>
                                 <column name="order_id" start-index="135" stop-index="144">
@@ -96,13 +88,11 @@
                             </left>
                             <between-expr>
                                 <literal-expression value="9" start-index="154" stop-index="154"/>
-                                <parameter-marker-expression value="2" start-index="154"
-                                                             stop-index="154"/>
+                                <parameter-marker-expression value="2" start-index="154" stop-index="154"/>
                             </between-expr>
                             <and-expr>
                                 <literal-expression value="10" start-index="160" stop-index="161"/>
-                                <parameter-marker-expression value="3" start-index="160"
-                                                             stop-index="160"/>
+                                <parameter-marker-expression value="3" start-index="160" stop-index="160"/>
                             </and-expr>
                         </between-expression>
                     </right>
@@ -110,30 +100,22 @@
             </expr>
         </where>
         <group-by>
-            <column-item name="item_id" start-index="171" stop-index="179" literal-start-index="172"
-                         literal-stop-index="180">
-                <owner name="i" start-index="171" stop-index="171" literal-start-index="172"
-                       literal-stop-index="172"/>
+            <column-item name="item_id" start-index="171" stop-index="179" literal-start-index="172" literal-stop-index="180">
+                <owner name="i" start-index="171" stop-index="171" literal-start-index="172" literal-stop-index="172"/>
             </column-item>
         </group-by>
         <order-by>
-            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198"
-                         literal-start-index="191" literal-stop-index="199">
-                <owner name="i" start-index="190" stop-index="190" literal-start-index="191"
-                       literal-stop-index="191"/>
+            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198" literal-start-index="191" literal-stop-index="199">
+                <owner name="i" start-index="190" stop-index="190" literal-start-index="191" literal-stop-index="191"/>
             </column-item>
         </order-by>
-        <limit start-index="205" stop-index="214" literal-start-index="206"
-               literal-stop-index="215">
-            <offset value="5" parameter-index="4" start-index="211" stop-index="211"
-                    literal-start-index="212" literal-stop-index="212"/>
-            <row-count value="3" parameter-index="5" start-index="214" stop-index="214"
-                       literal-start-index="215" literal-stop-index="215"/>
+        <limit start-index="205" stop-index="214" literal-start-index="206" literal-stop-index="215">
+            <offset value="5" parameter-index="4" start-index="211" stop-index="211" literal-start-index="212" literal-stop-index="212"/>
+            <row-count value="3" parameter-index="5" start-index="214" stop-index="214" literal-start-index="215" literal-stop-index="215"/>
         </limit>
     </select>
 
-    <select sql-case-id="select_pagination_with_diff_group_by_and_order_by"
-            parameters="1, 2, 9, 10, 5, 3">
+    <select sql-case-id="select_pagination_with_diff_group_by_and_order_by" parameters="1, 2, 9, 10, 5, 3">
         <from>
             <join-table>
                 <left>
@@ -171,8 +153,7 @@
         </projections>
         <where start-index="105" stop-index="160" literal-stop-index="161">
             <expr>
-                <binary-operation-expression start-index="111" stop-index="160"
-                                             literal-stop-index="161">
+                <binary-operation-expression start-index="111" stop-index="160" literal-stop-index="161">
                     <left>
                         <in-expression start-index="111" stop-index="129">
                             <not>false</not>
@@ -184,16 +165,12 @@
                             <right>
                                 <list-expression start-index="124" stop-index="129">
                                     <items>
-                                        <literal-expression value="1" start-index="125"
-                                                            stop-index="125"/>
-                                        <parameter-marker-expression value="0" start-index="125"
-                                                                     stop-index="125"/>
+                                        <literal-expression value="1" start-index="125" stop-index="125"/>
+                                        <parameter-marker-expression value="0" start-index="125" stop-index="125"/>
                                     </items>
                                     <items>
-                                        <literal-expression value="2" start-index="128"
-                                                            stop-index="128"/>
-                                        <parameter-marker-expression value="1" start-index="128"
-                                                                     stop-index="128"/>
+                                        <literal-expression value="2" start-index="128" stop-index="128"/>
+                                        <parameter-marker-expression value="1" start-index="128" stop-index="128"/>
                                     </items>
                                 </list-expression>
                             </right>
@@ -201,8 +178,7 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <between-expression start-index="135" stop-index="160"
-                                            literal-stop-index="161">
+                        <between-expression start-index="135" stop-index="160" literal-stop-index="161">
                             <not>false</not>
                             <left>
                                 <column name="order_id" start-index="135" stop-index="144">
@@ -211,13 +187,11 @@
                             </left>
                             <between-expr>
                                 <literal-expression value="9" start-index="154" stop-index="154"/>
-                                <parameter-marker-expression value="2" start-index="154"
-                                                             stop-index="154"/>
+                                <parameter-marker-expression value="2" start-index="154" stop-index="154"/>
                             </between-expr>
                             <and-expr>
                                 <literal-expression value="10" start-index="160" stop-index="161"/>
-                                <parameter-marker-expression value="3" start-index="160"
-                                                             stop-index="160"/>
+                                <parameter-marker-expression value="3" start-index="160" stop-index="160"/>
                             </and-expr>
                         </between-expression>
                     </right>
@@ -225,30 +199,22 @@
             </expr>
         </where>
         <group-by>
-            <column-item name="user_id" start-index="171" stop-index="179" literal-start-index="172"
-                         literal-stop-index="180">
-                <owner name="i" start-index="171" stop-index="171" literal-start-index="172"
-                       literal-stop-index="172"/>
+            <column-item name="user_id" start-index="171" stop-index="179" literal-start-index="172" literal-stop-index="180">
+                <owner name="i" start-index="171" stop-index="171" literal-start-index="172" literal-stop-index="172"/>
             </column-item>
         </group-by>
         <order-by>
-            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198"
-                         literal-start-index="191" literal-stop-index="199">
-                <owner name="i" start-index="190" stop-index="190" literal-start-index="191"
-                       literal-stop-index="191"/>
+            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198" literal-start-index="191" literal-stop-index="199">
+                <owner name="i" start-index="190" stop-index="190" literal-start-index="191" literal-stop-index="191"/>
             </column-item>
         </order-by>
-        <limit start-index="205" stop-index="214" literal-start-index="206"
-               literal-stop-index="215">
-            <offset value="5" parameter-index="4" start-index="211" stop-index="211"
-                    literal-start-index="212" literal-stop-index="212"/>
-            <row-count value="3" parameter-index="5" start-index="214" stop-index="214"
-                       literal-start-index="215" literal-stop-index="215"/>
+        <limit start-index="205" stop-index="214" literal-start-index="206" literal-stop-index="215">
+            <offset value="5" parameter-index="4" start-index="211" stop-index="211" literal-start-index="212" literal-stop-index="212"/>
+            <row-count value="3" parameter-index="5" start-index="214" stop-index="214" literal-start-index="215" literal-stop-index="215"/>
         </limit>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -258,54 +224,44 @@
                     <select>
                         <projections start-index="22" stop-index="158">
                             <top-projection alias="rownum_" start-index="22" stop-index="70">
-                                <top-value value="3" parameter-index="0" start-index="26"
-                                           stop-index="26"/>
+                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="84" stop-index="92">
                                 <owner name="i" start-index="84" stop-index="84"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="95"
-                                               stop-index="104">
+                            <column-projection name="order_id" alias="order_id" start-index="95" stop-index="104">
                                 <owner name="o" start-index="95" stop-index="95"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="119"
-                                               stop-index="126">
+                            <column-projection name="status" alias="status" start-index="119" stop-index="126">
                                 <owner name="o" start-index="119" stop-index="119"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="139"
-                                               stop-index="147">
+                            <column-projection name="user_id" alias="user_id" start-index="139" stop-index="147">
                                 <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="165" stop-index="173" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="165" stop-index="173" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="180" stop-index="193"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="180" stop-index="193" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="198" stop-index="218">
-                                            <column-left-value name="user_id" start-index="198"
-                                                               stop-index="206">
+                                            <column-left-value name="user_id" start-index="198" stop-index="206">
                                                 <owner name="o" start-index="198" stop-index="198"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="210"
-                                                                stop-index="218">
+                                            <column-right-value name="user_id" start-index="210" stop-index="218">
                                                 <owner name="i" start-index="210" stop-index="210"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="224" stop-index="246">
-                                            <column-left-value name="order_id" start-index="224"
-                                                               stop-index="233">
+                                            <column-left-value name="order_id" start-index="224" stop-index="233">
                                                 <owner name="o" start-index="224" stop-index="224"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="237"
-                                                                stop-index="246">
+                                            <column-right-value name="order_id" start-index="237" stop-index="246">
                                                 <owner name="i" start-index="237" stop-index="237"/>
                                             </column-right-value>
                                         </predicate>
@@ -361,10 +317,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="314" stop-index="322"
-                                         literal-start-index="315" literal-stop-index="323">
-                                <owner name="i" start-index="314" stop-index="314"
-                                       literal-start-index="315" literal-stop-index="315"/>
+                            <column-item name="item_id" start-index="314" stop-index="322" literal-start-index="315" literal-stop-index="323">
+                                <owner name="i" start-index="314" stop-index="314" literal-start-index="315" literal-stop-index="315"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -389,8 +343,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -400,54 +353,44 @@
                     <select>
                         <projections start-index="22" stop-index="176">
                             <top-projection alias="rownum_" start-index="22" stop-index="88">
-                                <top-value value="3" parameter-index="0" start-index="26"
-                                           stop-index="26"/>
+                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="102" stop-index="110">
                                 <owner name="i" start-index="102" stop-index="102"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="113"
-                                               stop-index="122">
+                            <column-projection name="order_id" alias="order_id" start-index="113" stop-index="122">
                                 <owner name="o" start-index="113" stop-index="113"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="137"
-                                               stop-index="144">
+                            <column-projection name="status" alias="status" start-index="137" stop-index="144">
                                 <owner name="o" start-index="137" stop-index="137"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="157"
-                                               stop-index="165">
+                            <column-projection name="user_id" alias="user_id" start-index="157" stop-index="165">
                                 <owner name="o" start-index="157" stop-index="157"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="183" stop-index="191" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="183" stop-index="191" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="198" stop-index="211"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="198" stop-index="211" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="216" stop-index="236">
-                                            <column-left-value name="user_id" start-index="216"
-                                                               stop-index="224">
+                                            <column-left-value name="user_id" start-index="216" stop-index="224">
                                                 <owner name="o" start-index="216" stop-index="216"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="228"
-                                                                stop-index="236">
+                                            <column-right-value name="user_id" start-index="228" stop-index="236">
                                                 <owner name="i" start-index="228" stop-index="228"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="242" stop-index="264">
-                                            <column-left-value name="order_id" start-index="242"
-                                                               stop-index="251">
+                                            <column-left-value name="order_id" start-index="242" stop-index="251">
                                                 <owner name="o" start-index="242" stop-index="242"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="255"
-                                                                stop-index="264">
+                                            <column-right-value name="order_id" start-index="255" stop-index="264">
                                                 <owner name="i" start-index="255" stop-index="255"/>
                                             </column-right-value>
                                         </predicate>
@@ -503,10 +446,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="332" stop-index="340"
-                                         literal-start-index="333" literal-stop-index="341">
-                                <owner name="i" start-index="332" stop-index="332"
-                                       literal-start-index="333" literal-stop-index="333"/>
+                            <column-item name="item_id" start-index="332" stop-index="340" literal-start-index="333" literal-stop-index="341">
+                                <owner name="i" start-index="332" stop-index="332" literal-start-index="333" literal-stop-index="333"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -531,8 +472,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by_and_parentheses"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -542,54 +482,44 @@
                     <select>
                         <projections start-index="22" stop-index="160">
                             <top-projection alias="rownum_" start-index="22" stop-index="72">
-                                <top-value value="3" parameter-index="0" start-index="27"
-                                           stop-index="27"/>
+                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="86" stop-index="94">
                                 <owner name="i" start-index="86" stop-index="86"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="97"
-                                               stop-index="106">
+                            <column-projection name="order_id" alias="order_id" start-index="97" stop-index="106">
                                 <owner name="o" start-index="97" stop-index="97"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="121"
-                                               stop-index="128">
+                            <column-projection name="status" alias="status" start-index="121" stop-index="128">
                                 <owner name="o" start-index="121" stop-index="121"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="141"
-                                               stop-index="149">
+                            <column-projection name="user_id" alias="user_id" start-index="141" stop-index="149">
                                 <owner name="o" start-index="141" stop-index="141"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="167" stop-index="175" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="167" stop-index="175" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="182" stop-index="195"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="182" stop-index="195" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="200" stop-index="220">
-                                            <column-left-value name="user_id" start-index="200"
-                                                               stop-index="208">
+                                            <column-left-value name="user_id" start-index="200" stop-index="208">
                                                 <owner name="o" start-index="200" stop-index="200"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="212"
-                                                                stop-index="220">
+                                            <column-right-value name="user_id" start-index="212" stop-index="220">
                                                 <owner name="i" start-index="212" stop-index="212"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="226" stop-index="248">
-                                            <column-left-value name="order_id" start-index="226"
-                                                               stop-index="235">
+                                            <column-left-value name="order_id" start-index="226" stop-index="235">
                                                 <owner name="o" start-index="226" stop-index="226"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="239"
-                                                                stop-index="248">
+                                            <column-right-value name="order_id" start-index="239" stop-index="248">
                                                 <owner name="i" start-index="239" stop-index="239"/>
                                             </column-right-value>
                                         </predicate>
@@ -645,10 +575,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="316" stop-index="324"
-                                         literal-start-index="317" literal-stop-index="325">
-                                <owner name="i" start-index="316" stop-index="316"
-                                       literal-start-index="317" literal-stop-index="317"/>
+                            <column-item name="item_id" start-index="316" stop-index="324" literal-start-index="317" literal-stop-index="325">
+                                <owner name="i" start-index="316" stop-index="316" literal-start-index="317" literal-stop-index="317"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -673,8 +601,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by_and_parentheses"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -684,54 +611,44 @@
                     <select>
                         <projections start-index="22" stop-index="178">
                             <top-projection alias="rownum_" start-index="22" stop-index="90">
-                                <top-value value="3" parameter-index="0" start-index="27"
-                                           stop-index="27"/>
+                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="104" stop-index="112">
                                 <owner name="i" start-index="104" stop-index="104"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="115"
-                                               stop-index="124">
+                            <column-projection name="order_id" alias="order_id" start-index="115" stop-index="124">
                                 <owner name="o" start-index="115" stop-index="115"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="139"
-                                               stop-index="146">
+                            <column-projection name="status" alias="status" start-index="139" stop-index="146">
                                 <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="159"
-                                               stop-index="167">
+                            <column-projection name="user_id" alias="user_id" start-index="159" stop-index="167">
                                 <owner name="o" start-index="159" stop-index="159"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="185" stop-index="193" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="185" stop-index="193" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="200" stop-index="213"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="200" stop-index="213" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="218" stop-index="238">
-                                            <column-left-value name="user_id" start-index="218"
-                                                               stop-index="226">
+                                            <column-left-value name="user_id" start-index="218" stop-index="226">
                                                 <owner name="o" start-index="218" stop-index="218"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="230"
-                                                                stop-index="238">
+                                            <column-right-value name="user_id" start-index="230" stop-index="238">
                                                 <owner name="i" start-index="230" stop-index="230"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="244" stop-index="266">
-                                            <column-left-value name="order_id" start-index="244"
-                                                               stop-index="253">
+                                            <column-left-value name="order_id" start-index="244" stop-index="253">
                                                 <owner name="o" start-index="244" stop-index="244"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="257"
-                                                                stop-index="266">
+                                            <column-right-value name="order_id" start-index="257" stop-index="266">
                                                 <owner name="i" start-index="257" stop-index="257"/>
                                             </column-right-value>
                                         </predicate>
@@ -787,10 +704,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="334" stop-index="342"
-                                         literal-start-index="335" literal-stop-index="343">
-                                <owner name="i" start-index="334" stop-index="334"
-                                       literal-start-index="335" literal-stop-index="335"/>
+                            <column-item name="item_id" start-index="334" stop-index="342" literal-start-index="335" literal-stop-index="343">
+                                <owner name="i" start-index="334" stop-index="334" literal-start-index="335" literal-stop-index="335"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -815,8 +730,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -826,54 +740,44 @@
                     <select>
                         <projections start-index="22" stop-index="158">
                             <top-projection alias="rownum_" start-index="22" stop-index="70">
-                                <top-value value="3" parameter-index="0" start-index="26"
-                                           stop-index="26"/>
+                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="84" stop-index="92">
                                 <owner name="i" start-index="84" stop-index="84"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="95"
-                                               stop-index="104">
+                            <column-projection name="order_id" alias="order_id" start-index="95" stop-index="104">
                                 <owner name="o" start-index="95" stop-index="95"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="119"
-                                               stop-index="126">
+                            <column-projection name="status" alias="status" start-index="119" stop-index="126">
                                 <owner name="o" start-index="119" stop-index="119"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="139"
-                                               stop-index="147">
+                            <column-projection name="user_id" alias="user_id" start-index="139" stop-index="147">
                                 <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="165" stop-index="173" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="165" stop-index="173" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="180" stop-index="193"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="180" stop-index="193" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="198" stop-index="218">
-                                            <column-left-value name="user_id" start-index="198"
-                                                               stop-index="206">
+                                            <column-left-value name="user_id" start-index="198" stop-index="206">
                                                 <owner name="o" start-index="198" stop-index="198"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="210"
-                                                                stop-index="218">
+                                            <column-right-value name="user_id" start-index="210" stop-index="218">
                                                 <owner name="i" start-index="210" stop-index="210"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="224" stop-index="246">
-                                            <column-left-value name="order_id" start-index="224"
-                                                               stop-index="233">
+                                            <column-left-value name="order_id" start-index="224" stop-index="233">
                                                 <owner name="o" start-index="224" stop-index="224"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="237"
-                                                                stop-index="246">
+                                            <column-right-value name="order_id" start-index="237" stop-index="246">
                                                 <owner name="i" start-index="237" stop-index="237"/>
                                             </column-right-value>
                                         </predicate>
@@ -929,10 +833,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="314" stop-index="322"
-                                         literal-start-index="315" literal-stop-index="323">
-                                <owner name="i" start-index="314" stop-index="314"
-                                       literal-start-index="315" literal-stop-index="315"/>
+                            <column-item name="user_id" start-index="314" stop-index="322" literal-start-index="315" literal-stop-index="323">
+                                <owner name="i" start-index="314" stop-index="314" literal-start-index="315" literal-stop-index="315"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -957,8 +859,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -968,54 +869,44 @@
                     <select>
                         <projections start-index="22" stop-index="176">
                             <top-projection alias="rownum_" start-index="22" stop-index="88">
-                                <top-value value="3" parameter-index="0" start-index="26"
-                                           stop-index="26"/>
+                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="102" stop-index="110">
                                 <owner name="i" start-index="102" stop-index="102"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="113"
-                                               stop-index="122">
+                            <column-projection name="order_id" alias="order_id" start-index="113" stop-index="122">
                                 <owner name="o" start-index="113" stop-index="113"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="137"
-                                               stop-index="144">
+                            <column-projection name="status" alias="status" start-index="137" stop-index="144">
                                 <owner name="o" start-index="137" stop-index="137"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="157"
-                                               stop-index="165">
+                            <column-projection name="user_id" alias="user_id" start-index="157" stop-index="165">
                                 <owner name="o" start-index="157" stop-index="157"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="183" stop-index="191" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="183" stop-index="191" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="198" stop-index="211"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="198" stop-index="211" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="216" stop-index="236">
-                                            <column-left-value name="user_id" start-index="216"
-                                                               stop-index="224">
+                                            <column-left-value name="user_id" start-index="216" stop-index="224">
                                                 <owner name="o" start-index="216" stop-index="216"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="228"
-                                                                stop-index="236">
+                                            <column-right-value name="user_id" start-index="228" stop-index="236">
                                                 <owner name="i" start-index="228" stop-index="228"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="242" stop-index="264">
-                                            <column-left-value name="order_id" start-index="242"
-                                                               stop-index="251">
+                                            <column-left-value name="order_id" start-index="242" stop-index="251">
                                                 <owner name="o" start-index="242" stop-index="242"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="255"
-                                                                stop-index="264">
+                                            <column-right-value name="order_id" start-index="255" stop-index="264">
                                                 <owner name="i" start-index="255" stop-index="255"/>
                                             </column-right-value>
                                         </predicate>
@@ -1071,10 +962,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="332" stop-index="340"
-                                         literal-start-index="333" literal-stop-index="341">
-                                <owner name="i" start-index="332" stop-index="332"
-                                       literal-start-index="333" literal-stop-index="333"/>
+                            <column-item name="user_id" start-index="332" stop-index="340" literal-start-index="333" literal-stop-index="341">
+                                <owner name="i" start-index="332" stop-index="332" literal-start-index="333" literal-stop-index="333"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -1099,8 +988,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by_and_parentheses"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -1110,54 +998,44 @@
                     <select>
                         <projections start-index="22" stop-index="160">
                             <top-projection alias="rownum_" start-index="22" stop-index="72">
-                                <top-value value="3" parameter-index="0" start-index="27"
-                                           stop-index="27"/>
+                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="86" stop-index="94">
                                 <owner name="i" start-index="86" stop-index="86"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="97"
-                                               stop-index="106">
+                            <column-projection name="order_id" alias="order_id" start-index="97" stop-index="106">
                                 <owner name="o" start-index="97" stop-index="97"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="121"
-                                               stop-index="128">
+                            <column-projection name="status" alias="status" start-index="121" stop-index="128">
                                 <owner name="o" start-index="121" stop-index="121"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="141"
-                                               stop-index="149">
+                            <column-projection name="user_id" alias="user_id" start-index="141" stop-index="149">
                                 <owner name="o" start-index="141" stop-index="141"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="167" stop-index="175" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="167" stop-index="175" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="182" stop-index="195"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="182" stop-index="195" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="200" stop-index="220">
-                                            <column-left-value name="user_id" start-index="200"
-                                                               stop-index="208">
+                                            <column-left-value name="user_id" start-index="200" stop-index="208">
                                                 <owner name="o" start-index="200" stop-index="200"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="212"
-                                                                stop-index="220">
+                                            <column-right-value name="user_id" start-index="212" stop-index="220">
                                                 <owner name="i" start-index="212" stop-index="212"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="226" stop-index="248">
-                                            <column-left-value name="order_id" start-index="226"
-                                                               stop-index="235">
+                                            <column-left-value name="order_id" start-index="226" stop-index="235">
                                                 <owner name="o" start-index="226" stop-index="226"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="239"
-                                                                stop-index="248">
+                                            <column-right-value name="order_id" start-index="239" stop-index="248">
                                                 <owner name="i" start-index="239" stop-index="239"/>
                                             </column-right-value>
                                         </predicate>
@@ -1213,10 +1091,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="316" stop-index="324"
-                                         literal-start-index="317" literal-stop-index="325">
-                                <owner name="i" start-index="316" stop-index="316"
-                                       literal-start-index="317" literal-stop-index="317"/>
+                            <column-item name="user_id" start-index="316" stop-index="324" literal-start-index="317" literal-stop-index="325">
+                                <owner name="i" start-index="316" stop-index="316" literal-start-index="317" literal-stop-index="317"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -1241,8 +1117,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by_and_parentheses"
-            parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -1252,54 +1127,44 @@
                     <select>
                         <projections start-index="22" stop-index="178">
                             <top-projection alias="rownum_" start-index="22" stop-index="90">
-                                <top-value value="3" parameter-index="0" start-index="27"
-                                           stop-index="27"/>
+                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="104" stop-index="112">
                                 <owner name="i" start-index="104" stop-index="104"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="115"
-                                               stop-index="124">
+                            <column-projection name="order_id" alias="order_id" start-index="115" stop-index="124">
                                 <owner name="o" start-index="115" stop-index="115"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="139"
-                                               stop-index="146">
+                            <column-projection name="status" alias="status" start-index="139" stop-index="146">
                                 <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="159"
-                                               stop-index="167">
+                            <column-projection name="user_id" alias="user_id" start-index="159" stop-index="167">
                                 <owner name="o" start-index="159" stop-index="159"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="185" stop-index="193" name="t_order"
-                                                  alias="o"/>
+                                    <simple-table start-index="185" stop-index="193" name="t_order" alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="200" stop-index="213"
-                                                  name="t_order_item" alias="i"/>
+                                    <simple-table start-index="200" stop-index="213" name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="218" stop-index="238">
-                                            <column-left-value name="user_id" start-index="218"
-                                                               stop-index="226">
+                                            <column-left-value name="user_id" start-index="218" stop-index="226">
                                                 <owner name="o" start-index="218" stop-index="218"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="230"
-                                                                stop-index="238">
+                                            <column-right-value name="user_id" start-index="230" stop-index="238">
                                                 <owner name="i" start-index="230" stop-index="230"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="244" stop-index="266">
-                                            <column-left-value name="order_id" start-index="244"
-                                                               stop-index="253">
+                                            <column-left-value name="order_id" start-index="244" stop-index="253">
                                                 <owner name="o" start-index="244" stop-index="244"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="257"
-                                                                stop-index="266">
+                                            <column-right-value name="order_id" start-index="257" stop-index="266">
                                                 <owner name="i" start-index="257" stop-index="257"/>
                                             </column-right-value>
                                         </predicate>
@@ -1355,10 +1220,8 @@
                             </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="334" stop-index="342"
-                                         literal-start-index="335" literal-stop-index="343">
-                                <owner name="i" start-index="334" stop-index="334"
-                                       literal-start-index="335" literal-stop-index="335"/>
+                            <column-item name="user_id" start-index="334" stop-index="342" literal-start-index="335" literal-stop-index="343">
+                                <owner name="i" start-index="334" stop-index="334" literal-start-index="335" literal-stop-index="335"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -1383,8 +1246,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_row_number_and_group_by_and_order_by"
-            parameters="1, 2, 9, 7, 5, 3">
+    <select sql-case-id="select_pagination_with_row_number_and_group_by_and_order_by" parameters="1, 2, 9, 7, 5, 3">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -1396,72 +1258,47 @@
                             <shorthand-projection start-index="22" stop-index="27">
                                 <owner start-index="22" stop-index="25" name="row_"/>
                             </shorthand-projection>
-                            <column-projection start-index="30" stop-index="35" name="rownum"
-                                               alias="rownum_"/>
+                            <column-projection start-index="30" stop-index="35" name="rownum" alias="rownum_"/>
                         </projections>
                         <from>
                             <subquery-table alias="row_">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
-                                            <column-projection start-index="58" stop-index="73"
-                                                               name="order_id" alias="order_id">
-                                                <owner start-index="58" stop-index="64"
-                                                       name="order0_"/>
+                                            <column-projection start-index="58" stop-index="73" name="order_id" alias="order_id">
+                                                <owner start-index="58" stop-index="64" name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="88" stop-index="101"
-                                                               name="status" alias="status">
-                                                <owner start-index="88" stop-index="94"
-                                                       name="order0_"/>
+                                            <column-projection start-index="88" stop-index="101" name="status" alias="status">
+                                                <owner start-index="88" stop-index="94" name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="114" stop-index="128"
-                                                               name="user_id" alias="user_id">
-                                                <owner start-index="114" stop-index="120"
-                                                       name="order0_"/>
+                                            <column-projection start-index="114" stop-index="128" name="user_id" alias="user_id">
+                                                <owner start-index="114" stop-index="120" name="order0_"/>
                                             </column-projection>
                                         </projections>
                                         <from>
                                             <join-table>
                                                 <left>
-                                                    <simple-table start-index="146" stop-index="160"
-                                                                  name="t_order" alias="order0_"/>
+                                                    <simple-table start-index="146" stop-index="160" name="t_order" alias="order0_"/>
                                                 </left>
                                                 <right>
-                                                    <simple-table start-index="167" stop-index="180"
-                                                                  name="t_order_item" alias="i"/>
+                                                    <simple-table start-index="167" stop-index="180" name="t_order_item" alias="i"/>
                                                 </right>
                                                 <joinSpecification>
                                                     <and-predicate>
-                                                        <predicate start-index="185"
-                                                                   stop-index="211">
-                                                            <column-left-value start-index="185"
-                                                                               stop-index="199"
-                                                                               name="user_id">
-                                                                <owner start-index="185"
-                                                                       stop-index="191"
-                                                                       name="order0_"/>
+                                                        <predicate start-index="185" stop-index="211">
+                                                            <column-left-value start-index="185" stop-index="199" name="user_id">
+                                                                <owner start-index="185" stop-index="191" name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="203"
-                                                                                stop-index="211"
-                                                                                name="user_id">
-                                                                <owner start-index="203"
-                                                                       stop-index="203" name="i"/>
+                                                            <column-right-value start-index="203" stop-index="211" name="user_id">
+                                                                <owner start-index="203" stop-index="203" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
-                                                        <predicate start-index="217"
-                                                                   stop-index="245">
-                                                            <column-left-value start-index="217"
-                                                                               stop-index="232"
-                                                                               name="order_id">
-                                                                <owner start-index="217"
-                                                                       stop-index="223"
-                                                                       name="order0_"/>
+                                                        <predicate start-index="217" stop-index="245">
+                                                            <column-left-value start-index="217" stop-index="232" name="order_id">
+                                                                <owner start-index="217" stop-index="223" name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="236"
-                                                                                stop-index="245"
-                                                                                name="order_id">
-                                                                <owner start-index="236"
-                                                                       stop-index="236" name="i"/>
+                                                            <column-right-value start-index="236" stop-index="245" name="order_id">
+                                                                <owner start-index="236" stop-index="236" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
                                                     </and-predicate>
@@ -1516,14 +1353,12 @@
                                             </expr>
                                         </where>
                                         <group-by>
-                                            <column-item start-index="325" stop-index="333"
-                                                         name="item_id">
+                                            <column-item start-index="325" stop-index="333" name="item_id">
                                                 <owner start-index="325" stop-index="325" name="i"/>
                                             </column-item>
                                         </group-by>
                                         <order-by>
-                                            <column-item start-index="344" stop-index="352"
-                                                         name="item_id" order-direction="DESC">
+                                            <column-item start-index="344" stop-index="352" name="item_id" order-direction="DESC">
                                                 <owner start-index="344" stop-index="344" name="i"/>
                                             </column-item>
                                         </order-by>
@@ -1567,8 +1402,7 @@
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_row_number_and_diff_group_by_and_order_by"
-            parameters="1, 2, 9, 7, 5, 3">
+    <select sql-case-id="select_pagination_with_row_number_and_diff_group_by_and_order_by" parameters="1, 2, 9, 7, 5, 3">
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
@@ -1580,72 +1414,47 @@
                             <shorthand-projection start-index="22" stop-index="27">
                                 <owner start-index="22" stop-index="25" name="row_"/>
                             </shorthand-projection>
-                            <column-projection start-index="30" stop-index="35" name="rownum"
-                                               alias="rownum_"/>
+                            <column-projection start-index="30" stop-index="35" name="rownum" alias="rownum_"/>
                         </projections>
                         <from>
                             <subquery-table alias="row_">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
-                                            <column-projection start-index="58" stop-index="73"
-                                                               name="order_id" alias="order_id">
-                                                <owner start-index="58" stop-index="64"
-                                                       name="order0_"/>
+                                            <column-projection start-index="58" stop-index="73" name="order_id" alias="order_id">
+                                                <owner start-index="58" stop-index="64" name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="88" stop-index="101"
-                                                               name="status" alias="status">
-                                                <owner start-index="88" stop-index="94"
-                                                       name="order0_"/>
+                                            <column-projection start-index="88" stop-index="101" name="status" alias="status">
+                                                <owner start-index="88" stop-index="94" name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="114" stop-index="128"
-                                                               name="user_id" alias="user_id">
-                                                <owner start-index="114" stop-index="120"
-                                                       name="order0_"/>
+                                            <column-projection start-index="114" stop-index="128" name="user_id" alias="user_id">
+                                                <owner start-index="114" stop-index="120" name="order0_"/>
                                             </column-projection>
                                         </projections>
                                         <from>
                                             <join-table>
                                                 <left>
-                                                    <simple-table start-index="146" stop-index="160"
-                                                                  name="t_order" alias="order0_"/>
+                                                    <simple-table start-index="146" stop-index="160" name="t_order" alias="order0_"/>
                                                 </left>
                                                 <right>
-                                                    <simple-table start-index="167" stop-index="180"
-                                                                  name="t_order_item" alias="i"/>
+                                                    <simple-table start-index="167" stop-index="180" name="t_order_item" alias="i"/>
                                                 </right>
                                                 <joinSpecification>
                                                     <and-predicate>
-                                                        <predicate start-index="185"
-                                                                   stop-index="211">
-                                                            <column-left-value start-index="185"
-                                                                               stop-index="199"
-                                                                               name="user_id">
-                                                                <owner start-index="185"
-                                                                       stop-index="191"
-                                                                       name="order0_"/>
+                                                        <predicate start-index="185" stop-index="211">
+                                                            <column-left-value start-index="185" stop-index="199" name="user_id">
+                                                                <owner start-index="185" stop-index="191" name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="203"
-                                                                                stop-index="211"
-                                                                                name="user_id">
-                                                                <owner start-index="203"
-                                                                       stop-index="203" name="i"/>
+                                                            <column-right-value start-index="203" stop-index="211" name="user_id">
+                                                                <owner start-index="203" stop-index="203" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
-                                                        <predicate start-index="217"
-                                                                   stop-index="245">
-                                                            <column-left-value start-index="217"
-                                                                               stop-index="232"
-                                                                               name="order_id">
-                                                                <owner start-index="217"
-                                                                       stop-index="223"
-                                                                       name="order0_"/>
+                                                        <predicate start-index="217" stop-index="245">
+                                                            <column-left-value start-index="217" stop-index="232" name="order_id">
+                                                                <owner start-index="217" stop-index="223" name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="236"
-                                                                                stop-index="245"
-                                                                                name="order_id">
-                                                                <owner start-index="236"
-                                                                       stop-index="236" name="i"/>
+                                                            <column-right-value start-index="236" stop-index="245" name="order_id">
+                                                                <owner start-index="236" stop-index="236" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
                                                     </and-predicate>
@@ -1700,14 +1509,12 @@
                                             </expr>
                                         </where>
                                         <group-by>
-                                            <column-item start-index="325" stop-index="333"
-                                                         name="user_id">
+                                            <column-item start-index="325" stop-index="333" name="user_id">
                                                 <owner start-index="325" stop-index="325" name="i"/>
                                             </column-item>
                                         </group-by>
                                         <order-by>
-                                            <column-item start-index="344" stop-index="352"
-                                                         name="item_id" order-direction="DESC">
+                                            <column-item start-index="344" stop-index="352" name="item_id" order-direction="DESC">
                                                 <owner start-index="344" stop-index="344" name="i"/>
                                             </column-item>
                                         </order-by>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination-group-by-order-by.xml
@@ -17,31 +17,32 @@
   -->
 
 <sql-parser-test-cases>
-    <select sql-case-id="select_pagination_with_group_by_and_order_by" parameters="1, 2, 9, 10, 5, 3">
+    <select sql-case-id="select_pagination_with_group_by_and_order_by"
+            parameters="1, 2, 9, 10, 5, 3">
         <from>
             <join-table>
                 <left>
-                    <simple-table name="t_order" alias="o" start-index="22" stop-index="30" />
+                    <simple-table name="t_order" alias="o" start-index="22" stop-index="30"/>
                 </left>
                 <right>
-                    <simple-table name="t_order_item" alias="i" start-index="37" stop-index="50" />
+                    <simple-table name="t_order_item" alias="i" start-index="37" stop-index="50"/>
                 </right>
                 <joinSpecification>
                     <and-predicate>
                         <predicate start-index="55" stop-index="75">
                             <column-left-value name="user_id" start-index="55" stop-index="63">
-                                <owner name="o" start-index="55" stop-index="55" />
+                                <owner name="o" start-index="55" stop-index="55"/>
                             </column-left-value>
                             <column-right-value name="user_id" start-index="67" stop-index="75">
-                                <owner name="i" start-index="67" stop-index="67" />
+                                <owner name="i" start-index="67" stop-index="67"/>
                             </column-right-value>
                         </predicate>
                         <predicate start-index="81" stop-index="103">
                             <column-left-value name="order_id" start-index="81" stop-index="90">
-                                <owner name="o" start-index="81" stop-index="81" />
+                                <owner name="o" start-index="81" stop-index="81"/>
                             </column-left-value>
                             <column-right-value name="order_id" start-index="94" stop-index="103">
-                                <owner name="i" start-index="94" stop-index="94" />
+                                <owner name="i" start-index="94" stop-index="94"/>
                             </column-right-value>
                         </predicate>
                     </and-predicate>
@@ -50,76 +51,113 @@
         </from>
         <projections start-index="7" stop-index="15">
             <column-projection name="user_id" start-index="7" stop-index="15">
-                <owner name="i" start-index="7" stop-index="7" />
+                <owner name="i" start-index="7" stop-index="7"/>
             </column-projection>
         </projections>
         <where start-index="105" stop-index="160" literal-stop-index="161">
-            <and-predicate>
-                <predicate start-index="111" stop-index="129">
-                    <column-left-value name="user_id" start-index="111" stop-index="119">
-                        <owner name="o" start-index="111" stop-index="111" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
-                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
-                        <literal-expression value="1" start-index="125" stop-index="125" />
-                        <literal-expression value="2" start-index="128" stop-index="128" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="135" stop-index="160" literal-stop-index="161">
-                    <column-left-value name="order_id" start-index="135" stop-index="144">
-                        <owner name="o" start-index="135" stop-index="135" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="154" stop-index="154" />
-                        <between-literal-expression value="9" start-index="154" stop-index="154" />
-                        <and-parameter-marker-expression value="3" start-index="160" stop-index="160" />
-                        <and-literal-expression value="10" start-index="160" stop-index="161"/>
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="111" stop-index="160"
+                                             literal-stop-index="161">
+                    <left>
+                        <in-expression start-index="111" stop-index="129">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="111" stop-index="119">
+                                    <owner name="o" start-index="111" stop-index="111"/>
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="124" stop-index="129">
+                                    <items>
+                                        <literal-expression value="1" start-index="125"
+                                                            stop-index="125"/>
+                                        <parameter-marker-expression value="0" start-index="125"
+                                                                     stop-index="125"/>
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="128"
+                                                            stop-index="128"/>
+                                        <parameter-marker-expression value="1" start-index="128"
+                                                                     stop-index="128"/>
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="135" stop-index="160"
+                                            literal-stop-index="161">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="135" stop-index="144">
+                                    <owner name="o" start-index="135" stop-index="135"/>
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="154" stop-index="154"/>
+                                <parameter-marker-expression value="2" start-index="154"
+                                                             stop-index="154"/>
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="160" stop-index="161"/>
+                                <parameter-marker-expression value="3" start-index="160"
+                                                             stop-index="160"/>
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <group-by>
-            <column-item name="item_id" start-index="171" stop-index="179" literal-start-index="172" literal-stop-index="180">
-                <owner name="i" start-index="171" stop-index="171" literal-start-index="172" literal-stop-index="172" />
+            <column-item name="item_id" start-index="171" stop-index="179" literal-start-index="172"
+                         literal-stop-index="180">
+                <owner name="i" start-index="171" stop-index="171" literal-start-index="172"
+                       literal-stop-index="172"/>
             </column-item>
         </group-by>
         <order-by>
-            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198" literal-start-index="191" literal-stop-index="199">
-                <owner name="i" start-index="190" stop-index="190" literal-start-index="191" literal-stop-index="191" />
+            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198"
+                         literal-start-index="191" literal-stop-index="199">
+                <owner name="i" start-index="190" stop-index="190" literal-start-index="191"
+                       literal-stop-index="191"/>
             </column-item>
         </order-by>
-        <limit start-index="205" stop-index="214" literal-start-index="206" literal-stop-index="215">
-            <offset value="5" parameter-index="4" start-index="211" stop-index="211" literal-start-index="212" literal-stop-index="212" />
-            <row-count value="3" parameter-index="5" start-index="214" stop-index="214" literal-start-index="215" literal-stop-index="215" />
+        <limit start-index="205" stop-index="214" literal-start-index="206"
+               literal-stop-index="215">
+            <offset value="5" parameter-index="4" start-index="211" stop-index="211"
+                    literal-start-index="212" literal-stop-index="212"/>
+            <row-count value="3" parameter-index="5" start-index="214" stop-index="214"
+                       literal-start-index="215" literal-stop-index="215"/>
         </limit>
     </select>
 
-    <select sql-case-id="select_pagination_with_diff_group_by_and_order_by" parameters="1, 2, 9, 10, 5, 3">
+    <select sql-case-id="select_pagination_with_diff_group_by_and_order_by"
+            parameters="1, 2, 9, 10, 5, 3">
         <from>
             <join-table>
                 <left>
-                    <simple-table name="t_order" alias="o" start-index="22" stop-index="30" />
+                    <simple-table name="t_order" alias="o" start-index="22" stop-index="30"/>
                 </left>
                 <right>
-                    <simple-table name="t_order_item" alias="i" start-index="37" stop-index="50" />
+                    <simple-table name="t_order_item" alias="i" start-index="37" stop-index="50"/>
                 </right>
                 <joinSpecification>
                     <and-predicate>
                         <predicate start-index="55" stop-index="75">
                             <column-left-value name="user_id" start-index="55" stop-index="63">
-                                <owner name="o" start-index="55" stop-index="55" />
+                                <owner name="o" start-index="55" stop-index="55"/>
                             </column-left-value>
                             <column-right-value name="user_id" start-index="67" stop-index="75">
-                                <owner name="i" start-index="67" stop-index="67" />
+                                <owner name="i" start-index="67" stop-index="67"/>
                             </column-right-value>
                         </predicate>
                         <predicate start-index="81" stop-index="103">
                             <column-left-value name="order_id" start-index="81" stop-index="90">
-                                <owner name="o" start-index="81" stop-index="81" />
+                                <owner name="o" start-index="81" stop-index="81"/>
                             </column-left-value>
                             <column-right-value name="order_id" start-index="94" stop-index="103">
-                                <owner name="i" start-index="94" stop-index="94" />
+                                <owner name="i" start-index="94" stop-index="94"/>
                             </column-right-value>
                         </predicate>
                     </and-predicate>
@@ -128,54 +166,91 @@
         </from>
         <projections start-index="7" stop-index="15">
             <column-projection name="user_id" start-index="7" stop-index="15">
-                <owner name="i" start-index="7" stop-index="7" />
+                <owner name="i" start-index="7" stop-index="7"/>
             </column-projection>
         </projections>
         <where start-index="105" stop-index="160" literal-stop-index="161">
-            <and-predicate>
-                <predicate start-index="111" stop-index="129">
-                    <column-left-value name="user_id" start-index="111" stop-index="119">
-                        <owner name="o" start-index="111" stop-index="111" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
-                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
-                        <literal-expression value="1" start-index="125" stop-index="125" />
-                        <literal-expression value="2" start-index="128" stop-index="128" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="135" stop-index="160" literal-stop-index="161">
-                    <column-left-value name="order_id" start-index="135" stop-index="144">
-                        <owner name="o" start-index="135" stop-index="135" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="154" stop-index="154" />
-                        <between-literal-expression value="9" start-index="154" stop-index="154" />
-                        <and-parameter-marker-expression value="3" start-index="160" stop-index="160" />
-                        <and-literal-expression value="10" start-index="160" stop-index="161" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="111" stop-index="160"
+                                             literal-stop-index="161">
+                    <left>
+                        <in-expression start-index="111" stop-index="129">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="111" stop-index="119">
+                                    <owner name="o" start-index="111" stop-index="111"/>
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="124" stop-index="129">
+                                    <items>
+                                        <literal-expression value="1" start-index="125"
+                                                            stop-index="125"/>
+                                        <parameter-marker-expression value="0" start-index="125"
+                                                                     stop-index="125"/>
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="128"
+                                                            stop-index="128"/>
+                                        <parameter-marker-expression value="1" start-index="128"
+                                                                     stop-index="128"/>
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="135" stop-index="160"
+                                            literal-stop-index="161">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="135" stop-index="144">
+                                    <owner name="o" start-index="135" stop-index="135"/>
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="154" stop-index="154"/>
+                                <parameter-marker-expression value="2" start-index="154"
+                                                             stop-index="154"/>
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="160" stop-index="161"/>
+                                <parameter-marker-expression value="3" start-index="160"
+                                                             stop-index="160"/>
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <group-by>
-            <column-item name="user_id" start-index="171" stop-index="179" literal-start-index="172" literal-stop-index="180">
-                <owner name="i" start-index="171" stop-index="171" literal-start-index="172" literal-stop-index="172" />
+            <column-item name="user_id" start-index="171" stop-index="179" literal-start-index="172"
+                         literal-stop-index="180">
+                <owner name="i" start-index="171" stop-index="171" literal-start-index="172"
+                       literal-stop-index="172"/>
             </column-item>
         </group-by>
         <order-by>
-            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198" literal-start-index="191" literal-stop-index="199">
-                <owner name="i" start-index="190" stop-index="190" literal-start-index="191" literal-stop-index="191" />
+            <column-item name="item_id" order-direction="DESC" start-index="190" stop-index="198"
+                         literal-start-index="191" literal-stop-index="199">
+                <owner name="i" start-index="190" stop-index="190" literal-start-index="191"
+                       literal-stop-index="191"/>
             </column-item>
         </order-by>
-        <limit start-index="205" stop-index="214" literal-start-index="206" literal-stop-index="215">
-            <offset value="5" parameter-index="4" start-index="211" stop-index="211" literal-start-index="212" literal-stop-index="212" />
-            <row-count value="3" parameter-index="5" start-index="214" stop-index="214" literal-start-index="215" literal-stop-index="215" />
+        <limit start-index="205" stop-index="214" literal-start-index="206"
+               literal-stop-index="215">
+            <offset value="5" parameter-index="4" start-index="211" stop-index="211"
+                    literal-start-index="212" literal-stop-index="212"/>
+            <row-count value="3" parameter-index="5" start-index="214" stop-index="214"
+                       literal-start-index="215" literal-stop-index="215"/>
         </limit>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -183,45 +258,55 @@
                     <select>
                         <projections start-index="22" stop-index="158">
                             <top-projection alias="rownum_" start-index="22" stop-index="70">
-                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26" />
+                                <top-value value="3" parameter-index="0" start-index="26"
+                                           stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="84" stop-index="92">
-                                <owner name="i" start-index="84" stop-index="84" />
+                                <owner name="i" start-index="84" stop-index="84"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="95" stop-index="104">
-                                <owner name="o" start-index="95" stop-index="95" />
+                            <column-projection name="order_id" alias="order_id" start-index="95"
+                                               stop-index="104">
+                                <owner name="o" start-index="95" stop-index="95"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="119" stop-index="126">
-                                <owner name="o" start-index="119" stop-index="119" />
+                            <column-projection name="status" alias="status" start-index="119"
+                                               stop-index="126">
+                                <owner name="o" start-index="119" stop-index="119"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="139" stop-index="147">
-                                <owner name="o" start-index="139" stop-index="139" />
+                            <column-projection name="user_id" alias="user_id" start-index="139"
+                                               stop-index="147">
+                                <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="165" stop-index="173" name="t_order" alias="o" />
+                                    <simple-table start-index="165" stop-index="173" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="180" stop-index="193" name="t_order_item" alias="i" />
+                                    <simple-table start-index="180" stop-index="193"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="198" stop-index="218">
-                                            <column-left-value name="user_id" start-index="198" stop-index="206">
-                                                <owner name="o" start-index="198" stop-index="198" />
+                                            <column-left-value name="user_id" start-index="198"
+                                                               stop-index="206">
+                                                <owner name="o" start-index="198" stop-index="198"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="210" stop-index="218">
-                                                <owner name="i" start-index="210" stop-index="210" />
+                                            <column-right-value name="user_id" start-index="210"
+                                                                stop-index="218">
+                                                <owner name="i" start-index="210" stop-index="210"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="224" stop-index="246">
-                                            <column-left-value name="order_id" start-index="224" stop-index="233">
-                                                <owner name="o" start-index="224" stop-index="224" />
+                                            <column-left-value name="order_id" start-index="224"
+                                                               stop-index="233">
+                                                <owner name="o" start-index="224" stop-index="224"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="237" stop-index="246">
-                                                <owner name="i" start-index="237" stop-index="237" />
+                                            <column-right-value name="order_id" start-index="237"
+                                                                stop-index="246">
+                                                <owner name="i" start-index="237" stop-index="237"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -229,34 +314,57 @@
                             </join-table>
                         </from>
                         <where start-index="248" stop-index="303" literal-stop-index="304">
-                            <and-predicate>
-                                <predicate start-index="254" stop-index="272">
-                                    <column-left-value name="user_id" start-index="254" stop-index="262">
-                                        <owner name="o" start-index="254" stop-index="254" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="268" stop-index="268" />
-                                        <parameter-marker-expression value="2" start-index="271" stop-index="271" />
-                                        <literal-expression value="1" start-index="268" stop-index="268" />
-                                        <literal-expression value="2" start-index="271" stop-index="271" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="278" stop-index="303" literal-stop-index="304">
-                                    <column-left-value name="order_id" start-index="278" stop-index="287">
-                                        <owner name="o" start-index="278" stop-index="278" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="297" stop-index="297" />
-                                        <and-parameter-marker-expression value="4" start-index="303" stop-index="303" />
-                                        <between-literal-expression value="9" start-index="297" stop-index="297" />
-                                        <and-literal-expression value="10" start-index="303" stop-index="304" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="254" stop-index="303" literal-stop-index="304">
+                                    <left>
+                                        <in-expression start-index="254" stop-index="272">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="254" stop-index="262">
+                                                    <owner name="o" start-index="254" stop-index="254" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="267" stop-index="272">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="268" stop-index="268" />
+                                                        <parameter-marker-expression value="1" start-index="268" stop-index="268" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="271" stop-index="271" />
+                                                        <parameter-marker-expression value="2" start-index="271" stop-index="271" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="278" stop-index="303" literal-stop-index="304">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="278" stop-index="287">
+                                                    <owner name="o" start-index="278" stop-index="278" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="297" stop-index="297" />
+                                                <parameter-marker-expression value="3" start-index="297" stop-index="297" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="303" stop-index="304" />
+                                                <parameter-marker-expression value="4" start-index="303" stop-index="303" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="314" stop-index="322" literal-start-index="315" literal-stop-index="323">
-                                <owner name="i" start-index="314" stop-index="314" literal-start-index="315" literal-stop-index="315" />
+                            <column-item name="item_id" start-index="314" stop-index="322"
+                                         literal-start-index="315" literal-stop-index="323">
+                                <owner name="i" start-index="314" stop-index="314"
+                                       literal-start-index="315" literal-stop-index="315"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -264,24 +372,27 @@
             </subquery-table>
         </from>
         <where start-index="333" stop-index="354" literal-start-index="334" literal-stop-index="355">
-            <and-predicate>
-                <predicate start-index="339" stop-index="354" literal-start-index="340" literal-stop-index="355">
-                    <column-left-value start-index="339" stop-index="350" literal-start-index="340" literal-stop-index="351" name="rownum_">
-                        <owner start-index="339" stop-index="342" literal-start-index="340" literal-stop-index="343" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="354" stop-index="354" value="5" />
-                        <literal-expression start-index="355" stop-index="355" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="339" stop-index="354" literal-start-index="340" literal-stop-index="355">
+                    <left>
+                        <column name="rownum_" start-index="339" stop-index="350" literal-start-index="340" literal-stop-index="351">
+                            <owner name="row_" start-index="339" stop-index="342" literal-start-index="340" literal-stop-index="343" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="355" stop-index="355" />
+                        <parameter-marker-expression value="5" start-index="354" stop-index="354" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -289,45 +400,55 @@
                     <select>
                         <projections start-index="22" stop-index="176">
                             <top-projection alias="rownum_" start-index="22" stop-index="88">
-                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26" />
+                                <top-value value="3" parameter-index="0" start-index="26"
+                                           stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="102" stop-index="110">
-                                <owner name="i" start-index="102" stop-index="102" />
+                                <owner name="i" start-index="102" stop-index="102"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="113" stop-index="122">
-                                <owner name="o" start-index="113" stop-index="113" />
+                            <column-projection name="order_id" alias="order_id" start-index="113"
+                                               stop-index="122">
+                                <owner name="o" start-index="113" stop-index="113"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="137" stop-index="144">
-                                <owner name="o" start-index="137" stop-index="137" />
+                            <column-projection name="status" alias="status" start-index="137"
+                                               stop-index="144">
+                                <owner name="o" start-index="137" stop-index="137"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="157" stop-index="165">
-                                <owner name="o" start-index="157" stop-index="157" />
+                            <column-projection name="user_id" alias="user_id" start-index="157"
+                                               stop-index="165">
+                                <owner name="o" start-index="157" stop-index="157"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="183" stop-index="191" name="t_order" alias="o" />
+                                    <simple-table start-index="183" stop-index="191" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="198" stop-index="211" name="t_order_item" alias="i" />
+                                    <simple-table start-index="198" stop-index="211"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="216" stop-index="236">
-                                            <column-left-value name="user_id" start-index="216" stop-index="224">
-                                                <owner name="o" start-index="216" stop-index="216" />
+                                            <column-left-value name="user_id" start-index="216"
+                                                               stop-index="224">
+                                                <owner name="o" start-index="216" stop-index="216"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="228" stop-index="236">
-                                                <owner name="i" start-index="228" stop-index="228" />
+                                            <column-right-value name="user_id" start-index="228"
+                                                                stop-index="236">
+                                                <owner name="i" start-index="228" stop-index="228"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="242" stop-index="264">
-                                            <column-left-value name="order_id" start-index="242" stop-index="251">
-                                                <owner name="o" start-index="242" stop-index="242" />
+                                            <column-left-value name="order_id" start-index="242"
+                                                               stop-index="251">
+                                                <owner name="o" start-index="242" stop-index="242"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="255" stop-index="264">
-                                                <owner name="i" start-index="255" stop-index="255" />
+                                            <column-right-value name="order_id" start-index="255"
+                                                                stop-index="264">
+                                                <owner name="i" start-index="255" stop-index="255"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -335,34 +456,57 @@
                             </join-table>
                         </from>
                         <where start-index="266" stop-index="321" literal-stop-index="322">
-                            <and-predicate>
-                                <predicate start-index="272" stop-index="290">
-                                    <column-left-value name="user_id" start-index="272" stop-index="280">
-                                        <owner name="o" start-index="272" stop-index="272" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="286" stop-index="286" />
-                                        <parameter-marker-expression value="2" start-index="289" stop-index="289" />
-                                        <literal-expression value="1" start-index="286" stop-index="286" />
-                                        <literal-expression value="2" start-index="289" stop-index="289" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="296" stop-index="321" literal-stop-index="322">
-                                    <column-left-value name="order_id" start-index="296" stop-index="305">
-                                        <owner name="o" start-index="296" stop-index="296" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="315" stop-index="315" />
-                                        <and-parameter-marker-expression value="4" start-index="321" stop-index="321" />
-                                        <between-literal-expression value="9" start-index="315" stop-index="315" />
-                                        <and-literal-expression value="10" start-index="321" stop-index="322" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="272" stop-index="321" literal-stop-index="322">
+                                    <left>
+                                        <in-expression start-index="272" stop-index="290">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="272" stop-index="280">
+                                                    <owner name="o" start-index="272" stop-index="272" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="285" stop-index="290">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="286" stop-index="286" />
+                                                        <parameter-marker-expression value="1" start-index="286" stop-index="286" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="289" stop-index="289" />
+                                                        <parameter-marker-expression value="2" start-index="289" stop-index="289" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="296" stop-index="321" literal-stop-index="322">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="296" stop-index="305">
+                                                    <owner name="o" start-index="296" stop-index="296" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="315" stop-index="315" />
+                                                <parameter-marker-expression value="3" start-index="315" stop-index="315" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="321" stop-index="322" />
+                                                <parameter-marker-expression value="4" start-index="321" stop-index="321" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="332" stop-index="340" literal-start-index="333" literal-stop-index="341">
-                                <owner name="i" start-index="332" stop-index="332" literal-start-index="333" literal-stop-index="333" />
+                            <column-item name="item_id" start-index="332" stop-index="340"
+                                         literal-start-index="333" literal-stop-index="341">
+                                <owner name="i" start-index="332" stop-index="332"
+                                       literal-start-index="333" literal-stop-index="333"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -370,24 +514,27 @@
             </subquery-table>
         </from>
         <where start-index="351" stop-index="372" literal-start-index="352" literal-stop-index="373">
-            <and-predicate>
-                <predicate start-index="357" stop-index="372" literal-start-index="358" literal-stop-index="373">
-                    <column-left-value start-index="357" stop-index="368" literal-start-index="358" literal-stop-index="369" name="rownum_">
-                        <owner start-index="357" stop-index="360" literal-start-index="358" literal-stop-index="361" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="372" stop-index="372" value="5" />
-                        <literal-expression start-index="373" stop-index="373" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="357" stop-index="372" literal-start-index="358" literal-stop-index="373">
+                    <left>
+                        <column name="rownum_" start-index="357" stop-index="368" literal-start-index="358" literal-stop-index="369">
+                            <owner name="row_" start-index="357" stop-index="360" literal-start-index="358" literal-stop-index="361" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="373" stop-index="373" />
+                        <parameter-marker-expression value="5" start-index="372" stop-index="372" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_group_by_and_order_by_and_parentheses"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -395,45 +542,55 @@
                     <select>
                         <projections start-index="22" stop-index="160">
                             <top-projection alias="rownum_" start-index="22" stop-index="72">
-                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27" />
+                                <top-value value="3" parameter-index="0" start-index="27"
+                                           stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="86" stop-index="94">
-                                <owner name="i" start-index="86" stop-index="86" />
+                                <owner name="i" start-index="86" stop-index="86"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="97" stop-index="106">
-                                <owner name="o" start-index="97" stop-index="97" />
+                            <column-projection name="order_id" alias="order_id" start-index="97"
+                                               stop-index="106">
+                                <owner name="o" start-index="97" stop-index="97"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="121" stop-index="128">
-                                <owner name="o" start-index="121" stop-index="121" />
+                            <column-projection name="status" alias="status" start-index="121"
+                                               stop-index="128">
+                                <owner name="o" start-index="121" stop-index="121"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="141" stop-index="149">
-                                <owner name="o" start-index="141" stop-index="141" />
+                            <column-projection name="user_id" alias="user_id" start-index="141"
+                                               stop-index="149">
+                                <owner name="o" start-index="141" stop-index="141"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="167" stop-index="175" name="t_order" alias="o" />
+                                    <simple-table start-index="167" stop-index="175" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="182" stop-index="195" name="t_order_item" alias="i" />
+                                    <simple-table start-index="182" stop-index="195"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="200" stop-index="220">
-                                            <column-left-value name="user_id" start-index="200" stop-index="208">
-                                                <owner name="o" start-index="200" stop-index="200" />
+                                            <column-left-value name="user_id" start-index="200"
+                                                               stop-index="208">
+                                                <owner name="o" start-index="200" stop-index="200"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="212" stop-index="220">
-                                                <owner name="i" start-index="212" stop-index="212" />
+                                            <column-right-value name="user_id" start-index="212"
+                                                                stop-index="220">
+                                                <owner name="i" start-index="212" stop-index="212"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="226" stop-index="248">
-                                            <column-left-value name="order_id" start-index="226" stop-index="235">
-                                                <owner name="o" start-index="226" stop-index="226" />
+                                            <column-left-value name="order_id" start-index="226"
+                                                               stop-index="235">
+                                                <owner name="o" start-index="226" stop-index="226"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="239" stop-index="248">
-                                                <owner name="i" start-index="239" stop-index="239" />
+                                            <column-right-value name="order_id" start-index="239"
+                                                                stop-index="248">
+                                                <owner name="i" start-index="239" stop-index="239"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -441,34 +598,57 @@
                             </join-table>
                         </from>
                         <where start-index="250" stop-index="305" literal-stop-index="306">
-                            <and-predicate>
-                                <predicate start-index="256" stop-index="274">
-                                    <column-left-value name="user_id" start-index="256" stop-index="264">
-                                        <owner name="o" start-index="256" stop-index="256" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
-                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
-                                        <literal-expression value="1" start-index="270" stop-index="270" />
-                                        <literal-expression value="2" start-index="273" stop-index="273" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="280" stop-index="305" literal-stop-index="306">
-                                    <column-left-value name="order_id" start-index="280" stop-index="289">
-                                        <owner name="o" start-index="280" stop-index="280" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="299" stop-index="299" />
-                                        <and-parameter-marker-expression value="4" start-index="305" stop-index="305" />
-                                        <between-literal-expression value="9" start-index="299" stop-index="299" />
-                                        <and-literal-expression value="10" start-index="305" stop-index="306" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="256" stop-index="305" literal-stop-index="306">
+                                    <left>
+                                        <in-expression start-index="256" stop-index="274">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="256" stop-index="264">
+                                                    <owner name="o" start-index="256" stop-index="256" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="269" stop-index="274">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="270" stop-index="270" />
+                                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="273" stop-index="273" />
+                                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="280" stop-index="305" literal-stop-index="306">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="280" stop-index="289">
+                                                    <owner name="o" start-index="280" stop-index="280" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="299" stop-index="299" />
+                                                <parameter-marker-expression value="3" start-index="299" stop-index="299" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="305" stop-index="306" />
+                                                <parameter-marker-expression value="4" start-index="305" stop-index="305" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="316" stop-index="324" literal-start-index="317" literal-stop-index="325">
-                                <owner name="i" start-index="316" stop-index="316" literal-start-index="317" literal-stop-index="317" />
+                            <column-item name="item_id" start-index="316" stop-index="324"
+                                         literal-start-index="317" literal-stop-index="325">
+                                <owner name="i" start-index="316" stop-index="316"
+                                       literal-start-index="317" literal-stop-index="317"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -476,24 +656,27 @@
             </subquery-table>
         </from>
         <where start-index="335" stop-index="356" literal-start-index="336" literal-stop-index="357">
-            <and-predicate>
-                <predicate start-index="341" stop-index="356" literal-start-index="342" literal-stop-index="357">
-                    <column-left-value start-index="341" stop-index="352" literal-start-index="342" literal-stop-index="353" name="rownum_">
-                        <owner start-index="341" stop-index="344" literal-start-index="342" literal-stop-index="345" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="356" stop-index="356" value="5" />
-                        <literal-expression start-index="357" stop-index="357" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="341" stop-index="356" literal-start-index="342" literal-stop-index="357">
+                    <left>
+                        <column name="rownum_" start-index="341" stop-index="352" literal-start-index="342" literal-stop-index="353">
+                            <owner name="row_" start-index="341" stop-index="344" literal-start-index="342" literal-stop-index="345" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="357" stop-index="357" />
+                        <parameter-marker-expression value="5" start-index="356" stop-index="356" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_group_by_and_order_by_and_parentheses"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -501,45 +684,55 @@
                     <select>
                         <projections start-index="22" stop-index="178">
                             <top-projection alias="rownum_" start-index="22" stop-index="90">
-                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27" />
+                                <top-value value="3" parameter-index="0" start-index="27"
+                                           stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="104" stop-index="112">
-                                <owner name="i" start-index="104" stop-index="104" />
+                                <owner name="i" start-index="104" stop-index="104"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="115" stop-index="124">
-                                <owner name="o" start-index="115" stop-index="115" />
+                            <column-projection name="order_id" alias="order_id" start-index="115"
+                                               stop-index="124">
+                                <owner name="o" start-index="115" stop-index="115"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="139" stop-index="146">
-                                <owner name="o" start-index="139" stop-index="139" />
+                            <column-projection name="status" alias="status" start-index="139"
+                                               stop-index="146">
+                                <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="159" stop-index="167">
-                                <owner name="o" start-index="159" stop-index="159" />
+                            <column-projection name="user_id" alias="user_id" start-index="159"
+                                               stop-index="167">
+                                <owner name="o" start-index="159" stop-index="159"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="185" stop-index="193" name="t_order" alias="o" />
+                                    <simple-table start-index="185" stop-index="193" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="200" stop-index="213" name="t_order_item" alias="i" />
+                                    <simple-table start-index="200" stop-index="213"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="218" stop-index="238">
-                                            <column-left-value name="user_id" start-index="218" stop-index="226">
-                                                <owner name="o" start-index="218" stop-index="218" />
+                                            <column-left-value name="user_id" start-index="218"
+                                                               stop-index="226">
+                                                <owner name="o" start-index="218" stop-index="218"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="230" stop-index="238">
-                                                <owner name="i" start-index="230" stop-index="230" />
+                                            <column-right-value name="user_id" start-index="230"
+                                                                stop-index="238">
+                                                <owner name="i" start-index="230" stop-index="230"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="244" stop-index="266">
-                                            <column-left-value name="order_id" start-index="244" stop-index="253">
-                                                <owner name="o" start-index="244" stop-index="244" />
+                                            <column-left-value name="order_id" start-index="244"
+                                                               stop-index="253">
+                                                <owner name="o" start-index="244" stop-index="244"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="257" stop-index="266">
-                                                <owner name="i" start-index="257" stop-index="257" />
+                                            <column-right-value name="order_id" start-index="257"
+                                                                stop-index="266">
+                                                <owner name="i" start-index="257" stop-index="257"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -547,34 +740,57 @@
                             </join-table>
                         </from>
                         <where start-index="268" stop-index="323" literal-stop-index="324">
-                            <and-predicate>
-                                <predicate start-index="274" stop-index="292">
-                                    <column-left-value name="user_id" start-index="274" stop-index="282">
-                                        <owner name="o" start-index="274" stop-index="274" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
-                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
-                                        <literal-expression value="1" start-index="288" stop-index="288" />
-                                        <literal-expression value="2" start-index="291" stop-index="291" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="298" stop-index="323" literal-stop-index="324">
-                                    <column-left-value name="order_id" start-index="298" stop-index="307">
-                                        <owner name="o" start-index="298" stop-index="298" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="317" stop-index="317" />
-                                        <and-parameter-marker-expression value="4" start-index="323" stop-index="323" />
-                                        <between-literal-expression value="9" start-index="317" stop-index="317" />
-                                        <and-literal-expression value="10" start-index="323" stop-index="324" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="274" stop-index="323" literal-stop-index="324">
+                                    <left>
+                                        <in-expression start-index="274" stop-index="292">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="274" stop-index="282">
+                                                    <owner name="o" start-index="274" stop-index="274" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="287" stop-index="292">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="288" stop-index="288" />
+                                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="291" stop-index="291" />
+                                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="298" stop-index="323" literal-stop-index="324">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="298" stop-index="307">
+                                                    <owner name="o" start-index="298" stop-index="298" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="317" stop-index="317" />
+                                                <parameter-marker-expression value="3" start-index="317" stop-index="317" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="323" stop-index="324" />
+                                                <parameter-marker-expression value="4" start-index="323" stop-index="323" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="item_id" start-index="334" stop-index="342" literal-start-index="335" literal-stop-index="343">
-                                <owner name="i" start-index="334" stop-index="334" literal-start-index="335" literal-stop-index="335" />
+                            <column-item name="item_id" start-index="334" stop-index="342"
+                                         literal-start-index="335" literal-stop-index="343">
+                                <owner name="i" start-index="334" stop-index="334"
+                                       literal-start-index="335" literal-stop-index="335"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -582,24 +798,27 @@
             </subquery-table>
         </from>
         <where start-index="353" stop-index="374" literal-start-index="354" literal-stop-index="375">
-            <and-predicate>
-                <predicate start-index="359" stop-index="374" literal-start-index="360" literal-stop-index="375">
-                    <column-left-value start-index="359" stop-index="370" literal-start-index="360" literal-stop-index="371" name="rownum_">
-                        <owner start-index="359" stop-index="362" literal-start-index="360" literal-stop-index="363" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="374" stop-index="374" value="5" />
-                        <literal-expression start-index="375" stop-index="375" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="359" stop-index="374" literal-start-index="360" literal-stop-index="375">
+                    <left>
+                        <column name="rownum_" start-index="359" stop-index="370" literal-start-index="360" literal-stop-index="371">
+                            <owner name="row_" start-index="359" stop-index="362" literal-start-index="360" literal-stop-index="363" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="375" stop-index="375" />
+                        <parameter-marker-expression value="5" start-index="374" stop-index="374" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -607,45 +826,55 @@
                     <select>
                         <projections start-index="22" stop-index="158">
                             <top-projection alias="rownum_" start-index="22" stop-index="70">
-                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26" />
+                                <top-value value="3" parameter-index="0" start-index="26"
+                                           stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="84" stop-index="92">
-                                <owner name="i" start-index="84" stop-index="84" />
+                                <owner name="i" start-index="84" stop-index="84"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="95" stop-index="104">
-                                <owner name="o" start-index="95" stop-index="95" />
+                            <column-projection name="order_id" alias="order_id" start-index="95"
+                                               stop-index="104">
+                                <owner name="o" start-index="95" stop-index="95"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="119" stop-index="126">
-                                <owner name="o" start-index="119" stop-index="119" />
+                            <column-projection name="status" alias="status" start-index="119"
+                                               stop-index="126">
+                                <owner name="o" start-index="119" stop-index="119"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="139" stop-index="147">
-                                <owner name="o" start-index="139" stop-index="139" />
+                            <column-projection name="user_id" alias="user_id" start-index="139"
+                                               stop-index="147">
+                                <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="165" stop-index="173" name="t_order" alias="o" />
+                                    <simple-table start-index="165" stop-index="173" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="180" stop-index="193" name="t_order_item" alias="i" />
+                                    <simple-table start-index="180" stop-index="193"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="198" stop-index="218">
-                                            <column-left-value name="user_id" start-index="198" stop-index="206">
-                                                <owner name="o" start-index="198" stop-index="198" />
+                                            <column-left-value name="user_id" start-index="198"
+                                                               stop-index="206">
+                                                <owner name="o" start-index="198" stop-index="198"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="210" stop-index="218">
-                                                <owner name="i" start-index="210" stop-index="210" />
+                                            <column-right-value name="user_id" start-index="210"
+                                                                stop-index="218">
+                                                <owner name="i" start-index="210" stop-index="210"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="224" stop-index="246">
-                                            <column-left-value name="order_id" start-index="224" stop-index="233">
-                                                <owner name="o" start-index="224" stop-index="224" />
+                                            <column-left-value name="order_id" start-index="224"
+                                                               stop-index="233">
+                                                <owner name="o" start-index="224" stop-index="224"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="237" stop-index="246">
-                                                <owner name="i" start-index="237" stop-index="237" />
+                                            <column-right-value name="order_id" start-index="237"
+                                                                stop-index="246">
+                                                <owner name="i" start-index="237" stop-index="237"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -653,34 +882,57 @@
                             </join-table>
                         </from>
                         <where start-index="248" stop-index="303" literal-stop-index="304">
-                            <and-predicate>
-                                <predicate start-index="254" stop-index="272">
-                                    <column-left-value name="user_id" start-index="254" stop-index="262">
-                                        <owner name="o" start-index="254" stop-index="254" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="268" stop-index="268" />
-                                        <parameter-marker-expression value="2" start-index="271" stop-index="271" />
-                                        <literal-expression value="1" start-index="268" stop-index="268" />
-                                        <literal-expression value="2" start-index="271" stop-index="271" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="278" stop-index="303" literal-stop-index="304">
-                                    <column-left-value name="order_id" start-index="278" stop-index="287">
-                                        <owner name="o" start-index="278" stop-index="278" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="297" stop-index="297" />
-                                        <and-parameter-marker-expression value="4" start-index="303" stop-index="303" />
-                                        <between-literal-expression value="9" start-index="297" stop-index="297" />
-                                        <and-literal-expression value="10" start-index="303" stop-index="304" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="254" stop-index="303" literal-stop-index="304">
+                                    <left>
+                                        <in-expression start-index="254" stop-index="272">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="254" stop-index="262">
+                                                    <owner name="o" start-index="254" stop-index="254" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="267" stop-index="272">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="268" stop-index="268" />
+                                                        <parameter-marker-expression value="1" start-index="268" stop-index="268" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="271" stop-index="271" />
+                                                        <parameter-marker-expression value="2" start-index="271" stop-index="271" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="278" stop-index="303" literal-stop-index="304">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="278" stop-index="287">
+                                                    <owner name="o" start-index="278" stop-index="278" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="297" stop-index="297" />
+                                                <parameter-marker-expression value="3" start-index="297" stop-index="297" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="303" stop-index="304" />
+                                                <parameter-marker-expression value="4" start-index="303" stop-index="303" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="314" stop-index="322" literal-start-index="315" literal-stop-index="323">
-                                <owner name="i" start-index="314" stop-index="314" literal-start-index="315" literal-stop-index="315" />
+                            <column-item name="user_id" start-index="314" stop-index="322"
+                                         literal-start-index="315" literal-stop-index="323">
+                                <owner name="i" start-index="314" stop-index="314"
+                                       literal-start-index="315" literal-stop-index="315"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -688,24 +940,27 @@
             </subquery-table>
         </from>
         <where start-index="333" stop-index="354" literal-start-index="334" literal-stop-index="355">
-            <and-predicate>
-                <predicate start-index="339" stop-index="354" literal-start-index="340" literal-stop-index="355">
-                    <column-left-value start-index="339" stop-index="350" literal-start-index="340" literal-stop-index="351" name="rownum_">
-                        <owner start-index="339" stop-index="342" literal-start-index="340" literal-stop-index="343" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="354" stop-index="354" value="5" />
-                        <literal-expression start-index="355" stop-index="355" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="339" stop-index="354" literal-start-index="340" literal-stop-index="355">
+                    <left>
+                        <column name="rownum_" start-index="339" stop-index="350" literal-start-index="340" literal-stop-index="351">
+                            <owner name="row_" start-index="339" stop-index="342" literal-start-index="340" literal-stop-index="343" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="355" stop-index="355" />
+                        <parameter-marker-expression value="5" start-index="354" stop-index="354" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -713,45 +968,55 @@
                     <select>
                         <projections start-index="22" stop-index="176">
                             <top-projection alias="rownum_" start-index="22" stop-index="88">
-                                <top-value value="3" parameter-index="0" start-index="26" stop-index="26" />
+                                <top-value value="3" parameter-index="0" start-index="26"
+                                           stop-index="26"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="102" stop-index="110">
-                                <owner name="i" start-index="102" stop-index="102" />
+                                <owner name="i" start-index="102" stop-index="102"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="113" stop-index="122">
-                                <owner name="o" start-index="113" stop-index="113" />
+                            <column-projection name="order_id" alias="order_id" start-index="113"
+                                               stop-index="122">
+                                <owner name="o" start-index="113" stop-index="113"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="137" stop-index="144">
-                                <owner name="o" start-index="137" stop-index="137" />
+                            <column-projection name="status" alias="status" start-index="137"
+                                               stop-index="144">
+                                <owner name="o" start-index="137" stop-index="137"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="157" stop-index="165">
-                                <owner name="o" start-index="157" stop-index="157" />
+                            <column-projection name="user_id" alias="user_id" start-index="157"
+                                               stop-index="165">
+                                <owner name="o" start-index="157" stop-index="157"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="183" stop-index="191" name="t_order" alias="o" />
+                                    <simple-table start-index="183" stop-index="191" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="198" stop-index="211" name="t_order_item" alias="i" />
+                                    <simple-table start-index="198" stop-index="211"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="216" stop-index="236">
-                                            <column-left-value name="user_id" start-index="216" stop-index="224">
-                                                <owner name="o" start-index="216" stop-index="216" />
+                                            <column-left-value name="user_id" start-index="216"
+                                                               stop-index="224">
+                                                <owner name="o" start-index="216" stop-index="216"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="228" stop-index="236">
-                                                <owner name="i" start-index="228" stop-index="228" />
+                                            <column-right-value name="user_id" start-index="228"
+                                                                stop-index="236">
+                                                <owner name="i" start-index="228" stop-index="228"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="242" stop-index="264">
-                                            <column-left-value name="order_id" start-index="242" stop-index="251">
-                                                <owner name="o" start-index="242" stop-index="242" />
+                                            <column-left-value name="order_id" start-index="242"
+                                                               stop-index="251">
+                                                <owner name="o" start-index="242" stop-index="242"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="255" stop-index="264">
-                                                <owner name="i" start-index="255" stop-index="255" />
+                                            <column-right-value name="order_id" start-index="255"
+                                                                stop-index="264">
+                                                <owner name="i" start-index="255" stop-index="255"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -759,34 +1024,57 @@
                             </join-table>
                         </from>
                         <where start-index="266" stop-index="321" literal-stop-index="322">
-                            <and-predicate>
-                                <predicate start-index="272" stop-index="290">
-                                    <column-left-value name="user_id" start-index="272" stop-index="280">
-                                        <owner name="o" start-index="272" stop-index="272" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="286" stop-index="286" />
-                                        <parameter-marker-expression value="2" start-index="289" stop-index="289" />
-                                        <literal-expression value="1" start-index="286" stop-index="286" />
-                                        <literal-expression value="2" start-index="289" stop-index="289" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="296" stop-index="321" literal-stop-index="322">
-                                    <column-left-value name="order_id" start-index="296" stop-index="305">
-                                        <owner name="o" start-index="296" stop-index="296" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="315" stop-index="315" />
-                                        <and-parameter-marker-expression value="4" start-index="321" stop-index="321" />
-                                        <between-literal-expression value="9" start-index="315" stop-index="315" />
-                                        <and-literal-expression value="10" start-index="321" stop-index="322" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="272" stop-index="321" literal-stop-index="322">
+                                    <left>
+                                        <in-expression start-index="272" stop-index="290">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="272" stop-index="280">
+                                                    <owner name="o" start-index="272" stop-index="272" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="285" stop-index="290">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="286" stop-index="286" />
+                                                        <parameter-marker-expression value="1" start-index="286" stop-index="286" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="289" stop-index="289" />
+                                                        <parameter-marker-expression value="2" start-index="289" stop-index="289" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="296" stop-index="321" literal-stop-index="322">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="296" stop-index="305">
+                                                    <owner name="o" start-index="296" stop-index="296" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="315" stop-index="315" />
+                                                <parameter-marker-expression value="3" start-index="315" stop-index="315" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="321" stop-index="322" />
+                                                <parameter-marker-expression value="4" start-index="321" stop-index="321" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="332" stop-index="340" literal-start-index="333" literal-stop-index="341">
-                                <owner name="i" start-index="332" stop-index="332" literal-start-index="333" literal-stop-index="333" />
+                            <column-item name="user_id" start-index="332" stop-index="340"
+                                         literal-start-index="333" literal-stop-index="341">
+                                <owner name="i" start-index="332" stop-index="332"
+                                       literal-start-index="333" literal-stop-index="333"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -794,24 +1082,27 @@
             </subquery-table>
         </from>
         <where start-index="351" stop-index="372" literal-start-index="352" literal-stop-index="373">
-            <and-predicate>
-                <predicate start-index="357" stop-index="372" literal-start-index="358" literal-stop-index="373">
-                    <column-left-value start-index="357" stop-index="368" literal-start-index="358" literal-stop-index="369" name="rownum_">
-                        <owner start-index="357" stop-index="360" literal-start-index="358" literal-stop-index="361" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="372" stop-index="372" value="5" />
-                        <literal-expression start-index="373" stop-index="373" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="357" stop-index="372" literal-start-index="358" literal-stop-index="373">
+                    <left>
+                        <column name="rownum_" start-index="357" stop-index="368" literal-start-index="358" literal-stop-index="369">
+                            <owner name="row_" start-index="357" stop-index="360" literal-start-index="358" literal-stop-index="361" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="373" stop-index="373" />
+                        <parameter-marker-expression value="5" start-index="372" stop-index="372" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_and_diff_group_by_and_order_by_and_parentheses"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -819,45 +1110,55 @@
                     <select>
                         <projections start-index="22" stop-index="160">
                             <top-projection alias="rownum_" start-index="22" stop-index="72">
-                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27" />
+                                <top-value value="3" parameter-index="0" start-index="27"
+                                           stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="86" stop-index="94">
-                                <owner name="i" start-index="86" stop-index="86" />
+                                <owner name="i" start-index="86" stop-index="86"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="97" stop-index="106">
-                                <owner name="o" start-index="97" stop-index="97" />
+                            <column-projection name="order_id" alias="order_id" start-index="97"
+                                               stop-index="106">
+                                <owner name="o" start-index="97" stop-index="97"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="121" stop-index="128">
-                                <owner name="o" start-index="121" stop-index="121" />
+                            <column-projection name="status" alias="status" start-index="121"
+                                               stop-index="128">
+                                <owner name="o" start-index="121" stop-index="121"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="141" stop-index="149">
-                                <owner name="o" start-index="141" stop-index="141" />
+                            <column-projection name="user_id" alias="user_id" start-index="141"
+                                               stop-index="149">
+                                <owner name="o" start-index="141" stop-index="141"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="167" stop-index="175" name="t_order" alias="o" />
+                                    <simple-table start-index="167" stop-index="175" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="182" stop-index="195" name="t_order_item" alias="i" />
+                                    <simple-table start-index="182" stop-index="195"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="200" stop-index="220">
-                                            <column-left-value name="user_id" start-index="200" stop-index="208">
-                                                <owner name="o" start-index="200" stop-index="200" />
+                                            <column-left-value name="user_id" start-index="200"
+                                                               stop-index="208">
+                                                <owner name="o" start-index="200" stop-index="200"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="212" stop-index="220">
-                                                <owner name="i" start-index="212" stop-index="212" />
+                                            <column-right-value name="user_id" start-index="212"
+                                                                stop-index="220">
+                                                <owner name="i" start-index="212" stop-index="212"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="226" stop-index="248">
-                                            <column-left-value name="order_id" start-index="226" stop-index="235">
-                                                <owner name="o" start-index="226" stop-index="226" />
+                                            <column-left-value name="order_id" start-index="226"
+                                                               stop-index="235">
+                                                <owner name="o" start-index="226" stop-index="226"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="239" stop-index="248">
-                                                <owner name="i" start-index="239" stop-index="239" />
+                                            <column-right-value name="order_id" start-index="239"
+                                                                stop-index="248">
+                                                <owner name="i" start-index="239" stop-index="239"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -865,34 +1166,57 @@
                             </join-table>
                         </from>
                         <where start-index="250" stop-index="305" literal-stop-index="306">
-                            <and-predicate>
-                                <predicate start-index="256" stop-index="274">
-                                    <column-left-value name="user_id" start-index="256" stop-index="264">
-                                        <owner name="o" start-index="256" stop-index="256" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
-                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
-                                        <literal-expression value="1" start-index="270" stop-index="270" />
-                                        <literal-expression value="2" start-index="273" stop-index="273" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="280" stop-index="305" literal-stop-index="306">
-                                    <column-left-value name="order_id" start-index="280" stop-index="289">
-                                        <owner name="o" start-index="280" stop-index="280" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="299" stop-index="299" />
-                                        <and-parameter-marker-expression value="4" start-index="305" stop-index="305" />
-                                        <between-literal-expression value="9" start-index="299" stop-index="299" />
-                                        <and-literal-expression value="10" start-index="305" stop-index="306" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="256" stop-index="305" literal-stop-index="306">
+                                    <left>
+                                        <in-expression start-index="256" stop-index="274">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="256" stop-index="264">
+                                                    <owner name="o" start-index="256" stop-index="256" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="269" stop-index="274">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="270" stop-index="270" />
+                                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="273" stop-index="273" />
+                                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="280" stop-index="305" literal-stop-index="306">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="280" stop-index="289">
+                                                    <owner name="o" start-index="280" stop-index="280" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="299" stop-index="299" />
+                                                <parameter-marker-expression value="3" start-index="299" stop-index="299" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="305" stop-index="306" />
+                                                <parameter-marker-expression value="4" start-index="305" stop-index="305" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="316" stop-index="324" literal-start-index="317" literal-stop-index="325">
-                                <owner name="i" start-index="316" stop-index="316" literal-start-index="317" literal-stop-index="317" />
+                            <column-item name="user_id" start-index="316" stop-index="324"
+                                         literal-start-index="317" literal-stop-index="325">
+                                <owner name="i" start-index="316" stop-index="316"
+                                       literal-start-index="317" literal-stop-index="317"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -900,24 +1224,27 @@
             </subquery-table>
         </from>
         <where start-index="335" stop-index="356" literal-start-index="336" literal-stop-index="357">
-            <and-predicate>
-                <predicate start-index="341" stop-index="356" literal-start-index="342" literal-stop-index="357">
-                    <column-left-value start-index="341" stop-index="352" literal-start-index="342" literal-stop-index="353" name="rownum_">
-                        <owner start-index="341" stop-index="344" literal-start-index="342" literal-stop-index="345" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="356" stop-index="356" value="5" />
-                        <literal-expression start-index="357" stop-index="357" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="341" stop-index="356" literal-start-index="342" literal-stop-index="357">
+                    <left>
+                        <column name="rownum_" start-index="341" stop-index="352" literal-start-index="342" literal-stop-index="353">
+                            <owner name="row_" start-index="341" stop-index="344" literal-start-index="342" literal-stop-index="345" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="357" stop-index="357" />
+                        <parameter-marker-expression value="5" start-index="356" stop-index="356" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by_and_parentheses" parameters="3, 1, 2, 9, 10, 6">
+    <select sql-case-id="select_pagination_with_top_percent_with_ties_and_diff_group_by_and_order_by_and_parentheses"
+            parameters="3, 1, 2, 9, 10, 6">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table alias="row_">
@@ -925,45 +1252,55 @@
                     <select>
                         <projections start-index="22" stop-index="178">
                             <top-projection alias="rownum_" start-index="22" stop-index="90">
-                                <top-value value="3" parameter-index="0" start-index="27" stop-index="27" />
+                                <top-value value="3" parameter-index="0" start-index="27"
+                                           stop-index="27"/>
                             </top-projection>
                             <column-projection name="item_id" start-index="104" stop-index="112">
-                                <owner name="i" start-index="104" stop-index="104" />
+                                <owner name="i" start-index="104" stop-index="104"/>
                             </column-projection>
-                            <column-projection name="order_id" alias="order_id" start-index="115" stop-index="124">
-                                <owner name="o" start-index="115" stop-index="115" />
+                            <column-projection name="order_id" alias="order_id" start-index="115"
+                                               stop-index="124">
+                                <owner name="o" start-index="115" stop-index="115"/>
                             </column-projection>
-                            <column-projection name="status" alias="status" start-index="139" stop-index="146">
-                                <owner name="o" start-index="139" stop-index="139" />
+                            <column-projection name="status" alias="status" start-index="139"
+                                               stop-index="146">
+                                <owner name="o" start-index="139" stop-index="139"/>
                             </column-projection>
-                            <column-projection name="user_id" alias="user_id" start-index="159" stop-index="167">
-                                <owner name="o" start-index="159" stop-index="159" />
+                            <column-projection name="user_id" alias="user_id" start-index="159"
+                                               stop-index="167">
+                                <owner name="o" start-index="159" stop-index="159"/>
                             </column-projection>
                         </projections>
                         <from>
                             <join-table>
                                 <left>
-                                    <simple-table start-index="185" stop-index="193" name="t_order" alias="o" />
+                                    <simple-table start-index="185" stop-index="193" name="t_order"
+                                                  alias="o"/>
                                 </left>
                                 <right>
-                                    <simple-table start-index="200" stop-index="213" name="t_order_item" alias="i" />
+                                    <simple-table start-index="200" stop-index="213"
+                                                  name="t_order_item" alias="i"/>
                                 </right>
                                 <joinSpecification>
                                     <and-predicate>
                                         <predicate start-index="218" stop-index="238">
-                                            <column-left-value name="user_id" start-index="218" stop-index="226">
-                                                <owner name="o" start-index="218" stop-index="218" />
+                                            <column-left-value name="user_id" start-index="218"
+                                                               stop-index="226">
+                                                <owner name="o" start-index="218" stop-index="218"/>
                                             </column-left-value>
-                                            <column-right-value name="user_id" start-index="230" stop-index="238">
-                                                <owner name="i" start-index="230" stop-index="230" />
+                                            <column-right-value name="user_id" start-index="230"
+                                                                stop-index="238">
+                                                <owner name="i" start-index="230" stop-index="230"/>
                                             </column-right-value>
                                         </predicate>
                                         <predicate start-index="244" stop-index="266">
-                                            <column-left-value name="order_id" start-index="244" stop-index="253">
-                                                <owner name="o" start-index="244" stop-index="244" />
+                                            <column-left-value name="order_id" start-index="244"
+                                                               stop-index="253">
+                                                <owner name="o" start-index="244" stop-index="244"/>
                                             </column-left-value>
-                                            <column-right-value name="order_id" start-index="257" stop-index="266">
-                                                <owner name="i" start-index="257" stop-index="257" />
+                                            <column-right-value name="order_id" start-index="257"
+                                                                stop-index="266">
+                                                <owner name="i" start-index="257" stop-index="257"/>
                                             </column-right-value>
                                         </predicate>
                                     </and-predicate>
@@ -971,34 +1308,57 @@
                             </join-table>
                         </from>
                         <where start-index="268" stop-index="323" literal-stop-index="324">
-                            <and-predicate>
-                                <predicate start-index="274" stop-index="292">
-                                    <column-left-value name="user_id" start-index="274" stop-index="282">
-                                        <owner name="o" start-index="274" stop-index="274" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
-                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
-                                        <literal-expression value="1" start-index="288" stop-index="288" />
-                                        <literal-expression value="2" start-index="291" stop-index="291" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="298" stop-index="323" literal-stop-index="324">
-                                    <column-left-value name="order_id" start-index="298" stop-index="307">
-                                        <owner name="o" start-index="298" stop-index="298" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="317" stop-index="317" />
-                                        <and-parameter-marker-expression value="4" start-index="323" stop-index="323" />
-                                        <between-literal-expression value="9" start-index="317" stop-index="317" />
-                                        <and-literal-expression value="10" start-index="323" stop-index="324" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="274" stop-index="323" literal-stop-index="324">
+                                    <left>
+                                        <in-expression start-index="274" stop-index="292">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="274" stop-index="282">
+                                                    <owner name="o" start-index="274" stop-index="274" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="287" stop-index="292">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="288" stop-index="288" />
+                                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="291" stop-index="291" />
+                                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="298" stop-index="323" literal-stop-index="324">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="298" stop-index="307">
+                                                    <owner name="o" start-index="298" stop-index="298" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="317" stop-index="317" />
+                                                <parameter-marker-expression value="3" start-index="317" stop-index="317" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="323" stop-index="324" />
+                                                <parameter-marker-expression value="4" start-index="323" stop-index="323" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                         <group-by>
-                            <column-item name="user_id" start-index="334" stop-index="342" literal-start-index="335" literal-stop-index="343">
-                                <owner name="i" start-index="334" stop-index="334" literal-start-index="335" literal-stop-index="335" />
+                            <column-item name="user_id" start-index="334" stop-index="342"
+                                         literal-start-index="335" literal-stop-index="343">
+                                <owner name="i" start-index="334" stop-index="334"
+                                       literal-start-index="335" literal-stop-index="335"/>
                             </column-item>
                         </group-by>
                     </select>
@@ -1006,74 +1366,102 @@
             </subquery-table>
         </from>
         <where start-index="353" stop-index="374" literal-start-index="354" literal-stop-index="375">
-            <and-predicate>
-                <predicate start-index="359" stop-index="374" literal-start-index="360" literal-stop-index="375">
-                    <column-left-value start-index="359" stop-index="370" literal-start-index="360" literal-stop-index="371" name="rownum_">
-                        <owner start-index="359" stop-index="362" literal-start-index="360" literal-stop-index="363" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="374" stop-index="374" value="5" />
-                        <literal-expression start-index="375" stop-index="375" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="359" stop-index="374" literal-start-index="360" literal-stop-index="375">
+                    <left>
+                        <column name="rownum_" start-index="359" stop-index="370" literal-start-index="360" literal-stop-index="371">
+                            <owner name="row_" start-index="359" stop-index="362" literal-start-index="360" literal-stop-index="363" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="375" stop-index="375" />
+                        <parameter-marker-expression value="5" start-index="374" stop-index="374" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_row_number_and_group_by_and_order_by" parameters="1, 2, 9, 7, 5, 3">
+    <select sql-case-id="select_pagination_with_row_number_and_group_by_and_order_by"
+            parameters="1, 2, 9, 7, 5, 3">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection  start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table start-index="14" stop-index="382" alias="t">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
-                            <shorthand-projection start-index="22" stop-index="27" >
+                            <shorthand-projection start-index="22" stop-index="27">
                                 <owner start-index="22" stop-index="25" name="row_"/>
                             </shorthand-projection>
-                            <column-projection start-index="30" stop-index="35" name="rownum"  alias="rownum_"/>
+                            <column-projection start-index="30" stop-index="35" name="rownum"
+                                               alias="rownum_"/>
                         </projections>
                         <from>
                             <subquery-table alias="row_">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
-                                            <column-projection start-index="58" stop-index="73" name="order_id" alias="order_id">
-                                                <owner start-index="58" stop-index="64" name="order0_"/>
+                                            <column-projection start-index="58" stop-index="73"
+                                                               name="order_id" alias="order_id">
+                                                <owner start-index="58" stop-index="64"
+                                                       name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="88" stop-index="101" name="status" alias="status">
-                                                <owner start-index="88" stop-index="94" name="order0_"/>
+                                            <column-projection start-index="88" stop-index="101"
+                                                               name="status" alias="status">
+                                                <owner start-index="88" stop-index="94"
+                                                       name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="114" stop-index="128" name="user_id" alias="user_id">
-                                                <owner start-index="114" stop-index="120" name="order0_"/>
+                                            <column-projection start-index="114" stop-index="128"
+                                                               name="user_id" alias="user_id">
+                                                <owner start-index="114" stop-index="120"
+                                                       name="order0_"/>
                                             </column-projection>
                                         </projections>
                                         <from>
                                             <join-table>
                                                 <left>
-                                                    <simple-table start-index="146" stop-index="160" name="t_order" alias="order0_"/>
+                                                    <simple-table start-index="146" stop-index="160"
+                                                                  name="t_order" alias="order0_"/>
                                                 </left>
                                                 <right>
-                                                    <simple-table start-index="167" stop-index="180" name="t_order_item" alias="i"/>
+                                                    <simple-table start-index="167" stop-index="180"
+                                                                  name="t_order_item" alias="i"/>
                                                 </right>
                                                 <joinSpecification>
                                                     <and-predicate>
-                                                        <predicate start-index="185" stop-index="211">
-                                                            <column-left-value start-index="185" stop-index="199" name="user_id">
-                                                                <owner start-index="185" stop-index="191" name="order0_"/>
+                                                        <predicate start-index="185"
+                                                                   stop-index="211">
+                                                            <column-left-value start-index="185"
+                                                                               stop-index="199"
+                                                                               name="user_id">
+                                                                <owner start-index="185"
+                                                                       stop-index="191"
+                                                                       name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="203" stop-index="211" name="user_id">
-                                                                <owner start-index="203" stop-index="203" name="i"/>
+                                                            <column-right-value start-index="203"
+                                                                                stop-index="211"
+                                                                                name="user_id">
+                                                                <owner start-index="203"
+                                                                       stop-index="203" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
-                                                        <predicate start-index="217" stop-index="245">
-                                                            <column-left-value start-index="217" stop-index="232" name="order_id">
-                                                                <owner start-index="217" stop-index="223" name="order0_"/>
+                                                        <predicate start-index="217"
+                                                                   stop-index="245">
+                                                            <column-left-value start-index="217"
+                                                                               stop-index="232"
+                                                                               name="order_id">
+                                                                <owner start-index="217"
+                                                                       stop-index="223"
+                                                                       name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="236" stop-index="245" name="order_id">
-                                                                <owner start-index="236" stop-index="236" name="i"/>
+                                                            <column-right-value start-index="236"
+                                                                                stop-index="245"
+                                                                                name="order_id">
+                                                                <owner start-index="236"
+                                                                       stop-index="236" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
                                                     </and-predicate>
@@ -1081,38 +1469,61 @@
                                             </join-table>
                                         </from>
                                         <where start-index="247" stop-index="314">
-                                            <and-predicate>
-                                                <predicate start-index="253" stop-index="277">
-                                                    <column-left-value start-index="253" stop-index="267" name="user_id">
-                                                        <owner start-index="253" stop-index="259" name="order0_" />
-                                                    </column-left-value>
-                                                    <in-right-value>
-                                                        <literal-expression start-index="273" stop-index="273" value="1" />
-                                                        <parameter-marker-expression start-index="273" stop-index="273" value="0"/>
-                                                        <literal-expression start-index="276" stop-index="276" value="2"/>
-                                                        <parameter-marker-expression start-index="276" stop-index="276" value="1" />
-                                                    </in-right-value>
-                                                </predicate>
-                                                <predicate start-index="283" stop-index="314">
-                                                    <column-left-value start-index="283" stop-index="298" name="order_id">
-                                                        <owner start-index="283" stop-index="289" name="order0_"/>
-                                                    </column-left-value>
-                                                    <between-right-value>
-                                                        <between-literal-expression start-index="308" stop-index="308" value="9" />
-                                                        <between-parameter-marker-expression start-index="308" stop-index="308" value="2"/>
-                                                        <and-literal-expression start-index="314" stop-index="314" value="7" />
-                                                        <and-parameter-marker-expression start-index="314" stop-index="314" value="3" />
-                                                    </between-right-value>
-                                                </predicate>
-                                            </and-predicate>
+                                            <expr>
+                                                <binary-operation-expression start-index="253" stop-index="314">
+                                                    <left>
+                                                        <in-expression start-index="253" stop-index="277">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="user_id" start-index="253" stop-index="267">
+                                                                    <owner name="order0_" start-index="253" stop-index="259" />
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <list-expression start-index="272" stop-index="277">
+                                                                    <items>
+                                                                        <literal-expression value="1" start-index="273" stop-index="273" />
+                                                                        <parameter-marker-expression value="0" start-index="273" stop-index="273" />
+                                                                    </items>
+                                                                    <items>
+                                                                        <literal-expression value="2" start-index="276" stop-index="276" />
+                                                                        <parameter-marker-expression value="1" start-index="276" stop-index="276" />
+                                                                    </items>
+                                                                </list-expression>
+                                                            </right>
+                                                        </in-expression>
+                                                    </left>
+                                                    <operator>AND</operator>
+                                                    <right>
+                                                        <between-expression start-index="283" stop-index="314">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="order_id" start-index="283" stop-index="298">
+                                                                    <owner name="order0_" start-index="283" stop-index="289" />
+                                                                </column>
+                                                            </left>
+                                                            <between-expr>
+                                                                <literal-expression value="9" start-index="308" stop-index="308" />
+                                                                <parameter-marker-expression value="2" start-index="308" stop-index="308" />
+                                                            </between-expr>
+                                                            <and-expr>
+                                                                <literal-expression value="7" start-index="314" stop-index="314" />
+                                                                <parameter-marker-expression value="3" start-index="314" stop-index="314" />
+                                                            </and-expr>
+                                                        </between-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </expr>
                                         </where>
                                         <group-by>
-                                            <column-item start-index="325" stop-index="333" name="item_id">
+                                            <column-item start-index="325" stop-index="333"
+                                                         name="item_id">
                                                 <owner start-index="325" stop-index="325" name="i"/>
                                             </column-item>
                                         </group-by>
                                         <order-by>
-                                            <column-item start-index="344" stop-index="352" name="item_id" order-direction="DESC">
+                                            <column-item start-index="344" stop-index="352"
+                                                         name="item_id" order-direction="DESC">
                                                 <owner start-index="344" stop-index="344" name="i"/>
                                             </column-item>
                                         </order-by>
@@ -1121,90 +1532,120 @@
                             </subquery-table>
                         </from>
                         <where start-index="365" stop-index="381">
-                            <and-predicate>
-                                <predicate start-index="371" stop-index="381">
-                                    <column-left-value start-index="371" stop-index="376" name="rownum" />
-                                    <operator type="&lt;="/>
-                                    <compare-right-value>
-                                        <literal-expression start-index="381" stop-index="381" value="5"/>
-                                        <parameter-marker-expression start-index="381" stop-index="381" value="4"/>
-                                    </compare-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="371" stop-index="381">
+                                    <left>
+                                        <column name="rownum" start-index="371" stop-index="376" />
+                                    </left>
+                                    <operator>&lt;=</operator>
+                                    <right>
+                                        <literal-expression value="5" start-index="381" stop-index="381" />
+                                        <parameter-marker-expression value="4" start-index="381" stop-index="381" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
         <where start-index="386" stop-index="404">
-            <and-predicate>
-                <predicate start-index="392" stop-index="404">
-                    <column-left-value start-index="392" stop-index="400" name="rownum_">
-                        <owner start-index="392" stop-index="392" name="t"/>
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <literal-expression start-index="404" stop-index="404" value="3" />
-                        <parameter-marker-expression start-index="404" stop-index="404" value="5"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="392" stop-index="404">
+                    <left>
+                        <column name="rownum_" start-index="392" stop-index="400">
+                            <owner name="t" start-index="392" stop-index="392" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="3" start-index="404" stop-index="404" />
+                        <parameter-marker-expression value="5" start-index="404" stop-index="404" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_pagination_with_row_number_and_diff_group_by_and_order_by" parameters="1, 2, 9, 7, 5, 3">
+    <select sql-case-id="select_pagination_with_row_number_and_diff_group_by_and_order_by"
+            parameters="1, 2, 9, 7, 5, 3">
         <projections start-index="7" stop-index="7">
-            <shorthand-projection  start-index="7" stop-index="7" />
+            <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
         <from>
             <subquery-table start-index="14" stop-index="382" alias="t">
                 <subquery>
                     <select>
                         <projections start-index="22" stop-index="43">
-                            <shorthand-projection start-index="22" stop-index="27" >
+                            <shorthand-projection start-index="22" stop-index="27">
                                 <owner start-index="22" stop-index="25" name="row_"/>
                             </shorthand-projection>
-                            <column-projection start-index="30" stop-index="35" name="rownum"  alias="rownum_"/>
+                            <column-projection start-index="30" stop-index="35" name="rownum"
+                                               alias="rownum_"/>
                         </projections>
                         <from>
                             <subquery-table alias="row_">
                                 <subquery>
                                     <select>
                                         <projections start-index="58" stop-index="139">
-                                            <column-projection start-index="58" stop-index="73" name="order_id" alias="order_id">
-                                                <owner start-index="58" stop-index="64" name="order0_"/>
+                                            <column-projection start-index="58" stop-index="73"
+                                                               name="order_id" alias="order_id">
+                                                <owner start-index="58" stop-index="64"
+                                                       name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="88" stop-index="101" name="status" alias="status">
-                                                <owner start-index="88" stop-index="94" name="order0_"/>
+                                            <column-projection start-index="88" stop-index="101"
+                                                               name="status" alias="status">
+                                                <owner start-index="88" stop-index="94"
+                                                       name="order0_"/>
                                             </column-projection>
-                                            <column-projection start-index="114" stop-index="128" name="user_id" alias="user_id">
-                                                <owner start-index="114" stop-index="120" name="order0_"/>
+                                            <column-projection start-index="114" stop-index="128"
+                                                               name="user_id" alias="user_id">
+                                                <owner start-index="114" stop-index="120"
+                                                       name="order0_"/>
                                             </column-projection>
                                         </projections>
                                         <from>
                                             <join-table>
                                                 <left>
-                                                    <simple-table start-index="146" stop-index="160" name="t_order" alias="order0_"/>
+                                                    <simple-table start-index="146" stop-index="160"
+                                                                  name="t_order" alias="order0_"/>
                                                 </left>
                                                 <right>
-                                                    <simple-table start-index="167" stop-index="180" name="t_order_item" alias="i"/>
+                                                    <simple-table start-index="167" stop-index="180"
+                                                                  name="t_order_item" alias="i"/>
                                                 </right>
                                                 <joinSpecification>
                                                     <and-predicate>
-                                                        <predicate start-index="185" stop-index="211">
-                                                            <column-left-value start-index="185" stop-index="199" name="user_id">
-                                                                <owner start-index="185" stop-index="191" name="order0_"/>
+                                                        <predicate start-index="185"
+                                                                   stop-index="211">
+                                                            <column-left-value start-index="185"
+                                                                               stop-index="199"
+                                                                               name="user_id">
+                                                                <owner start-index="185"
+                                                                       stop-index="191"
+                                                                       name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="203" stop-index="211" name="user_id">
-                                                                <owner start-index="203" stop-index="203" name="i"/>
+                                                            <column-right-value start-index="203"
+                                                                                stop-index="211"
+                                                                                name="user_id">
+                                                                <owner start-index="203"
+                                                                       stop-index="203" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
-                                                        <predicate start-index="217" stop-index="245">
-                                                            <column-left-value start-index="217" stop-index="232" name="order_id">
-                                                                <owner start-index="217" stop-index="223" name="order0_"/>
+                                                        <predicate start-index="217"
+                                                                   stop-index="245">
+                                                            <column-left-value start-index="217"
+                                                                               stop-index="232"
+                                                                               name="order_id">
+                                                                <owner start-index="217"
+                                                                       stop-index="223"
+                                                                       name="order0_"/>
                                                             </column-left-value>
-                                                            <column-right-value start-index="236" stop-index="245" name="order_id">
-                                                                <owner start-index="236" stop-index="236" name="i"/>
+                                                            <column-right-value start-index="236"
+                                                                                stop-index="245"
+                                                                                name="order_id">
+                                                                <owner start-index="236"
+                                                                       stop-index="236" name="i"/>
                                                             </column-right-value>
                                                         </predicate>
                                                     </and-predicate>
@@ -1212,38 +1653,61 @@
                                             </join-table>
                                         </from>
                                         <where start-index="247" stop-index="314">
-                                            <and-predicate>
-                                                <predicate start-index="253" stop-index="277">
-                                                    <column-left-value start-index="253" stop-index="267" name="user_id">
-                                                        <owner start-index="253" stop-index="259" name="order0_" />
-                                                    </column-left-value>
-                                                    <in-right-value>
-                                                        <literal-expression start-index="273" stop-index="273" value="1" />
-                                                        <parameter-marker-expression start-index="273" stop-index="273" value="0"/>
-                                                        <literal-expression start-index="276" stop-index="276" value="2"/>
-                                                        <parameter-marker-expression start-index="276" stop-index="276" value="1" />
-                                                    </in-right-value>
-                                                </predicate>
-                                                <predicate start-index="283" stop-index="314">
-                                                    <column-left-value start-index="283" stop-index="298" name="order_id">
-                                                        <owner start-index="283" stop-index="289" name="order0_"/>
-                                                    </column-left-value>
-                                                    <between-right-value>
-                                                        <between-literal-expression start-index="308" stop-index="308" value="9" />
-                                                        <between-parameter-marker-expression start-index="308" stop-index="308" value="2"/>
-                                                        <and-literal-expression start-index="314" stop-index="314" value="7" />
-                                                        <and-parameter-marker-expression start-index="314" stop-index="314" value="3" />
-                                                    </between-right-value>
-                                                </predicate>
-                                            </and-predicate>
+                                            <expr>
+                                                <binary-operation-expression start-index="253" stop-index="314">
+                                                    <left>
+                                                        <in-expression start-index="253" stop-index="277">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="user_id" start-index="253" stop-index="267">
+                                                                    <owner name="order0_" start-index="253" stop-index="259" />
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <list-expression start-index="272" stop-index="277">
+                                                                    <items>
+                                                                        <literal-expression value="1" start-index="273" stop-index="273" />
+                                                                        <parameter-marker-expression value="0" start-index="273" stop-index="273" />
+                                                                    </items>
+                                                                    <items>
+                                                                        <literal-expression value="2" start-index="276" stop-index="276" />
+                                                                        <parameter-marker-expression value="1" start-index="276" stop-index="276" />
+                                                                    </items>
+                                                                </list-expression>
+                                                            </right>
+                                                        </in-expression>
+                                                    </left>
+                                                    <operator>AND</operator>
+                                                    <right>
+                                                        <between-expression start-index="283" stop-index="314">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="order_id" start-index="283" stop-index="298">
+                                                                    <owner name="order0_" start-index="283" stop-index="289" />
+                                                                </column>
+                                                            </left>
+                                                            <between-expr>
+                                                                <literal-expression value="9" start-index="308" stop-index="308" />
+                                                                <parameter-marker-expression value="2" start-index="308" stop-index="308" />
+                                                            </between-expr>
+                                                            <and-expr>
+                                                                <literal-expression value="7" start-index="314" stop-index="314" />
+                                                                <parameter-marker-expression value="3" start-index="314" stop-index="314" />
+                                                            </and-expr>
+                                                        </between-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </expr>
                                         </where>
                                         <group-by>
-                                            <column-item start-index="325" stop-index="333" name="user_id">
+                                            <column-item start-index="325" stop-index="333"
+                                                         name="user_id">
                                                 <owner start-index="325" stop-index="325" name="i"/>
                                             </column-item>
                                         </group-by>
                                         <order-by>
-                                            <column-item start-index="344" stop-index="352" name="item_id" order-direction="DESC">
+                                            <column-item start-index="344" stop-index="352"
+                                                         name="item_id" order-direction="DESC">
                                                 <owner start-index="344" stop-index="344" name="i"/>
                                             </column-item>
                                         </order-by>
@@ -1252,34 +1716,38 @@
                             </subquery-table>
                         </from>
                         <where start-index="365" stop-index="381">
-                            <and-predicate>
-                                <predicate start-index="371" stop-index="381">
-                                    <column-left-value start-index="371" stop-index="376" name="rownum" />
-                                    <operator type="&lt;="/>
-                                    <compare-right-value>
-                                        <literal-expression start-index="381" stop-index="381" value="5"/>
-                                        <parameter-marker-expression start-index="381" stop-index="381" value="4"/>
-                                    </compare-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="371" stop-index="381">
+                                    <left>
+                                        <column name="rownum" start-index="371" stop-index="376" />
+                                    </left>
+                                    <operator>&lt;=</operator>
+                                    <right>
+                                        <literal-expression value="5" start-index="381" stop-index="381" />
+                                        <parameter-marker-expression value="4" start-index="381" stop-index="381" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
         <where start-index="386" stop-index="404">
-            <and-predicate>
-                <predicate start-index="392" stop-index="404">
-                    <column-left-value start-index="392" stop-index="400" name="rownum_">
-                        <owner start-index="392" stop-index="392" name="t"/>
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <literal-expression start-index="404" stop-index="404" value="3" />
-                        <parameter-marker-expression start-index="404" stop-index="404" value="5"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="392" stop-index="404">
+                    <left>
+                        <column name="rownum_" start-index="392" stop-index="400">
+                            <owner name="t" start-index="392" stop-index="392" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="3" start-index="404" stop-index="404" />
+                        <parameter-marker-expression value="5" start-index="404" stop-index="404" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-pagination.xml
@@ -55,30 +55,51 @@
         </projections>
         <!-- TODO parameters-count should be 4, because the last parameter is in offset -->
         <where start-index="99" stop-index="154" literal-stop-index="155">
-            <and-predicate>
-                <predicate start-index="105" stop-index="123">
-                    <column-left-value name="user_id" start-index="105" stop-index="113">
-                        <owner name="o" start-index="105" stop-index="105" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                        <literal-expression value="2" start-index="122" stop-index="122" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="129" stop-index="154" literal-stop-index="155">
-                    <column-left-value name="order_id" start-index="129" stop-index="138">
-                        <owner name="o" start-index="129" stop-index="129" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="148" stop-index="148" />
-                        <between-literal-expression value="9" start-index="148" stop-index="148" />
-                        <and-parameter-marker-expression value="3" start-index="154" stop-index="154" />
-                        <and-literal-expression value="10" start-index="154" stop-index="155" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
+                    <left>
+                        <in-expression start-index="105" stop-index="123">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="105" stop-index="113">
+                                    <owner name="o" start-index="105" stop-index="105" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="119" stop-index="122">
+                                    <items>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="122" stop-index="122" />
+                                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="129" stop-index="154" literal-stop-index="155">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="129" stop-index="138">
+                                    <owner name="o" start-index="129" stop-index="129" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="148" stop-index="148" />
+                                <parameter-marker-expression value="2" start-index="148" stop-index="148" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="154" stop-index="155" />
+                                <parameter-marker-expression value="3" start-index="154" stop-index="154" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="165" stop-index="173" literal-start-index="166" literal-stop-index="174">
@@ -128,30 +149,51 @@
             </shorthand-projection>
         </projections>
         <where start-index="99" stop-index="154" literal-stop-index="155">
-            <and-predicate>
-                <predicate start-index="105" stop-index="123">
-                    <column-left-value name="user_id" start-index="105" stop-index="113">
-                        <owner name="o" start-index="105" stop-index="105" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                        <literal-expression value="2" start-index="122" stop-index="122" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="129" stop-index="154" literal-stop-index="155">
-                    <column-left-value name="order_id" start-index="129" stop-index="138">
-                        <owner name="o" start-index="129" stop-index="129" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="148" stop-index="148" />
-                        <between-literal-expression value="9" start-index="148" stop-index="148" />
-                        <and-parameter-marker-expression value="3" start-index="154" stop-index="154" />
-                        <and-literal-expression value="10" start-index="154" stop-index="155" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
+                    <left>
+                        <in-expression start-index="105" stop-index="123">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="105" stop-index="113">
+                                    <owner name="o" start-index="105" stop-index="105" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="118" stop-index="123">
+                                    <items>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="122" stop-index="122" />
+                                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="129" stop-index="154" literal-stop-index="155">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="129" stop-index="138">
+                                    <owner name="o" start-index="129" stop-index="129" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="148" stop-index="148" />
+                                <parameter-marker-expression value="2" start-index="148" stop-index="148" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="154" stop-index="155" />
+                                <parameter-marker-expression value="3" start-index="154" stop-index="154" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="165" stop-index="173" literal-start-index="166" literal-stop-index="174">
@@ -200,30 +242,51 @@
             </shorthand-projection>
         </projections>
         <where start-index="103" stop-index="162" literal-stop-index="163">
-            <and-predicate>
-                <predicate start-index="109" stop-index="129">
-                    <column-left-value name="user_id" start-delimiter="`" end-delimiter="`" start-index="109" stop-index="119">
-                        <owner name="o" start-index="109" stop-index="109" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
-                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
-                        <literal-expression value="1" start-index="125" stop-index="125" />
-                        <literal-expression value="2" start-index="128" stop-index="128" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="135" stop-index="162" literal-stop-index="163">
-                    <column-left-value name="order_id" start-delimiter="`" end-delimiter="`" start-index="135" stop-index="146">
-                        <owner name="o" start-index="135" stop-index="135" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="156" stop-index="156" />
-                        <between-literal-expression value="9" start-index="156" stop-index="156" />
-                        <and-parameter-marker-expression value="3" start-index="162" stop-index="162" />
-                        <and-literal-expression value="10" start-index="162" stop-index="163" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="109" stop-index="162" literal-stop-index="163">
+                    <left>
+                        <in-expression start-index="109" stop-index="129">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-delimiter="`" end-delimiter="`" start-index="109" stop-index="119">
+                                    <owner name="o" start-index="109" stop-index="109" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="124" stop-index="129">
+                                    <items>
+                                        <literal-expression value="1" start-index="125" stop-index="125" />
+                                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="128" stop-index="128" />
+                                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="135" stop-index="162" literal-stop-index="163">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-delimiter="`" end-delimiter="`" start-index="135" stop-index="146">
+                                    <owner name="o" start-index="135" stop-index="135" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="156" stop-index="156" />
+                                <parameter-marker-expression value="2" start-index="156" stop-index="156" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="162" stop-index="163" />
+                                <parameter-marker-expression value="3" start-index="162" stop-index="162" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="173" stop-index="181" literal-start-index="174" literal-stop-index="182">
@@ -273,30 +336,51 @@
             </shorthand-projection>
         </projections>
         <where start-index="103" stop-index="162" literal-stop-index="163">
-            <and-predicate>
-                <predicate start-index="109" stop-index="129">
-                    <column-left-value name="user_id" start-delimiter="`" end-delimiter="`" start-index="109" stop-index="119">
-                        <owner name="o" start-index="109" stop-index="109" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
-                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
-                        <literal-expression value="1" start-index="125" stop-index="125" />
-                        <literal-expression value="2" start-index="128" stop-index="128" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="135" stop-index="162" literal-stop-index="163">
-                    <column-left-value name="order_id" start-delimiter="`" end-delimiter="`" start-index="135" stop-index="146">
-                        <owner name="o" start-index="135" stop-index="135" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="156" stop-index="156" />
-                        <between-literal-expression value="9" start-index="156" stop-index="156" />
-                        <and-parameter-marker-expression value="3" start-index="162" stop-index="162" />
-                        <and-literal-expression value="10" start-index="162" stop-index="163" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="109" stop-index="162" literal-stop-index="163">
+                    <left>
+                        <in-expression start-index="109" stop-index="129">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-delimiter="`" end-delimiter="`" start-index="109" stop-index="119">
+                                    <owner name="o" start-index="109" stop-index="109" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="124" stop-index="129">
+                                    <items>
+                                        <literal-expression value="1" start-index="125" stop-index="125" />
+                                        <parameter-marker-expression value="0" start-index="125" stop-index="125" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="128" stop-index="128" />
+                                        <parameter-marker-expression value="1" start-index="128" stop-index="128" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="135" stop-index="162" literal-stop-index="163">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-delimiter="`" end-delimiter="`" start-index="135" stop-index="146">
+                                    <owner name="o" start-index="135" stop-index="135" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="156" stop-index="156" />
+                                <parameter-marker-expression value="2" start-index="156" stop-index="156" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="162" stop-index="163" />
+                                <parameter-marker-expression value="3" start-index="162" stop-index="162" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="173" stop-index="181" literal-start-index="174" literal-stop-index="182">
@@ -365,30 +449,51 @@
                             </join-table>
                         </from>
                         <where start-index="250" stop-index="305" literal-stop-index="306">
-                            <and-predicate>
-                                <predicate start-index="256" stop-index="274">
-                                    <column-left-value name="user_id" start-index="256" stop-index="264">
-                                        <owner name="o" start-index="256" stop-index="256" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
-                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
-                                        <literal-expression value="1" start-index="270" stop-index="270" />
-                                        <literal-expression value="2" start-index="273" stop-index="273" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="280" stop-index="305" literal-stop-index="306">
-                                    <column-left-value name="order_id" start-index="280" stop-index="289">
-                                        <owner name="o" start-index="280" stop-index="280" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="299" stop-index="299" />
-                                        <and-parameter-marker-expression value="4" start-index="305" stop-index="305" />
-                                        <between-literal-expression value="9" start-index="299" stop-index="299" />
-                                        <and-literal-expression value="10" start-index="305" stop-index="306" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="256" stop-index="305" literal-stop-index="306">
+                                    <left>
+                                        <in-expression start-index="256" stop-index="274">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="256" stop-index="264">
+                                                    <owner name="o" start-index="256" stop-index="256" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="269" stop-index="274">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="270" stop-index="270" />
+                                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="273" stop-index="273" />
+                                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="280" stop-index="305" literal-stop-index="306">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="280" stop-index="289">
+                                                    <owner name="o" start-index="280" stop-index="280" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="299" stop-index="299" />
+                                                <parameter-marker-expression value="3" start-index="299" stop-index="299" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="305" stop-index="306" />
+                                                <parameter-marker-expression value="4" start-index="305" stop-index="305" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
@@ -452,30 +557,51 @@
                             </join-table>
                         </from>
                         <where start-index="268" stop-index="323" literal-stop-index="324">
-                            <and-predicate>
-                                <predicate start-index="274" stop-index="292">
-                                    <column-left-value name="user_id" start-index="274" stop-index="282">
-                                        <owner name="o" start-index="274" stop-index="274" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
-                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
-                                        <literal-expression value="1" start-index="288" stop-index="288" />
-                                        <literal-expression value="2" start-index="291" stop-index="291" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="298" stop-index="323" literal-stop-index="324">
-                                    <column-left-value name="order_id" start-index="298" stop-index="307">
-                                        <owner name="o" start-index="298" stop-index="298" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="317" stop-index="317" />
-                                        <and-parameter-marker-expression value="4" start-index="323" stop-index="323" />
-                                        <between-literal-expression value="9" start-index="317" stop-index="317" />
-                                        <and-literal-expression value="10" start-index="323" stop-index="324" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="274" stop-index="323" literal-stop-index="324">
+                                    <left>
+                                        <in-expression start-index="274" stop-index="292">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="274" stop-index="282">
+                                                    <owner name="o" start-index="274" stop-index="274" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="287" stop-index="292">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="288" stop-index="288" />
+                                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="291" stop-index="291" />
+                                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="298" stop-index="323" literal-stop-index="324">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="298" stop-index="307">
+                                                    <owner name="o" start-index="298" stop-index="298" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="317" stop-index="317" />
+                                                <parameter-marker-expression value="3" start-index="317" stop-index="317" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="323" stop-index="324" />
+                                                <parameter-marker-expression value="4" start-index="323" stop-index="323" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
@@ -521,30 +647,51 @@
         </projections>
         <!-- TODO parameters-count should be 4, because the last parameter is in offset -->
         <where start-index="99" stop-index="154" literal-stop-index="155">
-            <and-predicate>
-                <predicate start-index="105" stop-index="123">
-                    <column-left-value name="user_id" start-index="105" stop-index="113">
-                        <owner name="o" start-index="105" stop-index="105" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                        <literal-expression value="2" start-index="122" stop-index="122" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="129" stop-index="154" literal-stop-index="155">
-                    <column-left-value name="order_id" start-index="129" stop-index="138">
-                        <owner name="o" start-index="129" stop-index="129" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="148" stop-index="148" />
-                        <between-literal-expression value="9" start-index="148" stop-index="148" />
-                        <and-parameter-marker-expression value="3" start-index="154" stop-index="154" />
-                        <and-literal-expression value="10" start-index="154" stop-index="155" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
+                    <left>
+                        <in-expression start-index="105" stop-index="123">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="105" stop-index="113">
+                                    <owner name="o" start-index="105" stop-index="105" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="119" stop-index="122">
+                                    <items>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="122" stop-index="122" />
+                                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="129" stop-index="154" literal-stop-index="155">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="129" stop-index="138">
+                                    <owner name="o" start-index="129" stop-index="129" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="148" stop-index="148" />
+                                <parameter-marker-expression value="2" start-index="148" stop-index="148" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="154" stop-index="155" />
+                                <parameter-marker-expression value="3" start-index="154" stop-index="154" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="165" stop-index="173" literal-start-index="166" literal-stop-index="174">
@@ -594,30 +741,51 @@
             </shorthand-projection>
         </projections>
         <where start-index="99" stop-index="154" literal-stop-index="155">
-            <and-predicate>
-                <predicate start-index="105" stop-index="123">
-                    <column-left-value name="user_id" start-index="105" stop-index="113">
-                        <owner name="o" start-index="105" stop-index="105" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                        <literal-expression value="2" start-index="122" stop-index="122" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="129" stop-index="154" literal-stop-index="155">
-                    <column-left-value name="order_id" start-index="129" stop-index="138">
-                        <owner name="o" start-index="129" stop-index="129" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="148" stop-index="148" />
-                        <between-literal-expression value="9" start-index="148" stop-index="148" />
-                        <and-parameter-marker-expression value="3" start-index="154" stop-index="154" />
-                        <and-literal-expression value="10" start-index="154" stop-index="155" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
+                    <left>
+                        <in-expression start-index="105" stop-index="123">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="105" stop-index="113">
+                                    <owner name="o" start-index="105" stop-index="105" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="119" stop-index="122">
+                                    <items>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="122" stop-index="122" />
+                                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="129" stop-index="154" literal-stop-index="155">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="129" stop-index="138">
+                                    <owner name="o" start-index="129" stop-index="129" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="148" stop-index="148" />
+                                <parameter-marker-expression value="2" start-index="148" stop-index="148" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="154" stop-index="155" />
+                                <parameter-marker-expression value="3" start-index="154" stop-index="154" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" order-direction="DESC" start-index="165" stop-index="173" literal-start-index="166" literal-stop-index="174">
@@ -685,48 +853,71 @@
                             </join-table>
                         </from>
                         <where start-index="250" stop-index="305" literal-stop-index="306">
-                            <and-predicate>
-                                <predicate start-index="256" stop-index="274">
-                                    <column-left-value name="user_id" start-index="256" stop-index="264">
-                                        <owner name="o" start-index="256" stop-index="256" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
-                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
-                                        <literal-expression value="1" start-index="270" stop-index="270" />
-                                        <literal-expression value="2" start-index="273" stop-index="273" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="280" stop-index="305" literal-stop-index="306">
-                                    <column-left-value name="order_id" start-index="280" stop-index="289">
-                                        <owner name="o" start-index="280" stop-index="280" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="299" stop-index="299" />
-                                        <and-parameter-marker-expression value="4" start-index="305" stop-index="305" />
-                                        <between-literal-expression value="9" start-index="299" stop-index="299" />
-                                        <and-literal-expression value="10" start-index="305" stop-index="306" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="256" stop-index="305" literal-stop-index="306">
+                                    <left>
+                                        <in-expression start-index="256" stop-index="274">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="256" stop-index="264">
+                                                    <owner name="o" start-index="256" stop-index="256" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="269" stop-index="274">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="270" stop-index="270" />
+                                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="273" stop-index="273" />
+                                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="280" stop-index="305" literal-stop-index="306">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="280" stop-index="289">
+                                                    <owner name="o" start-index="280" stop-index="280" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="299" stop-index="299" />
+                                                <parameter-marker-expression value="3" start-index="299" stop-index="299" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="305" stop-index="306" />
+                                                <parameter-marker-expression value="4" start-index="305" stop-index="305" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
         <where start-index="316" stop-index="337" literal-start-index="317" literal-stop-index="338">
-            <and-predicate>
-                <predicate start-index="322" stop-index="337" literal-start-index="323" literal-stop-index="338">
-                    <column-left-value start-index="322" stop-index="333" literal-start-index="323" literal-stop-index="334" name="rownum_">
-                        <owner start-index="322" stop-index="325" literal-start-index="323" literal-stop-index="326" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="337" stop-index="337" value="5" />
-                        <literal-expression start-index="338" stop-index="338" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="322" stop-index="337" literal-start-index="323" literal-stop-index="338">
+                    <left>
+                        <column name="rownum_" start-index="322" stop-index="333" literal-start-index="323" literal-stop-index="334">
+                            <owner name="row_" start-index="322" stop-index="325" literal-start-index="323" literal-stop-index="326" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="338" stop-index="338" />
+                        <parameter-marker-expression value="5" start-index="337" stop-index="337" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -786,48 +977,71 @@
                             </join-table>
                         </from>
                         <where start-index="268" stop-index="323" literal-stop-index="324">
-                            <and-predicate>
-                                <predicate start-index="274" stop-index="292">
-                                    <column-left-value name="user_id" start-index="274" stop-index="282">
-                                        <owner name="o" start-index="274" stop-index="274" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
-                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
-                                        <literal-expression value="1" start-index="288" stop-index="288" />
-                                        <literal-expression value="2" start-index="291" stop-index="291" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="298" stop-index="323" literal-stop-index="324">
-                                    <column-left-value name="order_id" start-index="298" stop-index="307">
-                                        <owner name="o" start-index="298" stop-index="298" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="317" stop-index="317" />
-                                        <and-parameter-marker-expression value="4" start-index="323" stop-index="323" />
-                                        <between-literal-expression value="9" start-index="317" stop-index="317" />
-                                        <and-literal-expression value="10" start-index="323" stop-index="324" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="274" stop-index="323" literal-stop-index="324">
+                                    <left>
+                                        <in-expression start-index="274" stop-index="292">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="274" stop-index="282">
+                                                    <owner name="o" start-index="274" stop-index="274" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="287" stop-index="292">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="288" stop-index="288" />
+                                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="291" stop-index="291" />
+                                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="298" stop-index="323" literal-stop-index="324">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="298" stop-index="307">
+                                                    <owner name="o" start-index="298" stop-index="298" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="317" stop-index="317" />
+                                                <parameter-marker-expression value="3" start-index="317" stop-index="317" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="323" stop-index="324" />
+                                                <parameter-marker-expression value="4" start-index="323" stop-index="323" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
         <where start-index="334" stop-index="355" literal-start-index="335" literal-stop-index="356">
-            <and-predicate>
-                <predicate start-index="340" stop-index="355" literal-start-index="341" literal-stop-index="356">
-                    <column-left-value start-index="340" stop-index="351" literal-start-index="341" literal-stop-index="352" name="rownum_">
-                        <owner start-index="340" stop-index="343" literal-start-index="341" literal-stop-index="344" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="355" stop-index="355" value="5" />
-                        <literal-expression start-index="356" stop-index="356" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="340" stop-index="355" literal-start-index="341" literal-stop-index="356">
+                    <left>
+                        <column name="rownum_" start-index="340" stop-index="351" literal-start-index="341" literal-stop-index="352">
+                            <owner name="row_" start-index="340" stop-index="343" literal-start-index="341" literal-stop-index="344" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="6" start-index="356" stop-index="356" />
+                        <parameter-marker-expression value="5" start-index="355" stop-index="355" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -887,48 +1101,71 @@
                             </join-table>
                         </from>
                         <where start-index="250" stop-index="305" literal-stop-index="306">
-                            <and-predicate>
-                                <predicate start-index="256" stop-index="274">
-                                    <column-left-value name="user_id" start-index="256" stop-index="264">
-                                        <owner name="o" start-index="256" stop-index="256" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
-                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
-                                        <literal-expression value="1" start-index="270" stop-index="270" />
-                                        <literal-expression value="2" start-index="273" stop-index="273" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="280" stop-index="305" literal-stop-index="306">
-                                    <column-left-value name="order_id" start-index="280" stop-index="289">
-                                        <owner name="o" start-index="280" stop-index="280" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="299" stop-index="299" />
-                                        <and-parameter-marker-expression value="4" start-index="305" stop-index="305" />
-                                        <between-literal-expression value="9" start-index="299" stop-index="299" />
-                                        <and-literal-expression value="10" start-index="305" stop-index="306" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="256" stop-index="305" literal-stop-index="306">
+                                    <left>
+                                        <in-expression start-index="256" stop-index="274">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="256" stop-index="264">
+                                                    <owner name="o" start-index="256" stop-index="256" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="269" stop-index="274">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="270" stop-index="270" />
+                                                        <parameter-marker-expression value="1" start-index="270" stop-index="270" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="273" stop-index="273" />
+                                                        <parameter-marker-expression value="2" start-index="273" stop-index="273" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="280" stop-index="305" literal-stop-index="306">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="280" stop-index="289">
+                                                    <owner name="o" start-index="280" stop-index="280" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="299" stop-index="299" />
+                                                <parameter-marker-expression value="3" start-index="299" stop-index="299" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="305" stop-index="306" />
+                                                <parameter-marker-expression value="4" start-index="305" stop-index="305" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
-        <where start-index="316" stop-index="337" literal-start-index="317" literal-stop-index="338">
-            <and-predicate>
-                <predicate start-index="322" stop-index="338" literal-start-index="323" literal-stop-index="339">
-                    <column-left-value start-index="322" stop-index="333" literal-start-index="323" literal-stop-index="334" name="rownum_">
-                        <owner start-index="322" stop-index="325" literal-start-index="323" literal-stop-index="326" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="338" stop-index="338" value="5" />
-                        <literal-expression start-index="339" stop-index="339" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="316" stop-index="338" literal-start-index="317" literal-stop-index="339">
+            <expr>
+                <binary-operation-expression start-index="322" stop-index="338" literal-start-index="323" literal-stop-index="339">
+                    <left>
+                        <column name="rownum_" start-index="322" stop-index="333" literal-start-index="323" literal-stop-index="334">
+                            <owner name="row_" start-index="322" stop-index="325" literal-start-index="323" literal-stop-index="326" />
+                        </column>
+                    </left>
+                    <operator>&gt;=</operator>
+                    <right>
+                        <literal-expression value="6" start-index="339" stop-index="339" />
+                        <parameter-marker-expression value="5" start-index="338" stop-index="338" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -988,48 +1225,71 @@
                             </join-table>
                         </from>
                         <where start-index="268" stop-index="323" literal-stop-index="324">
-                            <and-predicate>
-                                <predicate start-index="274" stop-index="292">
-                                    <column-left-value name="user_id" start-index="274" stop-index="282">
-                                        <owner name="o" start-index="274" stop-index="274" />
-                                    </column-left-value>
-                                    <in-right-value>
-                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
-                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
-                                        <literal-expression value="1" start-index="288" stop-index="288" />
-                                        <literal-expression value="2" start-index="291" stop-index="291" />
-                                    </in-right-value>
-                                </predicate>
-                                <predicate start-index="298" stop-index="323" literal-stop-index="324">
-                                    <column-left-value name="order_id" start-index="298" stop-index="307">
-                                        <owner name="o" start-index="298" stop-index="298" />
-                                    </column-left-value>
-                                    <between-right-value>
-                                        <between-parameter-marker-expression value="3" start-index="317" stop-index="317" />
-                                        <and-parameter-marker-expression value="4" start-index="323" stop-index="323" />
-                                        <between-literal-expression value="9" start-index="317" stop-index="317" />
-                                        <and-literal-expression value="10" start-index="323" stop-index="324" />
-                                    </between-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="274" stop-index="323" literal-stop-index="324">
+                                    <left>
+                                        <in-expression start-index="274" stop-index="292">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="user_id" start-index="274" stop-index="282">
+                                                    <owner name="o" start-index="274" stop-index="274" />
+                                                </column>
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="287" stop-index="292">
+                                                    <items>
+                                                        <literal-expression value="1" start-index="288" stop-index="288" />
+                                                        <parameter-marker-expression value="1" start-index="288" stop-index="288" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="2" start-index="291" stop-index="291" />
+                                                        <parameter-marker-expression value="2" start-index="291" stop-index="291" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <between-expression start-index="298" stop-index="323" literal-stop-index="324">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="order_id" start-index="298" stop-index="307">
+                                                    <owner name="o" start-index="298" stop-index="298" />
+                                                </column>
+                                            </left>
+                                            <between-expr>
+                                                <literal-expression value="9" start-index="317" stop-index="317" />
+                                                <parameter-marker-expression value="3" start-index="317" stop-index="317" />
+                                            </between-expr>
+                                            <and-expr>
+                                                <literal-expression value="10" start-index="323" stop-index="324" />
+                                                <parameter-marker-expression value="4" start-index="323" stop-index="323" />
+                                            </and-expr>
+                                        </between-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
-        <where start-index="334" stop-index="355" literal-start-index="335" literal-stop-index="356">
-            <and-predicate>
-                <predicate start-index="340" stop-index="356" literal-start-index="341" literal-stop-index="357">
-                    <column-left-value start-index="340" stop-index="351" literal-start-index="341" literal-stop-index="352" name="rownum_">
-                        <owner start-index="340" stop-index="343" literal-start-index="341" literal-stop-index="344" name="row_" />
-                    </column-left-value>
-                    <operator type="&gt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression start-index="356" stop-index="356" value="5" />
-                        <literal-expression start-index="357" stop-index="357" value="6" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="334" stop-index="356" literal-start-index="335" literal-stop-index="357">
+            <expr>
+                <binary-operation-expression start-index="340" stop-index="356" literal-start-index="341" literal-stop-index="357">
+                    <left>
+                        <column name="rownum_" start-index="340" stop-index="351" literal-start-index="341" literal-stop-index="352">
+                            <owner name="row_" start-index="340" stop-index="343" literal-start-index="341" literal-stop-index="344" />
+                        </column>
+                    </left>
+                    <operator>&gt;=</operator>
+                    <right>
+                        <literal-expression value="6" start-index="357" stop-index="357" />
+                        <parameter-marker-expression value="5" start-index="356" stop-index="356" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1093,30 +1353,51 @@
                                             </join-table>
                                         </from>
                                         <where start-index="247" stop-index="314">
-                                            <and-predicate>
-                                                <predicate start-index="253" stop-index="277">
-                                                    <column-left-value start-index="253" stop-index="267" name="user_id">
-                                                        <owner start-index="253" stop-index="259" name="order0_" />
-                                                    </column-left-value>
-                                                    <in-right-value>
-                                                        <literal-expression start-index="273" stop-index="273" value="1" />
-                                                        <literal-expression start-index="276" stop-index="276" value="2" />
-                                                        <parameter-marker-expression start-index="273" stop-index="273" value="0" />
-                                                        <parameter-marker-expression start-index="276" stop-index="276" value="1" />
-                                                    </in-right-value>
-                                                </predicate>
-                                                <predicate start-index="283" stop-index="314">
-                                                    <column-left-value start-index="283" stop-index="298" name="order_id">
-                                                        <owner start-index="283" stop-index="289" name="order0_" />
-                                                    </column-left-value>
-                                                    <between-right-value>
-                                                        <between-literal-expression start-index="308" stop-index="308" value="9" />
-                                                        <between-parameter-marker-expression start-index="308" stop-index="308" value="2" />
-                                                        <and-literal-expression start-index="314" stop-index="314" value="7" />
-                                                        <and-parameter-marker-expression start-index="314" stop-index="314" value="3" />
-                                                    </between-right-value>
-                                                </predicate>
-                                            </and-predicate>
+                                            <expr>
+                                                <binary-operation-expression start-index="253" stop-index="314">
+                                                    <left>
+                                                        <in-expression start-index="253" stop-index="277">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="user_id" start-index="253" stop-index="267">
+                                                                    <owner name="order0_" start-index="253" stop-index="259" />
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <list-expression start-index="272" stop-index="277">
+                                                                    <items>
+                                                                        <literal-expression value="1" start-index="273" stop-index="273" />
+                                                                        <parameter-marker-expression value="0" start-index="273" stop-index="273" />
+                                                                    </items>
+                                                                    <items>
+                                                                        <literal-expression value="2" start-index="276" stop-index="276" />
+                                                                        <parameter-marker-expression value="1" start-index="276" stop-index="276" />
+                                                                    </items>
+                                                                </list-expression>
+                                                            </right>
+                                                        </in-expression>
+                                                    </left>
+                                                    <operator>AND</operator>
+                                                    <right>
+                                                        <between-expression start-index="283" stop-index="314">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="order_id" start-index="283" stop-index="298">
+                                                                    <owner name="order0_" start-index="283" stop-index="289" />
+                                                                </column>
+                                                            </left>
+                                                            <between-expr>
+                                                                <literal-expression value="9" start-index="308" stop-index="308" />
+                                                                <parameter-marker-expression value="2" start-index="308" stop-index="308" />
+                                                            </between-expr>
+                                                            <and-expr>
+                                                                <literal-expression value="7" start-index="314" stop-index="314" />
+                                                                <parameter-marker-expression value="3" start-index="314" stop-index="314" />
+                                                            </and-expr>
+                                                        </between-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </expr>
                                         </where>
                                         <order-by>
                                             <column-item start-index="325" stop-index="333" name="item_id" order-direction="DESC">
@@ -1128,19 +1409,19 @@
                             </subquery-table>
                         </from>
                         <where start-index="346" stop-index="362">
-                            <and-predicate>
-                                <predicate start-index="352" stop-index="362">
-                                    <column-left-value start-index="352" stop-index="357" name="rownum" />
-                                    <operator type="&lt;=" />
-                                    <compare-right-value>
-                                        <literal-expression start-index="362" stop-index="362" value="3" />
-                                        <parameter-marker-expression start-index="362" stop-index="362" value="4" />
-                                    </compare-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="352" stop-index="362">
+                                    <left>
+                                        <column name="rownum" start-index="352" stop-index="357" />
+                                    </left>
+                                    <operator>&lt;=</operator>
+                                    <right>
+                                        <literal-expression value="3" start-index="362" stop-index="362" />
+                                        <parameter-marker-expression value="4" start-index="362" stop-index="362" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
-
-
                     </select>
                 </subquery>
             </subquery-table>
@@ -1207,30 +1488,51 @@
                                             </join-table>
                                         </from>
                                         <where start-index="247" stop-index="314">
-                                            <and-predicate>
-                                                <predicate start-index="253" stop-index="277">
-                                                    <column-left-value start-index="253" stop-index="267" name="user_id">
-                                                        <owner start-index="253" stop-index="259" name="order0_" />
-                                                    </column-left-value>
-                                                    <in-right-value>
-                                                        <literal-expression start-index="273" stop-index="273" value="1" />
-                                                        <literal-expression start-index="276" stop-index="276" value="2" />
-                                                        <parameter-marker-expression start-index="273" stop-index="273" value="0" />
-                                                        <parameter-marker-expression start-index="276" stop-index="276" value="1" />
-                                                    </in-right-value>
-                                                </predicate>
-                                                <predicate start-index="283" stop-index="314">
-                                                    <column-left-value start-index="283" stop-index="298" name="order_id">
-                                                        <owner start-index="283" stop-index="289" name="order0_" />
-                                                    </column-left-value>
-                                                    <between-right-value>
-                                                        <between-literal-expression start-index="308" stop-index="308" value="9" />
-                                                        <between-parameter-marker-expression start-index="308" stop-index="308" value="2" />
-                                                        <and-literal-expression start-index="314" stop-index="314" value="7" />
-                                                        <and-parameter-marker-expression start-index="314" stop-index="314" value="3" />
-                                                    </between-right-value>
-                                                </predicate>
-                                            </and-predicate>
+                                            <expr>
+                                                <binary-operation-expression start-index="253" stop-index="314">
+                                                    <left>
+                                                        <in-expression start-index="253" stop-index="277">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="user_id" start-index="253" stop-index="267">
+                                                                    <owner name="order0_" start-index="253" stop-index="259" />
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <list-expression start-index="272" stop-index="277">
+                                                                    <items>
+                                                                        <literal-expression value="1" start-index="273" stop-index="273" />
+                                                                        <parameter-marker-expression value="0" start-index="273" stop-index="273" />
+                                                                    </items>
+                                                                    <items>
+                                                                        <literal-expression value="2" start-index="276" stop-index="276" />
+                                                                        <parameter-marker-expression value="1" start-index="276" stop-index="276" />
+                                                                    </items>
+                                                                </list-expression>
+                                                            </right>
+                                                        </in-expression>
+                                                    </left>
+                                                    <operator>AND</operator>
+                                                    <right>
+                                                        <between-expression start-index="283" stop-index="314">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="order_id" start-index="283" stop-index="298">
+                                                                    <owner name="order0_" start-index="283" stop-index="289" />
+                                                                </column>
+                                                            </left>
+                                                            <between-expr>
+                                                                <literal-expression value="9" start-index="308" stop-index="308" />
+                                                                <parameter-marker-expression value="2" start-index="308" stop-index="308" />
+                                                            </between-expr>
+                                                            <and-expr>
+                                                                <literal-expression value="7" start-index="314" stop-index="314" />
+                                                                <parameter-marker-expression value="3" start-index="314" stop-index="314" />
+                                                            </and-expr>
+                                                        </between-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </expr>
                                         </where>
                                         <order-by>
                                             <column-item start-index="325" stop-index="333" name="item_id" order-direction="DESC">
@@ -1242,34 +1544,38 @@
                             </subquery-table>
                         </from>
                         <where start-index="346" stop-index="362">
-                            <and-predicate>
-                                <predicate start-index="352" stop-index="362">
-                                    <column-left-value start-index="352" stop-index="357" name="rownum" />
-                                    <operator type="&lt;=" />
-                                    <compare-right-value>
-                                        <literal-expression start-index="362" stop-index="362" value="5" />
-                                        <parameter-marker-expression start-index="362" stop-index="362" value="4" />
-                                    </compare-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="352" stop-index="362">
+                                    <left>
+                                        <column name="rownum" start-index="352" stop-index="357" />
+                                    </left>
+                                    <operator>&lt;=</operator>
+                                    <right>
+                                        <literal-expression value="5" start-index="362" stop-index="362" />
+                                        <parameter-marker-expression value="4" start-index="362" stop-index="362" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
         <where start-index="367" stop-index="385">
-            <and-predicate>
-                <predicate start-index="373" stop-index="385">
-                    <column-left-value start-index="373" stop-index="381" name="rownum_">
-                        <owner start-index="373" stop-index="373" name="t" />
-                    </column-left-value>
-                    <operator type="&gt;" />
-                    <compare-right-value>
-                        <literal-expression start-index="385" stop-index="385" value="3" />
-                        <parameter-marker-expression start-index="385" stop-index="385" value="5" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="373" stop-index="385">
+                    <left>
+                        <column name="rownum_" start-index="373" stop-index="381">
+                            <owner name="t" start-index="373" stop-index="373" />
+                        </column>
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="3" start-index="385" stop-index="385" />
+                        <parameter-marker-expression value="5" start-index="385" stop-index="385" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1333,30 +1639,51 @@
                                             </join-table>
                                         </from>
                                         <where start-index="247" stop-index="314">
-                                            <and-predicate>
-                                                <predicate start-index="253" stop-index="277">
-                                                    <column-left-value start-index="253" stop-index="267" name="user_id">
-                                                        <owner start-index="253" stop-index="259" name="order0_" />
-                                                    </column-left-value>
-                                                    <in-right-value>
-                                                        <literal-expression start-index="273" stop-index="273" value="1" />
-                                                        <literal-expression start-index="276" stop-index="276" value="2" />
-                                                        <parameter-marker-expression start-index="273" stop-index="273" value="0" />
-                                                        <parameter-marker-expression start-index="276" stop-index="276" value="1" />
-                                                    </in-right-value>
-                                                </predicate>
-                                                <predicate start-index="283" stop-index="314">
-                                                    <column-left-value start-index="283" stop-index="298" name="order_id">
-                                                        <owner start-index="283" stop-index="289" name="order0_" />
-                                                    </column-left-value>
-                                                    <between-right-value>
-                                                        <between-literal-expression start-index="308" stop-index="308" value="9" />
-                                                        <between-parameter-marker-expression start-index="308" stop-index="308" value="2" />
-                                                        <and-literal-expression start-index="314" stop-index="314" value="7" />
-                                                        <and-parameter-marker-expression start-index="314" stop-index="314" value="3" />
-                                                    </between-right-value>
-                                                </predicate>
-                                            </and-predicate>
+                                            <expr>
+                                                <binary-operation-expression start-index="253" stop-index="314">
+                                                    <left>
+                                                        <in-expression start-index="253" stop-index="277">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="user_id" start-index="253" stop-index="267">
+                                                                    <owner name="order0_" start-index="253" stop-index="259" />
+                                                                </column>
+                                                            </left>
+                                                            <right>
+                                                                <list-expression start-index="272" stop-index="277">
+                                                                    <items>
+                                                                        <literal-expression value="1" start-index="273" stop-index="273" />
+                                                                        <parameter-marker-expression value="0" start-index="273" stop-index="273" />
+                                                                    </items>
+                                                                    <items>
+                                                                        <literal-expression value="2" start-index="276" stop-index="276" />
+                                                                        <parameter-marker-expression value="1" start-index="276" stop-index="276" />
+                                                                    </items>
+                                                                </list-expression>
+                                                            </right>
+                                                        </in-expression>
+                                                    </left>
+                                                    <operator>AND</operator>
+                                                    <right>
+                                                        <between-expression start-index="283" stop-index="314">
+                                                            <not>false</not>
+                                                            <left>
+                                                                <column name="order_id" start-index="283" stop-index="298">
+                                                                    <owner name="order0_" start-index="283" stop-index="289" />
+                                                                </column>
+                                                            </left>
+                                                            <between-expr>
+                                                                <literal-expression value="9" start-index="308" stop-index="308" />
+                                                                <parameter-marker-expression value="2" start-index="308" stop-index="308" />
+                                                            </between-expr>
+                                                            <and-expr>
+                                                                <literal-expression value="7" start-index="314" stop-index="314" />
+                                                                <parameter-marker-expression value="3" start-index="314" stop-index="314" />
+                                                            </and-expr>
+                                                        </between-expression>
+                                                    </right>
+                                                </binary-operation-expression>
+                                            </expr>
                                         </where>
                                         <order-by>
                                             <column-item start-index="325" stop-index="333" name="item_id" order-direction="DESC">
@@ -1368,34 +1695,38 @@
                             </subquery-table>
                         </from>
                         <where start-index="346" stop-index="362">
-                            <and-predicate>
-                                <predicate start-index="352" stop-index="362">
-                                    <column-left-value start-index="352" stop-index="357" name="rownum" />
-                                    <operator type="&lt;=" />
-                                    <compare-right-value>
-                                        <literal-expression start-index="362" stop-index="362" value="5" />
-                                        <parameter-marker-expression start-index="362" stop-index="362" value="4" />
-                                    </compare-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <binary-operation-expression start-index="352" stop-index="362">
+                                    <left>
+                                        <column name="rownum" start-index="352" stop-index="357" />
+                                    </left>
+                                    <operator>&lt;=</operator>
+                                    <right>
+                                        <literal-expression value="5" start-index="362" stop-index="362" />
+                                        <parameter-marker-expression value="4" start-index="362" stop-index="362" />
+                                    </right>
+                                </binary-operation-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
             </subquery-table>
         </from>
-        <where start-index="367" stop-index="385">
-            <and-predicate>
-                <predicate start-index="373" stop-index="386">
-                    <column-left-value start-index="373" stop-index="381" name="rownum_">
-                        <owner start-index="373" stop-index="373" name="t" />
-                    </column-left-value>
-                    <operator type="&gt;=" />
-                    <compare-right-value>
-                        <literal-expression start-index="386" stop-index="386" value="3" />
-                        <parameter-marker-expression start-index="386" stop-index="386" value="5" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="367" stop-index="386">
+            <expr>
+                <binary-operation-expression start-index="373" stop-index="386">
+                    <left>
+                        <column name="rownum_" start-index="373" stop-index="381">
+                            <owner name="t" start-index="373" stop-index="373" />
+                        </column>
+                    </left>
+                    <operator>&gt;=</operator>
+                    <right>
+                        <literal-expression value="3" start-index="386" stop-index="386" />
+                        <parameter-marker-expression value="5" start-index="386" stop-index="386" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1407,16 +1738,18 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="38" literal-stop-index="39">
-            <and-predicate>
-                <predicate start-index="28" stop-index="38" literal-stop-index="39">
-                    <column-left-value name="ROWNUM" start-index="28" stop-index="33" />
-                    <operator type="&lt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="38" stop-index="38" />
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="38" literal-stop-index="39">
+                    <left>
+                        <column name="ROWNUM" start-index="28" stop-index="33" />
+                    </left>
+                    <operator>&lt;=</operator>
+                    <right>
                         <literal-expression value="20" start-index="38" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="38" stop-index="38" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="49" stop-index="56" literal-start-index="50" literal-stop-index="57" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-sub-query.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select-sub-query.xml
@@ -52,17 +52,26 @@
                             <simple-table start-index="31" stop-index="37" name="t_order"/>
                         </from>
                         <where start-index="39" stop-index="62">
-                            <and-predicate>
-                                <predicate start-index="45" stop-index="62">
-                                    <column-left-value start-index="45" stop-index="52" name="order_id" />
-                                    <in-right-value>
-                                        <literal-expression start-index="58" stop-index="58" value="3" />
-                                        <parameter-marker-expression start-index="58" stop-index="58" value="0" />
-                                        <literal-expression start-index="61" stop-index="61" value="4" />
-                                        <parameter-marker-expression start-index="61" stop-index="61" value="1"/>
-                                    </in-right-value>
-                                </predicate>
-                            </and-predicate>
+                            <expr>
+                                <in-expression start-index="45" stop-index="62">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="order_id" start-index="45" stop-index="52" />
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="57" stop-index="62">
+                                            <items>
+                                                <literal-expression value="3" start-index="58" stop-index="58" />
+                                                <parameter-marker-expression value="0" start-index="58" stop-index="58" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="4" start-index="61" stop-index="61" />
+                                                <parameter-marker-expression value="1" start-index="61" stop-index="61" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </expr>
                         </where>
                     </select>
                 </subquery>
@@ -78,37 +87,39 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="85">
-            <and-predicate>
-                <predicate start-index="28" literal-stop-index="85">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <subquery-expression start-index="38" stop-index="85" literal-start-index="38" literal-stop-index="85">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="85">
+                    <left>
+                        <column name="user_id" start-index="28" stop-index="34" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <subquery start-index="38" stop-index="85">
                             <select>
-                                <table-reference>
-                                    <table-factor>
-                                        <table name="t_order_item" start-index="59" stop-index="70" />
-                                    </table-factor>
-                                </table-reference>
+                                <from start-index="59" stop-index="70">
+                                    <simple-table name="t_order_item" start-index="59" stop-index="70" />
+                                </from>
                                 <projections start-index="46" stop-index="52">
                                     <column-projection name="user_id" start-index="46" stop-index="52" />
                                 </projections>
-                                <where start-index="72" stop-index="85">
-                                    <and-predicate>
-                                        <predicate start-index="78" literal-stop-index="84">
-                                            <column-left-value name="id" start-index="78" stop-index="79" />
-                                            <operator type="=" />
-                                            <compare-right-value>
+                                <where start-index="72" stop-index="84">
+                                    <expr>
+                                        <binary-operation-expression start-index="78" stop-index="84">
+                                            <left>
+                                                <column name="id" start-index="78" stop-index="79" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
                                                 <literal-expression value="10" start-index="83" stop-index="84" />
-                                            </compare-right-value>
-                                        </predicate>
-                                    </and-predicate>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
                                 </where>
                             </select>
-                        </subquery-expression>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        </subquery>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -120,11 +131,14 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="93">
-            <and-predicate>
-                <predicate start-index="28" literal-stop-index="93">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <in-right-value>
-                        <subquery-expression start-index="39" stop-index="93" literal-start-index="39" literal-stop-index="93">
+            <expr>
+                <in-expression start-index="28" stop-index="93">
+                    <not>false</not>
+                    <left>
+                        <column name="user_id" start-index="28" stop-index="34" />
+                    </left>
+                    <right>
+                        <subquery start-index="39" stop-index="93">
                             <select>
                                 <from>
                                     <simple-table name="t_order_item" start-index="60" stop-index="71" />
@@ -133,21 +147,30 @@
                                     <column-projection name="user_id" start-index="47" stop-index="53" />
                                 </projections>
                                 <where start-index="73" stop-index="92">
-                                    <and-predicate>
-                                        <predicate start-index="79" literal-stop-index="92">
-                                            <column-left-value name="id" start-index="79" stop-index="80"  />
-                                            <in-right-value>
-                                                <literal-expression value="10" start-index="86" stop-index="87" />
-                                                <literal-expression value="11" start-index="90" stop-index="91" />
-                                            </in-right-value>
-                                        </predicate>
-                                    </and-predicate>
+                                    <expr>
+                                        <in-expression start-index="79" stop-index="92">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="id" start-index="79" stop-index="80" />
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="85" stop-index="92">
+                                                    <items>
+                                                        <literal-expression value="10" start-index="86" stop-index="87" />
+                                                    </items>
+                                                    <items>
+                                                        <literal-expression value="11" start-index="90" stop-index="91" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </expr>
                                 </where>
                             </select>
-                        </subquery-expression>
-                    </in-right-value>
-                </predicate>
-            </and-predicate>
+                        </subquery>
+                    </right>
+                </in-expression>
+            </expr>
         </where>
     </select>
 
@@ -158,12 +181,15 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="106">
-            <and-predicate>
-                <predicate start-index="28" stop-index="103" literal-stop-index="104">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <between-right-value>
-                        <between-subquery-expression start-index="44" stop-index="97" literal-start-index="44" literal-stop-index="97" >
+        <where start-index="22" stop-index="103" literal-stop-index="104">
+            <expr>
+                <between-expression start-index="28" stop-index="103" literal-stop-index="104">
+                    <not>false</not>
+                    <left>
+                        <column name="user_id" start-index="28" stop-index="34" />
+                    </left>
+                    <between-expr>
+                        <subquery start-index="44" stop-index="97">
                             <select>
                                 <from>
                                     <simple-table name="t_order_item" start-index="65" stop-index="76" />
@@ -172,23 +198,27 @@
                                     <column-projection name="user_id" start-index="52" stop-index="58" />
                                 </projections>
                                 <where start-index="78" stop-index="96">
-                                    <and-predicate>
-                                        <predicate start-index="84" stop-index="96" literal-stop-index="96">
-                                            <column-left-value name="order_id" start-index="84" stop-index="91" />
-                                            <operator type="=" />
-                                            <compare-right-value>
+                                    <expr>
+                                        <binary-operation-expression start-index="84" stop-index="96">
+                                            <left>
+                                                <column name="order_id" start-index="84" stop-index="91" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
                                                 <literal-expression value="10" start-index="95" stop-index="96" />
-                                            </compare-right-value>
-                                        </predicate>
-                                    </and-predicate>
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
                                 </where>
                             </select>
-                        </between-subquery-expression>
-                        <and-parameter-marker-expression value="0" start-index="103" stop-index="103" />
-                        <and-literal-expression value="12" start-index="103" stop-index="104" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+                        </subquery>
+                    </between-expr>
+                    <and-expr>
+                        <literal-expression value="12" start-index="103" stop-index="104" />
+                        <parameter-marker-expression value="0" start-index="103" stop-index="103" />
+                    </and-expr>
+                </between-expression>
+            </expr>
         </where>
     </select>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
@@ -19,29 +19,40 @@
 <sql-parser-test-cases>
     <select sql-case-id="select_constant_without_table" >
         <projections start-index="7" stop-index="12">
-            <expression-projection alias="a" start-index="7" stop-index="12" />
+            <expression-projection text="1" alias="a" start-index="7" stop-index="12" />
         </projections>
     </select>
 
     <select sql-case-id="select_sqlmode_ansi_quotes" >
         <projections start-index="7" stop-index="10">
-            <expression-projection start-index="7" stop-index="10" />
+            <expression-projection text="id" start-index="7" stop-index="10" />
         </projections>
         <from>
             <simple-table name="t_order" start-delimiter='"' end-delimiter='"' start-index="17" stop-index="25" />
         </from>
-<!--        TODO support where-->
         <where start-index="27" stop-index="49">
-
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="49">
+                    <left>
+                        <column name="id" start-delimiter='"' end-delimiter='"' start-index="33" stop-index="46">
+                            <owner name="t_order" start-delimiter='"' end-delimiter='"' start-index="33" stop-index="41" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="10" start-index="48" stop-index="49" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
     <select sql-case-id="select_with_union">
     </select>
-    
+
     <select sql-case-id="select_with_function_name" >
         <projections start-index="7" stop-index="23">
-            <expression-projection start-index="7" stop-index="23" />
+            <expression-projection text="current_timestamp" start-index="7" stop-index="23" />
         </projections>
     </select>
 
@@ -55,24 +66,35 @@
             </shorthand-projection>
         </projections>
         <where start-index="38" stop-index="71">
-            <and-predicate>
-                <predicate start-index="44" stop-index="54">
-                    <column-left-value name="user_id" start-index="44" stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="54" stop-index="54" />
-                        <literal-expression value="1" start-index="54" stop-index="54" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="60" stop-index="71">
-                    <column-left-value name="order_id" start-index="60" stop-index="67" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="71" stop-index="71" />
-                        <literal-expression value="1" start-index="71" stop-index="71" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="44" stop-index="71">
+                    <left>
+                        <binary-operation-expression start-index="44" stop-index="54">
+                            <left>
+                                <column name="user_id" start-index="44" stop-index="50" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="54" stop-index="54" />
+                                <parameter-marker-expression value="0" start-index="54" stop-index="54" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="60" stop-index="71">
+                            <left>
+                                <column name="order_id" start-index="60" stop-index="67" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="71" stop-index="71" />
+                                <parameter-marker-expression value="1" start-index="71" stop-index="71" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -90,26 +112,37 @@
             <column-projection name="status" start-index="40" stop-index="45" />
         </projections>
         <where start-index="68" stop-index="109">
-            <and-predicate>
-                <predicate start-index="74" stop-index="92">
-                    <column-left-value name="user_id" start-index="74" stop-index="88">
-                        <owner name="t_order" start-index="74" stop-index="80" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="92" stop-index="92" />
-                        <literal-expression value="1" start-index="92" stop-index="92" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="98" stop-index="109">
-                    <column-left-value name="order_id" start-index="98" stop-index="105" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="109" stop-index="109" />
-                        <literal-expression value="1" start-index="109" stop-index="109" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="74" stop-index="109">
+                    <left>
+                        <binary-operation-expression start-index="74" stop-index="92">
+                            <left>
+                                <column name="user_id" start-index="74" stop-index="88">
+                                    <owner name="t_order" start-index="74" stop-index="80" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="92" stop-index="92" />
+                                <parameter-marker-expression value="0" start-index="92" stop-index="92" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="98" stop-index="109">
+                            <left>
+                                <column name="order_id" start-index="98" stop-index="105" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="109" stop-index="109" />
+                                <parameter-marker-expression value="1" start-index="109" stop-index="109" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -121,16 +154,18 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="27" stop-index="44">
-            <and-predicate>
-                <predicate start-index="33" stop-index="44">
-                    <column-left-value name="item_id" start-index="33" stop-index="39" />
-                    <operator type="&lt;&gt;" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="44">
+                    <left>
+                        <column name="item_id" start-index="33" stop-index="39" />
+                    </left>
+                    <operator>&lt;&gt;</operator>
+                    <right>
                         <literal-expression value="1" start-index="44" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="55" stop-index="61" />
@@ -145,16 +180,18 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="27" stop-index="44">
-            <and-predicate>
-                <predicate start-index="33" stop-index="44">
-                    <column-left-value name="item_id" start-index="33" stop-index="39" />
-                    <operator type="!=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="44">
+                    <left>
+                        <column name="item_id" start-index="33" stop-index="39" />
+                    </left>
+                    <operator>!=</operator>
+                    <right>
                         <literal-expression value="1" start-index="44" stop-index="44" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="55" stop-index="61" />
@@ -169,15 +206,43 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="27" stop-index="77" literal-stop-index="87">
-            <!-- FIXME cannot parse IS NOT NULL -->
-            <!--<and-predicate>-->
-                <!--<predicate start-index="33" stop-index="51">-->
-                    <!--<column-left-value name="item_id" start-index="33" stop-index="39" />-->
-                <!--</predicate>-->
-                <!--<predicate start-index="57" stop-index="77" literal-stop-index="87">-->
-                    <!--<column-left-value name="item_id" start-index="57" stop-index="63" />-->
-                <!--</predicate>-->
-            <!--</and-predicate>-->
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="77" literal-stop-index="87">
+                    <left>
+                        <binary-operation-expression start-index="33" stop-index="51">
+                            <left>
+                                <column name="item_id" start-index="33" stop-index="39" />
+                            </left>
+                            <operator>IS</operator>
+                            <right>
+                                <literal-expression value="43..51" start-index="43" stop-index="51" />
+                            </right>
+                        </binary-operation-expression>
+                        <common-expression text="item_id IS NOT NULL" start-index="33" stop-index="51" />
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <in-expression start-index="57" stop-index="77" literal-stop-index="87">
+                            <not>true</not>
+                            <left>
+                                <column name="item_id" start-index="57" stop-index="63" />
+                            </left>
+                            <right>
+                                <list-expression start-index="72" stop-index="77" literal-stop-index="87">
+                                    <items>
+                                        <literal-expression value="100000" start-index="73" stop-index="78" />
+                                        <parameter-marker-expression value="0" start-index="73" stop-index="73" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="100001" start-index="81" stop-index="86" />
+                                        <parameter-marker-expression value="1" start-index="76" stop-index="76" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="88" stop-index="94" literal-start-index="98" literal-stop-index="104" />
@@ -192,15 +257,40 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="27" stop-index="83" literal-stop-index="93">
-            <!-- FIXME can not parse IS NOT NULL -->
-            <!--<and-predicate>-->
-                <!--<predicate start-index="33" stop-index="51">-->
-                    <!--<column-left-value name="item_id" start-index="33" stop-index="39" />-->
-                <!--</predicate>-->
-                <!--<predicate start-index="57" stop-index="83">-->
-                    <!--<column-left-value name="item_id" start-index="57" stop-index="63" />-->
-                <!--</predicate>-->
-            <!--</and-predicate>-->
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="83" literal-stop-index="93">
+                    <left>
+                        <binary-operation-expression start-index="33" stop-index="51">
+                            <left>
+                                <column name="item_id" start-index="33" stop-index="39" />
+                            </left>
+                            <operator>IS</operator>
+                            <right>
+                                <!-- TODO: literal value should be 'NOT NULL' -->
+                                <literal-expression value="43..51" start-index="43" stop-index="51" />
+                            </right>
+                        </binary-operation-expression>
+                        <common-expression text="item_id IS NOT NULL" start-index="33" stop-index="51" />
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="57" stop-index="83" literal-stop-index="93">
+                            <not>true</not>
+                            <left>
+                                <column name="item_id" start-index="57" stop-index="63" />
+                            </left>
+                            <between-expr>
+                                <literal-expression value="100000" start-index="77" stop-index="82" />
+                                <parameter-marker-expression value="0" start-index="77" stop-index="77" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="100001" start-index="88" stop-index="93" />
+                                <parameter-marker-expression value="1" start-index="83" stop-index="83" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="94" stop-index="100" literal-start-index="104" literal-stop-index="110" />
@@ -214,25 +304,36 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="33">
-            <and-predicate>
-                <predicate start-index="28" stop-index="38">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="38" stop-index="38" />
-                        <literal-expression value="1" start-index="38" stop-index="38" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="44" stop-index="55">
-                    <column-left-value name="order_id" start-index="44" stop-index="51" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="55" stop-index="55" />
-                        <literal-expression value="1" start-index="55" stop-index="55" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="55">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="55">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="38">
+                            <left>
+                                <column name="user_id" start-index="28" stop-index="34" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="38" stop-index="38" />
+                                <parameter-marker-expression value="0" start-index="38" stop-index="38" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="44" stop-index="55">
+                            <left>
+                                <column name="order_id" start-index="44" stop-index="51" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="55" stop-index="55" />
+                                <parameter-marker-expression value="1" start-index="55" stop-index="55" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -244,24 +345,35 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="56">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="order_id" start-index="28" stop-index="35" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="1" start-index="39" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="45" stop-index="56">
-                    <column-left-value name="order_id" start-index="45" stop-index="52" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="56" stop-index="56" />
-                        <literal-expression value="2" start-index="56" stop-index="56" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="56">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="39">
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="35" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="39" stop-index="39" />
+                                <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="45" stop-index="56">
+                            <left>
+                                <column name="order_id" start-index="45" stop-index="52" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="56" stop-index="56" />
+                                <parameter-marker-expression value="1" start-index="56" stop-index="56" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -272,27 +384,44 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="107">
-            <and-predicate>
-                <predicate start-index="28" stop-index="50" literal-stop-index="51">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <between-right-value>
-                        <between-parameter-marker-expression value="0" start-index="44" stop-index="44" />
-                        <between-literal-expression value="1" start-index="44" stop-index="44" />
-                        <and-parameter-marker-expression value="1" start-index="50" stop-index="50" />
-                        <and-literal-expression value="10" start-index="50" stop-index="51" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="56" stop-index="79" literal-start-index="57" literal-stop-index="80">
-                    <column-left-value name="order_id" start-index="56" stop-index="63" literal-start-index="57" literal-stop-index="64" />
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="73" stop-index="73" />
-                        <between-literal-expression value="2" start-index="74" stop-index="74" />
-                        <and-parameter-marker-expression value="3" start-index="79" stop-index="79" />
-                        <and-literal-expression value="5" start-index="80" stop-index="80" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="79" literal-stop-index="80">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="79" literal-stop-index="80">
+                    <left>
+                        <between-expression start-index="28" stop-index="50" literal-stop-index="51">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="28" stop-index="34" />
+                            </left>
+                            <between-expr>
+                                <literal-expression value="1" start-index="44" stop-index="44" />
+                                <parameter-marker-expression value="0" start-index="44" stop-index="44" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="50" stop-index="51" />
+                                <parameter-marker-expression value="1" start-index="50" stop-index="50" />
+                            </and-expr>
+                        </between-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="56" stop-index="79" literal-start-index="57" literal-stop-index="80">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="56" stop-index="63" literal-start-index="57" literal-stop-index="64" />
+                            </left>
+                            <between-expr>
+                                <literal-expression value="2" start-index="74" stop-index="74" />
+                                <parameter-marker-expression value="2" start-index="73" stop-index="73" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="5" start-index="80" stop-index="80" />
+                                <parameter-marker-expression value="3" start-index="79" stop-index="79" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="user_id" start-index="90" stop-index="96" literal-start-index="91" literal-stop-index="97" />
@@ -307,41 +436,70 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="119" literal-stop-index="120">
-            <and-predicate>
-                <predicate start-index="28" stop-index="39">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <operator type="&gt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="39" stop-index="39" />
-                        <literal-expression value="1" start-index="39" stop-index="39" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="45" stop-index="56" literal-stop-index="57">
-                    <column-left-value name="user_id" start-index="45" stop-index="51" />
-                    <operator type="&lt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="56" stop-index="56" />
-                        <literal-expression value="10" start-index="56" stop-index="57" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="62" stop-index="74" literal-start-index="63" literal-stop-index="75">
-                    <column-left-value name="order_id" start-index="62" stop-index="69" literal-start-index="63" literal-stop-index="70" />
-                    <operator type="&gt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="2" start-index="75" stop-index="75" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="80" stop-index="92" literal-start-index="81" literal-stop-index="93">
-                    <column-left-value name="order_id" start-index="80" stop-index="87" literal-start-index="81" literal-stop-index="88" />
-                    <operator type="&lt;=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="92" stop-index="92" />
-                        <literal-expression value="5" start-index="93" stop-index="93" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="92" literal-stop-index="93">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="92" literal-stop-index="93">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="74" literal-stop-index="75">
+                            <left>
+                                <binary-operation-expression start-index="28" stop-index="56" literal-stop-index="57">
+                                    <left>
+                                        <binary-operation-expression start-index="28" stop-index="39">
+                                            <left>
+                                                <column name="user_id" start-index="28" stop-index="34" />
+                                            </left>
+                                            <operator>&gt;=</operator>
+                                            <right>
+                                                <literal-expression value="1" start-index="39" stop-index="39" />
+                                                <parameter-marker-expression value="0" start-index="39" stop-index="39" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="45" stop-index="56" literal-stop-index="57">
+                                            <left>
+                                                <column name="user_id" start-index="45" stop-index="51" />
+                                            </left>
+                                            <operator>&lt;=</operator>
+                                            <right>
+                                                <literal-expression value="10" start-index="56" stop-index="57" />
+                                                <parameter-marker-expression value="1" start-index="56" stop-index="56" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="62" stop-index="74" literal-start-index="63" literal-stop-index="75">
+                                    <left>
+                                        <column name="order_id" start-index="62" stop-index="69" literal-start-index="63" literal-stop-index="70" />
+                                    </left>
+                                    <operator>&gt;=</operator>
+                                    <right>
+                                        <literal-expression value="2" start-index="75" stop-index="75" />
+                                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="80" stop-index="92" literal-start-index="81" literal-stop-index="93">
+                            <left>
+                                <column name="order_id" start-index="80" stop-index="87" literal-start-index="81" literal-stop-index="88" />
+                            </left>
+                            <operator>&lt;=</operator>
+                            <right>
+                                <literal-expression value="5" start-index="93" stop-index="93" />
+                                <parameter-marker-expression value="3" start-index="92" stop-index="92" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="user_id" start-index="103" stop-index="109" literal-start-index="104" literal-stop-index="110" />
@@ -357,28 +515,55 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="70" literal-stop-index="71">
-            <and-predicate>
-                <predicate start-index="28" stop-index="47">
-                    <column-left-value name="user_id" start-index="28" stop-index="34" />
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="40" stop-index="40" />
-                        <parameter-marker-expression value="1" start-index="43" stop-index="43" />
-                        <parameter-marker-expression value="2" start-index="46" stop-index="46" />
-                        <literal-expression value="1" start-index="40" stop-index="40" />
-                        <literal-expression value="2" start-index="43" stop-index="43" />
-                        <literal-expression value="3" start-index="46" stop-index="46" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="53" stop-index="70" literal-stop-index="71">
-                    <column-left-value name="order_id" start-index="53" stop-index="60" />
-                    <in-right-value>
-                        <parameter-marker-expression value="3" start-index="66" stop-index="66" />
-                        <parameter-marker-expression value="4" start-index="69" stop-index="69" />
-                        <literal-expression value="9" start-index="66" stop-index="66" />
-                        <literal-expression value="10" start-index="69" stop-index="70" />
-                    </in-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="70" literal-stop-index="71">
+                    <left>
+                        <in-expression start-index="28" stop-index="47">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="28" stop-index="34" />
+                            </left>
+                            <right>
+                                <list-expression start-index="39" stop-index="47">
+                                    <items>
+                                        <literal-expression value="1" start-index="40" stop-index="40" />
+                                        <parameter-marker-expression value="0" start-index="40" stop-index="40" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="43" stop-index="43" />
+                                        <parameter-marker-expression value="1" start-index="43" stop-index="43" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="3" start-index="46" stop-index="46" />
+                                        <parameter-marker-expression value="2" start-index="46" stop-index="46" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <in-expression start-index="53" stop-index="70" literal-stop-index="71">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="53" stop-index="60" />
+                            </left>
+                            <right>
+                                <list-expression start-index="65" stop-index="70" literal-stop-index="71">
+                                    <items>
+                                        <literal-expression value="9" start-index="66" stop-index="66" />
+                                        <parameter-marker-expression value="3" start-index="66" stop-index="66" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="10" start-index="69" stop-index="70" />
+                                        <parameter-marker-expression value="4" start-index="69" stop-index="69" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="user_id" start-index="81" stop-index="87" literal-start-index="82" literal-stop-index="88" />
@@ -394,26 +579,51 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="68" literal-stop-index="80">
-            <and-predicate>
-                <predicate start-index="28" stop-index="45" literal-stop-index="51">
-                    <column-left-value name="order_id" start-index="28" stop-index="35" />
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="41" stop-index="41" />
-                        <parameter-marker-expression value="1" start-index="44" stop-index="44" />
-                        <literal-expression value="1000" start-index="41" stop-index="44" />
-                        <literal-expression value="1001" start-index="47" stop-index="50" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="51" stop-index="68" literal-start-index="57" literal-stop-index="80">
-                    <column-left-value name="order_id" start-index="51" stop-index="58" literal-start-index="57" literal-stop-index="64" />
-                    <in-right-value>
-                        <parameter-marker-expression value="2" start-index="64" stop-index="64" />
-                        <parameter-marker-expression value="3" start-index="67" stop-index="67" />
-                        <literal-expression value="1001" start-index="70" stop-index="73" />
-                        <literal-expression value="1002" start-index="76" stop-index="79" />
-                    </in-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="68" literal-stop-index="80">
+                    <left>
+                        <in-expression start-index="28" stop-index="45" literal-stop-index="51">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="28" stop-index="35" />
+                            </left>
+                            <right>
+                                <list-expression start-index="40" stop-index="45" literal-stop-index="51">
+                                    <items>
+                                        <literal-expression value="1000" start-index="41" stop-index="44" />
+                                        <parameter-marker-expression value="0" start-index="41" stop-index="41" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="1001" start-index="47" stop-index="50" />
+                                        <parameter-marker-expression value="1" start-index="44" stop-index="44" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <in-expression start-index="51" stop-index="68" literal-start-index="57" literal-stop-index="80">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="51" stop-index="58" literal-start-index="57" literal-stop-index="64" />
+                            </left>
+                            <right>
+                                <list-expression start-index="63" stop-index="68" literal-start-index="69" literal-stop-index="80">
+                                    <items>
+                                        <literal-expression value="1001" start-index="70" stop-index="73" />
+                                        <parameter-marker-expression value="2" start-index="64" stop-index="64" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="1002" start-index="76" stop-index="79" />
+                                        <parameter-marker-expression value="3" start-index="67" stop-index="67" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="79" stop-index="86" literal-start-index="91" literal-stop-index="98" />
@@ -427,47 +637,176 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7"/>
         </projections>
-        <where></where>
+        <where start-index="22" stop-index="43">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="43">
+                    <left>
+                        <column name="is_deleted" start-index="28" stop-index="37" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="N" start-index="41" stop-index="43" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
     </select>
 
-    <select sql-case-id="select_count_like_concat" parameters="'init', 1, 2, 9, 10">
+    <select sql-case-id="select_count_like_concat" parameters="1, 2, 9, 10">
         <from>
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
             <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
-        <where start-index="47" stop-index="142" literal-stop-index="148">
-            <and-predicate>
-                <!-- TODO assert predicate with like  -->
-                <!--<predicate start-index="62" stop-index="79">-->
-                    <!--<column-left-value name="status" start-index="53" stop-index="60">-->
-                        <!--<owner name="o" start-index="53" stop-index="53" />-->
-                    <!--</column>-->
-                <!--</predicate>-->
-                <predicate start-index="93" stop-index="111" literal-start-index="98" literal-stop-index="116">
-                    <column-left-value name="user_id" start-index="93" stop-index="101" literal-start-index="98" literal-stop-index="106">
-                        <owner name="o" start-index="93" stop-index="93" literal-start-index="98" literal-stop-index="98" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="1" start-index="107" stop-index="107" />
-                        <parameter-marker-expression value="2" start-index="110" stop-index="110" />
-                        <literal-expression value="1" start-index="112" stop-index="112" />
-                        <literal-expression value="2" start-index="115" stop-index="115" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="117" stop-index="142" literal-start-index="122" literal-stop-index="148">
-                    <column-left-value name="order_id" start-index="117" stop-index="126" literal-start-index="122" literal-stop-index="131">
-                        <owner name="o" start-index="117" stop-index="117" literal-start-index="122" literal-stop-index="122" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="3" start-index="136" stop-index="136" />
-                        <between-literal-expression value="9" start-index="141" stop-index="141" />
-                        <and-parameter-marker-expression value="4" start-index="142" stop-index="142" />
-                        <and-literal-expression value="10" start-index="147" stop-index="148" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="47" stop-index="147" literal-stop-index="148">
+            <expr>
+                <binary-operation-expression start-index="53" stop-index="147" literal-stop-index="148">
+                    <left>
+                        <binary-operation-expression start-index="53" stop-index="116">
+                            <left>
+                                <binary-operation-expression start-index="53" stop-index="92">
+                                    <left>
+                                        <column name="status" start-index="53" stop-index="60">
+                                            <owner name="o" start-index="53" stop-index="53" />
+                                        </column>
+                                    </left>
+                                    <operator>LIKE</operator>
+                                    <right>
+                                        <list-expression start-index="67" stop-index="92">
+                                            <items>
+                                                <expression-projection text="CONCAT('%%', 'init', '%%')" start-index="67" stop-index="92" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </binary-operation-expression>
+                                <common-expression text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="92" />
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <in-expression start-index="98" stop-index="116">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="98" stop-index="106">
+                                            <owner name="o" start-index="98" stop-index="98" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="111" stop-index="116">
+                                            <items>
+                                                <literal-expression value="1" start-index="112" stop-index="112" />
+                                                <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="115" stop-index="115" />
+                                                <parameter-marker-expression value="1" start-index="115" stop-index="115" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="122" stop-index="147" literal-stop-index="148">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="122" stop-index="131">
+                                    <owner name="o" start-index="122" stop-index="122" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="141" stop-index="141" />
+                                <parameter-marker-expression value="2" start-index="141" stop-index="141" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="147" stop-index="148" />
+                                <parameter-marker-expression value="3" start-index="147" stop-index="147" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_count_like_concat_for_oracle_and_sqlserver" parameters="1, 2, 9, 10">
+        <from>
+            <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
+        </from>
+        <projections start-index="7" stop-index="30">
+            <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
+        </projections>
+        <where start-index="47" stop-index="147" literal-stop-index="148">
+            <expr>
+                <binary-operation-expression start-index="53" stop-index="147" literal-stop-index="148">
+                    <left>
+                        <binary-operation-expression start-index="53" stop-index="116">
+                            <left>
+                                <binary-operation-expression start-index="53" stop-index="92">
+                                    <left>
+                                        <column name="status" start-index="53" stop-index="60">
+                                            <owner name="o" start-index="53" stop-index="53" />
+                                        </column>
+                                    </left>
+                                    <operator>LIKE</operator>
+                                    <right>
+                                        <list-expression start-index="67" stop-index="92">
+                                            <items>
+                                                <expression-projection text="CONCAT('%%','init','%%')" start-index="67" stop-index="92" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </binary-operation-expression>
+                                <common-expression text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="92" />
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <in-expression start-index="98" stop-index="116">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="98" stop-index="106">
+                                            <owner name="o" start-index="98" stop-index="98" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="111" stop-index="116">
+                                            <items>
+                                                <literal-expression value="1" start-index="112" stop-index="112" />
+                                                <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="115" stop-index="115" />
+                                                <parameter-marker-expression value="1" start-index="115" stop-index="115" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="122" stop-index="147" literal-stop-index="148">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="122" stop-index="131">
+                                    <owner name="o" start-index="122" stop-index="122" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="141" stop-index="141" />
+                                <parameter-marker-expression value="2" start-index="141" stop-index="141" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="147" stop-index="148" />
+                                <parameter-marker-expression value="3" start-index="147" stop-index="147" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -478,47 +817,86 @@
         <projections start-index="7" stop-index="8">
             <column-projection name="id" start-index="7" stop-index="8"/>
         </projections>
-        <where></where>
+        <where start-index="21" stop-index="44">
+            <expr>
+                <binary-operation-expression start-index="27" stop-index="44">
+                    <left>
+                        <column name="fullname" start-index="27" stop-index="34" />
+                    </left>
+                    <operator>LIKE</operator>
+                    <right>
+                        <list-expression start-index="41" stop-index="44">
+                            <items>
+                                <literal-expression value="a%" start-index="41" stop-index="44" />
+                            </items>
+                        </list-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
     </select>
 
-    <select sql-case-id="select_count_tilde_concat" parameters="'init', 1, 2, 9, 10">
+    <select sql-case-id="select_count_tilde_concat" parameters="1, 2, 9, 10">
         <from>
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
             <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
-        <where start-index="47" stop-index="140" literal-stop-index="146">
-            <and-predicate>
-                <!-- TODO add predication assert for ~~ -->
-                <!--<predicate start-index="62" stop-index="79">-->
-                    <!--<column-left-value name="status" start-index="53" stop-index="60">-->
-                        <!--<owner name="o" start-index="53" stop-index="53" />-->
-                    <!--</column>-->
-                <!--</predicate>-->
-                <predicate start-index="91" stop-index="109" literal-start-index="96" literal-stop-index="114">
-                    <column-left-value name="user_id" start-index="91" stop-index="99" literal-start-index="96" literal-stop-index="104">
-                        <owner name="o" start-index="91" stop-index="91" literal-start-index="96" literal-stop-index="96" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="1" start-index="105" stop-index="105" />
-                        <parameter-marker-expression value="2" start-index="108" stop-index="108" />
-                        <literal-expression value="1" start-index="110" stop-index="110" />
-                        <literal-expression value="2" start-index="113" stop-index="113" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="115" stop-index="140" literal-start-index="120" literal-stop-index="146">
-                    <column-left-value name="order_id" start-index="115" stop-index="124" literal-start-index="120" literal-stop-index="129">
-                        <owner name="o" start-index="115" stop-index="115" literal-start-index="120" literal-stop-index="120" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="3" start-index="134" stop-index="134" />
-                        <between-literal-expression value="9" start-index="139" stop-index="139" />
-                        <and-parameter-marker-expression value="4" start-index="140" stop-index="140" />
-                        <and-literal-expression value="10" start-index="145" stop-index="146" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="47" stop-index="145" literal-stop-index="146">
+            <expr>
+                <binary-operation-expression start-index="53" stop-index="145" literal-stop-index="146">
+                    <left>
+                        <binary-operation-expression start-index="53" stop-index="114">
+                            <left>
+                                <common-expression text="o.status ~~ CONCAT('%%', 'init', '%%')" start-index="53" stop-index="90" />
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <in-expression start-index="96" stop-index="114">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="96" stop-index="104">
+                                            <owner name="o" start-index="96" stop-index="96" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="110" stop-index="113">
+                                            <items>
+                                                <literal-expression value="1" start-index="110" stop-index="110" />
+                                                <parameter-marker-expression value="0" start-index="110" stop-index="110" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="113" stop-index="113" />
+                                                <parameter-marker-expression value="1" start-index="113" stop-index="113" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="120" stop-index="145" literal-stop-index="146">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="120" stop-index="129">
+                                    <owner name="o" start-index="120" stop-index="120" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="139" stop-index="139" />
+                                <parameter-marker-expression value="2" start-index="139" stop-index="139" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="145" stop-index="146" />
+                                <parameter-marker-expression value="3" start-index="145" stop-index="145" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -559,30 +937,51 @@
             </shorthand-projection>
         </projections>
         <where start-index="99" stop-index="154" literal-stop-index="155">
-            <and-predicate>
-                <predicate start-index="105" stop-index="123">
-                    <column-left-value name="user_id" start-index="105" stop-index="113">
-                        <owner name="o" start-index="105" stop-index="105" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
-                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
-                        <literal-expression value="1" start-index="119" stop-index="119" />
-                        <literal-expression value="2" start-index="122" stop-index="122" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="129" stop-index="154" literal-stop-index="155">
-                    <column-left-value name="order_id" start-index="129" stop-index="138">
-                        <owner name="o" start-index="129" stop-index="129" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="148" stop-index="148" />
-                        <between-literal-expression value="9" start-index="148" stop-index="148" />
-                        <and-parameter-marker-expression value="3" start-index="154" stop-index="154" />
-                        <and-literal-expression value="10" start-index="154" stop-index="155" />
-                    </between-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
+                    <left>
+                        <in-expression start-index="105" stop-index="123">
+                            <not>false</not>
+                            <left>
+                                <column name="user_id" start-index="105" stop-index="113">
+                                    <owner name="o" start-index="105" stop-index="105" />
+                                </column>
+                            </left>
+                            <right>
+                                <list-expression start-index="118" stop-index="123">
+                                    <items>
+                                        <literal-expression value="1" start-index="119" stop-index="119" />
+                                        <parameter-marker-expression value="0" start-index="119" stop-index="119" />
+                                    </items>
+                                    <items>
+                                        <literal-expression value="2" start-index="122" stop-index="122" />
+                                        <parameter-marker-expression value="1" start-index="122" stop-index="122" />
+                                    </items>
+                                </list-expression>
+                            </right>
+                        </in-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <between-expression start-index="129" stop-index="154" literal-stop-index="155">
+                            <not>false</not>
+                            <left>
+                                <column name="order_id" start-index="129" stop-index="138">
+                                    <owner name="o" start-index="129" stop-index="129" />
+                                </column>
+                            </left>
+                            <between-expr>
+                                <literal-expression value="9" start-index="148" stop-index="148" />
+                                <parameter-marker-expression value="2" start-index="148" stop-index="148" />
+                            </between-expr>
+                            <and-expr>
+                                <literal-expression value="10" start-index="154" stop-index="155" />
+                                <parameter-marker-expression value="3" start-index="154" stop-index="154" />
+                            </and-expr>
+                        </between-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="165" stop-index="173" literal-start-index="166" literal-stop-index="174">
@@ -690,40 +1089,70 @@
             </shorthand-projection>
         </projections>
         <where start-index="147" stop-index="219" literal-stop-index="225">
-            <and-predicate>
-                <predicate start-index="153" stop-index="171">
-                    <column-left-value name="user_id" start-index="153" stop-index="161">
-                        <owner name="o" start-index="153" stop-index="153" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="167" stop-index="167" />
-                        <parameter-marker-expression value="1" start-index="170" stop-index="170" />
-                        <literal-expression value="1" start-index="167" stop-index="167" />
-                        <literal-expression value="2" start-index="170" stop-index="170" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="177" stop-index="202" literal-stop-index="203">
-                    <column-left-value name="order_id" start-index="177" stop-index="186">
-                        <owner name="o" start-index="177" stop-index="177" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="196" stop-index="196" />
-                        <between-literal-expression value="9" start-index="196" stop-index="196" />
-                        <and-parameter-marker-expression value="3" start-index="202" stop-index="202" />
-                        <and-literal-expression value="10" start-index="202" stop-index="203" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="208" stop-index="219" literal-start-index="209" literal-stop-index="225">
-                    <column-left-value name="status" start-index="208" stop-index="215" literal-start-index="209" literal-stop-index="216">
-                        <owner name="o" start-index="208" stop-index="208" literal-start-index="209" literal-stop-index="209" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="219" stop-index="219" />
-                        <literal-expression value="init" start-index="220" stop-index="225" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="153" stop-index="219" literal-stop-index="225">
+                    <left>
+                        <binary-operation-expression start-index="153" stop-index="202" literal-stop-index="203">
+                            <left>
+                                <in-expression start-index="153" stop-index="171">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="153" stop-index="161">
+                                            <owner name="o" start-index="153" stop-index="153" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="166" stop-index="171">
+                                            <items>
+                                                <literal-expression value="1" start-index="167" stop-index="167" />
+                                                <parameter-marker-expression value="0" start-index="167" stop-index="167" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="170" stop-index="170" />
+                                                <parameter-marker-expression value="1" start-index="170" stop-index="170" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <between-expression start-index="177" stop-index="202" literal-stop-index="203">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="order_id" start-index="177" stop-index="186">
+                                            <owner name="o" start-index="177" stop-index="177" />
+                                        </column>
+                                    </left>
+                                    <between-expr>
+                                        <literal-expression value="9" start-index="196" stop-index="196" />
+                                        <parameter-marker-expression value="2" start-index="196" stop-index="196" />
+                                    </between-expr>
+                                    <and-expr>
+                                        <literal-expression value="10" start-index="202" stop-index="203" />
+                                        <parameter-marker-expression value="3" start-index="202" stop-index="202" />
+                                    </and-expr>
+                                </between-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="208" stop-index="219" literal-start-index="209" literal-stop-index="225">
+                            <left>
+                                <column name="status" start-index="208" stop-index="215" literal-start-index="209" literal-stop-index="216">
+                                    <owner name="o" start-index="208" stop-index="208" literal-start-index="209" literal-stop-index="209" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="220" stop-index="225" />
+                                <parameter-marker-expression value="4" start-index="219" stop-index="219" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="230" stop-index="238" literal-start-index="236" literal-stop-index="244">
@@ -788,40 +1217,70 @@
             </shorthand-projection>
         </projections>
         <where start-index="138" stop-index="210" literal-stop-index="216">
-            <and-predicate>
-                <predicate start-index="144" stop-index="162">
-                    <column-left-value name="user_id" start-index="144" stop-index="152">
-                        <owner name="o" start-index="144" stop-index="144" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="158" stop-index="158" />
-                        <parameter-marker-expression value="1" start-index="161" stop-index="161" />
-                        <literal-expression value="1" start-index="158" stop-index="158" />
-                        <literal-expression value="2" start-index="161" stop-index="161" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="168" stop-index="193" literal-stop-index="194">
-                    <column-left-value name="order_id" start-index="168" stop-index="177">
-                        <owner name="o" start-index="168" stop-index="168" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="187" stop-index="187" />
-                        <between-literal-expression value="9" start-index="187" stop-index="187" />
-                        <and-parameter-marker-expression value="3" start-index="193" stop-index="193" />
-                        <and-literal-expression value="10" start-index="193" stop-index="194" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
-                    <column-left-value name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
-                        <owner name="o" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="210" stop-index="210" />
-                        <literal-expression value="init" start-index="211" stop-index="216" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="144" stop-index="210" literal-stop-index="216">
+                    <left>
+                        <binary-operation-expression start-index="144" stop-index="193" literal-stop-index="194">
+                            <left>
+                                <in-expression start-index="144" stop-index="162">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="144" stop-index="152">
+                                            <owner name="o" start-index="144" stop-index="144" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="157" stop-index="162">
+                                            <items>
+                                                <literal-expression value="1" start-index="158" stop-index="158" />
+                                                <parameter-marker-expression value="0" start-index="158" stop-index="158" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="161" stop-index="161" />
+                                                <parameter-marker-expression value="1" start-index="161" stop-index="161" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <between-expression start-index="168" stop-index="193" literal-stop-index="194">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="order_id" start-index="168" stop-index="177">
+                                            <owner name="o" start-index="168" stop-index="168" />
+                                        </column>
+                                    </left>
+                                    <between-expr>
+                                        <literal-expression value="9" start-index="187" stop-index="187" />
+                                        <parameter-marker-expression value="2" start-index="187" stop-index="187" />
+                                    </between-expr>
+                                    <and-expr>
+                                        <literal-expression value="10" start-index="193" stop-index="194" />
+                                        <parameter-marker-expression value="3" start-index="193" stop-index="193" />
+                                    </and-expr>
+                                </between-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
+                            <left>
+                                <column name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
+                                    <owner name="o" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="211" stop-index="216" />
+                                <parameter-marker-expression value="4" start-index="210" stop-index="210" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="221" stop-index="229" literal-start-index="227" literal-stop-index="235">
@@ -886,40 +1345,70 @@
             </shorthand-projection>
         </projections>
         <where start-index="138" stop-index="210" literal-stop-index="216">
-            <and-predicate>
-                <predicate start-index="144" stop-index="162">
-                    <column-left-value name="user_id" start-index="144" stop-index="152">
-                        <owner name="o" start-index="144" stop-index="144" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="158" stop-index="158" />
-                        <parameter-marker-expression value="1" start-index="161" stop-index="161" />
-                        <literal-expression value="1" start-index="158" stop-index="158" />
-                        <literal-expression value="2" start-index="161" stop-index="161" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="168" stop-index="193" literal-stop-index="194">
-                    <column-left-value name="order_id" start-index="168" stop-index="177">
-                        <owner name="o" start-index="168" stop-index="168" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="187" stop-index="187" />
-                        <between-literal-expression value="9" start-index="187" stop-index="187" />
-                        <and-parameter-marker-expression value="3" start-index="193" stop-index="193" />
-                        <and-literal-expression value="10" start-index="193" stop-index="194" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
-                    <column-left-value name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
-                        <owner name="c" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="210" stop-index="210" />
-                        <literal-expression value="init" start-index="211" stop-index="216" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="144" stop-index="210" literal-stop-index="216">
+                    <left>
+                        <binary-operation-expression start-index="144" stop-index="193" literal-stop-index="194">
+                            <left>
+                                <in-expression start-index="144" stop-index="162">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="144" stop-index="152">
+                                            <owner name="o" start-index="144" stop-index="144" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="157" stop-index="162">
+                                            <items>
+                                                <literal-expression value="1" start-index="158" stop-index="158" />
+                                                <parameter-marker-expression value="0" start-index="158" stop-index="158" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="161" stop-index="161" />
+                                                <parameter-marker-expression value="1" start-index="161" stop-index="161" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <between-expression start-index="168" stop-index="193" literal-stop-index="194">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="order_id" start-index="168" stop-index="177">
+                                            <owner name="o" start-index="168" stop-index="168" />
+                                        </column>
+                                    </left>
+                                    <between-expr>
+                                        <literal-expression value="9" start-index="187" stop-index="187" />
+                                        <parameter-marker-expression value="2" start-index="187" stop-index="187" />
+                                    </between-expr>
+                                    <and-expr>
+                                        <literal-expression value="10" start-index="193" stop-index="194" />
+                                        <parameter-marker-expression value="3" start-index="193" stop-index="193" />
+                                    </and-expr>
+                                </between-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
+                            <left>
+                                <column name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
+                                    <owner name="c" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="211" stop-index="216" />
+                                <parameter-marker-expression value="4" start-index="210" stop-index="210" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="221" stop-index="229" literal-start-index="227" literal-stop-index="235">
@@ -984,40 +1473,70 @@
             </shorthand-projection>
         </projections>
         <where start-index="138" stop-index="210" literal-stop-index="216">
-            <and-predicate>
-                <predicate start-index="144" stop-index="162">
-                    <column-left-value name="user_id" start-index="144" stop-index="152">
-                        <owner name="o" start-index="144" stop-index="144" />
-                    </column-left-value>
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="158" stop-index="158" />
-                        <parameter-marker-expression value="1" start-index="161" stop-index="161" />
-                        <literal-expression value="1" start-index="158" stop-index="158" />
-                        <literal-expression value="2" start-index="161" stop-index="161" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="168" stop-index="193" literal-stop-index="194">
-                    <column-left-value name="order_id" start-index="168" stop-index="177">
-                        <owner name="o" start-index="168" stop-index="168" />
-                    </column-left-value>
-                    <between-right-value>
-                        <between-parameter-marker-expression value="2" start-index="187" stop-index="187" />
-                        <between-literal-expression value="9" start-index="187" stop-index="187" />
-                        <and-parameter-marker-expression value="3" start-index="193" stop-index="193" />
-                        <and-literal-expression value="10" start-index="193" stop-index="194" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
-                    <column-left-value name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
-                        <owner name="c" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="210" stop-index="210" />
-                        <literal-expression value="init" start-index="211" stop-index="216" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="144" stop-index="210" literal-stop-index="216">
+                    <left>
+                        <binary-operation-expression start-index="144" stop-index="193" literal-stop-index="194">
+                            <left>
+                                <in-expression start-index="144" stop-index="162">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="user_id" start-index="144" stop-index="152">
+                                            <owner name="o" start-index="144" stop-index="144" />
+                                        </column>
+                                    </left>
+                                    <right>
+                                        <list-expression start-index="157" stop-index="162">
+                                            <items>
+                                                <literal-expression value="1" start-index="158" stop-index="158" />
+                                                <parameter-marker-expression value="0" start-index="158" stop-index="158" />
+                                            </items>
+                                            <items>
+                                                <literal-expression value="2" start-index="161" stop-index="161" />
+                                                <parameter-marker-expression value="1" start-index="161" stop-index="161" />
+                                            </items>
+                                        </list-expression>
+                                    </right>
+                                </in-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <between-expression start-index="168" stop-index="193" literal-stop-index="194">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="order_id" start-index="168" stop-index="177">
+                                            <owner name="o" start-index="168" stop-index="168" />
+                                        </column>
+                                    </left>
+                                    <between-expr>
+                                        <literal-expression value="9" start-index="187" stop-index="187" />
+                                        <parameter-marker-expression value="2" start-index="187" stop-index="187" />
+                                    </between-expr>
+                                    <and-expr>
+                                        <literal-expression value="10" start-index="193" stop-index="194" />
+                                        <parameter-marker-expression value="3" start-index="193" stop-index="193" />
+                                    </and-expr>
+                                </between-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="199" stop-index="210" literal-start-index="200" literal-stop-index="216">
+                            <left>
+                                <column name="status" start-index="199" stop-index="206" literal-start-index="200" literal-stop-index="207">
+                                    <owner name="c" start-index="199" stop-index="199" literal-start-index="200" literal-stop-index="200" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="init" start-index="211" stop-index="216" />
+                                <parameter-marker-expression value="4" start-index="210" stop-index="210" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="item_id" start-index="221" stop-index="229" literal-start-index="227" literal-stop-index="235">
@@ -1036,18 +1555,20 @@
             </column-projection>>
         </projections>
         <where start-index="56" stop-index="79">
-            <and-predicate>
-                <predicate start-index="62" stop-index="79">
-                    <column-left-value name="item_id" start-index="62" stop-index="75">
-                        <owner name="length" start-index="62" stop-index="67" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="79" stop-index="79" />
+            <expr>
+                <binary-operation-expression start-index="62" stop-index="79">
+                    <left>
+                        <column name="item_id" start-index="62" stop-index="75">
+                            <owner name="length" start-index="62" stop-index="67" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="79" stop-index="79" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="79" stop-index="79" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1080,151 +1601,237 @@
             </shorthand-projection>
         </projections>
         <where start-index="96" stop-index="115" literal-stop-index="118">
-            <and-predicate>
-                <predicate start-index="102" stop-index="115" literal-stop-index="118">
-                    <column-left-value name="order_id" start-index="102" stop-index="111">
-                        <owner name="o" start-index="102" stop-index="102" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="115" stop-index="115" />
+            <expr>
+                <binary-operation-expression start-index="102" stop-index="115" literal-stop-index="118">
+                    <left>
+                        <column name="order_id" start-index="102" stop-index="111">
+                            <owner name="o" start-index="102" stop-index="102" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1000" start-index="115" stop-index="118" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="115" stop-index="115" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_equal_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', 100, 200, 1, 2">
+    <select sql-case-id="select_equal_with_geography" parameters="1, 2">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="148" literal-stop-index="170">
-            <and-predicate>
-                <predicate start-index="28" stop-index="42" literal-stop-index="60">
-                    <column-left-value name="rule" start-index="28" stop-index="31" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="35" stop-index="42" />
-                        <literal-expression value="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="35" stop-index="60" />
-                        <common-expression literal-text="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="35" stop-index="60" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="48" stop-index="115" literal-start-index="66" literal-stop-index="137">
-                    <column-left-value name="start_point" start-index="48" stop-index="58" literal-start-index="66" literal-stop-index="76" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <common-expression literal-start-index="78" literal-stop-index="137" start-index="60" stop-index="115" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"/>
-                        <literal-expression start-index="78" stop-index="137" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"/>
-                    </compare-right-value>
-                    <!-- TODO assert expression -->
-                </predicate>
-                <predicate start-index="121" stop-index="131" literal-start-index="143" literal-stop-index="153">
-                    <column-left-value name="user_id" start-index="121" stop-index="127" literal-start-index="143" literal-stop-index="149" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="3" start-index="131" stop-index="131" />
-                        <literal-expression value="1" start-index="153" stop-index="153" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="137" stop-index="148" literal-start-index="159" literal-stop-index="170">
-                    <column-left-value name="order_id" start-index="137" stop-index="144" literal-start-index="159" literal-stop-index="166" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="148" stop-index="148" />
-                        <literal-expression value="2" start-index="170" stop-index="170" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="170">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="170">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="153">
+                            <left>
+                                <binary-operation-expression start-index="28" stop-index="137">
+                                    <left>
+                                        <binary-operation-expression start-index="28" stop-index="60">
+                                            <left>
+                                                <column name="rule" start-index="28" stop-index="31" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <common-expression text="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="35" stop-index="60" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="66" stop-index="137">
+                                            <left>
+                                                <column name="start_point" start-index="66" stop-index="76" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="78" stop-index="137" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="143" stop-index="153">
+                                    <left>
+                                        <column name="user_id" start-index="143" stop-index="149" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1" start-index="153" stop-index="153" />
+                                        <parameter-marker-expression value="0" start-index="153" stop-index="153" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="159" stop-index="170">
+                            <left>
+                                <column name="order_id" start-index="159" stop-index="166" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="170" stop-index="170" />
+                                <parameter-marker-expression value="1" start-index="170" stop-index="170" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_in_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', '{&quot;rule3&quot;:&quot;null3&quot;}', 100, 200, 1, 2">
+    <select sql-case-id="select_in_with_geography" parameters="1, 2">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="161" literal-stop-index="201">
-            <and-predicate>
-                <predicate start-index="28" stop-index="55" literal-stop-index="91">
-                    <column-left-value name="rule" start-index="28" stop-index="31" />
-                    <in-right-value>
-                        <parameter-marker-expression value="0" start-index="37" stop-index="44" />
-                        <parameter-marker-expression value="1" start-index="47" stop-index="54" />
-                        <literal-expression value="{&quot;rule2&quot;:&quot;null2&quot;}'::json" start-index="37" stop-index="62" />
-                        <literal-expression value="{&quot;rule3&quot;:&quot;null3&quot;}'::json" start-index="65" stop-index="90" />
-                    </in-right-value>
-                </predicate>
-                <predicate start-index="61" stop-index="128" literal-start-index="97" literal-stop-index="168">
-                    <column-left-value name="start_point" start-index="61" stop-index="71" literal-start-index="97" literal-stop-index="107" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <common-expression literal-start-index="109" literal-stop-index="168" start-index="73" stop-index="128" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"/>
-                    </compare-right-value>
-                    <!-- TODO assert expr -->
-                </predicate>
-                <predicate start-index="134" stop-index="144" literal-start-index="174" literal-stop-index="184">
-                    <column-left-value name="user_id" start-index="134" stop-index="140" literal-start-index="174" literal-stop-index="180" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="144" stop-index="144" />
-                        <literal-expression value="1" start-index="184" stop-index="184" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="150" stop-index="161" literal-start-index="190" literal-stop-index="201">
-                    <column-left-value name="order_id" start-index="150" stop-index="157" literal-start-index="190" literal-stop-index="197" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="5" start-index="161" stop-index="161" />
-                        <literal-expression value="2" start-index="201" stop-index="201" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="201">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="201">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="184">
+                            <left>
+                                <binary-operation-expression start-index="28" stop-index="168">
+                                    <left>
+                                        <in-expression start-index="28" stop-index="91">
+                                            <not>false</not>
+                                            <left>
+                                                <column name="rule" start-index="28" stop-index="31" />
+                                            </left>
+                                            <right>
+                                                <list-expression start-index="37" stop-index="90">
+                                                    <items>
+                                                        <common-expression text="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="37" stop-index="62" />
+                                                    </items>
+                                                    <items>
+                                                        <common-expression text="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="65" stop-index="90" />
+                                                    </items>
+                                                </list-expression>
+                                            </right>
+                                        </in-expression>
+                                    </left>
+                                    <operator>AND</operator>
+                                    <right>
+                                        <binary-operation-expression start-index="97" stop-index="168">
+                                            <left>
+                                                <column name="start_point" start-index="97" stop-index="107" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="109" stop-index="168" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="174" stop-index="184">
+                                    <left>
+                                        <column name="user_id" start-index="174" stop-index="180" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1" start-index="184" stop-index="184" />
+                                        <parameter-marker-expression value="0" start-index="184" stop-index="184" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="190" stop-index="201">
+                            <left>
+                                <column name="order_id" start-index="190" stop-index="197" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="201" stop-index="201" />
+                                <parameter-marker-expression value="1" start-index="201" stop-index="201" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
-    <select sql-case-id="select_between_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', '{&quot;rule3&quot;:&quot;null3&quot;}', 100, 200, 1">
+    <select sql-case-id="select_between_with_geography" parameters="1">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="151" literal-stop-index="191">
-            <and-predicate>
-                <predicate start-index="28" stop-index="61" literal-stop-index="97">
-                    <column-left-value name="rule" start-index="28" stop-index="31" />
-                    <between-right-value>
-                        <between-parameter-marker-expression value="0"  start-index="41" stop-index="48" literal-start-index="48" literal-stop-index="55" />
-                        <between-literal-expression value="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="41" stop-index="66" />
-                        <between-common-expression value="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="41" stop-index="66" />
-                        <and-parameter-marker-expression value="1" start-index="54" stop-index="61" />
-                        <and-literal-expression value="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="72" stop-index="97" />
-                        <and-common-expression literal-text="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="72" stop-index="97" />
-                    </between-right-value>
-                </predicate>
-                <predicate start-index="67" stop-index="134" literal-start-index="103" literal-stop-index="174">
-                    <column-left-value name="start_point" start-index="67" stop-index="77" literal-start-index="103" literal-stop-index="113" />
-                    <operator type="=" />
-                    <!-- TODO assert right value -->
-                    <compare-right-value>
-                        <common-expression literal-start-index="115" literal-stop-index="174" start-index="79" stop-index="134" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"/>
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="140" stop-index="151" literal-start-index="180" literal-stop-index="191">
-                    <column-left-value name="order_id" start-index="140" stop-index="147" literal-start-index="180" literal-stop-index="187" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="4" start-index="151" stop-index="151" />
-                        <literal-expression value="1" start-index="191" stop-index="191" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="22" stop-index="191">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="191">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="174">
+                            <left>
+                                <between-expression start-index="28" stop-index="97">
+                                    <not>false</not>
+                                    <left>
+                                        <column name="rule" start-index="28" stop-index="31" />
+                                    </left>
+                                    <between-expr>
+                                        <binary-operation-expression start-index="41" stop-index="66">
+                                            <left>
+                                                <literal-expression value="{&quot;rule2&quot;:&quot;null2&quot;}" start-index="41" stop-index="59" />
+                                            </left>
+                                            <operator>::</operator>
+                                            <right>
+                                                <common-expression text="jsonb" start-index="62" stop-index="66" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </between-expr>
+                                    <and-expr>
+                                        <common-expression text="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="72" stop-index="97" />
+                                    </and-expr>
+                                </between-expression>
+                            </left>
+                            <operator>AND</operator>
+                            <right>
+                                <binary-operation-expression start-index="103" stop-index="174">
+                                    <left>
+                                        <column name="start_point" start-index="103" stop-index="113" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="115" stop-index="174" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="180" stop-index="191">
+                            <left>
+                                <column name="order_id" start-index="180" stop-index="187" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="191" stop-index="191" />
+                                <parameter-marker-expression value="0" start-index="191" stop-index="191" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1236,19 +1843,21 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="29" stop-index="48">
-            <and-predicate>
-                <predicate start-index="35" stop-index="48">
-                    <column-left-value name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" start-index="35" stop-index="43" />
-                    <operator type="!=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="48" stop-index="48" />
+            <expr>
+                <binary-operation-expression start-index="35" stop-index="48">
+                    <left>
+                        <column name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" start-index="35" stop-index="43" />
+                    </left>
+                    <operator>!=</operator>
+                    <right>
                         <literal-expression value="1" start-index="48" stop-index="48" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="0" start-index="48" stop-index="48" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
-            <column-item name="item_id" start-index="59" stop-index="67" />
+            <column-item name="item_id" start-delimiter="&quot;" end-delimiter="&quot;" start-index="59" stop-index="67" />
         </order-by>
     </select>
 
@@ -1307,17 +1916,22 @@
                 <owner name="t_order_item" start-index="27" stop-index="38" />
             </column-projection>
         </projections>
-        <where>
-            <and-predicate>
-                <predicate start-index="82" stop-index="121">
-                    <column-left-value name="order_id" start-index="82" stop-index="97">
-                        <owner name="t_order" start-index="82" stop-index="88"/>
-                    </column-left-value>
-                    <column-right-value name="order_id" start-index="101" stop-index="121">
-                        <owner name="t_order_item" start-index="101" stop-index="112"/>
-                    </column-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="76" stop-index="121">
+            <expr>
+                <binary-operation-expression start-index="82" stop-index="121">
+                    <left>
+                        <column name="order_id" start-index="82" stop-index="97">
+                            <owner name="t_order" start-index="82" stop-index="88" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="101" stop-index="121">
+                            <owner name="t_order_item" start-index="101" stop-index="112" />
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1385,15 +1999,17 @@
             <shorthand-projection start-index="16" stop-index="16" />
         </projections>
         <where start-index="31" stop-index="51">
-            <and-predicate>
-                <predicate start-index="37" stop-index="51">
-                    <column-left-value name="order_id" start-index="37" stop-index="44" />
-                    <operator type="&gt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="37" stop-index="51">
+                    <left>
+                        <column name="order_id" start-index="37" stop-index="44" />
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="48" stop-index="51" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="62" stop-index="69" />
@@ -1420,16 +2036,21 @@
             </column-projection>
         </projections>
         <where start-index="76" stop-index="121">
-            <and-predicate>
-                <predicate start-index="82" stop-index="121">
-                    <column-left-value name="order_id" start-index="82" stop-index="97">
-                        <owner name="t_order" start-index="82" stop-index="88" />
-                    </column-left-value>
-                    <column-right-value name="order_id" start-index="101" stop-index="121">
-                        <owner name="t_order_item" start-index="101" stop-index="112" />
-                    </column-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="82" stop-index="121">
+                    <left>
+                        <column name="order_id" start-index="82" stop-index="97">
+                            <owner name="t_order" start-index="82" stop-index="88" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="101" stop-index="121">
+                            <owner name="t_order_item" start-index="101" stop-index="112" />
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="132" stop-index="147">
@@ -1446,15 +2067,17 @@
             <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="s" start-index="7" stop-index="28" />
         </projections>
         <where start-index="45" stop-index="65">
-            <and-predicate>
-                <predicate start-index="51" stop-index="65">
-                    <column-left-value name="order_id" start-index="51" stop-index="58" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="51" stop-index="65">
+                    <left>
+                        <column name="order_id" start-index="51" stop-index="58" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="62" stop-index="65" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1466,15 +2089,17 @@
             <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
         </projections>
         <where start-index="47" stop-index="67">
-            <and-predicate>
-                <predicate start-index="53" stop-index="67">
-                    <column-left-value name="order_id" start-index="53" stop-index="60" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="53" stop-index="67">
+                    <left>
+                        <column name="order_id" start-index="53" stop-index="60" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="64" stop-index="67" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1486,15 +2111,17 @@
             <aggregation-distinct-projection type="AVG" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
         </projections>
         <where start-index="43" stop-index="63">
-            <and-predicate>
-                <predicate start-index="49" stop-index="63">
-                    <column-left-value name="order_id" start-index="49" stop-index="56" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="49" stop-index="63">
+                    <left>
+                        <column name="order_id" start-index="49" stop-index="56" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="60" stop-index="63" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1506,16 +2133,18 @@
             <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="30" />
             <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="33" stop-index="54" />
         </projections>
-        <where start-index="75" stop-index="89">
-            <and-predicate>
-                <predicate start-index="75" stop-index="89">
-                    <column-left-value name="order_id" start-index="75" stop-index="82" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+        <where start-index="69" stop-index="89">
+            <expr>
+                <binary-operation-expression start-index="75" stop-index="89">
+                    <left>
+                        <column name="order_id" start-index="75" stop-index="82" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="86" stop-index="89" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1528,15 +2157,17 @@
             <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="17" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
-            <and-predicate>
-                <predicate start-index="63" stop-index="77">
-                    <column-left-value name="order_id" start-index="63" stop-index="70" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="63" stop-index="77">
+                    <left>
+                        <column name="order_id" start-index="63" stop-index="70" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="74" stop-index="77" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <group-by>
             <column-item name="order_id" start-index="88" stop-index="95" />
@@ -1582,15 +2213,17 @@
             <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT user_id + order_id)" distinct-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
-            <and-predicate>
-                <predicate start-index="63" stop-index="77">
-                    <column-left-value name="order_id" start-index="63" stop-index="70" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="63" stop-index="77">
+                    <left>
+                        <column name="order_id" start-index="63" stop-index="70" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="74" stop-index="77" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1604,15 +2237,17 @@
             <aggregation-projection type="COUNT" inner-expression="(order_id)" start-index="55" stop-index="69" />
         </projections>
         <where start-index="85" stop-index="105">
-            <and-predicate>
-                <predicate start-index="91" stop-index="105">
-                    <column-left-value name="order_id" start-index="91" stop-index="98" />
-                    <operator type="&lt;" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="91" stop-index="105">
+                    <left>
+                        <column name="order_id" start-index="91" stop-index="98" />
+                    </left>
+                    <operator>&lt;</operator>
+                    <right>
                         <literal-expression value="1100" start-index="102" stop-index="105" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1635,15 +2270,17 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="38">
-            <and-predicate>
-                <predicate start-index="28" stop-index="38">
-                    <column-left-value name="status" start-index="28" stop-index="33" />
-                    <operator type="=" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="38">
+                    <left>
+                        <column name="status" start-index="28" stop-index="33" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="\'" start-index="35" stop-index="38" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1655,13 +2292,17 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="38">
-            <and-predicate>
-                <predicate start-index="28" stop-index="38">
-                    <column-left-value name="status" start-index="28" stop-index="33" />
-                    <!-- FIXME incorrect parse result as column type: "\"" -->
-                    <column-right-value name="\" start-delimiter="&quot;" end-delimiter="&quot;" start-index="35" stop-index="38" />
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="38">
+                    <left>
+                        <column name="status" start-index="28" stop-index="33" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="\&quot;" start-index="35" stop-index="38" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1672,17 +2313,18 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="90" stop-index="104">
-            <and-predicate>
-                <!-- FIXME \n's index is incorrect -->
-                <predicate start-index="97" stop-index="106">
-                    <column-left-value name="status" start-index="97" stop-index="102" />
-                    <operator type="=" />
-                    <compare-right-value>
+        <where start-index="91" stop-index="106">
+            <expr>
+                <binary-operation-expression start-index="97" stop-index="106">
+                    <left>
+                        <column name="status" start-index="97" stop-index="102" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="104" stop-index="106" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1693,17 +2335,18 @@
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <!-- FIXME incorrect for start index and stop index with \n -->
-        <where start-index="85" stop-index="101">
-            <and-predicate>
-                <predicate start-index="92" stop-index="101">
-                    <column-left-value name="status" start-index="92" stop-index="97" />
-                    <operator type="=" />
-                    <compare-right-value>
+        <where start-index="86" stop-index="101">
+            <expr>
+                <binary-operation-expression start-index="92" stop-index="101">
+                    <left>
+                        <column name="status" start-index="92" stop-index="97" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="99" stop-index="101" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1733,24 +2376,35 @@
             <aggregation-projection type="SUM" inner-expression="(if(status=0, 1, 0))" alias="func_status" start-index="7" stop-index="29" />
         </projections>
         <where start-index="56" stop-index="89" literal-stop-index="93">
-            <and-predicate>
-                <predicate start-index="62" stop-index="72" literal-stop-index="73">
-                    <column-left-value name="user_id" start-index="62" stop-index="68" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="72" stop-index="72" />
-                        <literal-expression value="12" start-index="72" stop-index="73" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="78" stop-index="89" literal-start-index="79" literal-stop-index="93">
-                    <column-left-value name="order_id" start-index="78" stop-index="85" literal-start-index="79" literal-stop-index="86" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="89" stop-index="89" />
-                        <literal-expression value="1000" start-index="90" stop-index="93" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="62" stop-index="89" literal-stop-index="93">
+                    <left>
+                        <binary-operation-expression start-index="62" stop-index="72" literal-stop-index="73">
+                            <left>
+                                <column name="user_id" start-index="62" stop-index="68" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="12" start-index="72" stop-index="73" />
+                                <parameter-marker-expression value="0" start-index="72" stop-index="72" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="78" stop-index="89" literal-start-index="79" literal-stop-index="93">
+                            <left>
+                                <column name="order_id" start-index="78" stop-index="85" literal-start-index="79" literal-stop-index="86" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1000" start-index="90" stop-index="93" />
+                                <parameter-marker-expression value="1" start-index="89" stop-index="89" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1759,27 +2413,38 @@
             <simple-table name="t_order" start-index="45" stop-index="51" />
         </from>
         <projections start-index="7" stop-index="38">
-            <expression-projection alias="func_status" start-index="7" stop-index="38" />
+            <expression-projection text="INTERVAL(status,1,5)" alias="func_status" start-index="7" stop-index="38" />
         </projections>
         <where start-index="53" stop-index="86" literal-stop-index="90">
-            <and-predicate>
-                <predicate start-index="59" stop-index="69" literal-stop-index="70">
-                    <column-left-value name="user_id" start-index="59" stop-index="65" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="69" stop-index="69" />
-                        <literal-expression value="12" start-index="69" stop-index="70" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="75" stop-index="86" literal-start-index="76" literal-stop-index="90">
-                    <column-left-value name="order_id" start-index="75" stop-index="82" literal-start-index="76" literal-stop-index="83" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="86" stop-index="86" />
-                        <literal-expression value="1000" start-index="87" stop-index="90" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="59" stop-index="86" literal-stop-index="90">
+                    <left>
+                        <binary-operation-expression start-index="59" stop-index="69" literal-stop-index="70">
+                            <left>
+                                <column name="user_id" start-index="59" stop-index="65" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="12" start-index="69" stop-index="70" />
+                                <parameter-marker-expression value="0" start-index="69" stop-index="69" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="75" stop-index="86" literal-start-index="76" literal-stop-index="90">
+                            <left>
+                                <column name="order_id" start-index="75" stop-index="82" literal-start-index="76" literal-stop-index="83" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1000" start-index="87" stop-index="90" />
+                                <parameter-marker-expression value="1" start-index="86" stop-index="86" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1788,24 +2453,26 @@
             <simple-table name="t_order_item" start-index="44" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="37">
-            <expression-projection start-index="7" stop-index="37" />
+            <expression-projection text="CONCAT(LEFT(status, 7), 'test')" start-index="7" stop-index="37" />
         </projections>
         <where start-index="57" stop-index="74">
-            <and-predicate>
-                <predicate start-index="63" stop-index="74">
-                    <column-left-value name="user_id" start-index="63" stop-index="69" />
-                    <operator type="=" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="63" stop-index="74">
+                    <left>
+                        <column name="user_id" start-index="63" stop-index="69" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="10" start-index="73" stop-index="74" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
     <select sql-case-id="select_database">
         <projections start-index="7" stop-index="16">
-            <expression-projection start-index="7" stop-index="16" />
+            <expression-projection text="DATABASE()" start-index="7" stop-index="16" />
         </projections>
     </select>
 
@@ -1817,7 +2484,17 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="47">
-            <!-- FIXME cannot parse expr in left value -->
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="47">
+                    <left>
+                        <expression-projection text="MOD(order_id, 1)" start-index="28" stop-index="43" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="47" stop-index="47" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1829,10 +2506,17 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="79">
-            <!-- FIXME cannot parse expr in left value for predicate -->
-            <!--<and-predicate>-->
-                <!--<predicate start-index="28" stop-index="79" />-->
-            <!--</and-predicate>-->
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="79">
+                    <left>
+                        <expression-projection text="DATE_FORMAT(current_date, '%Y-%m-%d')" start-index="28" stop-index="64" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="2019-12-18" start-index="68" stop-index="79" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1844,36 +2528,53 @@
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
         <where start-index="22" stop-index="106">
-            <!-- FIXME cannot parse expr in left value -->
-            <!--<and-predicate>-->
-                <!--<predicate start-index="28" stop-index="106" />-->
-            <!--</and-predicate>-->
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="106">
+                    <left>
+                        <expression-projection text="ST_DISTANCE_SPHERE(POINT(113.358772, 23.1273723), POINT(user_id,order_id))" start-index="28" stop-index="101" />
+                    </left>
+                    <operator>!=</operator>
+                    <right>
+                        <literal-expression value="0" start-index="106" stop-index="106" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
     <select sql-case-id="select_current_user">
         <projections start-index="7" stop-index="18">
-            <expression-projection start-index="7" stop-index="18" />
+            <expression-projection text="CURRENT_USER" start-index="7" stop-index="18" />
         </projections>
     </select>
-    <select sql-case-id="select_with_match_against" parameters="hello, 10">
+    <select sql-case-id="select_with_match_against" parameters="10">
         <from>
             <simple-table name="t_order_item" start-index="14" stop-index="25" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="27" stop-index="116" literal-stop-index="121">
-            <and-predicate>
-                <predicate start-index="106" stop-index="116" literal-start-index="110" literal-stop-index="121">
-                    <column-left-value name="user_id" start-index="106" stop-index="112" literal-start-index="110" literal-stop-index="116" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression start-index="120" stop-index="121" value="10" />
-                        <parameter-marker-expression value="1" start-index="116" stop-index="116" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="27" stop-index="122" literal-stop-index="123">
+            <expr>
+                <binary-operation-expression start-index="33" stop-index="122" literal-stop-index="123">
+                    <left>
+                        <common-expression text="MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE)" start-index="33" stop-index="106" />
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="112" stop-index="122" literal-stop-index="123">
+                            <left>
+                                <column name="user_id" start-index="112" stop-index="118" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="10" start-index="122" stop-index="123" />
+                                <parameter-marker-expression value="0" start-index="122" stop-index="122" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1882,21 +2583,23 @@
             <simple-table name="tb_content_json" start-index="82" stop-index="98" alias="b" />
         </from>
         <projections start-index="7" stop-index="75">
-            <expression-projection start-index="7" stop-index="41" alias="nation" />
-            <expression-projection start-index="43" stop-index="75" alias="title" />
+            <expression-projection text="content_json->>'$.nation'" start-index="7" stop-index="41" alias="nation" />
+            <expression-projection text="content_json->>'$.title'" start-index="43" stop-index="75" alias="title" />
         </projections>
-        <where start-index="100" stop-index="119" literal-stop-index="121">
-            <and-predicate>
-                <predicate start-index="106" stop-index="119">
-                    <column-left-value name="content_id" start-index="106" stop-index="117">
-                        <owner stop-index="106" start-index="106" name="b"/>
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression start-index="119" stop-index="119" value="1" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="100" stop-index="119">
+            <expr>
+                <binary-operation-expression start-index="106" stop-index="119">
+                    <left>
+                        <column name="content_id" start-index="106" stop-index="117">
+                            <owner name="b" start-index="106" stop-index="106" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="1" start-index="119" stop-index="119" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 
@@ -1905,18 +2608,21 @@
             <simple-table name="t_order" start-index="70" stop-index="76" />
         </from>
         <projections start-index="7" stop-index="63">
-            <expression-projection alias="signed_content" start-index="7" stop-index="63" />
+            <expression-projection text="CONVERT(SUBSTRING(content, 5) , SIGNED)" alias="signed_content" start-index="7" stop-index="63" />
         </projections>
         <where start-index="78" stop-index="95">
-            <and-predicate>
-                <predicate start-index="84" stop-index="95">
-                    <column-left-value name="order_id" start-index="84" stop-index="91" />
-                    <operator type="=" />
-                    <compare-right-value>
+            <expr>
+                <binary-operation-expression start-index="84" stop-index="95">
+                    <left>
+                        <column name="order_id" start-index="84" stop-index="91" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="95" stop-index="95" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </select>
 </sql-parser-test-cases>
+

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
@@ -665,10 +665,7 @@
                     <left>
                         <binary-operation-expression start-index="53" stop-index="111" literal-stop-index="116">
                             <left>
-                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')"
-                                                   literal-text="o.status LIKE CONCAT('%%', 'init', '%%')"
-                                                   start-index="53" stop-index="87" literal-stop-index="92"/>
-
+                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')" literal-text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="87" literal-stop-index="92"/>
                                 <binary-operation-expression start-index="53" stop-index="87" literal-stop-index="92">
                                     <left>
                                         <column name="status" start-index="53" stop-index="60">
@@ -679,9 +676,7 @@
                                     <right>
                                         <list-expression start-index="67" stop-index="87">
                                             <items>
-                                                <expression-projection text="CONCAT('%%', ?, '%%')"
-                                                                       literal-text="CONCAT('%%', 'init', '%%')"
-                                                                       start-index="67" stop-index="87" literal-stop-index="92" />
+                                                <expression-projection text="CONCAT('%%', ?, '%%')" literal-text="CONCAT('%%', 'init', '%%')" start-index="67" stop-index="87" literal-stop-index="92" />
                                             </items>
                                         </list-expression>
                                     </right>
@@ -749,10 +744,7 @@
                     <left>
                         <binary-operation-expression start-index="53" stop-index="111" literal-stop-index="116">
                             <left>
-                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')"
-                                                   literal-text="o.status LIKE CONCAT('%%', 'init', '%%')"
-                                                   start-index="53" stop-index="87" literal-stop-index="92"/>
-
+                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')" literal-text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="87" literal-stop-index="92"/>
                                 <binary-operation-expression start-index="53" stop-index="87" literal-stop-index="92">
                                     <left>
                                         <column name="status" start-index="53" stop-index="60">
@@ -764,9 +756,7 @@
                                         <list-expression start-index="67" stop-index="87">
                                             <items>
                                                 <!-- 'text' is different from other database -->
-                                                <expression-projection text="CONCAT('%%',?,'%%')"
-                                                                       literal-text="CONCAT('%%','init','%%')"
-                                                                       start-index="67" stop-index="87" literal-stop-index="92" />
+                                                <expression-projection text="CONCAT('%%',?,'%%')" literal-text="CONCAT('%%','init','%%')" start-index="67" stop-index="87" literal-stop-index="92" />
                                             </items>
                                         </list-expression>
                                     </right>
@@ -860,9 +850,7 @@
                     <left>
                         <binary-operation-expression start-index="53" stop-index="109" literal-stop-index="114">
                             <left>
-                                <common-expression text="o.status ~~ CONCAT('%%', ?, '%%')"
-                                                   literal-text="o.status ~~ CONCAT('%%', 'init', '%%')"
-                                                   start-index="53" stop-index="85" literal-stop-index="90"/>
+                                <common-expression text="o.status ~~ CONCAT('%%', ?, '%%')" literal-text="o.status ~~ CONCAT('%%', 'init', '%%')" start-index="53" stop-index="85" literal-stop-index="90"/>
                             </left>
                             <operator>AND</operator>
                             <right>
@@ -1665,9 +1653,7 @@
                                             </left>
                                             <operator>=</operator>
                                             <right>
-                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
-                                                                   literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
-                                                                   start-index="60" stop-index="115" literal-start-index="78" literal-stop-index="137" />
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="60" stop-index="115" literal-start-index="78" literal-stop-index="137" />
                                             </right>
                                         </binary-operation-expression>
                                     </right>
@@ -1748,9 +1734,7 @@
                                             </left>
                                             <operator>=</operator>
                                             <right>
-                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
-                                                                   literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
-                                                                   start-index="73" stop-index="128" literal-start-index="109" literal-stop-index="168" />
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="73" stop-index="128" literal-start-index="109" literal-stop-index="168" />
                                             </right>
                                         </binary-operation-expression>
                                     </right>
@@ -1833,9 +1817,7 @@
                                     </left>
                                     <operator>=</operator>
                                     <right>
-                                        <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
-                                                           literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
-                                                           start-index="79" stop-index="134" literal-start-index="115" literal-stop-index="174" />
+                                        <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')" literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="79" stop-index="134" literal-start-index="115" literal-stop-index="174" />
                                     </right>
                                 </binary-operation-expression>
                             </right>
@@ -2583,9 +2565,7 @@
             <expr>
                 <binary-operation-expression start-index="33" stop-index="116" literal-stop-index="123">
                     <left>
-                        <common-expression text="MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE)"
-                                           literal-text="MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE)"
-                                           start-index="33" stop-index="100" literal-stop-index="106"/>
+                        <common-expression text="MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE)" literal-text="MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE)" start-index="33" stop-index="100" literal-stop-index="106"/>
                     </left>
                     <operator>AND</operator>
                     <right>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/select.xml
@@ -652,20 +652,24 @@
         </where>
     </select>
 
-    <select sql-case-id="select_count_like_concat" parameters="1, 2, 9, 10">
+    <select sql-case-id="select_count_like_concat" parameters="'init', 1, 2, 9, 10">
         <from>
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
             <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
-        <where start-index="47" stop-index="147" literal-stop-index="148">
+        <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
-                <binary-operation-expression start-index="53" stop-index="147" literal-stop-index="148">
+                <binary-operation-expression start-index="53" stop-index="142" literal-stop-index="148">
                     <left>
-                        <binary-operation-expression start-index="53" stop-index="116">
+                        <binary-operation-expression start-index="53" stop-index="111" literal-stop-index="116">
                             <left>
-                                <binary-operation-expression start-index="53" stop-index="92">
+                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')"
+                                                   literal-text="o.status LIKE CONCAT('%%', 'init', '%%')"
+                                                   start-index="53" stop-index="87" literal-stop-index="92"/>
+
+                                <binary-operation-expression start-index="53" stop-index="87" literal-stop-index="92">
                                     <left>
                                         <column name="status" start-index="53" stop-index="60">
                                             <owner name="o" start-index="53" stop-index="53" />
@@ -673,33 +677,34 @@
                                     </left>
                                     <operator>LIKE</operator>
                                     <right>
-                                        <list-expression start-index="67" stop-index="92">
+                                        <list-expression start-index="67" stop-index="87">
                                             <items>
-                                                <expression-projection text="CONCAT('%%', 'init', '%%')" start-index="67" stop-index="92" />
+                                                <expression-projection text="CONCAT('%%', ?, '%%')"
+                                                                       literal-text="CONCAT('%%', 'init', '%%')"
+                                                                       start-index="67" stop-index="87" literal-stop-index="92" />
                                             </items>
                                         </list-expression>
                                     </right>
                                 </binary-operation-expression>
-                                <common-expression text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="92" />
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <in-expression start-index="98" stop-index="116">
+                                <in-expression start-index="93" stop-index="111" literal-start-index="98" literal-stop-index="116">
                                     <not>false</not>
                                     <left>
-                                        <column name="user_id" start-index="98" stop-index="106">
-                                            <owner name="o" start-index="98" stop-index="98" />
+                                        <column name="user_id" start-index="93" stop-index="101" literal-start-index="98" literal-stop-index="106">
+                                            <owner name="o" start-index="93" stop-index="93" literal-start-index="98" literal-stop-index="98"/>
                                         </column>
                                     </left>
                                     <right>
-                                        <list-expression start-index="111" stop-index="116">
+                                        <list-expression start-index="107" stop-index="110" literal-stop-index="115">
                                             <items>
                                                 <literal-expression value="1" start-index="112" stop-index="112" />
-                                                <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+                                                <parameter-marker-expression value="1" start-index="107" stop-index="107" />
                                             </items>
                                             <items>
                                                 <literal-expression value="2" start-index="115" stop-index="115" />
-                                                <parameter-marker-expression value="1" start-index="115" stop-index="115" />
+                                                <parameter-marker-expression value="2" start-index="110" stop-index="110" />
                                             </items>
                                         </list-expression>
                                     </right>
@@ -709,20 +714,20 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <between-expression start-index="122" stop-index="147" literal-stop-index="148">
+                        <between-expression start-index="117" stop-index="142" literal-start-index="122" literal-stop-index="148">
                             <not>false</not>
                             <left>
-                                <column name="order_id" start-index="122" stop-index="131">
-                                    <owner name="o" start-index="122" stop-index="122" />
+                                <column name="order_id" start-index="117" stop-index="126" literal-start-index="122" literal-stop-index="131">
+                                    <owner name="o" start-index="117" stop-index="117" literal-start-index="122" literal-stop-index="122" />
                                 </column>
                             </left>
                             <between-expr>
                                 <literal-expression value="9" start-index="141" stop-index="141" />
-                                <parameter-marker-expression value="2" start-index="141" stop-index="141" />
+                                <parameter-marker-expression value="3" start-index="136" stop-index="136" />
                             </between-expr>
                             <and-expr>
                                 <literal-expression value="10" start-index="147" stop-index="148" />
-                                <parameter-marker-expression value="3" start-index="147" stop-index="147" />
+                                <parameter-marker-expression value="4" start-index="142" stop-index="142" />
                             </and-expr>
                         </between-expression>
                     </right>
@@ -731,20 +736,24 @@
         </where>
     </select>
 
-    <select sql-case-id="select_count_like_concat_for_oracle_and_sqlserver" parameters="1, 2, 9, 10">
+    <select sql-case-id="select_count_like_concat_oracle_sqlserver" parameters="'init', 1, 2, 9, 10">
         <from>
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
             <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
-        <where start-index="47" stop-index="147" literal-stop-index="148">
+        <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
-                <binary-operation-expression start-index="53" stop-index="147" literal-stop-index="148">
+                <binary-operation-expression start-index="53" stop-index="142" literal-stop-index="148">
                     <left>
-                        <binary-operation-expression start-index="53" stop-index="116">
+                        <binary-operation-expression start-index="53" stop-index="111" literal-stop-index="116">
                             <left>
-                                <binary-operation-expression start-index="53" stop-index="92">
+                                <common-expression text="o.status LIKE CONCAT('%%', ?, '%%')"
+                                                   literal-text="o.status LIKE CONCAT('%%', 'init', '%%')"
+                                                   start-index="53" stop-index="87" literal-stop-index="92"/>
+
+                                <binary-operation-expression start-index="53" stop-index="87" literal-stop-index="92">
                                     <left>
                                         <column name="status" start-index="53" stop-index="60">
                                             <owner name="o" start-index="53" stop-index="53" />
@@ -752,33 +761,35 @@
                                     </left>
                                     <operator>LIKE</operator>
                                     <right>
-                                        <list-expression start-index="67" stop-index="92">
+                                        <list-expression start-index="67" stop-index="87">
                                             <items>
-                                                <expression-projection text="CONCAT('%%','init','%%')" start-index="67" stop-index="92" />
+                                                <!-- 'text' is different from other database -->
+                                                <expression-projection text="CONCAT('%%',?,'%%')"
+                                                                       literal-text="CONCAT('%%','init','%%')"
+                                                                       start-index="67" stop-index="87" literal-stop-index="92" />
                                             </items>
                                         </list-expression>
                                     </right>
                                 </binary-operation-expression>
-                                <common-expression text="o.status LIKE CONCAT('%%', 'init', '%%')" start-index="53" stop-index="92" />
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <in-expression start-index="98" stop-index="116">
+                                <in-expression start-index="93" stop-index="111" literal-start-index="98" literal-stop-index="116">
                                     <not>false</not>
                                     <left>
-                                        <column name="user_id" start-index="98" stop-index="106">
-                                            <owner name="o" start-index="98" stop-index="98" />
+                                        <column name="user_id" start-index="93" stop-index="101" literal-start-index="98" literal-stop-index="106">
+                                            <owner name="o" start-index="93" stop-index="93" literal-start-index="98" literal-stop-index="98"/>
                                         </column>
                                     </left>
                                     <right>
-                                        <list-expression start-index="111" stop-index="116">
+                                        <list-expression start-index="107" stop-index="110" literal-stop-index="115">
                                             <items>
                                                 <literal-expression value="1" start-index="112" stop-index="112" />
-                                                <parameter-marker-expression value="0" start-index="112" stop-index="112" />
+                                                <parameter-marker-expression value="1" start-index="107" stop-index="107" />
                                             </items>
                                             <items>
                                                 <literal-expression value="2" start-index="115" stop-index="115" />
-                                                <parameter-marker-expression value="1" start-index="115" stop-index="115" />
+                                                <parameter-marker-expression value="2" start-index="110" stop-index="110" />
                                             </items>
                                         </list-expression>
                                     </right>
@@ -788,20 +799,20 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <between-expression start-index="122" stop-index="147" literal-stop-index="148">
+                        <between-expression start-index="117" stop-index="142" literal-start-index="122" literal-stop-index="148">
                             <not>false</not>
                             <left>
-                                <column name="order_id" start-index="122" stop-index="131">
-                                    <owner name="o" start-index="122" stop-index="122" />
+                                <column name="order_id" start-index="117" stop-index="126" literal-start-index="122" literal-stop-index="131">
+                                    <owner name="o" start-index="117" stop-index="117" literal-start-index="122" literal-stop-index="122" />
                                 </column>
                             </left>
                             <between-expr>
                                 <literal-expression value="9" start-index="141" stop-index="141" />
-                                <parameter-marker-expression value="2" start-index="141" stop-index="141" />
+                                <parameter-marker-expression value="3" start-index="136" stop-index="136" />
                             </between-expr>
                             <and-expr>
                                 <literal-expression value="10" start-index="147" stop-index="148" />
-                                <parameter-marker-expression value="3" start-index="147" stop-index="147" />
+                                <parameter-marker-expression value="4" start-index="142" stop-index="142" />
                             </and-expr>
                         </between-expression>
                     </right>
@@ -836,39 +847,41 @@
         </where>
     </select>
 
-    <select sql-case-id="select_count_tilde_concat" parameters="1, 2, 9, 10">
+    <select sql-case-id="select_count_tilde_concat" parameters="'init', 1, 2, 9, 10">
         <from>
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
             <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
-        <where start-index="47" stop-index="145" literal-stop-index="146">
+        <where start-index="47" stop-index="140" literal-stop-index="146">
             <expr>
-                <binary-operation-expression start-index="53" stop-index="145" literal-stop-index="146">
+                <binary-operation-expression start-index="53" stop-index="140" literal-stop-index="146">
                     <left>
-                        <binary-operation-expression start-index="53" stop-index="114">
+                        <binary-operation-expression start-index="53" stop-index="109" literal-stop-index="114">
                             <left>
-                                <common-expression text="o.status ~~ CONCAT('%%', 'init', '%%')" start-index="53" stop-index="90" />
+                                <common-expression text="o.status ~~ CONCAT('%%', ?, '%%')"
+                                                   literal-text="o.status ~~ CONCAT('%%', 'init', '%%')"
+                                                   start-index="53" stop-index="85" literal-stop-index="90"/>
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <in-expression start-index="96" stop-index="114">
+                                <in-expression start-index="91" stop-index="109" literal-stop-index="114" literal-start-index="96">
                                     <not>false</not>
                                     <left>
-                                        <column name="user_id" start-index="96" stop-index="104">
-                                            <owner name="o" start-index="96" stop-index="96" />
+                                        <column name="user_id" start-index="91" stop-index="99" literal-start-index="96" literal-stop-index="104">
+                                            <owner name="o" start-index="91" stop-index="91" literal-start-index="96" literal-stop-index="96"/>
                                         </column>
                                     </left>
                                     <right>
-                                        <list-expression start-index="110" stop-index="113">
+                                        <list-expression start-index="105" stop-index="108" literal-stop-index="113">
                                             <items>
                                                 <literal-expression value="1" start-index="110" stop-index="110" />
-                                                <parameter-marker-expression value="0" start-index="110" stop-index="110" />
+                                                <parameter-marker-expression value="1" start-index="105" stop-index="105" />
                                             </items>
                                             <items>
                                                 <literal-expression value="2" start-index="113" stop-index="113" />
-                                                <parameter-marker-expression value="1" start-index="113" stop-index="113" />
+                                                <parameter-marker-expression value="2" start-index="108" stop-index="108" />
                                             </items>
                                         </list-expression>
                                     </right>
@@ -878,20 +891,20 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <between-expression start-index="120" stop-index="145" literal-stop-index="146">
+                        <between-expression start-index="115" stop-index="140" literal-start-index="120" literal-stop-index="146">
                             <not>false</not>
                             <left>
-                                <column name="order_id" start-index="120" stop-index="129">
-                                    <owner name="o" start-index="120" stop-index="120" />
+                                <column name="order_id" start-index="115" stop-index="124" literal-start-index="120" literal-stop-index="129">
+                                    <owner name="o" start-index="115" stop-index="115" literal-start-index="120" literal-stop-index="120" />
                                 </column>
                             </left>
                             <between-expr>
                                 <literal-expression value="9" start-index="139" stop-index="139" />
-                                <parameter-marker-expression value="2" start-index="139" stop-index="139" />
+                                <parameter-marker-expression value="3" start-index="134" stop-index="134" />
                             </between-expr>
                             <and-expr>
                                 <literal-expression value="10" start-index="145" stop-index="146" />
-                                <parameter-marker-expression value="3" start-index="145" stop-index="145" />
+                                <parameter-marker-expression value="4" start-index="140" stop-index="140" />
                             </and-expr>
                         </between-expression>
                     </right>
@@ -1618,40 +1631,43 @@
         </where>
     </select>
 
-    <select sql-case-id="select_equal_with_geography" parameters="1, 2">
+    <select sql-case-id="select_equal_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', 100, 200, 1, 2">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="170">
+        <where start-index="22" stop-index="148" literal-stop-index="170">
             <expr>
-                <binary-operation-expression start-index="28" stop-index="170">
+                <binary-operation-expression start-index="28" stop-index="148" literal-stop-index="170">
                     <left>
-                        <binary-operation-expression start-index="28" stop-index="153">
+                        <binary-operation-expression start-index="28" stop-index="131" literal-stop-index="153">
                             <left>
-                                <binary-operation-expression start-index="28" stop-index="137">
+                                <binary-operation-expression start-index="28" stop-index="115" literal-stop-index="137">
                                     <left>
-                                        <binary-operation-expression start-index="28" stop-index="60">
+                                        <binary-operation-expression start-index="28" stop-index="42" literal-stop-index="60">
                                             <left>
                                                 <column name="rule" start-index="28" stop-index="31" />
                                             </left>
                                             <operator>=</operator>
                                             <right>
                                                 <common-expression text="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="35" stop-index="60" />
+                                                <parameter-marker-expression value="0" start-index="35" stop-index="42" />
                                             </right>
                                         </binary-operation-expression>
                                     </left>
                                     <operator>AND</operator>
                                     <right>
-                                        <binary-operation-expression start-index="66" stop-index="137">
+                                        <binary-operation-expression start-index="48" stop-index="115" literal-start-index="66" literal-stop-index="137">
                                             <left>
-                                                <column name="start_point" start-index="66" stop-index="76" />
+                                                <column name="start_point" start-index="48" stop-index="58" literal-start-index="66" literal-stop-index="76" />
                                             </left>
                                             <operator>=</operator>
                                             <right>
-                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="78" stop-index="137" />
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
+                                                                   literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
+                                                                   start-index="60" stop-index="115" literal-start-index="78" literal-stop-index="137" />
                                             </right>
                                         </binary-operation-expression>
                                     </right>
@@ -1659,14 +1675,14 @@
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <binary-operation-expression start-index="143" stop-index="153">
+                                <binary-operation-expression start-index="121" stop-index="131" literal-start-index="143" literal-stop-index="153">
                                     <left>
-                                        <column name="user_id" start-index="143" stop-index="149" />
+                                        <column name="user_id" start-index="121" stop-index="127" literal-start-index="143" literal-stop-index="149" />
                                     </left>
                                     <operator>=</operator>
                                     <right>
                                         <literal-expression value="1" start-index="153" stop-index="153" />
-                                        <parameter-marker-expression value="0" start-index="153" stop-index="153" />
+                                        <parameter-marker-expression value="3" start-index="131" stop-index="131" />
                                     </right>
                                 </binary-operation-expression>
                             </right>
@@ -1674,14 +1690,14 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <binary-operation-expression start-index="159" stop-index="170">
+                        <binary-operation-expression start-index="137" stop-index="148" literal-start-index="159" literal-stop-index="170">
                             <left>
-                                <column name="order_id" start-index="159" stop-index="166" />
+                                <column name="order_id" start-index="137" stop-index="144" literal-start-index="159" literal-stop-index="166" />
                             </left>
                             <operator>=</operator>
                             <right>
                                 <literal-expression value="2" start-index="170" stop-index="170" />
-                                <parameter-marker-expression value="1" start-index="170" stop-index="170" />
+                                <parameter-marker-expression value="4" start-index="148" stop-index="148" />
                             </right>
                         </binary-operation-expression>
                     </right>
@@ -1690,33 +1706,35 @@
         </where>
     </select>
 
-    <select sql-case-id="select_in_with_geography" parameters="1, 2">
+    <select sql-case-id="select_in_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', '{&quot;rule3&quot;:&quot;null3&quot;}', 100, 200, 1, 2">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="201">
+        <where start-index="22" stop-index="161" literal-stop-index="201">
             <expr>
-                <binary-operation-expression start-index="28" stop-index="201">
+                <binary-operation-expression start-index="28" stop-index="161" literal-stop-index="201">
                     <left>
-                        <binary-operation-expression start-index="28" stop-index="184">
+                        <binary-operation-expression start-index="28" stop-index="144" literal-stop-index="184">
                             <left>
-                                <binary-operation-expression start-index="28" stop-index="168">
+                                <binary-operation-expression start-index="28" stop-index="128" literal-stop-index="168">
                                     <left>
-                                        <in-expression start-index="28" stop-index="91">
+                                        <in-expression start-index="28" stop-index="55" literal-stop-index="91">
                                             <not>false</not>
                                             <left>
                                                 <column name="rule" start-index="28" stop-index="31" />
                                             </left>
                                             <right>
-                                                <list-expression start-index="37" stop-index="90">
+                                                <list-expression start-index="37" stop-index="54" literal-stop-index="90">
                                                     <items>
                                                         <common-expression text="'{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb" start-index="37" stop-index="62" />
+                                                        <parameter-marker-expression value="0" start-index="37" stop-index="44" />
                                                     </items>
                                                     <items>
                                                         <common-expression text="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="65" stop-index="90" />
+                                                        <parameter-marker-expression value="1" start-index="47" stop-index="54" />
                                                     </items>
                                                 </list-expression>
                                             </right>
@@ -1724,13 +1742,15 @@
                                     </left>
                                     <operator>AND</operator>
                                     <right>
-                                        <binary-operation-expression start-index="97" stop-index="168">
+                                        <binary-operation-expression start-index="61" stop-index="128" literal-start-index="97" literal-stop-index="168">
                                             <left>
-                                                <column name="start_point" start-index="97" stop-index="107" />
+                                                <column name="start_point" start-index="61" stop-index="71" literal-start-index="97" literal-stop-index="107" />
                                             </left>
                                             <operator>=</operator>
                                             <right>
-                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="109" stop-index="168" />
+                                                <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
+                                                                   literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
+                                                                   start-index="73" stop-index="128" literal-start-index="109" literal-stop-index="168" />
                                             </right>
                                         </binary-operation-expression>
                                     </right>
@@ -1738,14 +1758,14 @@
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <binary-operation-expression start-index="174" stop-index="184">
+                                <binary-operation-expression start-index="134" stop-index="144" literal-start-index="174" literal-stop-index="184">
                                     <left>
-                                        <column name="user_id" start-index="174" stop-index="180" />
+                                        <column name="user_id" start-index="134" stop-index="140" literal-start-index="174" literal-stop-index="180" />
                                     </left>
                                     <operator>=</operator>
                                     <right>
                                         <literal-expression value="1" start-index="184" stop-index="184" />
-                                        <parameter-marker-expression value="0" start-index="184" stop-index="184" />
+                                        <parameter-marker-expression value="4" start-index="144" stop-index="144" />
                                     </right>
                                 </binary-operation-expression>
                             </right>
@@ -1753,14 +1773,14 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <binary-operation-expression start-index="190" stop-index="201">
+                        <binary-operation-expression start-index="150" stop-index="161" literal-start-index="190" literal-stop-index="201">
                             <left>
-                                <column name="order_id" start-index="190" stop-index="197" />
+                                <column name="order_id" start-index="150" stop-index="157" literal-start-index="190" literal-stop-index="197" />
                             </left>
                             <operator>=</operator>
                             <right>
                                 <literal-expression value="2" start-index="201" stop-index="201" />
-                                <parameter-marker-expression value="1" start-index="201" stop-index="201" />
+                                <parameter-marker-expression value="5" start-index="161" stop-index="161" />
                             </right>
                         </binary-operation-expression>
                     </right>
@@ -1769,25 +1789,26 @@
         </where>
     </select>
 
-    <select sql-case-id="select_between_with_geography" parameters="1">
+    <select sql-case-id="select_between_with_geography" parameters="'{&quot;rule2&quot;:&quot;null2&quot;}', '{&quot;rule3&quot;:&quot;null3&quot;}', 100, 200, 1">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="22" stop-index="191">
+        <where start-index="22" stop-index="151" literal-stop-index="191">
             <expr>
-                <binary-operation-expression start-index="28" stop-index="191">
+                <binary-operation-expression start-index="28" stop-index="151" literal-stop-index="191">
                     <left>
-                        <binary-operation-expression start-index="28" stop-index="174">
+                        <binary-operation-expression start-index="28" stop-index="134" literal-stop-index="174">
                             <left>
-                                <between-expression start-index="28" stop-index="97">
+                                <between-expression start-index="28" stop-index="61" literal-stop-index="97">
                                     <not>false</not>
                                     <left>
                                         <column name="rule" start-index="28" stop-index="31" />
                                     </left>
                                     <between-expr>
+                                        <parameter-marker-expression value="0" start-index="41" stop-index="48" />
                                         <binary-operation-expression start-index="41" stop-index="66">
                                             <left>
                                                 <literal-expression value="{&quot;rule2&quot;:&quot;null2&quot;}" start-index="41" stop-index="59" />
@@ -1800,18 +1821,21 @@
                                     </between-expr>
                                     <and-expr>
                                         <common-expression text="'{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb" start-index="72" stop-index="97" />
+                                        <parameter-marker-expression value="1" start-index="54" stop-index="61" />
                                     </and-expr>
                                 </between-expression>
                             </left>
                             <operator>AND</operator>
                             <right>
-                                <binary-operation-expression start-index="103" stop-index="174">
+                                <binary-operation-expression start-index="67" stop-index="134" literal-start-index="103" literal-stop-index="174">
                                     <left>
-                                        <column name="start_point" start-index="103" stop-index="113" />
+                                        <column name="start_point" start-index="67" stop-index="77" literal-start-index="103" literal-stop-index="113" />
                                     </left>
                                     <operator>=</operator>
                                     <right>
-                                        <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')" start-index="115" stop-index="174" />
+                                        <common-expression text="ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')')"
+                                                           literal-text="ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')')"
+                                                           start-index="79" stop-index="134" literal-start-index="115" literal-stop-index="174" />
                                     </right>
                                 </binary-operation-expression>
                             </right>
@@ -1819,14 +1843,14 @@
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <binary-operation-expression start-index="180" stop-index="191">
+                        <binary-operation-expression start-index="140" stop-index="151" literal-start-index="180" literal-stop-index="191">
                             <left>
-                                <column name="order_id" start-index="180" stop-index="187" />
+                                <column name="order_id" start-index="140" stop-index="147" literal-start-index="180" literal-stop-index="187" />
                             </left>
                             <operator>=</operator>
                             <right>
                                 <literal-expression value="1" start-index="191" stop-index="191" />
-                                <parameter-marker-expression value="0" start-index="191" stop-index="191" />
+                                <parameter-marker-expression value="4" start-index="151" stop-index="151" />
                             </right>
                         </binary-operation-expression>
                     </right>
@@ -2547,29 +2571,32 @@
             <expression-projection text="CURRENT_USER" start-index="7" stop-index="18" />
         </projections>
     </select>
-    <select sql-case-id="select_with_match_against" parameters="10">
+
+    <select sql-case-id="select_with_match_against" parameters="'hello', 10">
         <from>
             <simple-table name="t_order_item" start-index="14" stop-index="25" />
         </from>
         <projections start-index="7" stop-index="7">
             <shorthand-projection start-index="7" stop-index="7" />
         </projections>
-        <where start-index="27" stop-index="122" literal-stop-index="123">
+        <where start-index="27" stop-index="116" literal-stop-index="123">
             <expr>
-                <binary-operation-expression start-index="33" stop-index="122" literal-stop-index="123">
+                <binary-operation-expression start-index="33" stop-index="116" literal-stop-index="123">
                     <left>
-                        <common-expression text="MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE)" start-index="33" stop-index="106" />
+                        <common-expression text="MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE)"
+                                           literal-text="MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE)"
+                                           start-index="33" stop-index="100" literal-stop-index="106"/>
                     </left>
                     <operator>AND</operator>
                     <right>
-                        <binary-operation-expression start-index="112" stop-index="122" literal-stop-index="123">
+                        <binary-operation-expression start-index="106" stop-index="116" literal-start-index="112" literal-stop-index="123">
                             <left>
-                                <column name="user_id" start-index="112" stop-index="118" />
+                                <column name="user_id" start-index="106" stop-index="112" literal-start-index="112" literal-stop-index="118"/>
                             </left>
                             <operator>=</operator>
                             <right>
                                 <literal-expression value="10" start-index="122" stop-index="123" />
-                                <parameter-marker-expression value="0" start-index="122" stop-index="122" />
+                                <parameter-marker-expression value="1" start-index="116" stop-index="116" />
                             </right>
                         </binary-operation-expression>
                     </right>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/update.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/update.xml
@@ -531,7 +531,7 @@
                                         <parameter-marker-expression value="1" start-index="58" stop-index="58" />
                                     </right>
                                 </binary-operation-expression>
-                                <common-expression text="order_id - ?" start-index="47" stop-index="58" />
+                                <common-expression text="order_id - ?" literal-text="order_id - 2" start-index="47" stop-index="58" />
                             </right>
                         </binary-operation-expression>
                     </left>
@@ -545,51 +545,6 @@
                             <right>
                                 <literal-expression value="3" start-index="74" stop-index="74" />
                                 <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                            </right>
-                        </binary-operation-expression>
-                    </right>
-                </binary-operation-expression>
-            </expr>
-        </where>
-    </update>
-
-    <update sql-case-id="update_with_where_calculation_for_postgresql" parameters="1, 2">
-        <table start-index="7" stop-index="13">
-            <simple-table name="t_order" start-index="7" stop-index="13"/>
-        </table>
-        <set start-index="15" stop-index="28" literal-stop-index="28">
-            <assignment start-index="19" stop-index="28" literal-stop-index="28">
-                <column name="status" start-index="19" stop-index="24" />
-                <assignment-value>
-                    <parameter-marker-expression value="0" start-index="28" stop-index="28" />
-                    <literal-expression value="1" start-index="28" stop-index="28" />
-                </assignment-value>
-            </assignment>
-        </set>
-        <where start-index="30" stop-index="74">
-            <expr>
-                <binary-operation-expression start-index="36" stop-index="74">
-                    <left>
-                        <binary-operation-expression start-index="36" stop-index="58">
-                            <left>
-                                <column name="order_id" start-index="36" stop-index="43" />
-                            </left>
-                            <operator>=</operator>
-                            <right>
-                                <common-expression text="order_id - 2" start-index="47" stop-index="58" />
-                            </right>
-                        </binary-operation-expression>
-                    </left>
-                    <operator>AND</operator>
-                    <right>
-                        <binary-operation-expression start-index="64" stop-index="74">
-                            <left>
-                                <column name="user_id" start-index="64" stop-index="70" />
-                            </left>
-                            <operator>=</operator>
-                            <right>
-                                <literal-expression value="2" start-index="74" stop-index="74" />
-                                <parameter-marker-expression value="1" start-index="74" stop-index="74" />
                             </right>
                         </binary-operation-expression>
                     </right>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/update.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/dml/update.xml
@@ -18,7 +18,9 @@
 
 <sql-parser-test-cases>
     <update sql-case-id="update_without_alias" parameters="'update', 1, 1">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="28" literal-stop-index="35">
             <assignment start-index="19" stop-index="28" literal-stop-index="35">
                 <column name="status" start-index="19" stop-index="24" />
@@ -28,30 +30,43 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="30" stop-index="63" literal-start-index="43" literal-stop-index="54">
-            <and-predicate>
-                <predicate start-index="36" stop-index="47" literal-start-index="43" literal-stop-index="54">
-                    <column-left-value name="order_id" start-index="36" stop-index="43" literal-start-index="43" literal-stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="47" stop-index="47" />
-                        <literal-expression value="1" start-index="54" stop-index="54" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="53" stop-index="63" literal-start-index="60" literal-stop-index="70">
-                    <column-left-value name="user_id" start-index="53" stop-index="59" literal-start-index="60" literal-stop-index="66" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="63" stop-index="63" />
-                        <literal-expression value="1" start-index="70" stop-index="70" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="30" stop-index="63" literal-start-index="37" literal-stop-index="70">
+            <expr>
+                <binary-operation-expression start-index="36" stop-index="63" literal-start-index="43" literal-stop-index="70">
+                    <left>
+                        <binary-operation-expression start-index="36" stop-index="47" literal-start-index="43" literal-stop-index="54">
+                            <left>
+                                <column name="order_id" start-index="36" stop-index="43" literal-start-index="43" literal-stop-index="50" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="54" stop-index="54" />
+                                <parameter-marker-expression value="1" start-index="47" stop-index="47" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="53" stop-index="63" literal-start-index="60" literal-stop-index="70">
+                            <left>
+                                <column name="user_id" start-index="53" stop-index="59" literal-start-index="60" literal-stop-index="66" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="70" stop-index="70" />
+                                <parameter-marker-expression value="2" start-index="63" stop-index="63" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_alias" parameters="'update', 1, 1">
-        <table name="t_order" alias="o" start-index="7" stop-index="18" />
+        <table start-index="7" stop-index="18" >
+            <simple-table name="t_order" alias="o" start-index="7" stop-index="18" />
+        </table>
         <set start-index="20" stop-index="35" literal-stop-index="42">
             <assignment start-index="24" stop-index="35" literal-stop-index="42">
                 <column name="status" start-index="24" stop-index="31">
@@ -64,33 +79,46 @@
             </assignment>
         </set>
         <where start-index="37" stop-index="74" literal-start-index="44" literal-stop-index="81">
-            <and-predicate>
-                <predicate start-index="43" stop-index="56" literal-start-index="50" literal-stop-index="63">
-                    <column-left-value name="order_id" start-index="43" stop-index="52" literal-start-index="50" literal-stop-index="59">
-                        <owner name="o" start-index="43" stop-index="43" literal-start-index="50" literal-stop-index="50" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="56" stop-index="56" />
-                        <literal-expression value="1" start-index="63" stop-index="63" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="62" stop-index="74" literal-start-index="69" literal-stop-index="81">
-                    <column-left-value name="user_id" start-index="62" stop-index="70" literal-start-index="69" literal-stop-index="77">
-                        <owner name="o" start-index="62" stop-index="62" literal-start-index="69" literal-stop-index="69" />
-                    </column-left-value>
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="1" start-index="81" stop-index="81" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="43" stop-index="74" literal-start-index="50" literal-stop-index="81">
+                    <left>
+                        <binary-operation-expression start-index="43" stop-index="56" literal-start-index="50" literal-stop-index="63">
+                            <left>
+                                <column name="order_id" start-index="43" stop-index="52" literal-start-index="50" literal-stop-index="59">
+                                    <owner name="o" start-index="43" stop-index="43" literal-start-index="50" literal-stop-index="50" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="63" stop-index="63" />
+                                <parameter-marker-expression value="1" start-index="56" stop-index="56" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="62" stop-index="74" literal-start-index="69" literal-stop-index="81">
+                            <left>
+                                <column name="user_id" start-index="62" stop-index="70" literal-start-index="69" literal-stop-index="77">
+                                    <owner name="o" start-index="62" stop-index="62" literal-start-index="69" literal-stop-index="69" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="81" stop-index="81" />
+                                <parameter-marker-expression value="2" start-index="74" stop-index="74" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_equal_with_geography" parameters="'2017-06-07', 100, 200, '{&quot;rule2&quot;:&quot;null2&quot;}', 3, 5, 7, 200">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="168" literal-stop-index="201">
             <assignment start-index="19" stop-index="32" literal-stop-index="43">
                 <column name="start_time" start-index="19" stop-index="28" />
@@ -134,29 +162,42 @@
             </assignment>
         </set>
         <where start-index="170" stop-index="203" literal-start-index="203" literal-stop-index="238">
-            <and-predicate>
-                <predicate start-index="176" stop-index="186" literal-start-index="209" literal-stop-index="219">
-                    <column-left-value name="user_id" start-index="176" stop-index="182" literal-start-index="209" literal-stop-index="215" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="6" start-index="186" stop-index="186" />
-                        <literal-expression value="7" start-index="219" stop-index="219" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="192" stop-index="203" literal-start-index="225" literal-stop-index="238">
-                    <column-left-value name="order_id" start-index="192" stop-index="199" literal-start-index="225" literal-stop-index="232" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="7" start-index="203" stop-index="203" />
-                        <literal-expression value="200" start-index="236" stop-index="238" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="176" stop-index="203" literal-start-index="209" literal-stop-index="238">
+                    <left>
+                        <binary-operation-expression start-index="176" stop-index="186" literal-start-index="209" literal-stop-index="219">
+                            <left>
+                                <column name="user_id" start-index="176" stop-index="182" literal-start-index="209" literal-stop-index="215" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="7" start-index="219" stop-index="219" />
+                                <parameter-marker-expression value="6" start-index="186" stop-index="186" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="192" stop-index="203" literal-start-index="225" literal-stop-index="238">
+                            <left>
+                                <column name="order_id" start-index="192" stop-index="199" literal-start-index="225" literal-stop-index="232" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="200" start-index="236" stop-index="238" />
+                                <parameter-marker-expression value="7" start-index="203" stop-index="203" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_without_condition">
-        <table name="t_order" alias="o" start-index="7" stop-index="15" />
+        <table start-index="7" stop-index="15">
+            <simple-table name="t_order" alias="o" start-index="7" stop-index="15"/>
+        </table>
         <set start-index="17" stop-index="41">
             <assignment start-index="21" stop-index="41">
                 <column name="status" start-index="21" stop-index="28">
@@ -170,7 +211,9 @@
     </update>
 
     <update sql-case-id="update_with_extra_keywords" parameters="'update', 1, 1">
-        <table name="t_order" start-index="27" stop-index="33" />
+        <table start-index="27" stop-index="33">
+            <simple-table name="t_order" start-index="27" stop-index="33"/>
+        </table>
         <set start-index="35" stop-index="48" literal-stop-index="55">
             <assignment start-index="39" stop-index="48" literal-start-index="39" literal-stop-index="55">
                 <column name="status" start-index="39" stop-index="44" />
@@ -181,29 +224,42 @@
             </assignment>
         </set>
         <where start-index="50" stop-index="83" literal-start-index="57" literal-stop-index="90">
-            <and-predicate>
-                <predicate start-index="56" stop-index="67" literal-start-index="63" literal-stop-index="74">
-                    <column-left-value name="order_id" start-index="56" stop-index="63" literal-start-index="63" literal-stop-index="70" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="67" stop-index="67" />
-                        <literal-expression value="1" start-index="74" stop-index="74" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="73" stop-index="83" literal-start-index="80" literal-stop-index="90">
-                    <column-left-value name="user_id" start-index="73" stop-index="79" literal-start-index="80" literal-stop-index="86" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="83" stop-index="83" />
-                        <literal-expression value="1" start-index="90" stop-index="90" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="56" stop-index="83" literal-start-index="63" literal-stop-index="90">
+                    <left>
+                        <binary-operation-expression start-index="56" stop-index="67" literal-start-index="63" literal-stop-index="74">
+                            <left>
+                                <column name="order_id" start-index="56" stop-index="63" literal-start-index="63" literal-stop-index="70" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="74" stop-index="74" />
+                                <parameter-marker-expression value="1" start-index="67" stop-index="67" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="73" stop-index="83" literal-start-index="80" literal-stop-index="90">
+                            <left>
+                                <column name="user_id" start-index="73" stop-index="79" literal-start-index="80" literal-stop-index="86" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="90" stop-index="90" />
+                                <parameter-marker-expression value="2" start-index="83" stop-index="83" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_special_character" parameters="'update', 1, 1">
-        <table name="t_order" start-delimiter="`" end-delimiter="`" start-index="7" stop-index="15" />
+        <table start-index="7" stop-index="15">
+            <simple-table name="t_order" start-delimiter="`" end-delimiter="`"  start-index="7" stop-index="15"/>
+        </table>
         <set start-index="17" stop-index="32" literal-stop-index="39">
             <assignment start-index="21" stop-index="32" literal-stop-index="39">
                 <column name="status" start-delimiter="`" end-delimiter="`" start-index="21" stop-index="28" />
@@ -214,29 +270,42 @@
             </assignment>
         </set>
         <where start-index="34" stop-index="69" literal-start-index="41" literal-stop-index="76">
-            <and-predicate>
-                <predicate start-index="40" stop-index="53" literal-start-index="47" literal-stop-index="60">
-                    <column-left-value name="order_id" start-delimiter="`" end-delimiter="`" start-index="40" stop-index="49" literal-start-index="47" literal-stop-index="56" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="53" stop-index="53" />
-                        <literal-expression value="1" start-index="60" stop-index="60" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="59" stop-index="69" literal-start-index="66" literal-stop-index="76">
-                    <column-left-value name="user_id" start-index="59" stop-index="65" literal-start-index="66" literal-stop-index="72" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="69" stop-index="69" />
-                        <literal-expression value="1" start-index="76" stop-index="76" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="40" stop-index="69" literal-start-index="47" literal-stop-index="76">
+                    <left>
+                        <binary-operation-expression start-index="40" stop-index="53" literal-start-index="47" literal-stop-index="60">
+                            <left>
+                                <column name="order_id" start-delimiter="`" end-delimiter="`" start-index="40" stop-index="49" literal-start-index="47" literal-stop-index="56" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="60" stop-index="60" />
+                                <parameter-marker-expression value="1" start-index="53" stop-index="53" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="59" stop-index="69" literal-start-index="66" literal-stop-index="76">
+                            <left>
+                                <column name="user_id" start-index="59" stop-index="65" literal-start-index="66" literal-stop-index="72" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="76" stop-index="76" />
+                                <parameter-marker-expression value="2" start-index="69" stop-index="69" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_special_comments" parameters="'update', 1, 1">
-        <table name="t_order" start-index="33" stop-index="39" />
+        <table start-index="33" stop-index="39">
+            <simple-table name="t_order" start-index="33" stop-index="39"/>
+        </table>
         <set start-index="41" stop-index="52" literal-stop-index="59">
             <assignment start-index="45" stop-index="52" literal-stop-index="59">
                 <column name="status" start-index="45" stop-index="50" />
@@ -247,29 +316,42 @@
             </assignment>
         </set>
         <where start-index="54" stop-index="87" literal-start-index="61" literal-stop-index="94">
-            <and-predicate>
-                <predicate start-index="60" stop-index="71" literal-start-index="67" literal-stop-index="78">
-                    <column-left-value name="order_id" start-index="60" stop-index="67" literal-start-index="67" literal-stop-index="74" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="71" stop-index="71" />
-                        <literal-expression value="1" start-index="78" stop-index="78" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="77" stop-index="87" literal-start-index="84" literal-stop-index="94">
-                    <column-left-value name="user_id" start-index="77" stop-index="83" literal-start-index="84" literal-stop-index="90" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="87" stop-index="87" />
-                        <literal-expression value="1" start-index="94" stop-index="94" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="60" stop-index="87" literal-start-index="67" literal-stop-index="94">
+                    <left>
+                        <binary-operation-expression start-index="60" stop-index="71" literal-start-index="67" literal-stop-index="78">
+                            <left>
+                                <column name="order_id" start-index="60" stop-index="67" literal-start-index="67" literal-stop-index="74" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="78" stop-index="78" />
+                                <parameter-marker-expression value="1" start-index="71" stop-index="71" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="77" stop-index="87" literal-start-index="84" literal-stop-index="94">
+                            <left>
+                                <column name="user_id" start-index="77" stop-index="83" literal-start-index="84" literal-stop-index="90" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="94" stop-index="94" />
+                                <parameter-marker-expression value="2" start-index="87" stop-index="87" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_without_parameters">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="35">
             <assignment start-index="19" stop-index="35">
                 <column name="status" start-index="19" stop-index="24" />
@@ -279,27 +361,40 @@
             </assignment>
         </set>
         <where start-index="37" stop-index="74">
-            <and-predicate>
-                <predicate start-index="43" stop-index="57">
-                    <column-left-value name="order_id" start-index="43" stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression value="1000" start-index="54" stop-index="57" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="63" stop-index="74">
-                    <column-left-value name="user_id" start-index="63" stop-index="69" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <literal-expression value="10" start-index="73" stop-index="74" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="43" stop-index="74">
+                    <left>
+                        <binary-operation-expression start-index="43" stop-index="57">
+                            <left>
+                                <column name="order_id" start-index="43" stop-index="50" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1000" start-index="54" stop-index="57" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="63" stop-index="74">
+                            <left>
+                                <column name="user_id" start-index="63" stop-index="69" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="10" start-index="73" stop-index="74" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_or" parameters="1000, 0, 10">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="35">
             <assignment start-index="19" stop-index="35">
                 <column name="status" start-index="19" stop-index="24" />
@@ -309,47 +404,59 @@
             </assignment>
         </set>
         <where start-index="37" stop-index="88" literal-stop-index="92">
-            <and-predicate>
-                <predicate start-index="44" stop-index="55" literal-stop-index="58">
-                    <column-left-value name="order_id" start-index="44" stop-index="51" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="55" stop-index="55" />
-                        <literal-expression value="1000" start-index="55" stop-index="58" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="78" stop-index="88" literal-start-index="81" literal-stop-index="92">
-                    <column-left-value name="user_id" start-index="78" stop-index="84" literal-start-index="81" literal-stop-index="87" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="88" stop-index="88" />
-                        <literal-expression value="10" start-index="91" stop-index="92" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
-            <and-predicate>
-                <predicate start-index="60" stop-index="71" literal-start-index="63" literal-stop-index="74">
-                    <column-left-value name="order_id" start-index="60" stop-index="67" literal-start-index="63" literal-stop-index="70" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="71" stop-index="71" />
-                        <literal-expression value="0" start-index="74" stop-index="74" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="78" stop-index="88" literal-start-index="81" literal-stop-index="92">
-                    <column-left-value name="user_id" start-index="78" stop-index="84" literal-start-index="81" literal-stop-index="87" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="88" stop-index="88" />
-                        <literal-expression value="10" start-index="91" stop-index="92" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="43" stop-index="88" literal-stop-index="92">
+                    <left>
+                        <binary-operation-expression start-index="44" stop-index="71" literal-stop-index="74">
+                            <left>
+                                <binary-operation-expression start-index="44" stop-index="55" literal-stop-index="58">
+                                    <left>
+                                        <column name="order_id" start-index="44" stop-index="51" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="1000" start-index="55" stop-index="58" />
+                                        <parameter-marker-expression value="0" start-index="55" stop-index="55" />
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>OR</operator>
+                            <right>
+                                <binary-operation-expression start-index="60" stop-index="71" literal-start-index="63" literal-stop-index="74">
+                                    <left>
+                                        <column name="order_id" start-index="60" stop-index="67" literal-start-index="63" literal-stop-index="70" />
+                                    </left>
+                                    <operator>=</operator>
+                                    <right>
+                                        <literal-expression value="0" start-index="74" stop-index="74" />
+                                        <parameter-marker-expression value="1" start-index="71" stop-index="71" />
+                                    </right>
+                                </binary-operation-expression>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="78" stop-index="88" literal-start-index="81" literal-stop-index="92">
+                            <left>
+                                <column name="user_id" start-index="78" stop-index="84" literal-start-index="81" literal-stop-index="87" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="10" start-index="91" stop-index="92" />
+                                <parameter-marker-expression value="2" start-index="88" stop-index="88" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_set_calculation" parameters="1, 2, 3">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="37" literal-stop-index="37">
             <assignment start-index="19" stop-index="37" literal-stop-index="37">
                 <column name="status" start-index="19" stop-index="24" />
@@ -358,30 +465,43 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="39" stop-index="72" literal-start-index="39" literal-stop-index="72">
-            <and-predicate>
-                <predicate start-index="45" stop-index="56" literal-start-index="45" literal-stop-index="56">
-                    <column-left-value name="order_id" start-index="45" stop-index="52" literal-start-index="45" literal-stop-index="52" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="56" stop-index="56" />
-                        <literal-expression value="2" start-index="56" stop-index="56" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="62" stop-index="72" literal-start-index="62" literal-stop-index="72">
-                    <column-left-value name="user_id" start-index="62" stop-index="68" literal-start-index="62" literal-stop-index="68" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="72" stop-index="72" />
-                        <literal-expression value="3" start-index="72" stop-index="72" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="39" stop-index="72">
+            <expr>
+                <binary-operation-expression start-index="45" stop-index="72">
+                    <left>
+                        <binary-operation-expression start-index="45" stop-index="56">
+                            <left>
+                                <column name="order_id" start-index="45" stop-index="52" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="56" stop-index="56" />
+                                <parameter-marker-expression value="1" start-index="56" stop-index="56" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="62" stop-index="72">
+                            <left>
+                                <column name="user_id" start-index="62" stop-index="68" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="3" start-index="72" stop-index="72" />
+                                <parameter-marker-expression value="2" start-index="72" stop-index="72" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_where_calculation" parameters="1, 2, 3">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="28" literal-stop-index="28">
             <assignment start-index="19" stop-index="28" literal-stop-index="28">
                 <column name="status" start-index="19" stop-index="24" />
@@ -391,29 +511,97 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="30" stop-index="74" literal-start-index="30" literal-stop-index="74">
-            <and-predicate>
-                <predicate start-index="36" stop-index="58" literal-start-index="36" literal-stop-index="58">
-                    <column-left-value name="order_id" start-index="36" stop-index="43" literal-start-index="36" literal-stop-index="43" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <common-expression text="order_id - ?" literal-text="order_id - 2" start-index="47" stop-index="58" literal-start-index="47" literal-stop-index="58"/>
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="64" stop-index="74" literal-start-index="64" literal-stop-index="74">
-                    <column-left-value name="user_id" start-index="64" stop-index="70" literal-start-index="64" literal-stop-index="70" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="74" stop-index="74" />
-                        <literal-expression value="3" start-index="74" stop-index="74" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="30" stop-index="74">
+            <expr>
+                <binary-operation-expression start-index="36" stop-index="74">
+                    <left>
+                        <binary-operation-expression start-index="36" stop-index="58">
+                            <left>
+                                <column name="order_id" start-index="36" stop-index="43" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <binary-operation-expression start-index="47" stop-index="58">
+                                    <left>
+                                        <column name="order_id" start-index="47" stop-index="54" />
+                                    </left>
+                                    <operator>-</operator>
+                                    <right>
+                                        <literal-expression value="2" start-index="58" stop-index="58" />
+                                        <parameter-marker-expression value="1" start-index="58" stop-index="58" />
+                                    </right>
+                                </binary-operation-expression>
+                                <common-expression text="order_id - ?" start-index="47" stop-index="58" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="64" stop-index="74">
+                            <left>
+                                <column name="user_id" start-index="64" stop-index="70" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="3" start-index="74" stop-index="74" />
+                                <parameter-marker-expression value="2" start-index="74" stop-index="74" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </update>
+
+    <update sql-case-id="update_with_where_calculation_for_postgresql" parameters="1, 2">
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
+        <set start-index="15" stop-index="28" literal-stop-index="28">
+            <assignment start-index="19" stop-index="28" literal-stop-index="28">
+                <column name="status" start-index="19" stop-index="24" />
+                <assignment-value>
+                    <parameter-marker-expression value="0" start-index="28" stop-index="28" />
+                    <literal-expression value="1" start-index="28" stop-index="28" />
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="30" stop-index="74">
+            <expr>
+                <binary-operation-expression start-index="36" stop-index="74">
+                    <left>
+                        <binary-operation-expression start-index="36" stop-index="58">
+                            <left>
+                                <column name="order_id" start-index="36" stop-index="43" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <common-expression text="order_id - 2" start-index="47" stop-index="58" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="64" stop-index="74">
+                            <left>
+                                <column name="user_id" start-index="64" stop-index="70" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="2" start-index="74" stop-index="74" />
+                                <parameter-marker-expression value="1" start-index="74" stop-index="74" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_column_equal_column" parameters="1">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="54" literal-stop-index="54">
             <assignment start-index="19" stop-index="37" literal-stop-index="37">
                 <column name="order_id" start-index="19" stop-index="26" />
@@ -429,27 +617,42 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="56" stop-index="97" literal-start-index="56" literal-stop-index="97">
-            <and-predicate>
-                <predicate start-index="62" stop-index="80" literal-start-index="62" literal-stop-index="80">
-                    <column-left-value name="order_id" start-index="62" stop-index="69" literal-start-index="62" literal-stop-index="69" />
-                    <operator type="=" />
-                    <column-right-value start-index="73" stop-index="80" name="order_id" />
-                </predicate>
-                <predicate start-index="86" stop-index="97" literal-start-index="86" literal-stop-index="97">
-                    <column-left-value name="order_id" start-index="86" stop-index="93" literal-start-index="86" literal-stop-index="93" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="0" start-index="97" stop-index="97" />
-                        <literal-expression value="1" start-index="97" stop-index="97" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="56" stop-index="97">
+            <expr>
+                <binary-operation-expression start-index="62" stop-index="97">
+                    <left>
+                        <binary-operation-expression start-index="62" stop-index="80">
+                            <left>
+                                <column name="order_id" start-index="62" stop-index="69" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="73" stop-index="80" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="86" stop-index="97">
+                            <left>
+                                <column name="order_id" start-index="86" stop-index="93" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="97" stop-index="97" />
+                                <parameter-marker-expression value="0" start-index="97" stop-index="97" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_case_when" parameters="3, 2, 4, 2, 10, 2, 3, 'll', 4, 'll', 10, 'll', 3, '2020-08-10T17:15:25.979+0800', 'jd'">
-        <table name="stock_freeze_detail" start-index="7" stop-index="25" />
+        <table start-index="7" stop-index="25">
+            <simple-table name="stock_freeze_detail" start-index="7" stop-index="25"/>
+        </table>
         <set start-index="27" stop-index="230" literal-stop-index="270" literal-start-index="27" >
             <assignment start-index="31" stop-index="106" literal-start-index="31" literal-stop-index="107">
                 <column name="row_status" start-index="31" stop-index="40" />
@@ -471,21 +674,25 @@
             </assignment>
         </set>
         <where start-index="232" stop-index="251" literal-start-index="272" literal-stop-index="294">
-            <and-predicate>
-                <predicate start-index="239" stop-index="251" literal-start-index="279" literal-stop-index="294">
-                    <column-left-value name="tenant_id" start-index="239" stop-index="247" literal-start-index="279" literal-stop-index="287" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="14" start-index="251" stop-index="251"/>
-                        <literal-expression value="jd" literal-start-index="291" literal-stop-index="294"/>
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+            <expr>
+                <binary-operation-expression start-index="239" stop-index="251" literal-start-index="279" literal-stop-index="294">
+                    <left>
+                        <column name="tenant_id" start-index="239" stop-index="247"  literal-start-index="279"  literal-stop-index="287"/>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="jd" start-index="291" stop-index="294" />
+                        <parameter-marker-expression value="14" start-index="251" stop-index="251" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 
     <update sql-case-id="update_with_order_by_row_count" parameters="'update', 1, 1, 10">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="28" literal-stop-index="35">
             <assignment start-index="19" stop-index="28" literal-stop-index="35">
                 <column name="status" start-index="19" stop-index="24" />
@@ -495,25 +702,36 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="30" stop-index="63" literal-start-index="43" literal-stop-index="54">
-            <and-predicate>
-                <predicate start-index="36" stop-index="47" literal-start-index="43" literal-stop-index="54">
-                    <column-left-value name="order_id" start-index="36" stop-index="43" literal-start-index="43" literal-stop-index="50" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="47" stop-index="47" />
-                        <literal-expression value="1" start-index="54" stop-index="54" />
-                    </compare-right-value>
-                </predicate>
-                <predicate start-index="53" stop-index="63" literal-start-index="60" literal-stop-index="70">
-                    <column-left-value name="user_id" start-index="53" stop-index="59" literal-start-index="60" literal-stop-index="66" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="2" start-index="63" stop-index="63" />
-                        <literal-expression value="1" start-index="70" stop-index="70" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+        <where start-index="30" stop-index="63" literal-start-index="37" literal-stop-index="70">
+            <expr>
+                <binary-operation-expression start-index="36" stop-index="63" literal-start-index="43" literal-stop-index="70">
+                    <left>
+                        <binary-operation-expression start-index="36" stop-index="47" literal-start-index="43" literal-stop-index="54">
+                            <left>
+                                <column name="order_id" start-index="36" stop-index="43" literal-start-index="43" literal-stop-index="50" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="54" stop-index="54" />
+                                <parameter-marker-expression value="1" start-index="47" stop-index="47" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="53" stop-index="63" literal-start-index="60" literal-stop-index="70">
+                            <left>
+                                <column name="user_id" start-index="53" stop-index="59" literal-start-index="60" literal-stop-index="66" />
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="70" stop-index="70" />
+                                <parameter-marker-expression value="2" start-index="63" stop-index="63" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
         <order-by>
             <column-item name="order_id" start-index="74" stop-index="81" literal-start-index="81" literal-stop-index="88"/>
@@ -524,7 +742,9 @@
     </update>
 
     <update sql-case-id="update_with_number" parameters="1, 1">
-        <table name="t_order" start-index="7" stop-index="13" />
+        <table start-index="7" stop-index="13">
+            <simple-table name="t_order" start-index="7" stop-index="13"/>
+        </table>
         <set start-index="15" stop-index="30" literal-stop-index="30">
             <assignment start-index="19" stop-index="30" literal-stop-index="30">
                 <column name="order_id" start-index="19" stop-index="26" />
@@ -534,17 +754,19 @@
                 </assignment-value>
             </assignment>
         </set>
-        <where start-index="32" stop-index="48" literal-start-index="43" literal-stop-index="43">
-            <and-predicate>
-                <predicate start-index="38" stop-index="48" literal-start-index="60" literal-stop-index="60">
-                    <column-left-value name="user_id" start-index="38" stop-index="44" literal-start-index="38" literal-stop-index="44" />
-                    <operator type="=" />
-                    <compare-right-value>
-                        <parameter-marker-expression value="1" start-index="48" stop-index="48" />
+        <where start-index="32" stop-index="48">
+            <expr>
+                <binary-operation-expression start-index="38" stop-index="48">
+                    <left>
+                        <column name="user_id" start-index="38" stop-index="44" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
                         <literal-expression value="1" start-index="48" stop-index="48" />
-                    </compare-right-value>
-                </predicate>
-            </and-predicate>
+                        <parameter-marker-expression value="1" start-index="48" stop-index="48" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
         </where>
     </update>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
@@ -17,9 +17,61 @@
   -->
 
 <sql-cases>
-    <sql-case id="select_with_expression" value="SELECT o.order_id + 1 * 2 as exp FROM t_order AS o ORDER BY o.order_id" />
+    <sql-case id="select_with_expression" value="SELECT o.order_id + 1 * 2 as exp FROM t_order AS o ORDER BY o.order_id" db-types="MySQL, H2, Oracle, SQL92, SQLServer"/>
+    <sql-case id="select_with_expression_for_postgresql" value="SELECT o.order_id + 1 * 2 as exp FROM t_order AS o ORDER BY o.order_id" db-types="PostgresQL" />
     <sql-case id="select_with_date_function" value="SELECT DATE(i.creation_date) AS creation_date FROM `t_order_item` AS i ORDER BY DATE(i.creation_date) DESC" db-types="MySQL" />
     <sql-case id="select_with_regexp" value="SELECT * FROM t_order_item t WHERE t.status REGEXP ? AND t.item_id IN (?, ?)" db-types="MySQL" />
     <sql-case id="select_with_case_expression" value="select t.*,o.item_id as item_id,(case when t.status = 'init' then '已启用' when t.status = 'failed' then '已停用' end) as stateName
     from t_order t left join t_order_item as o on o.order_id =t.order_id where t.order_id=1000 limit 1" db-types="MySQL,H2" />
+    <sql-case id="select_where_with_expr_with_or" value="SELECT * FROM t_order WHERE t_order.order_id = ? OR ? = t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_xor" value="SELECT * FROM t_order WHERE t_order.order_id = ? XOR ? = t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_and" value="SELECT * FROM t_order WHERE t_order.order_id = ? AND ? = t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_and_sign" value="SELECT * FROM t_order WHERE t_order.order_id = ? &amp;&amp; ? = t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_not" value="SELECT * FROM t_order WHERE NOT (? = t_order.order_id)" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_not_sign" value="SELECT * FROM t_order WHERE ! ( ? = t_order.order_id)" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_is" value="SELECT * FROM t_order WHERE ? = t_order.order_id IS FALSE" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_is_not" value="SELECT * FROM t_order WHERE ? = t_order.order_id IS NOT FALSE" db-types="MySQL"/>
+    <sql-case id="select_where_with_boolean_primary_with_is" value="SELECT * FROM t_order WHERE t_order.status IS NULL" db-types="MySQL"/>
+    <sql-case id="select_where_with_boolean_primary_with_is_not" value="SELECT * FROM t_order WHERE t_order.status IS NOT NULL" db-types="MySQL"/>
+    <sql-case id="select_where_with_boolean_primary_with_null_safe" value="SELECT * FROM t_order WHERE t_order.status &lt;=&gt; t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_boolean_primary_with_comparison_predicate" value="SELECT * FROM t_order WHERE t_order.status &gt;= t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_boolean_primary_with_comparison_subquery" value="SELECT * FROM t_order WHERE t_order.status &gt; ALL (SELECt status FROM t_order_item WHERE status &gt; ?)" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_in_subquery" value="SELECT * FROM t_order WHERE t_order.order_id NOT IN (SELECT order_id FROM t_order_item WHERE status &gt; ?)" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_in_expr" value="SELECT * FROM t_order WHERE t_order.order_id IN (?, ?, ?)" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_between" value="SELECT * FROM t_order WHERE t_order.order_id BETWEEN ? AND ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_sounds_like" value="SELECT * FROM t_order WHERE t_order.order_id SOUNDS LIKE '1%'" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_like" value="SELECT * FROM t_order WHERE t_order.order_id NOT LIKE '1%' ESCAPE '$'" db-types="MySQL"/>
+    <sql-case id="select_where_with_predicate_with_regexp" value="SELECT * FROM t_order WHERE t_order.order_id NOT REGEXP '[123]'" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_vertical_bar" value="SELECT * FROM t_order WHERE t_order.order_id | ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_ampersand" value="SELECT * FROM t_order WHERE t_order.order_id &amp; ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_signed_left_shift" value="SELECT * FROM t_order WHERE t_order.order_id &lt;&lt; ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_signed_right_shift" value="SELECT * FROM t_order WHERE t_order.order_id &gt;&gt; ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_plus" value="SELECT * FROM t_order WHERE t_order.order_id + ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_minus" value="SELECT * FROM t_order WHERE t_order.order_id - ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_asterisk" value="SELECT * FROM t_order WHERE t_order.order_id * ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_slash" value="SELECT * FROM t_order WHERE t_order.order_id / ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_div" value="SELECT * FROM t_order WHERE t_order.order_id DIV ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_mod" value="SELECT * FROM t_order WHERE t_order.order_id MOD ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_mod_sign" value="SELECT * FROM t_order WHERE t_order.order_id % ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_caret" value="SELECT * FROM t_order WHERE t_order.order_id ^ ?" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_plus_interval" value="SELECT * FROM t_order WHERE t_order.order_id + INTERVAL 1 SECOND" db-types="MySQL"/>
+    <sql-case id="select_where_with_bit_expr_with_minus_interval" value="SELECT * FROM t_order WHERE t_order.order_id - INTERVAL 1 SECOND" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_literals" value="SELECT * FROM t_order WHERE ? &lt; order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_column" value="SELECT * FROM t_order WHERE t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_function_call" value="SELECT * FROM t_order WHERE now() &lt; order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_collate" value="SELECT * FROM t_order WHERE order_id collate 'utf8mb4_0900_ai_ci'" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_variable" value="SELECT * FROM t_order WHERE @@max_connections &lt; order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_plus" value="SELECT * FROM t_order WHERE ? + t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_minus" value="SELECT * FROM t_order WHERE ? - t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_tilde" value="SELECT * FROM t_order WHERE ~t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_not" value="SELECT * FROM t_order WHERE !t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_binary" value="SELECT * FROM t_order WHERE BINARY t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_row" value="SELECT * FROM t_order WHERE ROW('abc', now()) = (order_id, status)" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_subquery" value="SELECT * FROM t_order WHERE (SELECT order_id FROM t_order_item WHERE status &gt; ?)" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_exists_subquery" value="SELECT * FROM t_order WHERE EXISTS (SELECT order_id FROM t_order_item WHERE status &gt; ? )" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_odbc_escape_syntax" value="SELECT * FROM t_order WHERE {ts '1994-02-04 12:23:00'}" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_json_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&quot;$[1]&quot;" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_json_unquote_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&gt; &quot;$[1]&quot;" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_match" value="SELECT * FROM t_order WHERE MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_case" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; 2 THEN 'true' ELSE 'false' END" db-types="MySQL"/>
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
@@ -24,6 +24,7 @@
     <sql-case id="select_with_case_expression" value="select t.*,o.item_id as item_id,(case when t.status = 'init' then '已启用' when t.status = 'failed' then '已停用' end) as stateName
     from t_order t left join t_order_item as o on o.order_id =t.order_id where t.order_id=1000 limit 1" db-types="MySQL,H2" />
     <sql-case id="select_where_with_expr_with_or" value="SELECT * FROM t_order WHERE t_order.order_id = ? OR ? = t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_expr_with_or_sign" value="SELECT * FROM t_order WHERE t_order.order_id = ? || ? = t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_expr_with_xor" value="SELECT * FROM t_order WHERE t_order.order_id = ? XOR ? = t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_expr_with_and" value="SELECT * FROM t_order WHERE t_order.order_id = ? AND ? = t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_expr_with_and_sign" value="SELECT * FROM t_order WHERE t_order.order_id = ? &amp;&amp; ? = t_order.order_id" db-types="MySQL"/>
@@ -66,12 +67,12 @@
     <sql-case id="select_where_with_simple_expr_with_tilde" value="SELECT * FROM t_order WHERE ~t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_not" value="SELECT * FROM t_order WHERE !t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_binary" value="SELECT * FROM t_order WHERE BINARY t_order.order_id" db-types="MySQL"/>
-    <sql-case id="select_where_with_simple_expr_with_row" value="SELECT * FROM t_order WHERE ROW('abc', now()) = (order_id, status)" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_row" value="SELECT * FROM t_order WHERE ROW(?, now()) = (order_id, status)" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_subquery" value="SELECT * FROM t_order WHERE (SELECT order_id FROM t_order_item WHERE status &gt; ?)" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_exists_subquery" value="SELECT * FROM t_order WHERE EXISTS (SELECT order_id FROM t_order_item WHERE status &gt; ? )" db-types="MySQL"/>
-    <sql-case id="select_where_with_simple_expr_with_odbc_escape_syntax" value="SELECT * FROM t_order WHERE {ts '1994-02-04 12:23:00'}" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_odbc_escape_syntax" value="SELECT * FROM t_order WHERE {ts ?}" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_json_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&quot;$[1]&quot;" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_json_unquote_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&gt; &quot;$[1]&quot;" db-types="MySQL"/>
-    <sql-case id="select_where_with_simple_expr_with_match" value="SELECT * FROM t_order WHERE MATCH (order_id) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" db-types="MySQL"/>
-    <sql-case id="select_where_with_simple_expr_with_case" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; 2 THEN 'true' ELSE 'false' END" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_match" value="SELECT * FROM t_order WHERE MATCH (order_id) AGAINST (? IN NATURAL LANGUAGE MODE)" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_case" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; ? THEN ? ELSE ? END" db-types="MySQL"/>
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-group-by.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select-group-by.xml
@@ -27,7 +27,7 @@
     <sql-case id="select_group_by_with_limit" value="SELECT user_id FROM t_order GROUP BY user_id ORDER BY user_id LIMIT ?" db-types="H2,MySQL,PostgreSQL" />
     <sql-case id="select_group_by_with_order_by_and_limit" value="SELECT user_id, SUM(order_id) AS orders_sum FROM t_order GROUP BY user_id ORDER BY SUM(order_id) LIMIT ?" db-types="H2,MySQL,PostgreSQL" />
     <sql-case id="select_with_item_alias_match_order_by_and_group_by_items" value="SELECT o.user_id uid FROM t_order o GROUP BY o.user_id ORDER BY o.user_id" db-types="H2,MySQL,SQLServer,PostgreSQL" />
-    <sql-case id="select_group_by_with_date_function" value="SELECT date_format(creation_date,  '%%y-%%m-%%d') as creation_date, count(*) as c_number FROM `t_order_item` WHERE order_id in (?, ?) GROUP BY date_format(creation_date, '%%y-%%m-%%d')" db-types="MySQL"/>
+    <sql-case id="select_group_by_with_date_function" value="SELECT date_format(creation_date,  '%y-%m-%d') as creation_date, count(*) as c_number FROM `t_order_item` WHERE order_id in (?, ?) GROUP BY date_format(creation_date, '%y-%m-%d')" db-types="MySQL"/>
     <sql-case id="select_group_by_with_keyword_alias" value="SELECT SUM(order_id) AS orders_sum, user_id as `key` FROM t_order GROUP BY `key`" db-types="MySQL" />
     <sql-case id="select_group_by_with_count_without_column_name" value="SELECT COUNT(order_id) AS orders_count, user_id FROM t_order GROUP BY 2 ORDER BY 2" db-types="MySQL,Oracle,SQLServer,PostgreSQL" />
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select.xml
@@ -34,10 +34,10 @@
     <sql-case id="select_equal_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id = ? AND order_id = ?" />
     <sql-case id="select_in_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id IN (?, ?) AND order_id IN (?, ?) ORDER BY order_id" />
     <sql-case id="select_with_N_string_in_expression" value="SELECT * FROM t_order WHERE is_deleted = 'N'" />
-    <sql-case id="select_count_like_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="MySQL, H2, PostgreSQL, SQL92"/>
-    <sql-case id="select_count_like_concat_for_oracle_and_sqlserver" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="Oracle, SQLServer"/>
+    <sql-case id="select_count_like_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="MySQL, H2, PostgreSQL, SQL92" />
+    <sql-case id="select_count_like_concat_oracle_sqlserver" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="Oracle, SQLServer" />
     <sql-case id="select_like_with_single_quotes" value="select id from admin where fullname like 'a%'" db-types="MySQL"/>
-    <sql-case id="select_count_tilde_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status ~~ CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="PostgreSQL" />
+    <sql-case id="select_count_tilde_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status ~~ CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="PostgreSQL" />
     <sql-case id="select_sharding_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id WHERE o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ? ORDER BY i.item_id" />
     <sql-case id="select_full_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id ORDER BY i.item_id" />
     <!--TODO Need to verify case insensitivity of table names in sharding rule-->
@@ -47,9 +47,9 @@
     <sql-case id="select_keyword_table_name_with_square_brackets" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id JOIN [select] c ON o.status = c.status WHERE o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ? AND c.status = ? ORDER BY i.item_id" db-types="SQLServer" />
     <sql-case id="select_alias_as_keyword" value="SELECT length.item_id password FROM t_order_item length where length.item_id = ? " db-types="MySQL,H2,SQLServer,Oracle" />
     <sql-case id="select_with_force_index_join" value="SELECT i.* FROM t_order o FORCE INDEX(order_index) JOIN t_order_item i ON o.order_id=i.order_id WHERE o.order_id = ?" db-types="MySQL" />
-    <sql-case id="select_equal_with_geography" value="SELECT * FROM t_order WHERE rule = '{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
-    <sql-case id="select_in_with_geography" value="SELECT * FROM t_order WHERE rule IN ('{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb, '{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb) AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
-    <sql-case id="select_between_with_geography" value="SELECT * FROM t_order WHERE rule BETWEEN '{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb AND '{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_equal_with_geography" value="SELECT * FROM t_order WHERE rule = ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_in_with_geography" value="SELECT * FROM t_order WHERE rule IN (?::jsonb, ?::jsonb) AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_between_with_geography" value="SELECT * FROM t_order WHERE rule BETWEEN ?::jsonb AND ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND order_id = ?" db-types="PostgreSQL" />
     <sql-case id="select_with_schema" value="SELECT * FROM db1.t_order" />
     <sql-case id="select_special_function_nested" value="SELECT sum(if(status=0, 1, 0)) func_status FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL" />
     <sql-case id="select_with_interval_function" value="SELECT INTERVAL(status,1,5) func_status FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL" />
@@ -59,7 +59,7 @@
     <sql-case id="select_with_date_format_function" value="SELECT * FROM t_order WHERE DATE_FORMAT(current_date, '%Y-%m-%d') = '2019-12-18'" db-types="MySQL" />
     <sql-case id="select_with_spatial_function" value="SELECT * FROM t_order WHERE ST_DISTANCE_SPHERE(POINT(113.358772, 23.1273723), POINT(user_id,order_id)) != 0" db-types="MySQL" />
     <sql-case id="select_current_user" value="SELECT CURRENT_USER" db-types="PostgreSQL"/>
-    <sql-case id="select_with_match_against" value="SELECT * FROM t_order_item WHERE MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE) AND user_id = ?" db-types="MySQL" />
+    <sql-case id="select_with_match_against" value="SELECT * FROM t_order_item WHERE MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE) AND user_id = ?" db-types="MySQL" />
     <sql-case id="select_with_json_separator" value="select content_json->>'$.nation' as nation,content_json->>'$.title' as title from tb_content_json b where b.content_id=1" db-types="MySQL" />
     <sql-case id="select_with_convert_function" value="SELECT CONVERT(SUBSTRING(content, 5) , SIGNED) AS signed_content FROM t_order WHERE order_id = 1" db-types="MySQL" />
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/select.xml
@@ -34,9 +34,10 @@
     <sql-case id="select_equal_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id = ? AND order_id = ?" />
     <sql-case id="select_in_with_same_sharding_column" value="SELECT * FROM t_order WHERE order_id IN (?, ?) AND order_id IN (?, ?) ORDER BY order_id" />
     <sql-case id="select_with_N_string_in_expression" value="SELECT * FROM t_order WHERE is_deleted = 'N'" />
-    <sql-case id="select_count_like_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" />
+    <sql-case id="select_count_like_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="MySQL, H2, PostgreSQL, SQL92"/>
+    <sql-case id="select_count_like_concat_for_oracle_and_sqlserver" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status LIKE CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="Oracle, SQLServer"/>
     <sql-case id="select_like_with_single_quotes" value="select id from admin where fullname like 'a%'" db-types="MySQL"/>
-    <sql-case id="select_count_tilde_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status ~~ CONCAT('%%', ?, '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="PostgreSQL" />
+    <sql-case id="select_count_tilde_concat" value="SELECT count(0) as orders_count FROM t_order o WHERE o.status ~~ CONCAT('%%', 'init', '%%') AND o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ?" db-types="PostgreSQL" />
     <sql-case id="select_sharding_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id WHERE o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ? ORDER BY i.item_id" />
     <sql-case id="select_full_route_with_binding_tables" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id ORDER BY i.item_id" />
     <!--TODO Need to verify case insensitivity of table names in sharding rule-->
@@ -46,9 +47,9 @@
     <sql-case id="select_keyword_table_name_with_square_brackets" value="SELECT i.* FROM t_order o JOIN t_order_item i ON o.user_id = i.user_id AND o.order_id = i.order_id JOIN [select] c ON o.status = c.status WHERE o.user_id IN (?, ?) AND o.order_id BETWEEN ? AND ? AND c.status = ? ORDER BY i.item_id" db-types="SQLServer" />
     <sql-case id="select_alias_as_keyword" value="SELECT length.item_id password FROM t_order_item length where length.item_id = ? " db-types="MySQL,H2,SQLServer,Oracle" />
     <sql-case id="select_with_force_index_join" value="SELECT i.* FROM t_order o FORCE INDEX(order_index) JOIN t_order_item i ON o.order_id=i.order_id WHERE o.order_id = ?" db-types="MySQL" />
-    <sql-case id="select_equal_with_geography" value="SELECT * FROM t_order WHERE rule = ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
-    <sql-case id="select_in_with_geography" value="SELECT * FROM t_order WHERE rule IN (?::jsonb, ?::jsonb) AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
-    <sql-case id="select_between_with_geography" value="SELECT * FROM t_order WHERE rule BETWEEN ?::jsonb AND ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_equal_with_geography" value="SELECT * FROM t_order WHERE rule = '{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_in_with_geography" value="SELECT * FROM t_order WHERE rule IN ('{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb, '{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb) AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND user_id = ? AND order_id = ?" db-types="PostgreSQL" />
+    <sql-case id="select_between_with_geography" value="SELECT * FROM t_order WHERE rule BETWEEN '{&quot;rule2&quot;:&quot;null2&quot;}'::jsonb AND '{&quot;rule3&quot;:&quot;null3&quot;}'::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||100||' '||200||')') AND order_id = ?" db-types="PostgreSQL" />
     <sql-case id="select_with_schema" value="SELECT * FROM db1.t_order" />
     <sql-case id="select_special_function_nested" value="SELECT sum(if(status=0, 1, 0)) func_status FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL" />
     <sql-case id="select_with_interval_function" value="SELECT INTERVAL(status,1,5) func_status FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL" />
@@ -58,7 +59,7 @@
     <sql-case id="select_with_date_format_function" value="SELECT * FROM t_order WHERE DATE_FORMAT(current_date, '%Y-%m-%d') = '2019-12-18'" db-types="MySQL" />
     <sql-case id="select_with_spatial_function" value="SELECT * FROM t_order WHERE ST_DISTANCE_SPHERE(POINT(113.358772, 23.1273723), POINT(user_id,order_id)) != 0" db-types="MySQL" />
     <sql-case id="select_current_user" value="SELECT CURRENT_USER" db-types="PostgreSQL"/>
-    <sql-case id="select_with_match_against" value="SELECT * FROM t_order_item WHERE MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE) AND user_id = ?" db-types="MySQL" />
+    <sql-case id="select_with_match_against" value="SELECT * FROM t_order_item WHERE MATCH(t_order_item.description) AGAINST ('hello' IN NATURAL LANGUAGE MODE) AND user_id = ?" db-types="MySQL" />
     <sql-case id="select_with_json_separator" value="select content_json->>'$.nation' as nation,content_json->>'$.title' as title from tb_content_json b where b.content_id=1" db-types="MySQL" />
     <sql-case id="select_with_convert_function" value="SELECT CONVERT(SUBSTRING(content, 5) , SIGNED) AS signed_content FROM t_order WHERE order_id = 1" db-types="MySQL" />
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/update.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/update.xml
@@ -27,7 +27,8 @@
     <sql-case id="update_without_parameters" value="UPDATE t_order SET status = 'update' WHERE order_id = 1000 AND user_id = 10" />
     <sql-case id="update_with_or" value="UPDATE t_order SET status = 'update' WHERE (order_id = ? OR order_id = ?) AND user_id = ?" />
     <sql-case id="update_with_set_calculation" value="UPDATE t_order SET status = status - ? WHERE order_id = ? AND user_id = ?" />
-    <sql-case id="update_with_where_calculation" value="UPDATE t_order SET status = ? WHERE order_id = order_id - ? AND user_id = ?" />
+    <sql-case id="update_with_where_calculation" value="UPDATE t_order SET status = ? WHERE order_id = order_id - ? AND user_id = ?" db-types="MySQL, H2, Oracle, SQLServer, SQL92"/>
+    <sql-case id="update_with_where_calculation_for_postgresql" value="UPDATE t_order SET status = ? WHERE order_id = order_id - 2 AND user_id = ?" db-types="PostgreSQL"/>
     <sql-case id="update_with_column_equal_column" value="update t_order set order_id = order_id, status = 'init' where order_id = order_id AND order_id = ?" db-types="MySQL"/>
     <sql-case id="update_with_case_when" value="update stock_freeze_detail set row_status=case WHEN (id=?) THEN ? WHEN (id=?) THEN ? WHEN (id=?) THEN ? end,
     update_user=case WHEN (id=?) THEN ? WHEN (id=?) THEN ? WHEN (id=?) THEN ? end, update_time=case WHEN (id=?) THEN ? end where  tenant_id = ?" db-types="MySQL"/>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/update.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/dml/update.xml
@@ -27,8 +27,7 @@
     <sql-case id="update_without_parameters" value="UPDATE t_order SET status = 'update' WHERE order_id = 1000 AND user_id = 10" />
     <sql-case id="update_with_or" value="UPDATE t_order SET status = 'update' WHERE (order_id = ? OR order_id = ?) AND user_id = ?" />
     <sql-case id="update_with_set_calculation" value="UPDATE t_order SET status = status - ? WHERE order_id = ? AND user_id = ?" />
-    <sql-case id="update_with_where_calculation" value="UPDATE t_order SET status = ? WHERE order_id = order_id - ? AND user_id = ?" db-types="MySQL, H2, Oracle, SQLServer, SQL92"/>
-    <sql-case id="update_with_where_calculation_for_postgresql" value="UPDATE t_order SET status = ? WHERE order_id = order_id - 2 AND user_id = ?" db-types="PostgreSQL"/>
+    <sql-case id="update_with_where_calculation" value="UPDATE t_order SET status = ? WHERE order_id = order_id - ? AND user_id = ?" />
     <sql-case id="update_with_column_equal_column" value="update t_order set order_id = order_id, status = 'init' where order_id = order_id AND order_id = ?" db-types="MySQL"/>
     <sql-case id="update_with_case_when" value="update stock_freeze_detail set row_status=case WHEN (id=?) THEN ? WHEN (id=?) THEN ? WHEN (id=?) THEN ? end,
     update_user=case WHEN (id=?) THEN ? WHEN (id=?) THEN ? WHEN (id=?) THEN ? end, update_time=case WHEN (id=?) THEN ? end where  tenant_id = ?" db-types="MySQL"/>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -30,4 +30,9 @@
     <!--<sql-case id="assertInsertWithAll" value="INSERT ALL INTO TABLE_XXX (field1) VALUES (field1) SELECT field1 FROM TABLE_XXX2" db-types="Oracle" />-->
     <!--<sql-case id="assertInsertWithFirst" value="INSERT FIRST INTO TABLE_XXX (field1) VALUES (field1) SELECT field1 FROM TABLE_XXX2" db-types="Oracle" />-->
     <!--<sql-case id="assertDeleteTableAlias" value="DELETE ALIAS_XXX FROM TABLES_XXX AS ALIAS_XXX" db-types="MySQL,Oracle,SQLServer"/>-->
+    <!--<sql-case id="assertSelectWithCaseWithParameterMarker" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; ? THEN 'true' ELSE 'false' END" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithOrSign" value="SELECT * FROM t_order WHERE t_order.order_id = ? || ? = t_order.order_id" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithMatchAgainstWithParameterMarker" value="SELECT * FROM TABLE_XXX WHERE MATCH(TABLE_XXX.COLUMN_XXX) AGAINST (? IN NATURAL LANGUAGE MODE)" db-types="MySQL" />-->
+    <!--<sql-case id="assertSelectLikeConcatWithParameterMarker" value="SELECT * FROM TABLE_XXX WHERE COLUMN_XXX LIKE CONCAT('%%', ?, '%%')" />-->
+    <!--<sql-case id="assertSelectGeographyWithParameterMarker" value="SELECT * FROM t_order WHERE rule BETWEEN ?::jsonb AND ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND order_id = ?" db-types="PostgreSQL" />-->
 </sql-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -30,8 +30,16 @@
     <!--<sql-case id="assertInsertWithAll" value="INSERT ALL INTO TABLE_XXX (field1) VALUES (field1) SELECT field1 FROM TABLE_XXX2" db-types="Oracle" />-->
     <!--<sql-case id="assertInsertWithFirst" value="INSERT FIRST INTO TABLE_XXX (field1) VALUES (field1) SELECT field1 FROM TABLE_XXX2" db-types="Oracle" />-->
     <!--<sql-case id="assertDeleteTableAlias" value="DELETE ALIAS_XXX FROM TABLES_XXX AS ALIAS_XXX" db-types="MySQL,Oracle,SQLServer"/>-->
-    <!--<sql-case id="assertSelectWithCaseWithParameterMarker" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; ? THEN 'true' ELSE 'false' END" db-types="MySQL"/>-->
-    <!--<sql-case id="assertSelectWithOrSign" value="SELECT * FROM t_order WHERE t_order.order_id = ? || ? = t_order.order_id" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithCaseWithParameterMarker" value="SELECT * FROM t_order WHERE CASE WHEN order_id &gt; ? THEN ? ELSE ? END" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithOrSignWithParameterMarker" value="SELECT * FROM t_order WHERE t_order.order_id = ? || ? = t_order.order_id" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithTildeWithParameterMarker" value="SELECT * FROM t_order WHERE ~t_order.order_id" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithBinaryWithParameterMarker" value="SELECT * FROM t_order WHERE BINARY t_order.order_id" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithJsonExtractSignWithParameterMarker" value="SELECT * FROM t_order WHERE order_id -&gt; ?" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithJsonUnquoteExtractSignWithParameterMarker" value="SELECT * FROM t_order WHERE order_id -&gt;&gt; ?" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithRowWithParameterMarker" value="SELECT * FROM t_order WHERE ROW(?, now()) = (order_id, status)" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithOdbcEscapeSyntaxWithParameterMarker" value="SELECT * FROM t_order WHERE {ts ?}" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithMatchWithParameterMarker" value="SELECT * FROM t_order WHERE MATCH (order_id) AGAINST (? IN NATURAL LANGUAGE MODE)" db-types="MySQL"/>-->
+    <!--<sql-case id="assertSelectWithCollateWithMarker" value="NOT SUPPORT SELECT * FROM t_order WHERE order_id collate ?" db-types="MySQL"/>-->
     <!--<sql-case id="assertSelectWithMatchAgainstWithParameterMarker" value="SELECT * FROM TABLE_XXX WHERE MATCH(TABLE_XXX.COLUMN_XXX) AGAINST (? IN NATURAL LANGUAGE MODE)" db-types="MySQL" />-->
     <!--<sql-case id="assertSelectLikeConcatWithParameterMarker" value="SELECT * FROM TABLE_XXX WHERE COLUMN_XXX LIKE CONCAT('%%', ?, '%%')" />-->
     <!--<sql-case id="assertSelectGeographyWithParameterMarker" value="SELECT * FROM t_order WHERE rule BETWEEN ?::jsonb AND ?::jsonb AND start_point=ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')') AND order_id = ?" db-types="PostgreSQL" />-->


### PR DESCRIPTION


Fixes #7880 .

Changes proposed in this pull request:
- Add TableAssert for UpdateStatementAssert.
- Add IdentifierValueAssert for ExpectedIndex, ExpectedColumnOrderByItem, ExpectedOwner, ExpectedSchema and ExpectedColumnProjection.
- Add ExpressionAssert and test cases for select where with expr.
- Adjust the whereClause of the old test case.
