### PR TITLE
Fix: alter index and drop index in OracleDDLStatementSQLVisitor.

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
@@ -49,6 +49,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.DropColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ModifyColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DataTypeSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
@@ -264,17 +265,22 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
         OracleCreateIndexStatement result = new OracleCreateIndexStatement();
         if (null != ctx.createIndexDefinitionClause().tableIndexClause()) {
             result.setTable((SimpleTableSegment) visit(ctx.createIndexDefinitionClause().tableIndexClause().tableName()));
+            result.setIndex((IndexSegment) visit(ctx.indexName()));
         }
         return result;
     }
     
     @Override
     public ASTNode visitAlterIndex(final AlterIndexContext ctx) {
-        return new OracleAlterIndexStatement();
+        OracleAlterIndexStatement result = new OracleAlterIndexStatement();
+        result.setIndex((IndexSegment) visit(ctx.indexName()));
+        return result;
     }
     
     @Override
     public ASTNode visitDropIndex(final DropIndexContext ctx) {
-        return new OracleDropIndexStatement();
+        OracleDropIndexStatement result = new OracleDropIndexStatement();
+        result.getIndexes().add((IndexSegment) visit(ctx.indexName()));
+        return result;
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/AlterIndexStatementAssert.java
@@ -22,7 +22,9 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterIndexStatementHandler;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAlterIndexStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.index.IndexAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterIndexStatementTestCase;
 
@@ -61,6 +63,8 @@ public final class AlterIndexStatementAssert {
     
     private static void assertIndex(final SQLCaseAssertContext assertContext, final AlterIndexStatement actual, final AlterIndexStatementTestCase expected) {
         // TODO should assert index for all databases(mysql and sqlserver do not parse index right now)
-//        IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
+        if (actual instanceof OracleAlterIndexStatement) {
+            IndexAssert.assertIs(assertContext, actual.getIndex().get(), expected.getIndex());
+        }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/CreateIndexStatementAssert.java
@@ -20,7 +20,9 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateIndexStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.index.IndexAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateIndexStatementTestCase;
 
@@ -56,6 +58,8 @@ public final class CreateIndexStatementAssert {
     
     private static void assertIndex(final SQLCaseAssertContext assertContext, final CreateIndexStatement actual, final CreateIndexStatementTestCase expected) {
         // TODO should assert index for all databases(mysql and sqlserver do not parse index right now)
-//        IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
+        if (actual instanceof OracleCreateIndexStatement) {
+            IndexAssert.assertIs(assertContext, actual.getIndex(), expected.getIndex());
+        }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/DropIndexStatementAssert.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/DropIndexStatementAssert.java
@@ -19,10 +19,14 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.DropIndexStatementHandler;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDropIndexStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.index.IndexAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropIndexStatementTestCase;
 
@@ -61,11 +65,12 @@ public final class DropIndexStatementAssert {
     
     private static void assertIndex(final SQLCaseAssertContext assertContext, final DropIndexStatement actual, final DropIndexStatementTestCase expected) {
         // TODO should assert index for all databases(mysql and sqlserver do not parse index right now)
-//        assertThat(assertContext.getText("Index size assertion error: "), actual.getIndexes().size(), is(expected.getIndexes().size()));
-//        int count = 0;
-//        for (IndexSegment each : actual.getIndexes()) {
-//            IndexAssert.assertIs(assertContext, each, expected.getIndexes().get(count));
-//            count++;
-//        }
+        if (actual instanceof OracleDropIndexStatement) {
+            int count = 0;
+            for (IndexSegment each : actual.getIndexes()) {
+                IndexAssert.assertIs(assertContext, each, expected.getIndexes().get(count));
+                count++;
+            }
+        }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-index.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-index.xml
@@ -18,10 +18,18 @@
 
 <!-- FIXME assert index -->
 <sql-parser-test-cases>
-    <alter-index sql-case-id="alter_index" />
-    <alter-index sql-case-id="alter_index_with_space" />
-    <alter-index sql-case-id="alter_index_with_quota" />
+    <alter-index sql-case-id="alter_index">
+        <index name="order_index" start-index="12" stop-index="22" />
+    </alter-index>
     
+    <alter-index sql-case-id="alter_index_with_space">
+        <index name="order_index" start-index="24" stop-index="34" />
+    </alter-index>
+    
+    <alter-index sql-case-id="alter_index_with_quota">
+        <index name="order_index" start-delimiter="&quot;" end-delimiter="&quot;" start-index="12" stop-index="24" />
+    </alter-index>
+
     <alter-index sql-case-id="alter_index_rebuild">
         <table name="t_order" start-index="27" stop-index="33" />
     </alter-index>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-index.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/create-index.xml
@@ -21,12 +21,14 @@
         <table>
             <simple-table name="t_log" start-index="28" stop-index="32" />
         </table>
+        <index name="t_log_index" start-index="13" stop-index="23" />
     </create-index>
     
     <create-index sql-case-id="create_unique_index">
         <table>
             <simple-table name="t_log" start-index="35" stop-index="39" />
         </table>
+        <index name="t_log_index" start-index="20" stop-index="30" />
     </create-index>
     
     <create-index sql-case-id="create_index_with_space">
@@ -45,6 +47,7 @@
         <table>
             <simple-table name="t_order" start-index="28" stop-index="34" />
         </table>
+        <index name="order_index" start-index="13" stop-index="23" />
     </create-index>
     
     <create-index sql-case-id="create_btree_index">
@@ -57,12 +60,14 @@
         <table>
             <simple-table name="t_order" start-delimiter="&quot;" end-delimiter="&quot;" start-index="30" stop-index="38" />
         </table>
+        <index name="order_index" start-delimiter="&quot;" end-delimiter="&quot;" start-index="13" stop-index="25" />
     </create-index>
     
     <create-index sql-case-id="create_index_with_function">
         <table>
             <simple-table name="t_order" start-index="33" stop-index="39" />
         </table>
+        <index name="idx_upper_status" start-index="13" stop-index="28" />
     </create-index>
     
     <create-index sql-case-id="create_index_with_double_quota">

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/drop-index.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/drop-index.xml
@@ -21,20 +21,27 @@
         <table name="t_log" start-index="26" stop-index="30" />
     </drop-index>
     
-    <drop-index sql-case-id="drop_index_without_on" />
+    <drop-index sql-case-id="drop_index_without_on">
+        <index name="order_index" start-index="11" stop-index="21" />
+    </drop-index>
     <drop-index sql-case-id="drop_index_if_exists" />
     
     <drop-index sql-case-id="drop_index_with_space">
         <table name="t_order" start-index="50" stop-index="56" />
     </drop-index>
     
-    <drop-index sql-case-id="drop_index_only_with_name" />
+    <drop-index sql-case-id="drop_index_only_with_name">
+        <index name="order_index" start-index="11" stop-index="21" />
+    </drop-index>
     
     <drop-index sql-case-id="drop_index_with_back_quota">
         <table name="t_order" start-delimiter="`" end-delimiter="`" start-index="28" stop-index="36" />
     </drop-index>
     
-    <drop-index sql-case-id="drop_index_with_quota" />
+    <drop-index sql-case-id="drop_index_with_quota">
+        <index name="order_index" start-delimiter="&quot;" end-delimiter="&quot;" start-index="11" stop-index="23" />
+    </drop-index>
+    
     <drop-index sql-case-id="drop_index_with_double_quota" />
     <drop-index sql-case-id="drop_index_concurrently" />
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
@@ -89,11 +89,6 @@
     <sql-case id="alter_table_drop_constraint" value="ALTER TABLE t_order DROP CONSTRAINT order_index" db-types="Oracle,PostgreSQL,SQLServer" />
     <sql-case id="alter_table_drop_primary_key_unique_key" value="ALTER TABLE t_order DROP PRIMARY KEY DROP UNIQUE (order_id) DROP CONSTRAINT order_index" db-types="Oracle" />
     <sql-case id="alter_table_rename_constraint" value="ALTER TABLE t_order RENAME CONSTRAINT order_index_bak TO order_index" db-types="Oracle" />
-    <sql-case id="alter_index" value="ALTER INDEX order_index REBUILD PARALLEL" db-types="Oracle" />
-    <sql-case id="alter_index_with_space" value="    ALTER INDEX
-        order_index
-    REBUILD PARALLEL    " db-types="Oracle" />
-    <sql-case id="alter_index_with_quota" value="ALTER INDEX &quot;order_index&quot; REBUILD PARALLEL" db-types="Oracle" />
     <sql-case id="alter_table_with_row_level" value="ALTER TABLE t_order FORCE ROW LEVEL SECURITY" db-types="PostgreSQL" />
     <sql-case id="alter_table_with_double_quota" value="ALTER TABLE &quot;t_order&quot; FORCE ROW LEVEL SECURITY" db-types="PostgreSQL" />
     <sql-case id="alter_table_alter_columns" value="ALTER TABLE t_order ALTER column4 TYPE VARCHAR(20), ALTER column5 TYPE VARCHAR(20), ALTER column6 TYPE VARCHAR(20)" db-types="PostgreSQL" />    
@@ -108,18 +103,25 @@
     <sql-case id="alter_table_drop_columns_sqlserver" value="ALTER TABLE t_order DROP COLUMN user_id, column5" db-types="SQLServer" />
     <sql-case id="alter_table_add_composite_primary_key_sqlserver" value="ALTER TABLE t_order ADD CONSTRAINT pk_order_id_user_id_status PRIMARY KEY (order_id, user_id, status)" db-types="SQLServer" />    
     <sql-case id="alter_table_add_constraints_sqlserver" value="ALTER TABLE t_order_item ADD PRIMARY KEY (order_id), UNIQUE (order_id), CHECK (order_id > 0), FOREIGN KEY (order_id) REFERENCES t_order (order_id) ON UPDATE CASCADE ON DELETE CASCADE" db-types="SQLServer" />
-    <sql-case id="alter_table_drop_constraints_sqlserver" value="ALTER TABLE t_order DROP CONSTRAINT pk_order_id, uk_order_id, order_index" db-types="SQLServer" />    
-    <sql-case id="alter_index_rebuild" value="ALTER INDEX order_index ON t_order REBUILD" db-types="SQLServer" />
-    <sql-case id="alter_index_with_quota_bracket" value="ALTER INDEX [order_index] ON [t_order] REBUILD" db-types="SQLServer" />
+    <sql-case id="alter_table_drop_constraints_sqlserver" value="ALTER TABLE t_order DROP CONSTRAINT pk_order_id, uk_order_id, order_index" db-types="SQLServer" />
     <sql-case id="alter_table_alter_column_for_postgresql" value="ALTER TABLE t_order ALTER column4 TYPE VARCHAR(20)" db-types="PostgreSQL" />
     <sql-case id="alter_table_alter_column_for_sqlserver" value="ALTER TABLE t_order ALTER COLUMN column4 VARCHAR(20)" db-types="SQLServer" />
     <sql-case id="alter_table_set_schema" value="ALTER TABLE t_order SET SCHEMA yourschema" db-types="PostgreSQL" />
     <sql-case id="alter_table_attach_partition" value="ALTER TABLE t_order ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')" db-types="PostgreSQL"/>
     <sql-case id="alter_table_detach_partition" value="ALTER TABLE t_order ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')" db-types="PostgreSQL"/>
     <sql-case id="alter_table_in_hash_partitioned_table" value="ALTER TABLE t_order ATTACH PARTITION orders_p4 FOR VALUES WITH (MODULUS 4, REMAINDER 3)" db-types="PostgreSQL" />
+    
+<!--    alter index test-->
+    <sql-case id="alter_index" value="ALTER INDEX order_index REBUILD PARALLEL" db-types="Oracle" />
+    <sql-case id="alter_index_with_space" value="    ALTER INDEX
+        order_index
+    REBUILD PARALLEL    " db-types="Oracle" />
+    <sql-case id="alter_index_with_quota" value="ALTER INDEX &quot;order_index&quot; REBUILD PARALLEL" db-types="Oracle" />
+    <sql-case id="alter_index_rebuild" value="ALTER INDEX order_index ON t_order REBUILD" db-types="SQLServer" />
+    <sql-case id="alter_index_with_quota_bracket" value="ALTER INDEX [order_index] ON [t_order] REBUILD" db-types="SQLServer" />
     <sql-case id="alter_index_set_tablespace" value="ALTER INDEX distributors SET TABLESPACE fasttablespace" db-types="PostgreSQL" />
     <sql-case id="alter_index_alter_column" value="ALTER INDEX t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL"/>
-
+    
 <!--    alter function test-->
     <sql-case id="alter_function_rename" value="ALTER FUNCTION sqrt(integer) RENAME TO square_root" db-types="PostgreSQL"/>
     <sql-case id="alter_function_set" value="ALTER FUNCTION check_password(text) SET search_path = admin,pg_temp" db-types="PostgreSQL" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/create.xml
@@ -36,7 +36,6 @@
     <sql-case id="create_object_table" value="CREATE TABLE t_log OF t_log_type" db-types="Oracle" />
     <sql-case id="create_local_temp_table" value="CREATE LOCAL TEMP TABLE t_temp_log(id int, status varchar(10))" db-types="PostgreSQL" />
     <sql-case id="create_unlogged_table" value="CREATE UNLOGGED TABLE t_log(id int, status varchar(10))" db-types="PostgreSQL" />
-    <sql-case id="create_index" value="CREATE INDEX t_log_index ON t_log (id)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />
     <sql-case id="create_unique_index" value="CREATE UNIQUE INDEX t_log_index ON t_log (id)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />
     
     <sql-case id="create_table_with_space" value="    CREATE TABLE t_order_item (
@@ -79,11 +78,6 @@
     <sql-case id="create_table_select" value="CREATE TABLE t_order_bak AS SELECT * FROM t_order" db-types="MySQL" />
     <sql-case id="create_table_like" value="CREATE TABLE t_order_bak (LIKE t_order)" db-types="MySQL" />
     -->
-    <sql-case id="create_index_with_space" value="    CREATE INDEX
-        order_index
-    ON
-        t_order (order_id)    " db-types="MySQL,SQLServer" />
-    <sql-case id="create_index_with_back_quota" value="CREATE INDEX `order_index` ON `t_order` (`order_id`)" db-types="MySQL" />
     <sql-case id="create_composite_index" value="CREATE INDEX order_index ON t_order (order_id, user_id, status)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />
     <sql-case id="create_btree_index" value="CREATE INDEX order_index ON t_order USING BTREE (order_id)" db-types="PostgreSQL" />
     <sql-case id="create_table_with_quota" value="CREATE TABLE &quot;t_order&quot; (&quot;order_id&quot; NUMBER(10), &quot;user_id&quot; NUMBER(10), &quot;status&quot; VARCHAR2(10), &quot;column1&quot; VARCHAR2(10), &quot;column2&quot; VARCHAR2(10), &quot;column3&quot; VARCHAR2(10))" db-types="Oracle" />
@@ -98,20 +92,13 @@
     <sql-case id="create_table_with_out_of_line_constraints_oracle" value="CREATE TABLE t_order_item (item_id NUMBER(10), order_id NUMBER(10), user_id NUMBER(10), status VARCHAR2(10), column1 VARCHAR2(10), column2 VARCHAR2(10), column3 VARCHAR2(10), PRIMARY KEY (item_id), UNIQUE (item_id), FOREIGN KEY (order_id) REFERENCES t_order (order_id) ON DELETE CASCADE), CHECK (item_id > 0))" db-types="Oracle" />
     <sql-case id="create_table_with_exist_index" value="CREATE TABLE t_order (order_id NUMBER(10) PRIMARY KEY USING INDEX order_index, user_id NUMBER(10), status VARCHAR2(10), column1 VARCHAR2(10), column2 VARCHAR2(10), column3 VARCHAR2(10))" db-types="Oracle" />
     <sql-case id="create_table_with_create_index" value="CREATE TABLE t_order (order_id NUMBER(10) PRIMARY KEY USING INDEX (CREATE INDEX order_index ON t_order (order_id)), user_id NUMBER(10), status VARCHAR2(10), column1 VARCHAR2(10), column2 VARCHAR2(10), column3 VARCHAR2(10))" db-types="Oracle" />
-    <sql-case id="create_table_with_partition_oracle" value="CREATE TABLE t_order (order_id NUMBER(10), user_id NUMBER(10), status VARCHAR2(10), column1 VARCHAR2(10), column2 VARCHAR2(10), column3 VARCHAR2(10)) PARTITION BY HASH (order_id) PARTITIONS 2" db-types="Oracle" />   
-    <sql-case id="create_index_with_quota" value="CREATE INDEX &quot;order_index&quot; ON &quot;t_order&quot; (&quot;order_id&quot;)" db-types="Oracle" />
-    <sql-case id="create_index_with_function" value="CREATE INDEX idx_upper_status ON t_order (UPPER(status))" db-types="Oracle,PostgreSQL" />
+    <sql-case id="create_table_with_partition_oracle" value="CREATE TABLE t_order (order_id NUMBER(10), user_id NUMBER(10), status VARCHAR2(10), column1 VARCHAR2(10), column2 VARCHAR2(10), column3 VARCHAR2(10)) PARTITION BY HASH (order_id) PARTITIONS 2" db-types="Oracle" />
     <sql-case id="create_table_with_double_quota" value="CREATE TABLE &quot;t_order&quot; (&quot;order_id&quot; INTEGER, &quot;user_id&quot; INTEGER, &quot;status&quot; VARCHAR(10), &quot;column1&quot; VARCHAR(10), &quot;column2&quot; VARCHAR(10), &quot;column3&quot; VARCHAR(10))" db-types="PostgreSQL" />
     <sql-case id="create_local_temporary_table" value="CREATE LOCAL TEMPORARY TABLE t_order (order_id INTEGER, user_id INTEGER, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="PostgreSQL" />
     <sql-case id="create_table_with_range_partition" value="CREATE TABLE t_order (order_id INTEGER, user_id INTEGER, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10)) PARTITION BY RANGE (order_id)" db-types="PostgreSQL" />
 <!--    TODO support create table with like and inherits on PostgreSQL-->
 <!--    <sql-case id="create_table_like" value="CREATE TABLE t_order_bak (LIKE t_order)" db-types="PostgreSQL" />-->
 <!--    <sql-case id="create_table_inherits" value="CREATE TABLE t_order_bak() inherits (t_order)" db-types="PostgreSQL" />-->
-    <sql-case id="create_index_with_double_quota" value="CREATE INDEX &quot;order_index&quot; ON &quot;t_order&quot; (&quot;order_id&quot;)" db-types="PostgreSQL" />
-    <sql-case id="create_index_with_double_quota_and_uescape" value="CREATE INDEX U&amp;&quot;order_index!0061t!+000061&quot; UESCAPE '!' ON u&amp;&quot;t_order&quot; (u&amp;&quot;order_id&quot;)" db-types="PostgreSQL" />
-    <sql-case id="create_index_concurrently" value="CREATE INDEX CONCURRENTLY order_index ON t_order (order_id)" db-types="PostgreSQL" />
-    <sql-case id="create_index_if_not_exists" value="CREATE INDEX IF NOT EXISTS order_index ON t_order (order_id)" db-types="PostgreSQL" />
-    <sql-case id="create_index_using_btree" value="CREATE INDEX order_index ON t_order (order_id) USING BTREE" db-types="PostgreSQL" />
     <sql-case id="create_table_with_bracket" value="CREATE TABLE [t_order] ([order_id] INT, [user_id] INT, [status] VARCHAR(10), [column1] VARCHAR(10), [column2] VARCHAR(10), [column3] VARCHAR(10))" db-types="SQLServer" />
     <sql-case id="create_table_with_identity" value="CREATE TABLE t_order (order_id INT IDENTITY, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="SQLServer" />
     <sql-case id="create_table_with_column_as" value="CREATE TABLE t_order (order_id INT, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column1 AS UPPER(status), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="SQLServer" />
@@ -122,11 +109,6 @@
     <sql-case id="create_table_with_inline_check_sqlserver" value="CREATE TABLE t_order (order_id INT CONSTRAINT chk_order_id CHECK (order_id > 0), user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="SQLServer" />
     <sql-case id="create_table_with_inline_constraints_sqlserver" value="CREATE TABLE t_order (order_id INT PRIMARY KEY UNIQUE CHECK (order_id > 0), user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="SQLServer" />
     <sql-case id="create_table_with_index" value="CREATE TABLE t_order (order_id INT INDEX order_index, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10))" db-types="SQLServer" />
-    <sql-case id="create_index_with_bracket" value="CREATE INDEX [order_index] ON [t_order] ([order_id])" db-types="SQLServer" />
-    <sql-case id="create_index_with_no_default_fill_factor" value="CREATE UNIQUE INDEX order_index ON t_order (order_id) WITH (fillfactor = 70)" db-types="PostgreSQL"/>
-    <sql-case id="create_index_with_tablespace" value="CREATE INDEX code_idx ON t_order (code) TABLESPACE indexspace" db-types="PostgreSQL"/>
-    <sql-case id="create_index_using_gist" value="CREATE INDEX pointloc ON t_order USING gist (func1(location,location))" db-types="PostgreSQL" />
-    <sql-case id="create_index_with_concurrently" value="CREATE INDEX CONCURRENTLY sales_quantity_index ON t_order(quantity)" db-types="PostgreSQL" />
     <sql-case id="create_gin_index" value="CREATE INDEX gin_idx ON t_order USING GIN (locations) WITH (fastupdate = off)" db-types="PostgreSQL" />
     <sql-case id="create_table_with_range_partitioned_and_values" value="CREATE TABLE t_order PARTITION OF cities (CONSTRAINT city_id_nonzero CHECK (city_id != 0)) FOR VALUES IN ('a', 'b') PARTITION BY RANGE (population)" db-types="PostgreSQL" />
     <sql-case id="create_table_partition_by_hash" value="CREATE TABLE t_order (order_id bigint not null,cust_id bigint not null,status text) PARTITION BY HASH (order_id)" db-types="PostgreSQL" />
@@ -135,7 +117,26 @@
     <sql-case id="create_table_in_tablespace" value="CREATE TABLE t_order (id serial,name text,location text) TABLESPACE diskvol1" db-types="PostgreSQL" />
     <sql-case id="create_table_with_sign_column" value="CREATE TABLE t_order(id INT PRIMARY KEY, order_id BIGINT(20) SIGNED)" db-types="MySQL" />
     <sql-case id="create_table_with_unsigned_column" value="CREATE TABLE t_order(id INT PRIMARY KEY, order_id BIGINT(20) UNSIGNED)" db-types="MySQL" />
-
+<!--    create index test-->
+    <sql-case id="create_index" value="CREATE INDEX t_log_index ON t_log (id)" db-types="H2,MySQL,PostgreSQL,Oracle,SQLServer" />
+    <sql-case id="create_index_with_space" value="    CREATE INDEX
+        order_index
+    ON
+        t_order (order_id)    " db-types="MySQL,SQLServer" />
+    <sql-case id="create_index_with_back_quota" value="CREATE INDEX `order_index` ON `t_order` (`order_id`)" db-types="MySQL" />
+    <sql-case id="create_index_with_quota" value="CREATE INDEX &quot;order_index&quot; ON &quot;t_order&quot; (&quot;order_id&quot;)" db-types="Oracle" />
+    <sql-case id="create_index_with_function" value="CREATE INDEX idx_upper_status ON t_order (UPPER(status))" db-types="Oracle,PostgreSQL" />
+    <sql-case id="create_index_with_bracket" value="CREATE INDEX [order_index] ON [t_order] ([order_id])" db-types="SQLServer" />
+    <sql-case id="create_index_with_no_default_fill_factor" value="CREATE UNIQUE INDEX order_index ON t_order (order_id) WITH (fillfactor = 70)" db-types="PostgreSQL"/>
+    <sql-case id="create_index_with_tablespace" value="CREATE INDEX code_idx ON t_order (code) TABLESPACE indexspace" db-types="PostgreSQL"/>
+    <sql-case id="create_index_using_gist" value="CREATE INDEX pointloc ON t_order USING gist (func1(location,location))" db-types="PostgreSQL" />
+    <sql-case id="create_index_with_concurrently" value="CREATE INDEX CONCURRENTLY sales_quantity_index ON t_order(quantity)" db-types="PostgreSQL" />
+    <sql-case id="create_index_with_double_quota" value="CREATE INDEX &quot;order_index&quot; ON &quot;t_order&quot; (&quot;order_id&quot;)" db-types="PostgreSQL" />
+    <sql-case id="create_index_with_double_quota_and_uescape" value="CREATE INDEX U&amp;&quot;order_index!0061t!+000061&quot; UESCAPE '!' ON u&amp;&quot;t_order&quot; (u&amp;&quot;order_id&quot;)" db-types="PostgreSQL" />
+    <sql-case id="create_index_concurrently" value="CREATE INDEX CONCURRENTLY order_index ON t_order (order_id)" db-types="PostgreSQL" />
+    <sql-case id="create_index_if_not_exists" value="CREATE INDEX IF NOT EXISTS order_index ON t_order (order_id)" db-types="PostgreSQL" />
+    <sql-case id="create_index_using_btree" value="CREATE INDEX order_index ON t_order (order_id) USING BTREE" db-types="PostgreSQL" />
+    
 <!--    create database test-->
     <sql-case id="create_database" value="CREATE DATABASE lusiadas" db-types="PostgreSQL" />
     <sql-case id="create_database_owner" value="CREATE DATABASE sales OWNER salesapp TABLESPACE salesspace" db-types="PostgreSQL" />

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/drop.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/drop.xml
@@ -23,28 +23,14 @@
     <sql-case id="drop_table_restrict" value="DROP TABLE t_log RESTRICT" db-types="MySQL,PostgreSQL" />
     <sql-case id="drop_table_cascade" value="DROP TABLE t_log CASCADE" db-types="MySQL,PostgreSQL" />
     <sql-case id="drop_table_cascade_constraints_and_purge" value="DROP TABLE t_log CASCADE CONSTRAINTS PURGE" db-types="Oracle" />
-    <sql-case id="drop_index" value="DROP INDEX t_log_index ON t_log" db-types="MySQL,SQLServer" />
-    <sql-case id="drop_index_without_on" value="DROP INDEX order_index" db-types="PostgreSQL,Oracle" />
-    <sql-case id="drop_index_if_exists" value="DROP INDEX IF EXISTS order_index" db-types="PostgreSQL" />
     <sql-case id="drop_table_with_space" value="    DROP TABLE
         t_order    "/>
     <sql-case id="drop_table_with_back_quota" value="DROP TABLE `t_order`" left-delimiter="`" right-delimiter="`" db-types="MySQL" />
     <sql-case id="drop_tables" value="DROP TABLE t_order_item, t_order" db-types="MySQL,PostgreSQL,SQLServer" />
     <sql-case id="drop_temporary_table" value="DROP TEMPORARY TABLE t_order" db-types="MySQL" />
-    <sql-case id="drop_index_with_space" value="    DROP INDEX
-        order_index
-    ON
-        t_order    " db-types="MySQL,SQLServer" />
-    <sql-case id="drop_index_only_with_name" value="DROP INDEX order_index" db-types="Oracle,PostgreSQL" />
-    <sql-case id="drop_index_with_back_quota" value="DROP INDEX `order_index` ON `t_order`" db-types="MySQL" />
     <sql-case id="drop_table_with_quota" value="DROP TABLE &quot;t_order&quot;" db-types="Oracle" />
-    <sql-case id="drop_index_with_quota" value="DROP INDEX &quot;order_index&quot; ON &quot;t_order&quot;" db-types="Oracle" />
     <sql-case id="drop_table_with_double_quota" value="DROP TABLE &quot;t_order&quot;" db-types="PostgreSQL" />
-    <sql-case id="drop_index_with_double_quota" value="DROP INDEX &quot;order_index&quot;" db-types="PostgreSQL" />
-    <sql-case id="drop_index_concurrently" value="DROP INDEX CONCURRENTLY order_index" db-types="PostgreSQL" />
     <sql-case id="drop_table_with_bracket" value="DROP TABLE [t_order]" db-types="SQLServer" />
-    <sql-case id="drop_index_with_bracket" value="DROP INDEX [order_index] ON [t_order]" db-types="SQLServer" />
-    <sql-case id="drop_index_if_exists_on_table" value="DROP INDEX IF EXISTS order_index ON t_order" db-types="SQLServer" />
     <sql-case id="drop_database_if_exist" value="DROP DATABASE IF EXISTS database1" db-types="PostgreSQL" />
     <sql-case id="drop_database" value="DROP DATABASE database1" db-types="PostgreSQL" />
     <sql-case id="drop_function" value="DROP FUNCTION sqrt(integer)" db-types="PostgreSQL" />
@@ -55,4 +41,19 @@
 <!--    <sql-case id="drop_server" value="DROP SERVER foo" db-types="PostgreSQL" />-->
 <!--    <sql-case id="drop_trigger" value="DROP TRIGGER if_dist_exists ON films" db-types="PostgreSQL" />-->
     <sql-case id="drop_view" value="DROP VIEW kinds" db-types="PostgreSQL" />
+<!--drop index test-->
+    <sql-case id="drop_index" value="DROP INDEX t_log_index ON t_log" db-types="MySQL,SQLServer" />
+    <sql-case id="drop_index_without_on" value="DROP INDEX order_index" db-types="PostgreSQL,Oracle" />
+    <sql-case id="drop_index_if_exists" value="DROP INDEX IF EXISTS order_index" db-types="PostgreSQL" />
+    <sql-case id="drop_index_with_space" value="    DROP INDEX
+        order_index
+    ON
+        t_order    " db-types="MySQL,SQLServer" />
+    <sql-case id="drop_index_only_with_name" value="DROP INDEX order_index" db-types="Oracle,PostgreSQL" />
+    <sql-case id="drop_index_with_back_quota" value="DROP INDEX `order_index` ON `t_order`" db-types="MySQL" />
+    <sql-case id="drop_index_with_quota" value="DROP INDEX &quot;order_index&quot; ON &quot;t_order&quot;" db-types="Oracle" />
+    <sql-case id="drop_index_with_double_quota" value="DROP INDEX &quot;order_index&quot;" db-types="PostgreSQL" />
+    <sql-case id="drop_index_concurrently" value="DROP INDEX CONCURRENTLY order_index" db-types="PostgreSQL" />
+    <sql-case id="drop_index_with_bracket" value="DROP INDEX [order_index] ON [t_order]" db-types="SQLServer" />
+    <sql-case id="drop_index_if_exists_on_table" value="DROP INDEX IF EXISTS order_index ON t_order" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
Fixes #9060.

Changes proposed in this pull request:
- fix: alter index and drop index in OracleDDLStatementSQLVisitor.
-
-
