### PR TITLE
feat: add contributor over time graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![Gitter](https://badges.gitter.im/shardingsphere/shardingsphere.svg)](https://gitter.im/shardingsphere/Lobby)
 [![GitHub release](https://img.shields.io/github/release/apache/shardingsphere.svg)](https://github.com/apache/shardingsphere/releases)
 [![Stargazers over time](https://starchart.cc/apache/shardingsphere.svg)](https://starchart.cc/apache/shardingsphere)
+**Contributor over time**
+[![Contributor over time](https://contributor-graph-api.apiseven.com/contributors-svg?chart=contributorOverTime&repo=apache/shardingsphere)](https://www.apiseven.com/en/contributor-graph?chart=contributorOverTime&repo=apache/shardingsphere)
 
 [![Build Status](https://api.travis-ci.org/apache/shardingsphere.svg?branch=master&status=created)](https://travis-ci.org/apache/shardingsphere)
 [![codecov](https://codecov.io/gh/apache/shardingsphere/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/shardingsphere)


### PR DESCRIPTION
Hi community!

We're the maintainers of [Apache APISIX](https://github.com/apache/apisix). To better present how our community grows, we develop a tool to show contributors growing history on https://github.com/api7/contributor-graph. Since we found it helpful, we think maybe if it could help some other community.

### WHAT IT IS

Basically, it just shows the contributors growth over time. All of the procedures are running on GCP, and it would automatically update the graph each day, so the link would always present the real-time data. There is some other stuff to [play around](https://www.apiseven.com/en/contributor-graph) with if you would like to give it a try~

![image](https://user-images.githubusercontent.com/34589752/119444760-c00eb500-bcf9-11eb-8162-3817032e08a7.png)

### HOW IT WORKS

We use Github API to get all commits, try to find the “Github way” to filter commits so the result data would be similar to Github, and then get the first commit time of each contributor.

Don't hesitate to tell us if there is a better place to present this graph other than this, or there are some other worries or other features you would like to have~🍻 

