### PR TITLE
Complete missing protocol impl for MySQLColumnDefinition41Packet with COM_FIELD_LIST command

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/MySQLColumnDefinition41Packet.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/MySQLColumnDefinition41Packet.java
@@ -62,10 +62,12 @@ public final class MySQLColumnDefinition41Packet implements MySQLPacket {
     
     private final int decimals;
     
+    private final boolean containDefaultValues;
+    
     public MySQLColumnDefinition41Packet(final int sequenceId, final ResultSetMetaData resultSetMetaData, final int columnIndex) throws SQLException {
         this(sequenceId, resultSetMetaData.getSchemaName(columnIndex), resultSetMetaData.getTableName(columnIndex), resultSetMetaData.getTableName(columnIndex), 
                 resultSetMetaData.getColumnLabel(columnIndex), resultSetMetaData.getColumnName(columnIndex), resultSetMetaData.getColumnDisplaySize(columnIndex), 
-                MySQLBinaryColumnType.valueOfJDBCType(resultSetMetaData.getColumnType(columnIndex)), resultSetMetaData.getScale(columnIndex));
+                MySQLBinaryColumnType.valueOfJDBCType(resultSetMetaData.getColumnType(columnIndex)), resultSetMetaData.getScale(columnIndex), false);
     }
     
     /*
@@ -74,12 +76,14 @@ public final class MySQLColumnDefinition41Packet implements MySQLPacket {
      * @see <a href="https://github.com/apache/shardingsphere/issues/4358"></a>
      */
     public MySQLColumnDefinition41Packet(final int sequenceId, final String schema, final String table, final String orgTable,
-                                         final String name, final String orgName, final int columnLength, final MySQLBinaryColumnType columnType, final int decimals) {
-        this(sequenceId, 0, schema, table, orgTable, name, orgName, columnLength, columnType, decimals);
+                                         final String name, final String orgName, final int columnLength, final MySQLBinaryColumnType columnType, 
+                                         final int decimals, final boolean containDefaultValues) {
+        this(sequenceId, 0, schema, table, orgTable, name, orgName, columnLength, columnType, decimals, containDefaultValues);
     }
     
     public MySQLColumnDefinition41Packet(final int sequenceId, final int flags, final String schema, final String table, final String orgTable,
-                                         final String name, final String orgName, final int columnLength, final MySQLBinaryColumnType columnType, final int decimals) {
+                                         final String name, final String orgName, final int columnLength, final MySQLBinaryColumnType columnType, 
+                                         final int decimals, final boolean containDefaultValues) {
         this.sequenceId = sequenceId;
         characterSet = MySQLServerInfo.CHARSET;
         this.flags = flags;
@@ -91,6 +95,7 @@ public final class MySQLColumnDefinition41Packet implements MySQLPacket {
         this.columnLength = columnLength;
         this.columnType = columnType;
         this.decimals = decimals;
+        this.containDefaultValues = containDefaultValues;
     }
     
     public MySQLColumnDefinition41Packet(final MySQLPacketPayload payload) {
@@ -108,6 +113,7 @@ public final class MySQLColumnDefinition41Packet implements MySQLPacket {
         flags = payload.readInt2();
         decimals = payload.readInt1();
         payload.skipReserved(2);
+        containDefaultValues = false;
     }
     
     @Override
@@ -125,5 +131,9 @@ public final class MySQLColumnDefinition41Packet implements MySQLPacket {
         payload.writeInt2(flags);
         payload.writeInt1(decimals);
         payload.writeReserved(2);
+        if (containDefaultValues) {
+            payload.writeIntLenenc(0);
+            payload.writeStringLenenc("");
+        }
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -84,7 +84,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
     private Collection<DatabasePacket<?>> createParameterColumnDefinition41Packets(final int parameterCount) {
         Collection<DatabasePacket<?>> result = new LinkedList<>();
         for (int i = 0; i < parameterCount; i++) {
-            result.add(new MySQLColumnDefinition41Packet(++currentSequenceId, "", "", "", "?", "", 0, MySQLBinaryColumnType.MYSQL_TYPE_VAR_STRING, 0));
+            result.add(new MySQLColumnDefinition41Packet(++currentSequenceId, "", "", "", "?", "", 0, MySQLBinaryColumnType.MYSQL_TYPE_VAR_STRING, 0, false));
         }
         result.add(new MySQLEofPacket(++currentSequenceId));
         return result;
@@ -93,7 +93,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
     private Collection<DatabasePacket<?>> createProjectionColumnDefinition41Packets(final int projectionCount) {
         Collection<DatabasePacket<?>> result = new LinkedList<>();
         for (int i = 0; i < projectionCount; i++) {
-            result.add(new MySQLColumnDefinition41Packet(++currentSequenceId, "", "", "", "", "", 0, MySQLBinaryColumnType.MYSQL_TYPE_VAR_STRING, 0));
+            result.add(new MySQLColumnDefinition41Packet(++currentSequenceId, "", "", "", "", "", 0, MySQLBinaryColumnType.MYSQL_TYPE_VAR_STRING, 0, false));
         }
         result.add(new MySQLEofPacket(++currentSequenceId));
         return result;

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilder.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/builder/ResponsePacketBuilder.java
@@ -54,7 +54,7 @@ public final class ResponsePacketBuilder {
         result.add(new MySQLFieldCountPacket(++sequenceId, queryHeader.size()));
         for (QueryHeader each : queryHeader) {
             result.add(new MySQLColumnDefinition41Packet(++sequenceId, getColumnFieldDetailFlag(each), each.getSchema(), each.getTable(), each.getTable(),
-                    each.getColumnLabel(), each.getColumnName(), each.getColumnLength(), MySQLBinaryColumnType.valueOfJDBCType(each.getColumnType()), each.getDecimals()));
+                    each.getColumnLabel(), each.getColumnName(), each.getColumnLength(), MySQLBinaryColumnType.valueOfJDBCType(each.getColumnType()), each.getDecimals(), false));
         }
         result.add(new MySQLEofPacket(++sequenceId));
         return result;

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/fieldlist/MySQLComFieldListPacketExecutor.java
@@ -71,7 +71,7 @@ public final class MySQLComFieldListPacketExecutor implements CommandExecutor {
         while (databaseCommunicationEngine.next()) {
             String columnName = databaseCommunicationEngine.getQueryResponseRow().getCells().iterator().next().getData().toString();
             result.add(new MySQLColumnDefinition41Packet(
-                    ++currentSequenceId, schemaName, packet.getTable(), packet.getTable(), columnName, columnName, 100, MySQLBinaryColumnType.MYSQL_TYPE_VARCHAR, 0));
+                    ++currentSequenceId, schemaName, packet.getTable(), packet.getTable(), columnName, columnName, 100, MySQLBinaryColumnType.MYSQL_TYPE_VARCHAR, 0, true));
         }
         result.add(new MySQLEofPacket(++currentSequenceId));
         return result;


### PR DESCRIPTION
The protocol impl is missing if using COM_FIELD_LIST command.

please check: https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnDefinition41

```
  if command was COM_FIELD_LIST {
lenenc_int     length of default-values
string[$len]   default values
  }
```