### PR TITLE
Add schema prefix before table name to some SQL script in test

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding/db0.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding/db0.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `db0`;
 CREATE SCHEMA `db0`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `db0`.`t_order_0`;
+DROP TABLE IF EXISTS `db0`.`t_order_1`;
+DROP TABLE IF EXISTS `db0`.`t_order_item_0`;
+DROP TABLE IF EXISTS `db0`.`t_order_item_1`;
+DROP TABLE IF EXISTS `db0`.`t_config`;
+CREATE TABLE `db0`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `db0`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `db0`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `db0`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `db0`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding/db1.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding/db1.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `db1`;
 CREATE SCHEMA `db1`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `db1`.`t_order_0`;
+DROP TABLE IF EXISTS `db1`.`t_order_1`;
+DROP TABLE IF EXISTS `db1`.`t_order_item_0`;
+DROP TABLE IF EXISTS `db1`.`t_order_item_1`;
+DROP TABLE IF EXISTS `db1`.`t_config`;
+CREATE TABLE `db1`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `db1`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `db1`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `db1`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `db1`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/read_ds_0.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/read_ds_0.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `read_ds_0`;
 CREATE SCHEMA `read_ds_0`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `read_ds_0`.`t_order_0`;
+DROP TABLE IF EXISTS `read_ds_0`.`t_order_1`;
+DROP TABLE IF EXISTS `read_ds_0`.`t_order_item_0`;
+DROP TABLE IF EXISTS `read_ds_0`.`t_order_item_1`;
+DROP TABLE IF EXISTS `read_ds_0`.`t_config`;
+CREATE TABLE `read_ds_0`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `read_ds_0`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `read_ds_0`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `read_ds_0`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `read_ds_0`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/read_ds_1.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/read_ds_1.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `read_ds_1`;
 CREATE SCHEMA `read_ds_1`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `read_ds_1`.`t_order_0`;
+DROP TABLE IF EXISTS `read_ds_1`.`t_order_1`;
+DROP TABLE IF EXISTS `read_ds_1`.`t_order_item_0`;
+DROP TABLE IF EXISTS `read_ds_1`.`t_order_item_1`;
+DROP TABLE IF EXISTS `read_ds_1`.`t_config`;
+CREATE TABLE `read_ds_1`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `read_ds_1`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `read_ds_1`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `read_ds_1`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `read_ds_1`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/write_ds_0.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/write_ds_0.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `write_ds_0`;
 CREATE SCHEMA `write_ds_0`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `write_ds_0`.`t_order_0`;
+DROP TABLE IF EXISTS `write_ds_0`.`t_order_1`;
+DROP TABLE IF EXISTS `write_ds_0`.`t_order_item_0`;
+DROP TABLE IF EXISTS `write_ds_0`.`t_order_item_1`;
+DROP TABLE IF EXISTS `write_ds_0`.`t_config`;
+CREATE TABLE `write_ds_0`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `write_ds_0`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `write_ds_0`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `write_ds_0`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `write_ds_0`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/write_ds_1.sql
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/schema/sharding_readwrite_splitting/write_ds_1.sql
@@ -17,13 +17,13 @@
 
 DROP SCHEMA IF EXISTS `write_ds_1`;
 CREATE SCHEMA `write_ds_1`;
-DROP TABLE IF EXISTS `t_order_0`;
-DROP TABLE IF EXISTS `t_order_1`;
-DROP TABLE IF EXISTS `t_order_item_0`;
-DROP TABLE IF EXISTS `t_order_item_1`;
-DROP TABLE IF EXISTS `t_config`;
-CREATE TABLE `t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
-CREATE TABLE `t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
-CREATE TABLE `t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));
+DROP TABLE IF EXISTS `write_ds_1`.`t_order_0`;
+DROP TABLE IF EXISTS `write_ds_1`.`t_order_1`;
+DROP TABLE IF EXISTS `write_ds_1`.`t_order_item_0`;
+DROP TABLE IF EXISTS `write_ds_1`.`t_order_item_1`;
+DROP TABLE IF EXISTS `write_ds_1`.`t_config`;
+CREATE TABLE `write_ds_1`.`t_order_0` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `write_ds_1`.`t_order_1` (`order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_id`));
+CREATE TABLE `write_ds_1`.`t_order_item_0` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `write_ds_1`.`t_order_item_1` (`order_item_id` INT NOT NULL, `order_id` INT NOT NULL, `user_id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`order_item_id`));
+CREATE TABLE `write_ds_1`.`t_config` (`id` INT NOT NULL, `status` VARCHAR(45) NULL, PRIMARY KEY (`id`));


### PR DESCRIPTION
Changes proposed in this pull request:
- Explictly add schema prefix before table names to some SQL scripts in test. For tools use 'Default Schema' like MySQL Workbench, these scripts should specify target schema through 'USE target_schema', or statements will be targted to the current 'Default Schema'. However, as 'USE' is not supported by all databases, like Postgre, we should then explictly add schema prefix before table names.