### PR TITLE
Patch automatically synthesized by R-Hero! 🎩

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactory.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-route/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/ShardingRouteEngineFactory.java
@@ -177,6 +177,6 @@ public final class ShardingRouteEngineFactory {
             return false;
         }
         SelectStatementContext select = (SelectStatementContext) sqlStatementContext;
-        return tableNames.size() == shardingTableNames.size() && (select.containsJoinQuery() || select.isContainsSubquery());
+        return((tableNames.size())==(shardingTableNames.size()));
     }
 }


### PR DESCRIPTION
### Patch automatically synthesized by R-Hero! :tophat:

:robot: R-Hero has found a patch for [this](https://github.com/apache/shardingsphere/commit/dde3bb99e090f32338fc81d09bb6a427efd2aba9) commit. [R-Hero is a bot for automatic bug fixing](https://github.com/eclipse/repairnator), it has reproduced the bug and was able to fix it.

----------------

Your feedback is very valuable to improve its patch generation skills. 
If you would like to contribute, simply use the links below:

Do you think this patch is helpful? [ [Yes :clap:](http://sequencer.westeurope.cloudapp.azure.com:8081/apache/shardingsphere/0/0) ] / [ [Incorrect but useful :handshake:](http://sequencer.westeurope.cloudapp.azure.com:8081/apache/shardingsphere/0/1) ] / [ [Useless :-1:](http://sequencer.westeurope.cloudapp.azure.com:8081/apache/shardingsphere/0/2) ]

If you would like to provide more detailed feedback:heart: to the R-Hero team, please [tell us your thoughts in a Github issue](https://github.com/eclipse/repairnator/issues/new?title=[FEEDBACK]apache/shardingsphere)

If you don't want to receive more of these PRs in the future:broken_heart:, [let us know and we'll stop sending you patches](https://github.com/eclipse/repairnator/issues/new?title=[BLACKLIST]apache/shardingsphere)
