### PR TITLE
Support governance for JDBC scenario

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/yaml/YamlGovernanceShardingSphereDataSourceFactory.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/yaml/YamlGovernanceShardingSphereDataSourceFactory.java
@@ -59,6 +59,21 @@ public final class YamlGovernanceShardingSphereDataSourceFactory {
     /**
      * Create ShardingSphere data source.
      *
+     * @param dataSourceMap data source
+     * @param governance governance configuration
+     * @param rulesYamlFile YAML file for rule configurations
+     * @return ShardingSphere data source
+     * @throws SQLException  SQL exception
+     * @throws IOException  SQL exception
+     */
+    public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final YamlGovernanceConfiguration governance, final File rulesYamlFile) throws SQLException, IOException {
+        YamlGovernanceRootRuleConfigurations configurations = unmarshal(rulesYamlFile);
+        return createDataSource(dataSourceMap, configurations, configurations.getProps(), governance);
+    }
+    
+    /**
+     * Create ShardingSphere data source.
+     *
      * @param dataSourceMap data source map
      * @param yamlFile YAML file for rule configurations
      * @return ShardingSphere data source

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/src/test/java/org/apache/shardingsphere/test/integration/junit/container/adapter/impl/ShardingSphereJDBCContainer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/src/test/java/org/apache/shardingsphere/test/integration/junit/container/adapter/impl/ShardingSphereJDBCContainer.java
@@ -17,24 +17,24 @@
 
 package org.apache.shardingsphere.test.integration.junit.container.adapter.impl;
 
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory;
 import org.apache.shardingsphere.driver.governance.api.yaml.YamlGovernanceShardingSphereDataSourceFactory;
 import org.apache.shardingsphere.test.integration.env.EnvironmentPath;
 import org.apache.shardingsphere.test.integration.junit.container.ShardingSphereContainer;
 import org.apache.shardingsphere.test.integration.junit.container.adapter.ShardingSphereAdapterContainer;
+import org.apache.shardingsphere.test.integration.junit.container.governance.ZookeeperContainer;
 import org.apache.shardingsphere.test.integration.junit.container.storage.ShardingSphereStorageContainer;
 import org.apache.shardingsphere.test.integration.junit.param.model.ParameterizedArray;
 import org.testcontainers.containers.wait.strategy.WaitStrategy;
-import org.testcontainers.lifecycle.Startable;
 
 import javax.sql.DataSource;
 import java.io.File;
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 /**
  * ShardingSphere JDBC container.
@@ -43,20 +43,52 @@ public final class ShardingSphereJDBCContainer extends ShardingSphereAdapterCont
     
     private final AtomicBoolean isHealthy = new AtomicBoolean();
     
-    private Map<String, DataSource> dataSourceMap;
+    private DataSource dataSource;
     
     public ShardingSphereJDBCContainer(final ParameterizedArray parameterizedArray) {
         super("ShardingSphere-JDBC", "ShardingSphere-JDBC", true, parameterizedArray);
     }
     
+    @SneakyThrows
     @Override
     public void start() {
         super.start();
-        List<Startable> startables = getDependencies().stream()
-                .filter(e -> e instanceof ShardingSphereStorageContainer)
-                .collect(Collectors.toList());
-        dataSourceMap = ((ShardingSphereStorageContainer) startables.get(0)).getDataSourceMap();
+        Optional<ZookeeperContainer> governance = getDependencies().stream()
+                .filter(x -> x instanceof ZookeeperContainer)
+                .map(x -> (ZookeeperContainer) x)
+                .findFirst();
+        ShardingSphereStorageContainer storageContainer = getDependencies().stream()
+                .filter(x -> x instanceof ShardingSphereStorageContainer)
+                .map(x -> (ShardingSphereStorageContainer) x)
+                .findFirst()
+                .orElseThrow(Exception::new);
+        Map<String, DataSource> dataSourceMap = storageContainer.getDataSourceMap();
+        try {
+            if ("sharding_governance".equals(getParameterizedArray().getScenario())) {
+                dataSource = createDataSource(dataSourceMap, governance, 0);
+            } else {
+                dataSource = YamlShardingSphereDataSourceFactory.createDataSource(dataSourceMap, new File(EnvironmentPath.getRulesConfigurationFile(getParameterizedArray().getScenario())));
+            }
+        } catch (SQLException | IOException ex) {
+            throw new RuntimeException(ex);
+        }
         isHealthy.set(true);
+    }
+    
+    @SneakyThrows
+    private DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final Optional<ZookeeperContainer> governance, final int retry) {
+        try {
+            return YamlGovernanceShardingSphereDataSourceFactory.createDataSource(
+                    dataSourceMap,
+                    governance.orElseThrow(() -> new NullPointerException("Governance Container cannot be null.")).getGovernanceConfiguration(),
+                    new File(EnvironmentPath.getRulesConfigurationFile(getParameterizedArray().getScenario()))
+            );
+        } catch (NullPointerException ex) {
+            if (retry == 0) {
+                return createDataSource(dataSourceMap, governance, 1);
+            }
+            throw ex;
+        }
     }
     
     /**
@@ -65,14 +97,7 @@ public final class ShardingSphereJDBCContainer extends ShardingSphereAdapterCont
      * @return data source
      */
     public DataSource getDataSource() {
-        try {
-            if ("sharding_governance".equals(getParameterizedArray().getScenario())) {
-                return YamlGovernanceShardingSphereDataSourceFactory.createDataSource(new File(EnvironmentPath.getRulesConfigurationFile(getParameterizedArray().getScenario())));
-            }
-            return YamlShardingSphereDataSourceFactory.createDataSource(dataSourceMap, new File(EnvironmentPath.getRulesConfigurationFile(getParameterizedArray().getScenario())));
-        } catch (SQLException | IOException ex) {
-            throw new RuntimeException(ex);
-        }
+        return dataSource;
     }
     
     @Override

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/src/test/java/org/apache/shardingsphere/test/integration/junit/container/governance/ZookeeperContainer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/src/test/java/org/apache/shardingsphere/test/integration/junit/container/governance/ZookeeperContainer.java
@@ -17,9 +17,13 @@
 
 package org.apache.shardingsphere.test.integration.junit.container.governance;
 
+import org.apache.shardingsphere.governance.core.yaml.config.YamlGovernanceCenterConfiguration;
+import org.apache.shardingsphere.governance.core.yaml.config.YamlGovernanceConfiguration;
 import org.apache.shardingsphere.test.integration.junit.container.ShardingSphereContainer;
 import org.apache.shardingsphere.test.integration.junit.param.model.ParameterizedArray;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.util.Properties;
 
 public class ZookeeperContainer extends ShardingSphereContainer {
     
@@ -28,4 +32,38 @@ public class ZookeeperContainer extends ShardingSphereContainer {
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*PrepRequestProcessor \\(sid:[0-9]+\\) started.*"));
     }
     
+    /**
+     * Get server lists.
+     *
+     * @return server lists
+     */
+    public String getServerLists() {
+        return getHost() + ":" + getMappedPort(2181);
+    }
+    
+    /**
+     * Get governance configuration.
+     *
+     * @return governance configuration
+     */
+    public YamlGovernanceConfiguration getGovernanceConfiguration() {
+        YamlGovernanceConfiguration result = new YamlGovernanceConfiguration();
+        result.setName("governance_ds");
+        result.setOverwrite(true);
+        result.setRegistryCenter(createGovernanceCenterConfiguration());
+        return result;
+    }
+    
+    private YamlGovernanceCenterConfiguration createGovernanceCenterConfiguration() {
+        YamlGovernanceCenterConfiguration configuration = new YamlGovernanceCenterConfiguration();
+        configuration.setServerLists(getServerLists());
+        configuration.setType("zookeeper");
+        Properties props = new Properties();
+        props.setProperty("retryIntervalMilliseconds", "500");
+        props.setProperty("timeToLiveSeconds", "60");
+        props.setProperty("maxRetries", "3");
+        props.setProperty("operationTimeoutMilliseconds", "500");
+        configuration.setProps(props);
+        return configuration;
+    }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/engine-env.properties
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/engine-env.properties
@@ -21,7 +21,7 @@ it.env.type=${it.env}
 it.adapters=jdbc
 
 #it.scenarios=db,tbl,dbtbl_with_read_write_splitting,read_write_splitting,encrypt,dbtbl_with_read_write_splitting_and_encrypt,sharding_governance,shadow
-it.scenarios=db,tbl,dbtbl_with_read_write_splitting,read_write_splitting,encrypt,dbtbl_with_read_write_splitting_and_encrypt
+it.scenarios=db,tbl,dbtbl_with_read_write_splitting,read_write_splitting,encrypt,dbtbl_with_read_write_splitting_and_encrypt,sharding_governance
 
 #it.databases=H2,MySQL,Oracle,SQLServer,PostgreSQL
 it.databases=H2


### PR DESCRIPTION
This case for covering multi-JDBC with coordinator scenario. 
Now, in this case, it is dependent on the Zookeeper Container(Docker environment, not a fake container). It aginst `native` sematic. So I am looking for a stable and reliable embedded zookeeper server except for the curator-test framework.

Changes proposed in this pull request:
- add a new method to create datasource in YamlGovernanceShardingSphereDataSourceFactory.java.
- complete sharding_governance case.

