### PR TITLE
Rename AuthorityCheckAlgorithm to AuthorityProvideAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-api/src/main/java/org/apache/shardingsphere/authority/api/config/AuthorityRuleConfiguration.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-api/src/main/java/org/apache/shardingsphere/authority/api/config/AuthorityRuleConfiguration.java
@@ -29,5 +29,5 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmC
 @Getter
 public final class AuthorityRuleConfiguration implements RuleConfiguration {
     
-    private final ShardingSphereAlgorithmConfiguration checker;
+    private final ShardingSphereAlgorithmConfiguration provider;
 }

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-api/src/main/java/org/apache/shardingsphere/authority/spi/AuthorityProvideAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-api/src/main/java/org/apache/shardingsphere/authority/spi/AuthorityProvideAlgorithm.java
@@ -28,9 +28,9 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Authority check algorithm.
+ * Authority provide algorithm.
 */
-public interface AuthorityCheckAlgorithm extends ShardingSphereAlgorithm {
+public interface AuthorityProvideAlgorithm extends ShardingSphereAlgorithm {
     
     /**
      * Initialize authority.

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/AuthorityContext.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/AuthorityContext.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.authority;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.authority.spi.AuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
 
 /**
  * Authority context.
@@ -31,7 +31,7 @@ public final class AuthorityContext {
     
     private static final AuthorityContext INSTANCE = new AuthorityContext();
     
-    private volatile AuthorityCheckAlgorithm checker;
+    private volatile AuthorityProvideAlgorithm provider;
     
     /**
      * Get instance.
@@ -43,11 +43,11 @@ public final class AuthorityContext {
     }
     
     /**
-     * Initial authority checker.
+     * Initial authority provide algorithm.
      * 
-     * @param checker authority checker
+     * @param provider authority provide algorithm
      */
-    public synchronized void init(final AuthorityCheckAlgorithm checker) {
-        this.checker = checker;
+    public synchronized void init(final AuthorityProvideAlgorithm provider) {
+        this.provider = provider;
     }
 }

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/algorithm/storage/StorageAuthorityProviderAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/algorithm/storage/StorageAuthorityProviderAlgorithm.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.authority.algorithm.storage;
 
 import org.apache.shardingsphere.authority.algorithm.storage.loader.StoragePrivilegeLoadEngine;
 import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
-import org.apache.shardingsphere.authority.spi.AuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
@@ -30,9 +30,9 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Storage authority check algorithm.
+ * Storage authority provide algorithm.
 */
-public final class StorageAuthorityCheckAlgorithm implements AuthorityCheckAlgorithm {
+public final class StorageAuthorityProviderAlgorithm implements AuthorityProvideAlgorithm {
     
     private final Map<ShardingSphereUser, ShardingSpherePrivileges> userPrivilegeMap = new ConcurrentHashMap<>();
     

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/checker/AuthorityChecker.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/checker/AuthorityChecker.java
@@ -43,7 +43,7 @@ public final class AuthorityChecker implements SQLChecker<AuthorityRule> {
         if (null == grantee) {
             return true;
         }
-        return AuthorityContext.getInstance().getChecker().findPrivileges(grantee).map(optional -> optional.hasPrivileges(schemaName)).orElse(false);
+        return AuthorityContext.getInstance().getProvider().findPrivileges(grantee).map(optional -> optional.hasPrivileges(schemaName)).orElse(false);
     }
     
     @Override
@@ -51,7 +51,7 @@ public final class AuthorityChecker implements SQLChecker<AuthorityRule> {
         if (null == grantee) {
             return new SQLCheckResult(true, "");
         }
-        Optional<ShardingSpherePrivileges> privileges = AuthorityContext.getInstance().getChecker().findPrivileges(grantee);
+        Optional<ShardingSpherePrivileges> privileges = AuthorityContext.getInstance().getProvider().findPrivileges(grantee);
         // TODO add error msg
         return privileges.map(optional -> new SQLCheckResult(optional.hasPrivileges(Collections.singletonList(getPrivilege(sqlStatement))), "")).orElseGet(() -> new SQLCheckResult(false, ""));
     }

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/rule/AuthorityRule.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/rule/AuthorityRule.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.authority.rule;
 
 import org.apache.shardingsphere.authority.api.config.AuthorityRuleConfiguration;
 import org.apache.shardingsphere.authority.AuthorityContext;
-import org.apache.shardingsphere.authority.spi.AuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
@@ -35,12 +35,12 @@ import java.util.Map;
 public final class AuthorityRule implements GlobalRule {
 
     static {
-        ShardingSphereServiceLoader.register(AuthorityCheckAlgorithm.class);
+        ShardingSphereServiceLoader.register(AuthorityProvideAlgorithm.class);
     }
     
     public AuthorityRule(final AuthorityRuleConfiguration config, final Map<String, ShardingSphereMetaData> mataDataMap, final Collection<ShardingSphereUser> users) {
-        AuthorityCheckAlgorithm checker = ShardingSphereAlgorithmFactory.createAlgorithm(config.getChecker(), AuthorityCheckAlgorithm.class);
-        checker.init(mataDataMap, users);
-        AuthorityContext.getInstance().init(checker);
+        AuthorityProvideAlgorithm provider = ShardingSphereAlgorithmFactory.createAlgorithm(config.getProvider(), AuthorityProvideAlgorithm.class);
+        provider.init(mataDataMap, users);
+        AuthorityContext.getInstance().init(provider);
     }
 }

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/yaml/config/YamlAuthorityRuleConfiguration.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/yaml/config/YamlAuthorityRuleConfiguration.java
@@ -30,7 +30,7 @@ import org.apache.shardingsphere.infra.yaml.config.algorithm.YamlShardingSphereA
 @Setter
 public final class YamlAuthorityRuleConfiguration implements YamlRuleConfiguration {
     
-    private YamlShardingSphereAlgorithmConfiguration checker;
+    private YamlShardingSphereAlgorithmConfiguration provider;
     
     @Override
     public Class<AuthorityRuleConfiguration> getRuleConfigurationType() {

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapper.java
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapper.java
@@ -33,13 +33,13 @@ public final class AuthorityRuleConfigurationYamlSwapper implements YamlRuleConf
     @Override
     public YamlAuthorityRuleConfiguration swapToYamlConfiguration(final AuthorityRuleConfiguration data) {
         YamlAuthorityRuleConfiguration result = new YamlAuthorityRuleConfiguration();
-        result.setChecker(algorithmSwapper.swapToYamlConfiguration(data.getChecker()));
+        result.setProvider(algorithmSwapper.swapToYamlConfiguration(data.getProvider()));
         return result;
     }
     
     @Override
     public AuthorityRuleConfiguration swapToObject(final YamlAuthorityRuleConfiguration yamlConfig) {
-        return new AuthorityRuleConfiguration(algorithmSwapper.swapToObject(yamlConfig.getChecker()));
+        return new AuthorityRuleConfiguration(algorithmSwapper.swapToObject(yamlConfig.getProvider()));
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/resources/META-INF/services/org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm
+++ b/shardingsphere-features/shardingsphere-authority/shardingsphere-authority-common/src/main/resources/META-INF/services/org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityCheckAlgorithm
+org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityProviderAlgorithm

--- a/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/authority/GovernanceAuthorityContext.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/authority/GovernanceAuthorityContext.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.governance.context.authority;
 import com.google.common.eventbus.Subscribe;
 import lombok.Setter;
 import org.apache.shardingsphere.authority.AuthorityContext;
-import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityCheckAlgorithm;
-import org.apache.shardingsphere.authority.spi.AuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityProviderAlgorithm;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
 import org.apache.shardingsphere.governance.core.event.model.auth.PrivilegeChangedEvent;
 import org.apache.shardingsphere.governance.core.event.model.auth.UserRuleChangedEvent;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataAwareEventSubscriber;
@@ -61,7 +61,7 @@ public final class GovernanceAuthorityContext implements MetaDataAwareEventSubsc
 
     private void reloadAuthority(final Collection<ShardingSphereUser> users) {
         // TODO reload AuthorityCheckAlgorithm from SPI
-        AuthorityCheckAlgorithm result = new StorageAuthorityCheckAlgorithm();
+        AuthorityProvideAlgorithm result = new StorageAuthorityProviderAlgorithm();
         result.init(metaDataContexts.getMetaDataMap(), users);
         AuthorityContext.getInstance().init(result);
     }

--- a/shardingsphere-governance/shardingsphere-governance-context/src/test/java/org/apache/shardingsphere/governance/context/metadata/GovernanceMetaDataContextsTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/test/java/org/apache/shardingsphere/governance/context/metadata/GovernanceMetaDataContextsTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.governance.context.metadata;
 
-import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityProviderAlgorithm;
 import org.apache.shardingsphere.governance.core.event.model.auth.UserRuleChangedEvent;
 import org.apache.shardingsphere.governance.core.event.model.datasource.DataSourceChangedEvent;
 import org.apache.shardingsphere.governance.core.event.model.metadata.MetaDataDeletedEvent;
@@ -159,7 +159,7 @@ public final class GovernanceMetaDataContextsTest {
     
     @Test
     public void assertAuthorityChanged() {
-        StorageAuthorityCheckAlgorithm authority = new StorageAuthorityCheckAlgorithm();
+        StorageAuthorityProviderAlgorithm authority = new StorageAuthorityProviderAlgorithm();
         UserRuleChangedEvent event = new UserRuleChangedEvent(Collections.singleton(mock(ShardingSphereUser.class)));
         governanceMetaDataContexts.renew(event);
         assertThat(governanceMetaDataContexts.getUsers().getUsers().size(), is(1));

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutorTest.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.proxy.backend.text.admin.mysql.executor;
 
 import org.apache.shardingsphere.authority.AuthorityContext;
-import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityCheckAlgorithm;
-import org.apache.shardingsphere.authority.spi.AuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityProviderAlgorithm;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.context.metadata.impl.StandardMetaDataContexts;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
@@ -61,13 +61,13 @@ public final class ShowDatabasesExecutorTest {
         showDatabasesExecutor = new ShowDatabasesExecutor();
         Field metaDataContexts = ProxyContext.getInstance().getClass().getDeclaredField("metaDataContexts");
         metaDataContexts.setAccessible(true);
-        initAuthorityCheckAlgorithm();
+        initAuthorityProvider();
         metaDataContexts.set(ProxyContext.getInstance(), new StandardMetaDataContexts(getMetaDataMap(), mock(ShardingSphereRuleMetaData.class), 
                 mock(ExecutorEngine.class), new ShardingSphereUsers(Collections.singleton(new ShardingSphereUser("root", "root", ""))), new ConfigurationProperties(new Properties())));
     }
     
-    private void initAuthorityCheckAlgorithm() {
-        AuthorityCheckAlgorithm algorithm = new StorageAuthorityCheckAlgorithm();
+    private void initAuthorityProvider() {
+        AuthorityProvideAlgorithm algorithm = new StorageAuthorityProviderAlgorithm();
         algorithm.init(Collections.emptyMap(), Collections.emptyList());
         AuthorityContext.getInstance().init(algorithm);
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -59,5 +59,5 @@
 #
 #rules:
 #  - !AUTHORITY
-#    checker:
+#    provider:
 #      type: STORAGE

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/auth/MySQLAuthenticationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/auth/MySQLAuthenticationHandlerTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.frontend.mysql.auth;
 
 import com.google.common.primitives.Bytes;
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityCheckAlgorithm;
+import org.apache.shardingsphere.authority.algorithm.storage.StorageAuthorityProviderAlgorithm;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLServerErrorCode;
 import org.apache.shardingsphere.db.protocol.mysql.packet.handshake.MySQLAuthPluginData;
 import org.apache.shardingsphere.infra.check.SQLChecker;
@@ -121,7 +121,7 @@ public final class MySQLAuthenticationHandlerTest {
     }
     
     private void setAuthority(final ShardingSphereUser user) {
-        StorageAuthorityCheckAlgorithm algorithm = new StorageAuthorityCheckAlgorithm();
+        StorageAuthorityProviderAlgorithm algorithm = new StorageAuthorityProviderAlgorithm();
         algorithm.init(Collections.emptyMap(), Collections.emptyList());
         initProxyContext(user);
     }


### PR DESCRIPTION
The YAML to config authority changed to:

```yaml
rules:
  - !AUTHORITY
    provider:
      type: STORAGE
```