### PR TITLE
Fix issue : SHOW SHARDING RULE throw NullPointerException when keyGenerateStrategy and default strategy is not configured

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/impl/ShardingRuleQueryBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/impl/ShardingRuleQueryBackendHandler.java
@@ -136,6 +136,9 @@ public final class ShardingRuleQueryBackendHandler extends SchemaRequiredBackend
     }
     
     private String generateKeyGenerateStrategy(final ShardingRuleConfiguration ruleConfig, final KeyGenerateStrategyConfiguration keyGenerateStrategy) {
+        if (null == keyGenerateStrategy) {
+            return "";
+        }
         StringBuilder result = new StringBuilder();
         result.append("column:");
         result.append(keyGenerateStrategy.getColumn());


### PR DESCRIPTION
Fixes #9865.

Changes proposed in this pull request:
- SHOW SHARDING RULE throw NullPointerException when keyGenerateStrategy and default strategy is not configured
