### PR TITLE
Use RuleConfigurationFixture instead of ShardingRuleConfiguration for test case in governance module

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/RegistryCenterTest.java
@@ -124,11 +124,10 @@ public final class RegistryCenterTest {
         result.setPassword("root");
         return result;
     }
-    
+
+    @SuppressWarnings("unchecked")
     private Collection<RuleConfiguration> createRuleConfigurations() {
-        // TODO use RuleConfigurationFixture instead of ShardingRuleConfiguration for test case
-        return Collections.emptyList();
-//        return new YamlRuleConfigurationSwapperEngine().swapToRuleConfigurations(YamlEngine.unmarshal(readYAML(SCHEMA_RULE_YAML), Collection.class));
+        return new YamlRuleConfigurationSwapperEngine().swapToRuleConfigurations(YamlEngine.unmarshal(readYAML(SCHEMA_RULE_YAML), Collection.class));
     }
     
     @SuppressWarnings("unchecked")

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/config/service/impl/SchemaRuleRegistryServiceTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/config/service/impl/SchemaRuleRegistryServiceTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.governance.core.registry.config.service.impl;
 
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.governance.core.registry.config.event.rule.RuleConfigurationsAlteredEvent;
 import org.apache.shardingsphere.governance.core.registry.config.event.rule.RuleConfigurationsAlteredSQLNotificationEvent;
 import org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
@@ -66,7 +65,6 @@ public final class SchemaRuleRegistryServiceTest {
     
     @Test
     public void assertLoadWithExistedNode() {
-        String test = readYAML();
         when(registryCenterRepository.get("/metadata/foo_db/rules")).thenReturn(readYAML());
         Collection<RuleConfiguration> actual = schemaRuleRegistryService.load("foo_db");
         assertThat(actual.size(), is(1));

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/config/service/impl/SchemaRuleRegistryServiceTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/config/service/impl/SchemaRuleRegistryServiceTest.java
@@ -17,19 +17,30 @@
 
 package org.apache.shardingsphere.governance.core.registry.config.service.impl;
 
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.governance.core.registry.config.event.rule.RuleConfigurationsAlteredEvent;
 import org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class SchemaRuleRegistryServiceTest {
@@ -54,20 +65,17 @@ public final class SchemaRuleRegistryServiceTest {
     
     @Test
     public void assertLoadWithExistedNode() {
-        // TODO use RuleConfigurationFixture instead of ShardingRuleConfiguration for test case
-//        when(registryCenterRepository.get("/metadata/foo_db/rules")).thenReturn(readYAML());
-//        Collection<RuleConfiguration> actual = schemaRuleRegistryService.load("foo_db");
-//        assertThat(actual.size(), is(1));
-//        ShardingRuleConfiguration actualShardingRuleConfig = (ShardingRuleConfiguration) actual.iterator().next();
-//        assertThat(actualShardingRuleConfig.getTables().size(), is(1));
-//        assertThat(actualShardingRuleConfig.getTables().iterator().next().getLogicTable(), is("t_order"));
+        String test = readYAML();
+        when(registryCenterRepository.get("/metadata/foo_db/rules")).thenReturn(readYAML());
+        Collection<RuleConfiguration> actual = schemaRuleRegistryService.load("foo_db");
+        assertThat(actual.size(), is(1));
     }
-    
-//    @SneakyThrows({IOException.class, URISyntaxException.class})
-//    private String readYAML() {
-//        return Files.readAllLines(Paths.get(ClassLoader.getSystemResource("yaml/regcenter/data-schema-rule.yaml").toURI()))
-//                .stream().filter(each -> !each.startsWith("#")).map(each -> each + System.lineSeparator()).collect(Collectors.joining());
-//    }
+
+    @SneakyThrows({IOException.class, URISyntaxException.class})
+    private String readYAML() {
+        return Files.readAllLines(Paths.get(ClassLoader.getSystemResource("yaml/regcenter/data-schema-rule.yaml").toURI()))
+                .stream().filter(each -> !each.startsWith("#")).map(each -> each + System.lineSeparator()).collect(Collectors.joining());
+    }
     
     @Test
     public void assertUpdate() {

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/RuleConfigurationFixture.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/RuleConfigurationFixture.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.fixture;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
+
+@Getter
+@Setter
+public class RuleConfigurationFixture implements RuleConfiguration {
+
+    private String name;
+
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/YamlRuleConfigurationFixture.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/YamlRuleConfigurationFixture.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.fixture;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.yaml.config.YamlRuleConfiguration;
+
+@Getter
+@Setter
+public final class YamlRuleConfigurationFixture implements YamlRuleConfiguration {
+    
+    private String name;
+    
+    @Override
+    public Class<RuleConfigurationFixture> getRuleConfigurationType() {
+        return RuleConfigurationFixture.class;
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/YamlRuleConfigurationSwapperFixture.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/fixture/YamlRuleConfigurationSwapperFixture.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.fixture;
+
+import org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapper;
+
+public final class YamlRuleConfigurationSwapperFixture implements YamlRuleConfigurationSwapper<YamlRuleConfigurationFixture, RuleConfigurationFixture> {
+    
+    @Override
+    public Class<RuleConfigurationFixture> getTypeClass() {
+        return RuleConfigurationFixture.class;
+    }
+    
+    @Override
+    public YamlRuleConfigurationFixture swapToYamlConfiguration(final RuleConfigurationFixture data) {
+        YamlRuleConfigurationFixture result = new YamlRuleConfigurationFixture();
+        result.setName(data.getName());
+        return result;
+    }
+    
+    @Override
+    public RuleConfigurationFixture swapToObject(final YamlRuleConfigurationFixture yamlConfig) {
+        RuleConfigurationFixture result = new RuleConfigurationFixture();
+        result.setName(yamlConfig.getName());
+        return result;
+    }
+    
+    @Override
+    public String getRuleTagName() {
+        return "FIXTURE";
+    }
+    
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapper
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.swapper.YamlRuleConfigurationSwapper
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-- !FIXTURE
-  name: test
+org.apache.shardingsphere.governance.core.registry.fixture.YamlRuleConfigurationSwapperFixture


### PR DESCRIPTION
Fixes #10537.

Changes proposed in this pull request:
- Use RuleConfigurationFixture instead of ShardingRuleConfiguration for test case in governance module #
