### PR TITLE
Complete Oracle drop table partition grammar

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -223,6 +223,10 @@ partitionSetName
     : identifier
     ;
 
+partitionKeyValue
+    : NUMBER_ | dateTimeLiterals
+    ;
+
 zonemapName
     : identifier
     ;
@@ -257,6 +261,10 @@ oracleId
 
 collationName
     : STRING_ | IDENTIFIER_
+    ;
+
+columnCollationName
+    : identifier
     ;
 
 alias
@@ -497,4 +505,8 @@ matchNone
 
 hashSubpartitionQuantity
     : NUMBER
+    ;
+
+odciParameters
+    : identifier
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1005,7 +1005,7 @@ updateGlobalIndexClause
 
 updateAllIndexesClause
     : UPDATE INDEXES
-    (LP_ indexName LP_ (updateIndexPartition | updateIndexSubpartition)
+    (LP_ indexName LP_ (updateIndexPartition | updateIndexSubpartition) RP_
     (COMMA_ indexName LP_ (updateIndexPartition | updateIndexSubpartition) RP_)* RP_)?
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1017,7 +1017,7 @@ updateIndexPartition
 indexPartitionDesc
     : PARTITION
     (partitionName
-    ((segmentAttributesClause | indexCompression) | PARAMETERS LP_ SQ_ odciParameters SQ_ RP_ )?
+    ((segmentAttributesClause | indexCompression)+ | PARAMETERS LP_ SQ_ odciParameters SQ_ RP_ )?
     usableSpecification?
     )?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -988,11 +988,11 @@ dropTablePartition
     ;
 
 partitionExtendedNames
-    : (PARTITION | PARTITIONS) (partitionName | partitionForClauses) (DOT_ (partitionName | partitionForClauses))*
+    : (PARTITION | PARTITIONS) (partitionName | partitionForClauses) (COMMA_ (partitionName | partitionForClauses))*
     ;
 
 partitionForClauses
-    : FOR LP_ partitionKeyValue (DOT_ partitionKeyValue)* RP_
+    : FOR LP_ partitionKeyValue (COMMA_ partitionKeyValue)* RP_
     ;
 
 updateIndexClauses
@@ -1006,12 +1006,12 @@ updateGlobalIndexClause
 updateAllIndexesClause
     : UPDATE INDEXES
     (LP_ indexName LP_ (updateIndexPartition | updateIndexSubpartition)
-    (DOT_ indexName LP_ (updateIndexPartition | updateIndexSubpartition) RP_)* RP_)?
+    (COMMA_ indexName LP_ (updateIndexPartition | updateIndexSubpartition) RP_)* RP_)?
     ;
 
 updateIndexPartition
     : indexPartitionDesc indexSubpartitionClause?
-    (DOT_ indexPartitionDesc indexSubpartitionClause?)*
+    (COMMA_ indexPartitionDesc indexSubpartitionClause?)*
     ;
 
 indexPartitionDesc
@@ -1023,14 +1023,14 @@ indexPartitionDesc
     ;
 
 indexSubpartitionClause
-    : STORE IN LP_ tablespaceName (DOT_ tablespaceName)* RP_
+    : STORE IN LP_ tablespaceName (COMMA_ tablespaceName)* RP_
     | LP_ SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)? indexCompression? usableSpecification?
-    (DOT_ SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)? indexCompression? usableSpecification?)* RP_
+    (COMMA_ SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)? indexCompression? usableSpecification?)* RP_
     ;
 
 updateIndexSubpartition
     : SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)?
-    (DOT_ SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)?)*
+    (COMMA_ SUBPARTITION subpartitionName? (TABLESPACE tablespaceName)?)*
     ;
 
 supplementalLoggingProps

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -106,7 +106,7 @@ oidClause
     ;
 
 oidIndexClause
-    : OIDINDEX indexName? LP_ ((physicalAttributesClause | TABLESPACE tablespaceName)+ | ) RP_
+    : OIDINDEX indexName? LP_ (physicalAttributesClause | TABLESPACE tablespaceName)* RP_
     ;
 
 createRelationalTableClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -106,7 +106,7 @@ oidClause
     ;
 
 oidIndexClause
-    : OIDINDEX indexName? LP_ (physicalAttributesClause | TABLESPACE tablespaceName)+ RP_
+    : OIDINDEX indexName? LP_ ((physicalAttributesClause | TABLESPACE tablespaceName)+ | ) RP_
     ;
 
 createRelationalTableClause
@@ -491,7 +491,7 @@ commitClause
     ;
 
 physicalProperties
-    : deferredSegmentCreation? segmentAttributesClause tableCompression? inmemoryTableClause? ilmClause?
+    : deferredSegmentCreation? segmentAttributesClause? tableCompression? inmemoryTableClause? ilmClause?
     | deferredSegmentCreation? (organizationClause?|externalPartitionClause?)
     | clusterClause
     ;
@@ -501,9 +501,9 @@ deferredSegmentCreation
     ;
 
 segmentAttributesClause
-    : physicalAttributesClause
+    : ( physicalAttributesClause
     | (TABLESPACE tablespaceName | TABLESPACE SET tablespaceSetName)
-    | loggingClause
+    | loggingClause)+
     ;
 
 physicalAttributesClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -903,6 +903,10 @@ PARALLEL
     : P A R A L L E L
     ;
 
+NOPARALLEL
+    : N O P A R A L L E L
+    ;
+
 LOG
     : L O G
     ;
@@ -1180,7 +1184,7 @@ PCTTHRESHOLD
     ;
 
 PARAMETERS
-    : P A R A M E  T E R S
+    : P A R A M E T E R S
     ;
 
 LOCATION
@@ -1409,4 +1413,8 @@ EDITIONABLE
 
 NONEDITIONABLE
     : N O N E D I T I O N A B L E
+    ;
+
+INDEXES
+    : I N D E X E S
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-table.xml
@@ -1035,4 +1035,28 @@
     <alter-table sql-case-id="alter_table_drop_partition">
         <table name="t_order" start-index="12" stop-index="18"/>
     </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_global_index">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_all_index">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_all_index_partition">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_all_index_subpartition">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_global_index_parallel">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_drop_partition_update_all_index_noparallel">
+        <table name="t_order" start-index="12" stop-index="18"/>
+    </alter-table>
 </sql-parser-test-cases>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
@@ -125,6 +125,12 @@
     <sql-case id="alter_table_add_range_partition" value="ALTER TABLE t_order ADD PARTITION range_p_order VALUES LESS THAN(100)" db-types="Oracle" />
     <sql-case id="alter_table_add_list_partition" value="ALTER TABLE t_order ADD PARTITION list_p_order VALUES(100, 200, 300)" db-types="Oracle" />
     <sql-case id="alter_table_drop_partition" value="ALTER TABLE t_order DROP PARTITION list_p_order" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_global_index" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE GLOBAL INDEXES" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_all_index" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE INDEXES" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_all_index_partition" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE INDEXES (order_index (PARTITION))" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_all_index_subpartition" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE INDEXES (order_index (SUBPARTITION))" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_global_index_parallel" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE GLOBAL INDEXES PARALLEL" db-types="Oracle" />
+    <sql-case id="alter_table_drop_partition_update_all_index_noparallel" value="ALTER TABLE t_order DROP PARTITION list_p_order UPDATE INDEXES NOPARALLEL" db-types="Oracle" />
 <!--    alter index test-->
     <sql-case id="alter_index" value="ALTER INDEX order_index REBUILD PARALLEL" db-types="Oracle" />
     <sql-case id="alter_index_with_space" value="    ALTER INDEX


### PR DESCRIPTION
Relates #9694 .

Changes proposed in this pull request:
- Complete `drop_table_partition` of [ALTER TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLE.html#GUID-552E7373-BF93-477D-9DA3-B2C9386F2877) and add corresponding test cases

@wgy8283335 
