### PR TITLE
fix projection owner check when exist subquery temporary table

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-rewrite/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -90,7 +90,7 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
             return false;
         }
         Optional<OwnerSegment> ownerSegment = ((ShorthandProjectionSegment) projectionSegment).getOwner();
-        return ownerSegment.map(segment -> selectStatementContext.getTablesContext().findTableNameFromSQL(segment.getIdentifier().getValue()).equalsIgnoreCase(tableName)).orElse(true);
+        return ownerSegment.map(segment -> selectStatementContext.getTablesContext().findTableNameFromSQL(segment.getIdentifier().getValue()).orElse("").equalsIgnoreCase(tableName)).orElse(true);
     }
     
     private SubstitutableColumnNameToken generateSQLToken(final ColumnProjectionSegment segment, final String tableName) {

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.infra.binder.segment.table;
 
 import lombok.Getter;
 import lombok.ToString;
-import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 
@@ -74,7 +74,7 @@ public final class TablesContext {
             return Optional.of(tables.iterator().next().getTableName().getIdentifier().getValue());
         }
         if (column.getOwner().isPresent()) {
-            return Optional.ofNullable(findTableNameFromSQL(column.getOwner().get().getIdentifier().getValue()));
+            return findTableNameFromSQL(column.getOwner().get().getIdentifier().getValue());
         }
         return findTableNameFromMetaData(column.getIdentifier().getValue(), schema);
     }
@@ -91,7 +91,7 @@ public final class TablesContext {
             return Optional.of(tables.iterator().next().getTableName().getIdentifier().getValue());
         }
         if (null != column.getOwner()) {
-            return Optional.of(findTableNameFromSQL(column.getOwner()));
+            return findTableNameFromSQL(column.getOwner());
         }
         return findTableNameFromMetaData(column.getName(), schema);
     }
@@ -101,13 +101,13 @@ public final class TablesContext {
      * @param tableNameOrAlias table name or alias
      * @return table name
      */
-    public String findTableNameFromSQL(final String tableNameOrAlias) {
+    public Optional<String> findTableNameFromSQL(final String tableNameOrAlias) {
         for (SimpleTableSegment each : tables) {
             if (tableNameOrAlias.equalsIgnoreCase(each.getTableName().getIdentifier().getValue()) || tableNameOrAlias.equals(each.getAlias().orElse(null))) {
-                return each.getTableName().getIdentifier().getValue();
+                return Optional.of(each.getTableName().getIdentifier().getValue());
             }
         }
-        return null;
+        return Optional.empty();
     }
     
     private Optional<String> findTableNameFromMetaData(final String columnName, final ShardingSphereSchema schema) {

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
@@ -74,7 +74,7 @@ public final class TablesContext {
             return Optional.of(tables.iterator().next().getTableName().getIdentifier().getValue());
         }
         if (column.getOwner().isPresent()) {
-            return Optional.of(findTableNameFromSQL(column.getOwner().get().getIdentifier().getValue()));
+            return Optional.ofNullable(findTableNameFromSQL(column.getOwner().get().getIdentifier().getValue()));
         }
         return findTableNameFromMetaData(column.getIdentifier().getValue(), schema);
     }
@@ -107,7 +107,7 @@ public final class TablesContext {
                 return each.getTableName().getIdentifier().getValue();
             }
         }
-        throw new IllegalStateException("Can not find owner from table.");
+        return null;
     }
     
     private Optional<String> findTableNameFromMetaData(final String columnName, final ShardingSphereSchema schema) {


### PR DESCRIPTION
Fixes #10257.

Changes proposed in this pull request:
- remove exception check in TablesContext#findTableNameFromSQL method
- support subquery temporary table when init ProjectionsContext
