### PR TITLE
Use different ports between test cases to support Maven parallel execution

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/governance/util/EmbedTestingServer.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/governance/util/EmbedTestingServer.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EmbedTestingServer {
     
-    private static final int PORT = 3181;
+    private static final int PORT = 3183;
     
     private static volatile TestingServer testingServer;
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-encrypt.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-encrypt.properties
@@ -36,4 +36,4 @@ spring.shardingsphere.governance.name=governance-spring-boot-encrypt-test
 spring.shardingsphere.governance.overwrite=true
 
 spring.shardingsphere.governance.registry-center.type=TestRegistry
-spring.shardingsphere.governance.registry-center.server-lists=localhost:3181
+spring.shardingsphere.governance.registry-center.server-lists=localhost:3183

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-readwrite-splitting.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-readwrite-splitting.properties
@@ -46,5 +46,5 @@ spring.shardingsphere.governance.name=governance-spring-boot-read-query-test
 spring.shardingsphere.governance.overwrite=true
 
 spring.shardingsphere.governance.registry-center.type=TestRegistry
-spring.shardingsphere.governance.registry-center.server-lists=localhost:3181
+spring.shardingsphere.governance.registry-center.server-lists=localhost:3183
 

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-registry-readwrite-splitting.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-registry-readwrite-splitting.properties
@@ -19,4 +19,4 @@ spring.shardingsphere.governance.name=governance-spring-boot-registry-readwrite-
 spring.shardingsphere.governance.overwrite=true
 
 spring.shardingsphere.governance.registry-center.type=TestRegistry
-spring.shardingsphere.governance.registry-center.server-lists=localhost:3181
+spring.shardingsphere.governance.registry-center.server-lists=localhost:3183

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-registry.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-registry.properties
@@ -19,4 +19,4 @@ spring.shardingsphere.governance.name=governance-spring-boot-test
 spring.shardingsphere.governance.overwrite=true
 
 spring.shardingsphere.governance.registry-center.type=TestRegistry
-spring.shardingsphere.governance.registry-center.server-lists=localhost:3181
+spring.shardingsphere.governance.registry-center.server-lists=localhost:3183

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-sharding.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/test/resources/application-sharding.properties
@@ -71,5 +71,5 @@ spring.shardingsphere.props.executor-size=100
 
 spring.shardingsphere.governance.name=governance-spring-boot-sharding-test
 spring.shardingsphere.governance.registry-center.type=TestRegistry
-spring.shardingsphere.governance.registry-center.server-lists=localhost:3181
+spring.shardingsphere.governance.registry-center.server-lists=localhost:3183
 spring.shardingsphere.governance.overwrite=true

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/java/org/apache/shardingsphere/spring/namespace/governance/util/EmbedTestingServer.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/java/org/apache/shardingsphere/spring/namespace/governance/util/EmbedTestingServer.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class EmbedTestingServer {
     
-    private static final int PORT = 3181;
+    private static final int PORT = 3182;
     
     private static volatile TestingServer testingServer;
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/encrypt-governance.xml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/encrypt-governance.xml
@@ -25,7 +25,7 @@
                            ">
     <import resource="namespace/encrypt-data-source-namespace.xml" />
     
-    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3181">
+    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3182">
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">1000</prop>

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/readwrite-splitting-governance.xml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/readwrite-splitting-governance.xml
@@ -26,7 +26,7 @@
                            ">
     <import resource="namespace/readwrite-splitting-data-source-namespace.xml" />
     
-    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3181">
+    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3182">
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">1000</prop>

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/sharding-governance.xml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/sharding-governance.xml
@@ -34,7 +34,7 @@
         <prop key="operation-timeout-milliseconds">1000</prop>
     </util:properties>
     
-    <governance:reg-center id="registryCenterRepository" type="TestRegistry" server-lists="localhost:3181">
+    <governance:reg-center id="registryCenterRepository" type="TestRegistry" server-lists="localhost:3182">
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">1000</prop>

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/sharding-readwrite-splitting-governance.xml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/test/resources/META-INF/rdb/sharding-readwrite-splitting-governance.xml
@@ -26,7 +26,7 @@
                            ">
     <import resource="namespace/sharding-readwrite-splitting-namespace.xml" />
     
-    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3181">
+    <governance:reg-center id="regCenter" type="TestRegistry" server-lists="localhost:3182">
         <props>
             <prop key="max-retries">3</prop>
             <prop key="operation-timeout-milliseconds">1000</prop>


### PR DESCRIPTION
Use different ports between test cases to support Maven parallel execution

Fixes #10492.

Changes proposed in this pull request:
- Change the port number of org.apache.shardingsphere.spring.namespace.governance.util.EmbedTestingServer and related configuration files to 3182
- Change the port number of org.apache.shardingsphere.spring.boot.governance.util.EmbedTestingServer and related configuration files to 3183
