### PR TITLE
Remove useless log for SchemaMetaDataLoader.loadAllTableNames()

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-logging/shardingsphere-agent-logging-base/src/main/java/org/apache/shardingsphere/agent/plugin/logging/base/advice/SchemaMetaDataLoaderAdvice.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-logging/shardingsphere-agent-logging-base/src/main/java/org/apache/shardingsphere/agent/plugin/logging/base/advice/SchemaMetaDataLoaderAdvice.java
@@ -17,11 +17,12 @@
 
 package org.apache.shardingsphere.agent.plugin.logging.base.advice;
 
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.agent.api.advice.ClassStaticMethodAroundAdvice;
+import org.apache.shardingsphere.agent.api.result.MethodInvocationResult;
+
 import java.lang.reflect.Method;
 import java.util.Collection;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.agent.api.result.MethodInvocationResult;
-import org.apache.shardingsphere.agent.api.advice.ClassStaticMethodAroundAdvice;
 
 /**
  * Schema meta data loader advice.
@@ -33,6 +34,6 @@ public final class SchemaMetaDataLoaderAdvice implements ClassStaticMethodAround
     @SuppressWarnings("unchecked")
     public void afterMethod(final Class<?> clazz, final Method method, final Object[] args, final MethodInvocationResult result) {
         Collection<String> results = (Collection<String>) result.getResult();
-        log.info("Loading {} tables' meta data for unconfigured tables.", results.size());
+        log.info("Loading {} tables.", results.size());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/SchemaMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/SchemaMetaDataLoader.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.infra.metadata.schema.builder.loader;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.schema.builder.loader.adapter.MetaDataLoaderConnectionAdapter;
 
@@ -36,7 +35,6 @@ import java.util.List;
  * Schema meta data loader.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@Slf4j(topic = "ShardingSphere-metadata")
 public final class SchemaMetaDataLoader {
     
     private static final String TABLE_TYPE = "TABLE";
@@ -58,7 +56,6 @@ public final class SchemaMetaDataLoader {
         try (MetaDataLoaderConnectionAdapter connectionAdapter = new MetaDataLoaderConnectionAdapter(databaseType, dataSource.getConnection())) {
             result = loadAllTableNames(connectionAdapter);
         }
-        log.info("Loading {} tables' meta data for unconfigured tables.", result.size());
         if (result.isEmpty()) {
             return Collections.emptyList();
         }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/SchemaMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/SchemaMetaDataLoader.java
@@ -27,7 +27,6 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -52,14 +51,9 @@ public final class SchemaMetaDataLoader {
      * @throws SQLException SQL exception
      */
     public static Collection<String> loadAllTableNames(final DataSource dataSource, final DatabaseType databaseType) throws SQLException {
-        Collection<String> result;
         try (MetaDataLoaderConnectionAdapter connectionAdapter = new MetaDataLoaderConnectionAdapter(databaseType, dataSource.getConnection())) {
-            result = loadAllTableNames(connectionAdapter);
+            return loadAllTableNames(connectionAdapter);
         }
-        if (result.isEmpty()) {
-            return Collections.emptyList();
-        }
-        return result;
     }
     
     private static Collection<String> loadAllTableNames(final Connection connection) throws SQLException {


### PR DESCRIPTION
For #9365.