### PR TITLE
Fixed the bug that the order of multiple sharding keys in the Hint strategy

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/hint/HintManager.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/hint/HintManager.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.infra.hint;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -34,9 +34,9 @@ public final class HintManager implements AutoCloseable {
     
     private static final ThreadLocal<HintManager> HINT_MANAGER_HOLDER = new ThreadLocal<>();
     
-    private final Multimap<String, Comparable<?>> databaseShardingValues = HashMultimap.create();
+    private final Multimap<String, Comparable<?>> databaseShardingValues = ArrayListMultimap.create();
     
-    private final Multimap<String, Comparable<?>> tableShardingValues = HashMultimap.create();
+    private final Multimap<String, Comparable<?>> tableShardingValues = ArrayListMultimap.create();
     
     private boolean databaseShardingOnly;
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/hint/HintManagerTest.java
@@ -19,13 +19,16 @@ package org.apache.shardingsphere.infra.hint;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class HintManagerTest {
-    
+
     @Test(expected = IllegalStateException.class)
     public void assertGetInstanceTwice() {
         try {
@@ -35,7 +38,7 @@ public final class HintManagerTest {
             HintManager.clear();
         }
     }
-    
+
     @Test
     public void assertSetDatabaseShardingValue() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -43,59 +46,65 @@ public final class HintManagerTest {
             hintManager.setDatabaseShardingValue(3);
             assertTrue(HintManager.isDatabaseShardingOnly());
             assertThat(HintManager.getDatabaseShardingValues("").size(), is(1));
-            assertTrue(HintManager.getDatabaseShardingValues("").contains(3));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getDatabaseShardingValues(""));
+            assertThat(shardingValues.get(0), is(3));
         }
     }
-    
+
     @Test
     public void assertAddDatabaseShardingValue() {
         try (HintManager hintManager = HintManager.getInstance()) {
             hintManager.addDatabaseShardingValue("logicTable", 1);
             hintManager.addDatabaseShardingValue("logicTable", 3);
             assertThat(HintManager.getDatabaseShardingValues("logicTable").size(), is(2));
-            assertTrue(HintManager.getDatabaseShardingValues("logicTable").contains(1));
-            assertTrue(HintManager.getDatabaseShardingValues("logicTable").contains(3));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getDatabaseShardingValues("logicTable"));
+            assertThat(shardingValues.get(0), is(1));
+            assertThat(shardingValues.get(1), is(3));
         }
     }
-    
+
     @Test
     public void assertAddTableShardingValue() {
         try (HintManager hintManager = HintManager.getInstance()) {
             hintManager.addTableShardingValue("logicTable", 1);
             hintManager.addTableShardingValue("logicTable", 3);
             assertThat(HintManager.getTableShardingValues("logicTable").size(), is(2));
-            assertTrue(HintManager.getTableShardingValues("logicTable").contains(1));
-            assertTrue(HintManager.getTableShardingValues("logicTable").contains(3));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getTableShardingValues("logicTable"));
+            assertThat(shardingValues.get(0), is(1));
+            assertThat(shardingValues.get(1), is(3));
         }
     }
-    
+
     @Test
     public void assertGetDatabaseShardingValuesWithoutLogicTable() {
         try (HintManager hintManager = HintManager.getInstance()) {
             hintManager.setDatabaseShardingValue(1);
             assertThat(HintManager.getDatabaseShardingValues().size(), is(1));
-            assertTrue(HintManager.getDatabaseShardingValues().contains(1));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getDatabaseShardingValues());
+            assertThat(shardingValues.get(0), is(1));
         }
     }
-    
+
     @Test
     public void assertGetDatabaseShardingValuesWithLogicTable() {
         try (HintManager hintManager = HintManager.getInstance()) {
             hintManager.addDatabaseShardingValue("logic_table", 1);
             assertThat(HintManager.getDatabaseShardingValues("logic_table").size(), is(1));
-            assertTrue(HintManager.getDatabaseShardingValues("logic_table").contains(1));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getDatabaseShardingValues("logic_table"));
+            assertThat(shardingValues.get(0), is(1));
         }
     }
-    
+
     @Test
     public void assertGetTableShardingValues() {
         try (HintManager hintManager = HintManager.getInstance()) {
             hintManager.addTableShardingValue("logic_table", 1);
             assertThat(HintManager.getTableShardingValues("logic_table").size(), is(1));
-            assertTrue(HintManager.getTableShardingValues("logic_table").contains(1));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getTableShardingValues("logic_table"));
+            assertThat(shardingValues.get(0), is(1));
         }
     }
-    
+
     @Test
     public void assertIsDatabaseShardingOnly() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -103,14 +112,14 @@ public final class HintManagerTest {
             assertTrue(HintManager.isDatabaseShardingOnly());
         }
     }
-    
+
     @Test
     public void assertIsDatabaseShardingOnlyWithoutSet() {
         HintManager hintManager = HintManager.getInstance();
         hintManager.close();
         assertFalse(HintManager.isDatabaseShardingOnly());
     }
-    
+
     @Test
     public void assertAddDatabaseShardingValueOnlyDatabaseSharding() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -119,10 +128,11 @@ public final class HintManagerTest {
             hintManager.addDatabaseShardingValue("logic_table", 2);
             assertFalse(HintManager.isDatabaseShardingOnly());
             assertThat(HintManager.getDatabaseShardingValues("logic_table").size(), is(1));
-            assertTrue(HintManager.getDatabaseShardingValues("logic_table").contains(2));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getDatabaseShardingValues("logic_table"));
+            assertThat(shardingValues.get(0), is(2));
         }
     }
-    
+
     @Test
     public void assertAddTableShardingValueOnlyDatabaseSharding() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -131,10 +141,11 @@ public final class HintManagerTest {
             hintManager.addTableShardingValue("logic_table", 2);
             assertFalse(HintManager.isDatabaseShardingOnly());
             assertThat(HintManager.getTableShardingValues("logic_table").size(), is(1));
-            assertTrue(HintManager.getTableShardingValues("logic_table").contains(2));
+            List<Comparable<?>> shardingValues = new ArrayList<>(HintManager.getTableShardingValues("logic_table"));
+            assertThat(shardingValues.get(0), is(2));
         }
     }
-    
+
     @Test
     public void assertSetPrimaryRouteOnly() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -142,7 +153,7 @@ public final class HintManagerTest {
             assertTrue(HintManager.isWriteRouteOnly());
         }
     }
-    
+
     @Test
     public void assertIsPrimaryRouteOnly() {
         try (HintManager hintManager = HintManager.getInstance()) {
@@ -150,14 +161,14 @@ public final class HintManagerTest {
             assertTrue(HintManager.isWriteRouteOnly());
         }
     }
-    
+
     @Test
     public void assertIsPrimaryRouteOnlyWithoutSet() {
         HintManager hintManager = HintManager.getInstance();
         hintManager.close();
         assertFalse(HintManager.isWriteRouteOnly());
     }
-    
+
     @Test
     public void assertClose() {
         HintManager hintManager = HintManager.getInstance();
@@ -168,3 +179,5 @@ public final class HintManagerTest {
         assertTrue(HintManager.getTableShardingValues("logic_table").isEmpty());
     }
 }
+
+


### PR DESCRIPTION
In the Hint strategy, since HintManager uses HashMultimap to store the sharding keys, the order of the multiple sharding keys obtained by the sharding algorithm may be inconsistent with expectations.