### PR TITLE
Fix ReadyForQuery may be missing when Simple Query

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecuteEngineTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecuteEngineTest.java
@@ -50,6 +50,6 @@ public final class PostgreSQLCommandExecuteEngineTest {
         PostgreSQLCommandExecuteEngine commandExecuteEngine = new PostgreSQLCommandExecuteEngine();
         when(queryCommandExecutor.getResponseType()).thenReturn(ResponseType.UPDATE);
         commandExecuteEngine.writeQueryData(channelHandlerContext, null, queryCommandExecutor, 0);
-        verify(channelHandlerContext, times(0)).write(isA(PostgreSQLReadyForQueryPacket.class));
+        verify(channelHandlerContext, times(1)).write(isA(PostgreSQLReadyForQueryPacket.class));
     }
 }


### PR DESCRIPTION
I've tested it by sysbench and simplily tested it by psql. I don't think some FATAL about transaction is related to this PR.


```
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Dropping table 'sbtest1'...
Dropping table 'sbtest2'...
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Initializing worker threads...

Creating table 'sbtest2'...
Creating table 'sbtest1'...
Inserting 10000 records into 'sbtest1'
Inserting 10000 records into 'sbtest2'
Creating a secondary index on 'sbtest1'...
Creating a secondary index on 'sbtest2'...
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 1216.06 qps: 14596.97 (r/w/o: 12164.16/0.00/2432.81) lat (ms,99%): 36.24 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 1956.30 qps: 23476.56 (r/w/o: 19563.85/0.00/3912.71) lat (ms,99%): 10.84 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 8 tps: 1922.28 qps: 23067.81 (r/w/o: 19223.24/0.00/3844.57) lat (ms,99%): 11.87 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            509560
        write:                           0
        other:                           101912
        total:                           611472
    transactions:                        50956  (1698.22 per sec.)
    queries:                             611472 (20378.69 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0044s
    total number of events:              50956

Latency (ms):
         min:                                    1.70
         avg:                                    4.71
         max:                                  140.08
         99th percentile:                       18.28
         sum:                               239927.55

Threads fairness:
    events (avg/stddev):           6369.5000/22.58
    execution time (avg/stddev):   29.9909/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 1738.68 qps: 20868.83 (r/w/o: 17390.68/0.00/3478.16) lat (ms,99%): 13.95 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 1751.70 qps: 21019.14 (r/w/o: 17515.83/0.00/3503.31) lat (ms,99%): 12.30 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 8 tps: 1499.12 qps: 17990.20 (r/w/o: 14991.87/0.00/2998.33) lat (ms,99%): 19.29 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            499050
        write:                           0
        other:                           99810
        total:                           598860
    transactions:                        49905  (1663.19 per sec.)
    queries:                             598860 (19958.26 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0046s
    total number of events:              49905

Latency (ms):
         min:                                    1.66
         avg:                                    4.81
         max:                                  238.92
         99th percentile:                       15.00
         sum:                               239940.81

Threads fairness:
    events (avg/stddev):           6238.1250/17.98
    execution time (avg/stddev):   29.9926/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 14661.98 qps: 14661.98 (r/w/o: 14661.98/0.00/0.00) lat (ms,99%): 2.76 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 20778.64 qps: 20778.64 (r/w/o: 20778.64/0.00/0.00) lat (ms,99%): 1.25 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            553776
        write:                           0
        other:                           0
        total:                           553776
    transactions:                        553776 (18457.73 per sec.)
    queries:                             553776 (18457.73 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0013s
    total number of events:              553776

Latency (ms):
         min:                                    0.14
         avg:                                    0.43
         max:                                  166.78
         99th percentile:                        1.58
         sum:                               239751.04

Threads fairness:
    events (avg/stddev):           69222.0000/150.36
    execution time (avg/stddev):   29.9689/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 414.35 qps: 6638.76 (r/w/o: 4149.87/0.00/2488.89) lat (ms,99%): 102.97 err/s: 0.00 reconn/s: 0.00
FATAL: PQexecPrepared() failed: 7 current transaction is aborted, commands ignored until end of transaction block
FATAL: `thread_run' function failed: /usr/share/sysbench/oltp_common.lua:469: SQL error, errno = 0, state = '25P02': current transaction is aborted, commands ignored until end of transaction block
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

FATAL: PQexecPrepared() failed: 7 current transaction is aborted, commands ignored until end of transaction block
FATAL: `thread_run' function failed: /usr/share/sysbench/oltp_common.lua:469: SQL error, errno = 0, state = '25P02': current transaction is aborted, commands ignored until end of transaction block
FATAL: PQexecPrepared() failed: 7 current transaction is aborted, commands ignored until end of transaction block
FATAL: `thread_run' function failed: /usr/share/sysbench/oltp_common.lua:487: SQL error, errno = 0, state = '25P02': current transaction is aborted, commands ignored until end of transaction block
sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 693.32 qps: 693.32 (r/w/o: 0.00/0.00/693.32) lat (ms,99%): 26.20 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 750.60 qps: 750.60 (r/w/o: 0.00/0.00/750.60) lat (ms,99%): 24.83 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 8 tps: 636.00 qps: 636.00 (r/w/o: 0.00/0.00/636.00) lat (ms,99%): 87.56 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            0
        write:                           0
        other:                           20808
        total:                           20808
    transactions:                        20808  (693.36 per sec.)
    queries:                             20808  (693.36 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0091s
    total number of events:              20808

Latency (ms):
         min:                                    1.12
         avg:                                   11.53
         max:                                  420.39
         99th percentile:                       32.53
         sum:                               240019.86

Threads fairness:
    events (avg/stddev):           2601.0000/2.87
    execution time (avg/stddev):   30.0025/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 758.31 qps: 758.31 (r/w/o: 0.00/0.00/758.31) lat (ms,99%): 20.00 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 756.14 qps: 756.14 (r/w/o: 0.00/0.00/756.14) lat (ms,99%): 20.37 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 8 tps: 675.81 qps: 675.81 (r/w/o: 0.00/0.00/675.81) lat (ms,99%): 23.52 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            0
        write:                           0
        other:                           21912
        total:                           21912
    transactions:                        21912  (730.12 per sec.)
    queries:                             21912  (730.12 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0105s
    total number of events:              21912

Latency (ms):
         min:                                    1.08
         avg:                                   10.95
         max:                                   82.80
         99th percentile:                       21.11
         sum:                               240023.47

Threads fairness:
    events (avg/stddev):           2739.0000/1.80
    execution time (avg/stddev):   30.0029/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Running the test with following options:
Number of threads: 8
Report intermediate results every 10 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 10s ] thds: 8 tps: 620.53 qps: 620.53 (r/w/o: 0.00/0.00/620.53) lat (ms,99%): 27.66 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 8 tps: 1351.16 qps: 1351.16 (r/w/o: 0.00/0.00/1351.16) lat (ms,99%): 19.65 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 8 tps: 5329.28 qps: 5329.28 (r/w/o: 0.00/0.00/5329.28) lat (ms,99%): 12.52 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            0
        write:                           0
        other:                           73008
        total:                           73008
    transactions:                        73008  (2433.32 per sec.)
    queries:                             73008  (2433.32 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

General statistics:
    total time:                          30.0024s
    total number of events:              73008

Latency (ms):
         min:                                    0.12
         avg:                                    3.29
         max:                                  314.45
         99th percentile:                       20.74
         sum:                               239947.74

Threads fairness:
    events (avg/stddev):           9126.0000/181.96
    execution time (avg/stddev):   29.9935/0.00

sysbench 1.0.20 (using bundled LuaJIT 2.1.0-beta2)

Dropping table 'sbtest1'...
Dropping table 'sbtest2'...

```