### PR TITLE
add global rule configurations event,listener, persist into and load from RegistryCenter

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
@@ -221,7 +221,7 @@ public final class RegistryCenter {
         return !Strings.isNullOrEmpty(repository.get(node.getPropsPath()));
     }
     
-    private void persistGlobalRuleConfigurations(final Collection<RuleConfiguration> globalRuleConfigs, boolean isOverwrite){
+    private void persistGlobalRuleConfigurations(final Collection<RuleConfiguration> globalRuleConfigs, final boolean isOverwrite) {
         if (!globalRuleConfigs.isEmpty() && (isOverwrite || !hasGlobalRuleConfigurations())) {
             repository.persist(node.getGlobalRuleNode(), YamlEngine.marshal(new YamlRuleConfigurationSwapperEngine().swapToYamlRuleConfigurations(globalRuleConfigs)));
         }
@@ -289,8 +289,8 @@ public final class RegistryCenter {
      * 
      * @return global rule configurations
      */
-    public Collection<RuleConfiguration> loadGlobalRuleConfigurations () {
-        return Strings.isNullOrEmpty(repository.get(node.getGlobalRuleNode())) ? Collections.emptyList() : YamlConfigurationConverter.convertRuleConfigurations(repository.get(node.getGlobalRuleNode()));
+    public Collection<RuleConfiguration> loadGlobalRuleConfigurations() {
+        return hasGlobalRuleConfigurations() ? YamlConfigurationConverter.convertRuleConfigurations(repository.get(node.getGlobalRuleNode())) : Collections.emptyList();
     }
     
     /**

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenter.java
@@ -221,6 +221,16 @@ public final class RegistryCenter {
         return !Strings.isNullOrEmpty(repository.get(node.getPropsPath()));
     }
     
+    private void persistGlobalRuleConfigurations(final Collection<RuleConfiguration> globalRuleConfigs, boolean isOverwrite){
+        if (!globalRuleConfigs.isEmpty() && (isOverwrite || !hasGlobalRuleConfigurations())) {
+            repository.persist(node.getGlobalRuleNode(), YamlEngine.marshal(new YamlRuleConfigurationSwapperEngine().swapToYamlRuleConfigurations(globalRuleConfigs)));
+        }
+    }
+    
+    private boolean hasGlobalRuleConfigurations() {
+        return !Strings.isNullOrEmpty(repository.get(node.getGlobalRuleNode()));
+    }
+    
     private void persistSchemaName(final String schemaName) {
         String schemaNames = repository.get(node.getMetadataNodePath());
         if (Strings.isNullOrEmpty(schemaNames)) {
@@ -272,6 +282,15 @@ public final class RegistryCenter {
      */
     public Properties loadProperties() {
         return Strings.isNullOrEmpty(repository.get(node.getPropsPath())) ? new Properties() : YamlConfigurationConverter.convertProperties(repository.get(node.getPropsPath()));
+    }
+    
+    /**
+     * Load global rule configurations.
+     * 
+     * @return global rule configurations
+     */
+    public Collection<RuleConfiguration> loadGlobalRuleConfigurations () {
+        return Strings.isNullOrEmpty(repository.get(node.getGlobalRuleNode())) ? Collections.emptyList() : YamlConfigurationConverter.convertRuleConfigurations(repository.get(node.getGlobalRuleNode()));
     }
     
     /**

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterNode.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterNode.java
@@ -56,7 +56,9 @@ public final class RegistryCenterNode {
     private static final String SCHEMA_NODE = "schema";
     
     private static final String USERS_NODE = "users";
-    
+
+    private static final String GLOBAL_RULE_NODE = "rule";
+
     private static final String PRIVILEGE_NODE = "privilegenode";
     
     private static final String PROPS_NODE = "props";
@@ -254,7 +256,16 @@ public final class RegistryCenterNode {
     public String getUsersNode() {
         return getFullPath(USERS_NODE);
     }
-
+    
+    /**
+     * Get global rule node path.
+     *
+     * @return global rule node path
+     */
+    public String getGlobalRuleNode() {
+        return getFullPath(GLOBAL_RULE_NODE);
+    }
+    
     /**
      * Get privilege node path.
      *

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/listener/event/rule/GlobalRuleConfigurationsChangedEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/listener/event/rule/GlobalRuleConfigurationsChangedEvent.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.listener.event.rule;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.governance.core.registry.listener.event.GovernanceEvent;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
+
+import java.util.Collection;
+
+/**
+ * Global rule configurations event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class GlobalRuleConfigurationsChangedEvent implements GovernanceEvent {
+    
+    private final String schemaName;
+    
+    private final Collection<RuleConfiguration> ruleConfigurations;
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/listener/impl/GlobalRuleChangedListener.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/listener/impl/GlobalRuleChangedListener.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.listener.impl;
+
+import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.governance.core.registry.RegistryCenterNode;
+import org.apache.shardingsphere.governance.core.registry.listener.PostGovernanceRepositoryEventListener;
+import org.apache.shardingsphere.governance.core.registry.listener.event.GovernanceEvent;
+import org.apache.shardingsphere.governance.core.registry.listener.event.rule.GlobalRuleConfigurationsChangedEvent;
+import org.apache.shardingsphere.governance.core.yaml.config.YamlRuleConfigurationWrap;
+import org.apache.shardingsphere.governance.repository.api.RegistryRepository;
+import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEvent;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.YamlRuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapperEngine;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Global rule changed listener.
+ */
+public final class GlobalRuleChangedListener extends PostGovernanceRepositoryEventListener<GovernanceEvent> {
+    
+    public GlobalRuleChangedListener(final RegistryRepository registryRepository) {
+        super(registryRepository, Collections.singleton(new RegistryCenterNode().getGlobalRuleNode()));
+    }
+    
+    @Override
+    protected Optional<GovernanceEvent> createEvent(final DataChangedEvent event) {
+        return Optional.of(new GlobalRuleConfigurationsChangedEvent("", getGlobalRuleConfigurations(event)));
+    }
+    
+    private Collection<RuleConfiguration> getGlobalRuleConfigurations(final DataChangedEvent event) {
+        Collection<YamlRuleConfiguration> globalRuleConfigs = YamlEngine.unmarshal(event.getValue(), YamlRuleConfigurationWrap.class).getRules();
+        Preconditions.checkState(!globalRuleConfigs.isEmpty(), "No available global rule to load for governance.");
+        return new YamlRuleConfigurationSwapperEngine().swapToRuleConfigurations(globalRuleConfigs);
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterNodeTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterNodeTest.java
@@ -86,22 +86,27 @@ public final class RegistryCenterNodeTest {
     public void assertGetRulePath() {
         assertThat(registryCenterNode.getRulePath(DefaultSchema.LOGIC_NAME), is("/metadata/logic_db/rule"));
     }
-
+    
     @Test
     public void assertGetUsersNodePath() {
         assertThat(registryCenterNode.getUsersNode(), is("/users"));
     }
-
+    
+    @Test
+    public void assertGetGlobalRuleNodePath() {
+        assertThat(registryCenterNode.getGlobalRuleNode(), is("/rule"));
+    }
+    
     @Test
     public void assertGetPropsPath() {
         assertThat(registryCenterNode.getPropsPath(), is("/props"));
     }
-
+    
     @Test
     public void assertGetSchemaName() {
         assertThat(registryCenterNode.getSchemaName("/metadata/logic_db/rule"), is(DefaultSchema.LOGIC_NAME));
     }
-
+    
     @Test
     public void assertGetAllSchemaConfigPaths() {
         Collection<String> actual = registryCenterNode.getAllSchemaConfigPaths(Collections.singletonList(DefaultSchema.LOGIC_NAME));

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
@@ -500,11 +500,13 @@ public final class RegistryCenterTest {
         RegistryCenter registryCenter = new RegistryCenter(registryRepository);
         Collection<RuleConfiguration> globalRuleConfigs = registryCenter.loadGlobalRuleConfigurations();
         assertTrue(!globalRuleConfigs.isEmpty());
-        Collection<ShardingSphereUser> users = globalRuleConfigs.stream().filter(each -> each instanceof AuthorityRuleConfiguration).flatMap(each -> ((AuthorityRuleConfiguration) each).getUsers().stream()).collect(Collectors.toList());
+        Collection<ShardingSphereUser> users = globalRuleConfigs.stream().filter(each -> each instanceof AuthorityRuleConfiguration)
+                .flatMap(each -> ((AuthorityRuleConfiguration) each).getUsers().stream()).collect(Collectors.toList());
         Optional<ShardingSphereUser> user = users.stream().filter(each -> each.getGrantee().equals(new Grantee("root", ""))).findFirst();
         assertTrue(user.isPresent());
         assertThat(user.get().getPassword(), is("root"));
-        Collection<ShardingSphereAlgorithmConfiguration> providers = globalRuleConfigs.stream().filter(each -> each instanceof AuthorityRuleConfiguration && Objects.nonNull(((AuthorityRuleConfiguration) each).getProvider()))
+        Collection<ShardingSphereAlgorithmConfiguration> providers = globalRuleConfigs.stream()
+                .filter(each -> each instanceof AuthorityRuleConfiguration && Objects.nonNull(((AuthorityRuleConfiguration) each).getProvider()))
                 .map(each -> ((AuthorityRuleConfiguration) each).getProvider()).collect(Collectors.toList());
         assertTrue(!providers.isEmpty());
         Optional<ShardingSphereAlgorithmConfiguration> nativeProvider = providers.stream().filter(each -> "NATIVE".equals(each.getType())).findFirst();

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.governance.core.registry;
 
 import lombok.SneakyThrows;
+import org.apache.shardingsphere.authority.api.config.AuthorityRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.governance.core.registry.listener.event.datasource.DataSourceAddedEvent;
@@ -63,6 +64,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -98,6 +100,8 @@ public final class RegistryCenterTest {
     private static final String SHADOW_RULE_YAML = "yaml/registryCenter/data-shadow-rule.yaml";
     
     private static final String USERS_YAML = "yaml/registryCenter/data-users.yaml";
+    
+    private static final String GLOBAL_RULE_YAML = "yaml/registryCenter/data-global-rule.yaml";
     
     private static final String PROPS_YAML = ConfigurationPropertyKey.SQL_SHOW.getKey() + ": false\n";
     
@@ -488,6 +492,23 @@ public final class RegistryCenterTest {
         RegistryCenter registryCenter = new RegistryCenter(registryRepository);
         Properties actual = registryCenter.loadProperties();
         assertThat(actual.get(ConfigurationPropertyKey.SQL_SHOW.getKey()), is(Boolean.FALSE));
+    }
+    
+    @Test
+    public void assertLoadGlobalRuleConfigurations() {
+        when(registryRepository.get("/rule")).thenReturn(readYAML(GLOBAL_RULE_YAML));
+        RegistryCenter registryCenter = new RegistryCenter(registryRepository);
+        Collection<RuleConfiguration> globalRuleConfigs = registryCenter.loadGlobalRuleConfigurations();
+        assertTrue(!globalRuleConfigs.isEmpty());
+        Collection<ShardingSphereUser> users = globalRuleConfigs.stream().filter(each -> each instanceof AuthorityRuleConfiguration).flatMap(each -> ((AuthorityRuleConfiguration) each).getUsers().stream()).collect(Collectors.toList());
+        Optional<ShardingSphereUser> user = users.stream().filter(each -> each.getGrantee().equals(new Grantee("root", ""))).findFirst();
+        assertTrue(user.isPresent());
+        assertThat(user.get().getPassword(), is("root"));
+        Collection<ShardingSphereAlgorithmConfiguration> providers = globalRuleConfigs.stream().filter(each -> each instanceof AuthorityRuleConfiguration && Objects.nonNull(((AuthorityRuleConfiguration) each).getProvider()))
+                .map(each -> ((AuthorityRuleConfiguration) each).getProvider()).collect(Collectors.toList());
+        assertTrue(!providers.isEmpty());
+        Optional<ShardingSphereAlgorithmConfiguration> nativeProvider = providers.stream().filter(each -> "NATIVE".equals(each.getType())).findFirst();
+        assertTrue(nativeProvider.isPresent());
     }
     
     @Test

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/listener/impl/GlobalRuleChangedListenerTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/listener/impl/GlobalRuleChangedListenerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.listener.impl;
+
+import org.apache.shardingsphere.governance.core.registry.listener.event.GovernanceEvent;
+import org.apache.shardingsphere.governance.core.registry.listener.event.rule.GlobalRuleConfigurationsChangedEvent;
+import org.apache.shardingsphere.governance.core.registry.listener.metadata.MetaDataListenerTest;
+import org.apache.shardingsphere.governance.repository.api.RegistryRepository;
+import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEvent;
+import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEvent.Type;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class GlobalRuleChangedListenerTest extends MetaDataListenerTest {
+    
+    private GlobalRuleChangedListener globalRuleChangedListener;
+    
+    @Mock
+    private RegistryRepository registryRepository;
+    
+    @Before
+    public void setUp() {
+        globalRuleChangedListener = new GlobalRuleChangedListener(registryRepository);
+    }
+    
+    @Test
+    public void assertCreateEvent() {
+        Optional<GovernanceEvent> event = globalRuleChangedListener.createEvent(new DataChangedEvent("rule", readYAML("yaml/authority-rule.yaml"), Type.UPDATED));
+        assertTrue(event.isPresent());
+        assertThat(event.get(), instanceOf(GlobalRuleConfigurationsChangedEvent.class));
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/yaml/authority-rule.yaml
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/yaml/authority-rule.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !AUTHORITY
+    users:
+      - root@%:root
+      - sharding@:sharding
+    provider:
+      type: NATIVE

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/yaml/registryCenter/data-global-rule.yaml
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/yaml/registryCenter/data-global-rule.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !AUTHORITY
+    users:
+      - root@%:root
+      - sharding@:sharding
+    provider:
+      type: NATIVE


### PR DESCRIPTION
Fixes #10252.

Changes proposed in this pull request:
- add global rule configurations persist and load in RegistryCenter.
- add global rule changed event and listener.
- add GLOBAL_RULE_NODE in RegistryCenterNode.
