### PR TITLE
optimize cacheCurrentRow logic of GroupByStreamMergeResult

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-merge/src/main/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResult.java
@@ -73,11 +73,15 @@ public final class GroupByStreamMergedResult extends OrderByStreamMergedResult {
     
     private boolean aggregateCurrentGroupByRowAndNext() throws SQLException {
         boolean result = false;
+        boolean cachedRow = false;
         Map<AggregationProjection, AggregationUnit> aggregationUnitMap = Maps.toMap(
                 selectStatementContext.getProjectionsContext().getAggregationProjections(), input -> AggregationUnitFactory.create(input.getType(), input instanceof AggregationDistinctProjection));
         while (currentGroupByValues.equals(new GroupByValue(getCurrentQueryResult(), selectStatementContext.getGroupByContext().getItems()).getGroupValues())) {
             aggregate(aggregationUnitMap);
-            cacheCurrentRow();
+            if (!cachedRow) {
+                cacheCurrentRow();
+                cachedRow = true;
+            }
             result = super.next();
             if (!result) {
                 break;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-merge/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-merge/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
@@ -114,7 +114,7 @@ public final class GroupByStreamMergedResultTest {
         when(queryResult1.getValue(6, Object.class)).thenReturn(20);
         QueryResult queryResult2 = mockQueryResult();
         when(queryResult2.next()).thenReturn(true, true, true, false);
-        when(queryResult2.getValue(1, Object.class)).thenReturn(20, 30, 30, 40);
+        when(queryResult2.getValue(1, Object.class)).thenReturn(20, 30, 40);
         when(queryResult2.getValue(2, Object.class)).thenReturn(0);
         when(queryResult2.getValue(3, Object.class)).thenReturn(2, 2, 3, 3, 3, 4);
         when(queryResult2.getValue(5, Object.class)).thenReturn(2, 2, 3, 3, 3, 4);


### PR DESCRIPTION
within `aggregateCurrentGroupByRowAndNext` logic, 
all of rows from one group will be appended into `currentRow` field, but we only use first one of them.
so I add a `cachedRow` flag to optimize it.