### PR TITLE
fix miss shardingsphere-encrypt-api dependency in example pom.xml

### DIFF
--- a/examples/example-core/config-utility/pom.xml
+++ b/examples/example-core/config-utility/pom.xml
@@ -37,5 +37,9 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-encrypt-common</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-encrypt-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -89,6 +89,11 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-encrypt-api</artifactId>
+                <version>${shardingsphere.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.shardingsphere</groupId>
                 <artifactId>shardingsphere-jdbc-core</artifactId>
                 <version>${shardingsphere.version}</version>
             </dependency>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
example模块的TestQueryAssistedShardingEncryptAlgorithm类依赖了org.apache.shardingsphere.encrypt.spi.QueryAssistedEncryptAlgorithm类，这个类在shardingsphere-encrypt-api模块中才存在，这里增加这个shardingsphere-encrypt-api模块的依赖，来解决example的编译报错问题
