### PR TITLE
Support PostgreSQL numeric type

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
@@ -42,6 +42,7 @@ public final class PostgreSQLBinaryProtocolValueFactory {
         setInt2BinaryProtocolValue();
         setDoubleBinaryProtocolValue();
         setFloatBinaryProtocolValue();
+        setNumericBinaryProtocolValue();
         setDateBinaryProtocolValue();
         setTimeBinaryProtocolValue();
     }
@@ -79,6 +80,11 @@ public final class PostgreSQLBinaryProtocolValueFactory {
     private static void setFloatBinaryProtocolValue() {
         PostgreSQLFloatBinaryProtocolValue binaryProtocolValue = new PostgreSQLFloatBinaryProtocolValue();
         BINARY_PROTOCOL_VALUES.put(PostgreSQLBinaryColumnType.POSTGRESQL_TYPE_FLOAT4, binaryProtocolValue);
+    }
+    
+    private static void setNumericBinaryProtocolValue() {
+        PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
+        BINARY_PROTOCOL_VALUES.put(PostgreSQLBinaryColumnType.POSTGRESQL_TYPE_NUMERIC, binaryProtocolValue);
     }
     
     private static void setDateBinaryProtocolValue() {

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLNumericBinaryProtocolValue.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLNumericBinaryProtocolValue.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.binary.bind.protocol;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+
+/**
+ * Binary protocol value for numeric for PostgreSQL.
+ */
+public final class PostgreSQLNumericBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
+    
+    @Override
+    public int getColumnLength(final Object value) {
+        if (null == value) {
+            return 0;
+        }
+        return value.toString().getBytes(StandardCharsets.UTF_8).length;
+    }
+    
+    @Override
+    public Object read(final PostgreSQLPacketPayload payload) {
+        payload.getByteBuf().readerIndex(payload.getByteBuf().readerIndex() - 4);
+        byte[] bytes = new byte[payload.readInt4()];
+        payload.getByteBuf().readBytes(bytes);
+        return new BigDecimal(new String(bytes));
+    }
+    
+    @Override
+    public void write(final PostgreSQLPacketPayload payload, final Object value) {
+        if (null == value) {
+            return;
+        }
+        payload.writeBytes(value.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLBinaryProtocolValueFactoryTest.java
@@ -62,6 +62,12 @@ public final class PostgreSQLBinaryProtocolValueFactoryTest {
     }
     
     @Test
+    public void assertGetNumericBinaryProtocolValue() {
+        PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLBinaryColumnType.POSTGRESQL_TYPE_NUMERIC);
+        assertThat(binaryProtocolValue, instanceOf(PostgreSQLNumericBinaryProtocolValue.class));
+    }
+    
+    @Test
     public void assertGetDateBinaryProtocolValue() {
         PostgreSQLBinaryProtocolValue binaryProtocolValue = PostgreSQLBinaryProtocolValueFactory.getBinaryProtocolValue(PostgreSQLBinaryColumnType.POSTGRESQL_TYPE_DATE);
         assertThat(binaryProtocolValue, instanceOf(PostgreSQLDateBinaryProtocolValue.class));

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLNumericBinaryProtocolValueTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/binary/bind/protocol/PostgreSQLNumericBinaryProtocolValueTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.binary.bind.protocol;
+
+import io.netty.buffer.ByteBuf;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class PostgreSQLNumericBinaryProtocolValueTest {
+    
+    @Test
+    public void assertGetColumnLength() {
+        PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
+        assertThat(binaryProtocolValue.getColumnLength(null), is(0));
+        assertThat(binaryProtocolValue.getColumnLength(new BigDecimal("1234567890.12")), is(13));
+    }
+    
+    @Test
+    public void assertRead() {
+        PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
+        String decimalText = "1234567890.12";
+        BigDecimal expectedDecimal = new BigDecimal(decimalText);
+        int columnLength = binaryProtocolValue.getColumnLength(expectedDecimal);
+        int expectedLength = 4 + columnLength;
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
+        byteBuf.writeInt(columnLength);
+        byteBuf.writeBytes(decimalText.getBytes(StandardCharsets.UTF_8));
+        byteBuf.readInt();
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        Object result = binaryProtocolValue.read(payload);
+        assertNotNull(result);
+        assertTrue(result instanceof BigDecimal);
+        assertThat(result, is(expectedDecimal));
+        assertThat(byteBuf.readerIndex(), is(expectedLength));
+    }
+    
+    @Test
+    public void assertWrite() {
+        PostgreSQLNumericBinaryProtocolValue binaryProtocolValue = new PostgreSQLNumericBinaryProtocolValue();
+        String decimalText = "1234567890.12";
+        BigDecimal decimal = new BigDecimal(decimalText);
+        int columnLength = binaryProtocolValue.getColumnLength(decimal);
+        ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(columnLength);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf);
+        binaryProtocolValue.write(payload, decimal);
+        byte[] actualBytes = new byte[columnLength];
+        byteBuf.readBytes(actualBytes);
+        assertThat(new String(actualBytes, StandardCharsets.UTF_8), is(decimalText));
+    }
+    
+}


### PR DESCRIPTION
Fixes #9000.

Changes proposed in this pull request:
- Support PostgreSQL numeric type. Notice: There is only text mode in `Bind` when i'm testing, so binary mode is just tested in unit test but not in real demo.
