### PR TITLE
Support Connection.createArrayOf for Sharding-JDBC

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/adapter/AbstractPreparedStatementAdapter.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.driver.jdbc.adapter;
 
 import com.google.common.io.CharStreams;
+import java.sql.Array;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.driver.jdbc.adapter.invocation.SetParameterMethodInvocation;
@@ -168,6 +169,11 @@ public abstract class AbstractPreparedStatementAdapter extends AbstractUnsupport
     
     @Override
     public final void setClob(final int parameterIndex, final Reader x, final long length) {
+        setParameter(parameterIndex, x);
+    }
+    
+    @Override
+    public void setArray(final int parameterIndex, final Array x) {
         setParameter(parameterIndex, x);
     }
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.driver.jdbc.core.connection;
 
 import com.google.common.base.Preconditions;
+import java.sql.Array;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.shardingsphere.driver.jdbc.adapter.AbstractConnectionAdapter;
@@ -268,5 +269,12 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter im
         } else {
             shardingTransactionManager.rollback();
         }
+    }
+    
+    @Override
+    public Array createArrayOf(final String typeName, final Object[] elements) throws SQLException {
+        String dataSourceName = getDataSourceMap().entrySet().iterator().next().getKey();
+        Connection connection = getConnection(dataSourceName);
+        return connection.createArrayOf(typeName, elements);
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationConnection.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.driver.jdbc.unsupported;
 
 import org.apache.shardingsphere.driver.jdbc.adapter.WrapperAdapter;
 
-import java.sql.Array;
 import java.sql.Blob;
 import java.sql.CallableStatement;
 import java.sql.Clob;
@@ -122,11 +121,6 @@ public abstract class AbstractUnsupportedOperationConnection extends WrapperAdap
     @Override
     public final SQLXML createSQLXML() throws SQLException {
         throw new SQLFeatureNotSupportedException("createSQLXML");
-    }
-    
-    @Override
-    public final Array createArrayOf(final String typeName, final Object[] elements) throws SQLException {
-        throw new SQLFeatureNotSupportedException("createArrayOf");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationPreparedStatement.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/unsupported/AbstractUnsupportedOperationPreparedStatement.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.driver.jdbc.unsupported;
 import org.apache.shardingsphere.driver.jdbc.adapter.AbstractStatementAdapter;
 
 import java.io.Reader;
-import java.sql.Array;
 import java.sql.NClob;
 import java.sql.PreparedStatement;
 import java.sql.Ref;
@@ -72,11 +71,6 @@ public abstract class AbstractUnsupportedOperationPreparedStatement extends Abst
     @Override
     public final void setNCharacterStream(final int parameterIndex, final Reader x, final long length) throws SQLException {
         throw new SQLFeatureNotSupportedException("setNCharacterStream");
-    }
-    
-    @Override
-    public final void setArray(final int parameterIndex, final Array x) throws SQLException {
-        throw new SQLFeatureNotSupportedException("setArray");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationConnectionTest.java
@@ -122,11 +122,6 @@ public final class UnsupportedOperationConnectionTest {
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertCreateArrayOf() throws SQLException {
-        shardingSphereConnection.createArrayOf("", null);
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertCreateStruct() throws SQLException {
         shardingSphereConnection.createStruct("", null);
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationPreparedStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationPreparedStatementTest.java
@@ -79,11 +79,6 @@ public final class UnsupportedOperationPreparedStatementTest {
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertSetArray() throws SQLException {
-        shardingSpherePreparedStatement.setArray(1, null);
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertSetRowId() throws SQLException {
         shardingSpherePreparedStatement.setRowId(1, null);
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/connection/CircuitBreakerConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/connection/CircuitBreakerConnection.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.governance.internal.circuit.connection;
 
+import java.sql.Array;
 import org.apache.shardingsphere.driver.governance.internal.circuit.metadata.CircuitBreakerDatabaseMetaData;
 import org.apache.shardingsphere.driver.governance.internal.circuit.statement.CircuitBreakerPreparedStatement;
 import org.apache.shardingsphere.driver.governance.internal.circuit.statement.CircuitBreakerStatement;
@@ -133,6 +134,11 @@ public final class CircuitBreakerConnection extends AbstractUnsupportedOperation
     @Override
     public boolean isValid(final int timeout) {
         return true;
+    }
+    
+    @Override
+    public Array createArrayOf(final String typeName, final Object[] elements) {
+        return null;
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/statement/CircuitBreakerPreparedStatement.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/circuit/statement/CircuitBreakerPreparedStatement.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.driver.governance.internal.circuit.statement;
 
+import java.sql.Array;
 import lombok.Getter;
 import org.apache.shardingsphere.driver.jdbc.unsupported.AbstractUnsupportedOperationPreparedStatement;
 import org.apache.shardingsphere.driver.governance.internal.circuit.connection.CircuitBreakerConnection;
@@ -210,6 +211,10 @@ public final class CircuitBreakerPreparedStatement extends AbstractUnsupportedOp
     
     @Override
     public void setClob(final int parameterIndex, final Reader reader) {
+    }
+    
+    @Override
+    public void setArray(final int parameterIndex, final Array x) {
     }
     
     @Override


### PR DESCRIPTION
Fixes #9164.

Changes proposed in this pull request:
- Support Connection.createArrayOf for Sharding-JDBC

Solution description:
- underlying `connection.createArrayOf` has no side effect
- delegate `ShardingSphereConnection.createArrayOf` to any of dataSource `connection.createArrayOf`
