### PR TITLE
fix docker.cn.md&&docker.en.md: update the image name

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/docker.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/docker.cn.md
@@ -7,7 +7,7 @@ weight = 3
 ## 拉取官方 Docker 镜像
 
 ```bash
-docker pull apache/shardingsphere-proxy
+docker pull apache/sharding-proxy
 ```
 
 ## 手动构建 Docker 镜像（可选）
@@ -28,7 +28,7 @@ mvn clean package -Prelease,docker
 ## 运行 Docker
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3308 -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3308 -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **说明**
@@ -37,7 +37,7 @@ docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3
 * 必须挂载配置路径到 /opt/shardingsphere-proxy/conf。
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OPTS="-Djava.awt.headless=true" -e PORT=3308 -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OPTS="-Djava.awt.headless=true" -e PORT=3308 -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **说明**
@@ -45,7 +45,7 @@ docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OP
 * 可以自定义JVM相关参数到环境变量 `JVM_OPTS` 中。
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -v /${your_work_dir}/ext-lib:/opt/shardingsphere-proxy/ext-lib -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -v /${your_work_dir}/ext-lib:/opt/shardingsphere-proxy/ext-lib -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **说明**

--- a/docs/document/content/user-manual/shardingsphere-proxy/docker.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/docker.en.md
@@ -7,7 +7,7 @@ weight = 3
 ## Pull Official Docker Clone
 
 ```bash
-docker pull apache/shardingsphere-proxy
+docker pull apache/sharding-proxy
 ```
 
 ## Build Docker Clone Manually (Optional)
@@ -28,7 +28,7 @@ Please refer to [Example](https://github.com/apache/shardingsphere/tree/master/s
 ## Run Docker
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3308 -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3308 -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **Notice**
@@ -37,7 +37,7 @@ docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e PORT=3
 * You have to volume conf dir to /opt/shardingsphere-proxy/conf.
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OPTS="-Djava.awt.headless=true" -e PORT=3308 -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OPTS="-Djava.awt.headless=true" -e PORT=3308 -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **Notice**
@@ -45,7 +45,7 @@ docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -e JVM_OP
 * You can define JVM related parameters to environment variable `JVM_OPTS`.
 
 ```bash
-docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -v /${your_work_dir}/ext-lib:/opt/shardingsphere-proxy/ext-lib -p13308:3308 apache/shardingsphere-proxy:latest
+docker run -d -v /${your_work_dir}/conf:/opt/shardingsphere-proxy/conf -v /${your_work_dir}/ext-lib:/opt/shardingsphere-proxy/ext-lib -p13308:3308 apache/sharding-proxy:latest
 ```
 
 **Notice**


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
there is don't have `apache/shardingsphere-proxy` image in dockerhub,there only have `apache/shardinging-proxy` image
![image](https://user-images.githubusercontent.com/29670394/114364500-0bd32800-9bac-11eb-98a5-5c4321159969.png)
![image](https://user-images.githubusercontent.com/29670394/114364736-46d55b80-9bac-11eb-8425-81e2b437f0a9.png)

