### PR TITLE
Fix parseDateTime error when sharding value is Date or LocalDateTime

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
@@ -33,7 +33,11 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Properties;
 
 /**
  * Auto interval sharding algorithm.

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
@@ -30,12 +30,10 @@ import org.apache.shardingsphere.sharding.api.sharding.standard.StandardSharding
 import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * Auto interval sharding algorithm.
@@ -124,7 +122,16 @@ public final class AutoIntervalShardingAlgorithm implements StandardShardingAlgo
     }
     
     private long parseDate(final Comparable<?> shardingValue) {
-        LocalDateTime dateValue = LocalDateTime.parse(shardingValue.toString(), DATE_TIME_FORMAT);
+        LocalDateTime dateValue;
+        if (shardingValue instanceof LocalDateTime) {
+            dateValue = (LocalDateTime) shardingValue;
+        } else if (shardingValue instanceof Date) {
+            dateValue = ((Date) shardingValue).toInstant()
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime();
+        } else {
+            dateValue = LocalDateTime.parse(shardingValue.toString(), DATE_TIME_FORMAT);
+        }
         return Duration.between(dateTimeLower, dateValue).toMillis() / 1000;
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -31,7 +31,11 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-common/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sharding.rule;
 
-import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import lombok.AccessLevel;
@@ -441,6 +440,6 @@ public final class ShardingRule implements DataNodeContainedRule, TableContained
     
     @Override
     public Collection<String> getTables() {
-        return tableRules.stream().map((Function<TableRule, String>) TableRule::getLogicTable).collect(Collectors.toList());
+        return tableRules.stream().map(TableRule::getLogicTable).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Fix #8470

Changes proposed in this pull request:
- There is not need to import  com.google.common.base.Function, and it can't compile after importing.
- The second commit is fixing the parsing of dateTime. when the sharding value is LocalDateTime or Date, toString() will give the string with the format as yyyy-MM-dd'T'HH:mm:ss. and it can not be parsed when user already set the different date format in configuation.
