### PR TITLE
Fix Oracle addColumnSpecification grammar

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -304,7 +304,7 @@ operateColumnClause
     ;
 
 addColumnSpecification
-    : ADD LP_ columnOrVirtualDefinitions RP_ columnProperties? 
+    : ADD LP_ columnOrVirtualDefinitions RP_ columnProperties?
     ;
 
 columnOrVirtualDefinitions

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -304,11 +304,11 @@ operateColumnClause
     ;
 
 addColumnSpecification
-    : ADD columnOrVirtualDefinitions columnProperties?
+    : ADD LP_ columnOrVirtualDefinitions RP_ columnProperties? 
     ;
 
 columnOrVirtualDefinitions
-    : LP_? columnOrVirtualDefinition (COMMA_ columnOrVirtualDefinition)* RP_? | columnOrVirtualDefinition
+    : columnOrVirtualDefinition (COMMA_ columnOrVirtualDefinition)* 
     ;
 
 columnOrVirtualDefinition

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-table.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/case/ddl/alter-table.xml
@@ -26,6 +26,15 @@
         </add-column>
     </alter-table>
     
+    <alter-table sql-case-id="alter_table_oracle">
+        <table name="t_log" start-index="12" stop-index="16" />
+        <add-column>
+            <column-definition type="varchar" start-index="23" stop-index="38">
+                <column name="name" />
+            </column-definition>
+        </add-column>
+    </alter-table>
+    
     <alter-table sql-case-id="alter_table_if_exists_only">
         <table name="t_log" start-index="27" stop-index="31" />
         <add-column>
@@ -715,17 +724,17 @@
     <alter-table sql-case-id="alter_table_add_columns_oracle">
         <table name="t_order" start-index="12" stop-index="18" />
         <add-column>
-            <column-definition type="VARCHAR2" start-index="24" stop-index="43">
+            <column-definition type="VARCHAR2" start-index="25" stop-index="44">
                 <column name="column4" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR2" start-index="49" stop-index="68">
+            <column-definition type="VARCHAR2" start-index="47" stop-index="66">
                 <column name="column5" />
             </column-definition>
         </add-column>
         <add-column>
-            <column-definition type="VARCHAR2" start-index="74" stop-index="93">
+            <column-definition type="VARCHAR2" start-index="69" stop-index="88">
                 <column name="column6" />
             </column-definition>
         </add-column>
@@ -919,7 +928,7 @@
     <alter-table sql-case-id="alter_table_with_optimize_memory_read">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="43" stop-index="58">
+            <column-definition type="VARCHAR" start-index="44" stop-index="59">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -928,7 +937,7 @@
     <alter-table sql-case-id="alter_table_with_no_optimize_memory_write">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="47" stop-index="62">
+            <column-definition type="VARCHAR" start-index="48" stop-index="63">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -937,7 +946,7 @@
     <alter-table sql-case-id="alter_table_with_enable_validate">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -946,7 +955,7 @@
     <alter-table sql-case-id="alter_table_with_primary_key">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -955,7 +964,7 @@
     <alter-table sql-case-id="alter_table_with_index_clause">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -964,7 +973,7 @@
     <alter-table sql-case-id="alter_table_with_exception_clause">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -973,7 +982,7 @@
     <alter-table sql-case-id="alter_table_with_cascade">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -982,7 +991,7 @@
     <alter-table sql-case-id="alter_table_with_keep_index">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -991,7 +1000,7 @@
     <alter-table sql-case-id="alter_table_with_enable_table_lock">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -1000,7 +1009,7 @@
     <alter-table sql-case-id="alter_table_with_enable_all_triggers">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -1009,7 +1018,7 @@
     <alter-table sql-case-id="alter_table_with_disable_container_map">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>
@@ -1018,7 +1027,7 @@
     <alter-table sql-case-id="alter_table_with_disable_containers_default">
         <table name="t_log" start-index="12" stop-index="16"/>
         <add-column>
-            <column-definition type="VARCHAR" start-index="22" stop-index="37">
+            <column-definition type="VARCHAR" start-index="23" stop-index="38">
                 <column name="name" />
             </column-definition>
         </add-column>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-test/src/main/resources/sql/supported/ddl/alter.xml
@@ -17,7 +17,8 @@
   -->
 
 <sql-cases>
-    <sql-case id="alter_table" value="ALTER TABLE t_log ADD name varchar(10)" />
+    <sql-case id="alter_table" value="ALTER TABLE t_log ADD name varchar(10)" db-types="MySQL, PostgreSQL" />
+    <sql-case id="alter_table_oracle" value="ALTER TABLE t_log ADD (name varchar(10))" db-types="Oracle" />
     <sql-case id="alter_table_not_null" value="alter table t1 add c2 real  not null" db-types="MySQL" />
     <sql-case id="alter_table_not_null_first" value="alter table t1 add c2 real  not null first" db-types="MySQL" />
     <sql-case id="alter_table_not_null_after" value="alter table t1 add c4 real  not null after c2" db-types="MySQL" />
@@ -32,7 +33,7 @@
     <sql-case id="alter_table_with_space" value="    ALTER TABLE
         t_order" db-types="MySQL,Oracle" />
     <sql-case id="alter_table_with_back_quota" value="ALTER TABLE `t_order` FORCE" db-types="MySQL" />
-    <sql-case id="alter_table_add_column" value="ALTER TABLE t_order ADD column4 VARCHAR(10)" />
+    <sql-case id="alter_table_add_column" value="ALTER TABLE t_order ADD column4 VARCHAR(10)" db-types="MySQL, PostgreSQL" />
     <sql-case id="alter_table_add_columns" value="ALTER TABLE t_order ADD column4 VARCHAR(10), ADD column5 VARCHAR(10), ADD column6 VARCHAR(10)" db-types="MySQL,PostgreSQL" />
     <sql-case id="alter_table_add_columns_integer_type_mysql" value="ALTER TABLE t_order ADD column4 INTEGER, ADD column5 TINYINT, ADD column6 MEDIUMINT" db-types="MySQL" />
     <sql-case id="alter_table_add_columns_integer_type_oracle" value="ALTER TABLE t_order ADD (column4 INTEGER, column5 INT, column6 SMALLINT)" db-types="Oracle" />
@@ -80,7 +81,7 @@
     <sql-case id="alter_table_with_quota" value="ALTER TABLE &quot;t_order&quot; PARALLEL" db-types="Oracle" />
 <!--    TODO support PostgreSQL-->
     <sql-case id="alter_table_add_check" value="ALTER TABLE t_order ADD CONSTRAINT chk_order_id CHECK (order_id > 0)" db-types="Oracle,SQLServer" />
-    <sql-case id="alter_table_add_columns_oracle" value="ALTER TABLE t_order ADD column4 VARCHAR2(10) ADD column5 VARCHAR2(10) ADD column6 VARCHAR2(10)" db-types="Oracle" />
+    <sql-case id="alter_table_add_columns_oracle" value="ALTER TABLE t_order ADD (column4 VARCHAR2(10), column5 VARCHAR2(10), column6 VARCHAR2(10))" db-types="Oracle" />
     <sql-case id="alter_table_modify_columns_oracle" value="ALTER TABLE t_order MODIFY column4 VARCHAR2(20) MODIFY column5 VARCHAR2(20) MODIFY column6 VARCHAR2(20)" db-types="Oracle" />
     <sql-case id="alter_table_drop_columns_oracle" value="ALTER TABLE t_order DROP COLUMN user_id DROP COLUMN column5" db-types="Oracle" />
     <sql-case id="alter_table_add_primary_foreign_key" value="ALTER TABLE t_order_item ADD PRIMARY KEY (order_id) UNIQUE (order_id) CHECK (order_id > 0) FOREIGN KEY (order_id) REFERENCES t_order (order_id) ON DELETE CASCADE CHECK (order_id > 0)" db-types="Oracle" />
@@ -110,18 +111,18 @@
     <sql-case id="alter_table_attach_partition" value="ALTER TABLE t_order ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')" db-types="PostgreSQL"/>
     <sql-case id="alter_table_detach_partition" value="ALTER TABLE t_order ATTACH PARTITION measurement_y2016m07 FOR VALUES FROM ('2016-07-01') TO ('2016-08-01')" db-types="PostgreSQL"/>
     <sql-case id="alter_table_in_hash_partitioned_table" value="ALTER TABLE t_order ATTACH PARTITION orders_p4 FOR VALUES WITH (MODULUS 4, REMAINDER 3)" db-types="PostgreSQL" />
-    <sql-case id="alter_table_with_optimize_memory_read" value="ALTER TABLE t_log MEMOPTIMIZE FOR READ ADD name VARCHAR(10)" db-types="Oracle" />
-    <sql-case id="alter_table_with_no_optimize_memory_write" value="ALTER TABLE t_log NO MEMOPTIMIZE FOR WRITE ADD name VARCHAR(10)" db-types="Oracle" />
-    <sql-case id="alter_table_with_enable_validate" value="ALTER TABLE t_log ADD name VARCHAR(10) ENABLE VALIDATE PRIMARY KEY" db-types="Oracle" />
-    <sql-case id="alter_table_with_primary_key" value="ALTER TABLE t_log ADD name VARCHAR(10) ENABLE PRIMARY KEY" db-types="Oracle" />
-    <sql-case id="alter_table_with_index_clause" value="ALTER TABLE t_log ADD name VARCHAR(10) ENABLE PRIMARY KEY USING INDEX t_log" db-types="Oracle" />
-    <sql-case id="alter_table_with_exception_clause" value="ALTER TABLE t_log ADD name VARCHAR(10) DISABLE PRIMARY KEY EXCEPTIONS INTO t_log" db-types="Oracle" />
-    <sql-case id="alter_table_with_cascade" value="ALTER TABLE t_log ADD name VARCHAR(10) DISABLE PRIMARY KEY CASCADE" db-types="Oracle" />
-    <sql-case id="alter_table_with_keep_index" value="ALTER TABLE t_log ADD name VARCHAR(10) DISABLE PRIMARY KEY KEEP INDEX" db-types="Oracle" />
-    <sql-case id="alter_table_with_enable_table_lock" value="ALTER TABLE t_log ADD name VARCHAR(10) ENABLE TABLE LOCK" db-types="Oracle" />
-    <sql-case id="alter_table_with_enable_all_triggers" value="ALTER TABLE t_log ADD name VARCHAR(10) ENABLE ALL TRIGGERS" db-types="Oracle" />
-    <sql-case id="alter_table_with_disable_container_map" value="ALTER TABLE t_log ADD name VARCHAR(10) DISABLE CONTAINER_MAP" db-types="Oracle" />
-    <sql-case id="alter_table_with_disable_containers_default" value="ALTER TABLE t_log ADD name VARCHAR(10) DISABLE CONTAINERS_DEFAULT" db-types="Oracle" />
+    <sql-case id="alter_table_with_optimize_memory_read" value="ALTER TABLE t_log MEMOPTIMIZE FOR READ ADD (name VARCHAR(10))" db-types="Oracle" />
+    <sql-case id="alter_table_with_no_optimize_memory_write" value="ALTER TABLE t_log NO MEMOPTIMIZE FOR WRITE ADD (name VARCHAR(10))" db-types="Oracle" />
+    <sql-case id="alter_table_with_enable_validate" value="ALTER TABLE t_log ADD (name VARCHAR(10)) ENABLE VALIDATE PRIMARY KEY" db-types="Oracle" />
+    <sql-case id="alter_table_with_primary_key" value="ALTER TABLE t_log ADD (name VARCHAR(10)) ENABLE PRIMARY KEY" db-types="Oracle" />
+    <sql-case id="alter_table_with_index_clause" value="ALTER TABLE t_log ADD (name VARCHAR(10)) ENABLE PRIMARY KEY USING INDEX t_log" db-types="Oracle" />
+    <sql-case id="alter_table_with_exception_clause" value="ALTER TABLE t_log ADD (name VARCHAR(10)) DISABLE PRIMARY KEY EXCEPTIONS INTO t_log" db-types="Oracle" />
+    <sql-case id="alter_table_with_cascade" value="ALTER TABLE t_log ADD (name VARCHAR(10)) DISABLE PRIMARY KEY CASCADE" db-types="Oracle" />
+    <sql-case id="alter_table_with_keep_index" value="ALTER TABLE t_log ADD (name VARCHAR(10)) DISABLE PRIMARY KEY KEEP INDEX" db-types="Oracle" />
+    <sql-case id="alter_table_with_enable_table_lock" value="ALTER TABLE t_log ADD (name VARCHAR(10)) ENABLE TABLE LOCK" db-types="Oracle" />
+    <sql-case id="alter_table_with_enable_all_triggers" value="ALTER TABLE t_log ADD (name VARCHAR(10)) ENABLE ALL TRIGGERS" db-types="Oracle" />
+    <sql-case id="alter_table_with_disable_container_map" value="ALTER TABLE t_log ADD (name VARCHAR(10)) DISABLE CONTAINER_MAP" db-types="Oracle" />
+    <sql-case id="alter_table_with_disable_containers_default" value="ALTER TABLE t_log ADD (name VARCHAR(10)) DISABLE CONTAINERS_DEFAULT" db-types="Oracle" />
     <sql-case id="alter_table_add_range_partition" value="ALTER TABLE t_order ADD PARTITION range_p_order VALUES LESS THAN(100)" db-types="Oracle" />
     <sql-case id="alter_table_add_list_partition" value="ALTER TABLE t_order ADD PARTITION list_p_order VALUES(100, 200, 300)" db-types="Oracle" />
     <sql-case id="alter_table_drop_partition" value="ALTER TABLE t_order DROP PARTITION list_p_order" db-types="Oracle" />


### PR DESCRIPTION
Relates #9694.

Changes proposed in this pull request:
- Fix Oracle `addColumnSpecification` grammar of [ALTER TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-TABLE.html#GUID-552E7373-BF93-477D-9DA3-B2C9386F2877)

