### PR TITLE
Add some keywords in the "CREATE TABLE" in ORACLE.

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -20,7 +20,7 @@ grammar DDLStatement;
 import Symbol, Keyword, OracleKeyword, Literals, BaseRule;
 
 createTable
-    : CREATE createTableSpecification TABLE tableName createDefinitionClause
+    : CREATE createTableSpecification TABLE tableName createSharingClause createDefinitionClause createMemOptimizeClause createParentClause
     ;
 
 createIndex
@@ -49,7 +49,7 @@ truncateTable
     ;
 
 createTableSpecification
-    : (GLOBAL TEMPORARY)?
+    : ((GLOBAL | PRIVATE) TEMPORARY | SHARDED | DUPLICATED)?
     ;
 
 tablespaceClauseWithParen
@@ -64,8 +64,24 @@ domainIndexClause
     : indexTypeName
     ;
 
+createSharingClause
+    : (SHARING EQ_ (METADATA | DATA | EXTENDED DATA | NONE))?
+    ;
+
 createDefinitionClause
+    : createRelationalTableClause 
+    ;
+    
+createRelationalTableClause
     : (LP_ relationalProperties RP_)? (ON COMMIT (DELETE | PRESERVE) ROWS)?
+    ;
+    
+createMemOptimizeClause
+    : (MEMOPTIMIZE FOR READ)? (MEMOPTIMIZE FOR WRITE)? 
+    ;    
+
+createParentClause
+    : (PARENT tableName)?
     ;
 
 relationalProperties

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -770,3 +770,43 @@ JSON
 DEC
     : D E C
     ;
+
+SHARING
+    : S H A R I N G
+    ;
+
+PRIVATE
+    : P R I V A T E
+    ;
+
+SHARDED
+    : S H A R D E D
+    ;
+
+DUPLICATED
+    : D U P L I C A T E D
+    ;
+
+METADATA
+    : M E T A D A T A
+    ;
+
+DATA
+    : D A T A
+    ;
+
+EXTENDED
+    : E X T E N D E D
+    ;
+
+NONE
+    : N O N E
+    ;
+
+MEMOPTIMIZE
+    : M E M O P T I M I Z E
+    ;
+
+PARENT
+    : P A R E N T
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -810,4 +810,3 @@ MEMOPTIMIZE
 PARENT
     : P A R E N T
     ;
-    

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -810,3 +810,4 @@ MEMOPTIMIZE
 PARENT
     : P A R E N T
     ;
+    

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
@@ -97,7 +97,7 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
     @Override
     public ASTNode visitCreateDefinitionClause(final CreateDefinitionClauseContext ctx) {
         CollectionValue<CreateDefinitionSegment> result = new CollectionValue<>();
-        for (RelationalPropertyContext each : ctx.relationalProperties().relationalProperty()) {
+        for (RelationalPropertyContext each : ctx.createRelationalTableClause().relationalProperties().relationalProperty()) {
             if (null != each.columnDefinition()) {
                 result.getValue().add((ColumnDefinitionSegment) visit(each.columnDefinition()));
             }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
@@ -76,7 +76,37 @@
             <column name="status" />
         </column-definition>
     </create-table>
-    
+
+    <create-table sql-case-id="create_private_temporary_table">
+        <table name="t_temp_log" start-index="31" stop-index="40" />
+        <column-definition type="int" start-index="42" stop-index="47">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="50" stop-index="67">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_shared_table">
+        <table name="t_temp_log" start-index="21" stop-index="30" />
+        <column-definition type="int" start-index="32" stop-index="37">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="40" stop-index="57">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_duplicated_table">
+        <table name="t_temp_log" start-index="24" stop-index="33" />
+        <column-definition type="int" start-index="35" stop-index="40">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="43" stop-index="60">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_local_temp_table">
         <table name="t_temp_log" start-index="24" stop-index="33" />
         <column-definition type="int" start-index="35" stop-index="40">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-table.xml
@@ -107,6 +107,76 @@
         </column-definition>
     </create-table>
 
+    <create-table sql-case-id="create_table_with_sharing_metadata">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="39" stop-index="56">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="59" stop-index="76">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+    
+    <create-table sql-case-id="create_table_with_sharing_data">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="35" stop-index="52">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="55" stop-index="72">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_sharing_extended_data">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="44" stop-index="61">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="64" stop-index="81">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_sharing_none">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="35" stop-index="52">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="55" stop-index="72">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_optimize_read">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="19" stop-index="36">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="39" stop-index="56">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_optimize_write">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="19" stop-index="36">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="39" stop-index="56">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
+    <create-table sql-case-id="create_table_with_parent">
+        <table name="t_log" start-index="13" stop-index="17" />
+        <column-definition type="int" primary-key="true" start-index="19" stop-index="36">
+            <column name="id" />
+        </column-definition>
+        <column-definition type="varchar" start-index="39" stop-index="56">
+            <column name="status" />
+        </column-definition>
+    </create-table>
+
     <create-table sql-case-id="create_local_temp_table">
         <table name="t_temp_log" start-index="24" stop-index="33" />
         <column-definition type="int" start-index="35" stop-index="40">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
@@ -26,6 +26,13 @@
     <sql-case id="create_private_temporary_table" value="CREATE PRIVATE TEMPORARY TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
     <sql-case id="create_shared_table" value="CREATE SHARDED TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
     <sql-case id="create_duplicated_table" value="CREATE DUPLICATED TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_table_with_sharing_metadata" value="CREATE TABLE t_log SHARING = METADATA (id int PRIMARY KEY, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_table_with_sharing_data" value="CREATE TABLE t_log SHARING = DATA (id int PRIMARY KEY, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_table_with_sharing_extended_data" value="CREATE TABLE t_log SHARING = EXTENDED DATA (id int PRIMARY KEY, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_table_with_sharing_none" value="CREATE TABLE t_log SHARING = NONE (id int PRIMARY KEY, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_table_with_optimize_read" value="CREATE TABLE t_log(id int PRIMARY KEY, status varchar(10)) MEMOPTIMIZE FOR READ" db-types="Oracle" />
+    <sql-case id="create_table_with_optimize_write" value="CREATE TABLE t_log(id int PRIMARY KEY, status varchar(10)) MEMOPTIMIZE FOR WRITE" db-types="Oracle" />
+    <sql-case id="create_table_with_parent" value="CREATE TABLE t_log(id int PRIMARY KEY, status varchar(10)) PARENT t_log_parent" db-types="Oracle" />
     <sql-case id="create_local_temp_table" value="CREATE LOCAL TEMP TABLE t_temp_log(id int, status varchar(10))" db-types="PostgreSQL" />
     <sql-case id="create_unlogged_table" value="CREATE UNLOGGED TABLE t_log(id int, status varchar(10))" db-types="PostgreSQL" />
     <sql-case id="create_index" value="CREATE INDEX t_log_index ON t_log (id)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
@@ -23,6 +23,9 @@
     <sql-case id="create_table_if_not_exists" value="CREATE TABLE IF NOT EXISTS t_log(id int, status varchar(10))" db-types="MySQL,PostgreSQL" />
     <sql-case id="create_temporary_table_if_not_exists" value="CREATE TEMPORARY TABLE IF NOT EXISTS t_temp_log(id int, status varchar(10))" db-types="MySQL,PostgreSQL" />
     <sql-case id="create_global_temporary_table" value="CREATE GLOBAL TEMPORARY TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle,PostgreSQL" />
+    <sql-case id="create_private_temporary_table" value="CREATE PRIVATE TEMPORARY TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_shared_table" value="CREATE SHARDED TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
+    <sql-case id="create_duplicated_table" value="CREATE DUPLICATED TABLE t_temp_log(id int, status varchar(10))" db-types="Oracle" />
     <sql-case id="create_local_temp_table" value="CREATE LOCAL TEMP TABLE t_temp_log(id int, status varchar(10))" db-types="PostgreSQL" />
     <sql-case id="create_unlogged_table" value="CREATE UNLOGGED TABLE t_log(id int, status varchar(10))" db-types="PostgreSQL" />
     <sql-case id="create_index" value="CREATE INDEX t_log_index ON t_log (id)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />


### PR DESCRIPTION
Fixes #6480.

Add some keywords in the "CREATE TABLE".
The keywords are below: PRIVATE SHARDED DUPLICATED SHARING METADATA DATA EXTENDED NONE MEMOPTIMIZE FOR PARENT.

Changes proposed in this pull request:
- support for SQL “creating table” with keywords: sharing, optimize, parent.
- support for “SQL creating private” with keywords: temporary, shared, duplicated table.
-
