### PR TITLE
fix example pom miss shardingsphere-read-write-splitting-api dependency

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -167,6 +167,11 @@
                 <artifactId>shardingsphere-infra-common</artifactId>
                 <version>${shardingsphere.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-read-write-splitting-api</artifactId>
+                <version>${shardingsphere.version}</version>
+            </dependency>
             
             <dependency>
                 <groupId>org.aspectj</groupId>

--- a/examples/shardingsphere-jdbc-example/sharding-example/sharding-raw-jdbc-example/pom.xml
+++ b/examples/shardingsphere-jdbc-example/sharding-example/sharding-raw-jdbc-example/pom.xml
@@ -38,5 +38,9 @@
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-jdbc-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-read-write-splitting-api</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:

解决example模块下，缺乏shardingsphere-read-write-splitting-api依赖的问题