### PR TITLE
Fix 9892 : RegisterCenter.renew(DataSourceAddedEvent e) throw UnsupportedOperationException when RDL add resource

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
@@ -148,6 +148,7 @@ public final class RegistryCenter {
     
     private void addDataSourceConfigurations(final String schemaName, final Map<String, DataSourceConfiguration> dataSourceConfigurations) {
         Map<String, DataSourceConfiguration> dataSourceConfigurationMap = loadDataSourceConfigurations(schemaName);
+        dataSourceConfigurationMap = new LinkedHashMap<>(dataSourceConfigurationMap);
         dataSourceConfigurationMap.putAll(dataSourceConfigurations);
         repository.persist(node.getMetadataDataSourcePath(schemaName), YamlEngine.marshal(createYamlDataSourceConfigurationWrap(dataSourceConfigurationMap)));
     }

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
@@ -148,7 +148,6 @@ public final class RegistryCenter {
     
     private void addDataSourceConfigurations(final String schemaName, final Map<String, DataSourceConfiguration> dataSourceConfigurations) {
         Map<String, DataSourceConfiguration> dataSourceConfigurationMap = loadDataSourceConfigurations(schemaName);
-        dataSourceConfigurationMap = new LinkedHashMap<>(dataSourceConfigurationMap);
         dataSourceConfigurationMap.putAll(dataSourceConfigurations);
         repository.persist(node.getMetadataDataSourcePath(schemaName), YamlEngine.marshal(createYamlDataSourceConfigurationWrap(dataSourceConfigurationMap)));
     }

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/yaml/config/YamlConfigurationConverter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/yaml/config/YamlConfigurationConverter.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.governance.core.yaml.config;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
@@ -68,7 +67,9 @@ public final class YamlConfigurationConverter {
      * @return data source configurations
      */
     public static Map<String, DataSourceConfiguration> convertDataSourceConfigurations(final Map<String, Map<String, Object>> yamlDataSourceConfigs) {
-        return Maps.transformValues(yamlDataSourceConfigs, new YamlDataSourceConfigurationSwapper()::swapToDataSourceConfiguration);
+        Map<String, DataSourceConfiguration> result = new LinkedHashMap<>(yamlDataSourceConfigs.size());
+        yamlDataSourceConfigs.forEach((key, value) -> result.put(key, new YamlDataSourceConfigurationSwapper().swapToDataSourceConfiguration(value)));
+        return result;
     }
     
     /**

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
@@ -573,6 +573,27 @@ public final class RegistryCenterTest {
     }
     
     @Test
+    public void assertRenewDataSourceEventHasDataSourceConfig() {
+        DataSourceAddedEvent event = new DataSourceAddedEvent("sharding_db", createDataSourceConfigurations());
+        RegistryCenter registryCenter = new RegistryCenter(registryRepository);
+        String dataSourceYaml = "dataSources:\n"
+            + " ds_0:\n"
+            + "   dataSourceClassName: xxx\n"
+            + "   url: jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false\n"
+            + "   username: root\n"
+            + "   password: root\n"
+            + "   connectionTimeoutMilliseconds: 30000\n"
+            + "   idleTimeoutMilliseconds: 60000\n"
+            + "   maxLifetimeMilliseconds: 1800000\n"
+            + "   maxPoolSize: 50\n"
+            + "   minPoolSize: 1\n"
+            + "   maintenanceIntervalMilliseconds: 30000\n";
+        when(registryRepository.get("/metadata/sharding_db/datasource")).thenReturn(dataSourceYaml);
+        registryCenter.renew(event);
+        verify(registryRepository).persist(startsWith("/metadata/sharding_db/datasource"), anyString());
+    }
+    
+    @Test
     public void assertRenewRuleEvent() {
         RuleConfigurationsAlteredEvent event = new RuleConfigurationsAlteredEvent("sharding_db", createRuleConfigurations());
         RegistryCenter registryCenter = new RegistryCenter(registryRepository);


### PR DESCRIPTION
Fixes #9892.

Changes proposed in this pull request:
- re-implement `YamlConfigurationConverter.convertDataSourceConfigurations` to support `Map.put`
