### PR TITLE
Fix rule definition in Oracle `ALTER DATABASE`'s  `defaultSettingsClauses`

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1355,7 +1355,7 @@ defaultSettingsClauses
     | SET DEFAULT (BIGFILE | SMALLFILE) TABLESPACE
     | DEFAULT TABLESPACE tablespaceName
     | DEFAULT LOCAL? TEMPORARY TABLESPACE (tablespaceName | tablespaceGroupName)
-    | RENAME GLOBAL_NAME TO databaseName DO_ domain (DQ_ domain)*
+    | RENAME GLOBAL_NAME TO databaseName DOT_ domain (DOT_ domain)*
     | ENABLE BLOCK CHANGE TRACKING (USING FILE fileName REUSE?)?
     | DISABLE BLOCK CHANGE TRACKING
     | NO? FORCE FULL DATABASE CACHING

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -1794,3 +1794,7 @@ PROPERTY
 DEFAULT_CREDENTIAL
     : D E F A U L T UL_ C R E D E N T I A L
     ;
+
+TIME_ZONE
+    : T I M E UL_ Z O N E
+    ;


### PR DESCRIPTION
Relates #10136 

Hi @tristaZero, @Liangda-w. I changed the `defaultSettingsClauses`'s definition, please check it.

Changes proposed in this pull request:
- In the [defaultSettingsClauses](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/ALTER-DATABASE.html#GUID-8069872F-E680-4511-ADD8-A4E30AF67986) of `ALTER DATABASE` Oracle statement, I added `DOT_`
- I added `TIME_ZONE` in OracleKeyword.g4 file.
