### PR TITLE
Add test case for RuleConfigurationChecker

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/AlgorithmProvidedEncryptRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/AlgorithmProvidedEncryptRuleConfigurationCheckerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.rule.checker;
+
+import org.apache.shardingsphere.encrypt.algorithm.config.AlgorithmProvidedEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.ordered.OrderedSPIRegistry;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Algorithm provided encrypt rule configuration checker test.
+ */
+public final class AlgorithmProvidedEncryptRuleConfigurationCheckerTest {
+    static {
+        ShardingSphereServiceLoader.register(RuleConfigurationChecker.class);
+    }
+
+    @Test
+    public void assertCheckPass() {
+        AlgorithmProvidedEncryptRuleConfiguration ruleConfig = mock(AlgorithmProvidedEncryptRuleConfiguration.class);
+        EncryptAlgorithm encryptAlgorithm = mock(EncryptAlgorithm.class);
+        when(ruleConfig.getEncryptors()).thenReturn(Collections.singletonMap("type1", encryptAlgorithm));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(AlgorithmProvidedEncryptRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckNoPass() {
+        AlgorithmProvidedEncryptRuleConfiguration ruleConfig = mock(AlgorithmProvidedEncryptRuleConfiguration.class);
+        when(ruleConfig.getEncryptors()).thenReturn(Collections.emptyMap());
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(AlgorithmProvidedEncryptRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+
+}

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/AlgorithmProvidedEncryptRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/AlgorithmProvidedEncryptRuleConfigurationCheckerTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/EncryptRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/EncryptRuleConfigurationCheckerTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/EncryptRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/checker/EncryptRuleConfigurationCheckerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.rule.checker;
+
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.ordered.OrderedSPIRegistry;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Encrypt rule configuration checker test.
+ */
+public final class EncryptRuleConfigurationCheckerTest {
+    static {
+        ShardingSphereServiceLoader.register(RuleConfigurationChecker.class);
+    }
+
+    @Test
+    public void assertCheckPass() {
+        EncryptRuleConfiguration ruleConfig = mock(EncryptRuleConfiguration.class);
+        ShardingSphereAlgorithmConfiguration algorithmConfiguration = mock(ShardingSphereAlgorithmConfiguration.class);
+        when(ruleConfig.getEncryptors()).thenReturn(Collections.singletonMap("type1", algorithmConfiguration));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(EncryptRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckNoPass() {
+        EncryptRuleConfiguration ruleConfig = mock(EncryptRuleConfiguration.class);
+        when(ruleConfig.getEncryptors()).thenReturn(Collections.emptyMap());
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(EncryptRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+}

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/AlgorithmProvidedReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/AlgorithmProvidedReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -27,8 +27,8 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/AlgorithmProvidedReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/AlgorithmProvidedReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.readwritesplitting.rule.checker;
+
+import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.spi.ordered.OrderedSPIRegistry;
+import org.apache.shardingsphere.readwritesplitting.algorithm.config.AlgorithmProvidedReadwriteSplittingRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Algorithm provided readwrite-splitting ruleConfiguration checker testcase.
+ */
+public final class AlgorithmProvidedReadwriteSplittingRuleConfigurationCheckerTest {
+    static {
+        ShardingSphereServiceLoader.register(RuleConfigurationChecker.class);
+    }
+
+    @Test
+    public void assertCheckPass() {
+        AlgorithmProvidedReadwriteSplittingRuleConfiguration ruleConfig = mock(AlgorithmProvidedReadwriteSplittingRuleConfiguration.class);
+        ReadwriteSplittingDataSourceRuleConfiguration ds0 = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
+        when(ds0.getAutoAwareDataSourceName()).thenReturn("ds0");
+        when(ruleConfig.getDataSources()).thenReturn(Collections.singletonList(ds0));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(AlgorithmProvidedReadwriteSplittingRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckNoPass() {
+        AlgorithmProvidedReadwriteSplittingRuleConfiguration ruleConfig = mock(AlgorithmProvidedReadwriteSplittingRuleConfiguration.class);
+        ReadwriteSplittingDataSourceRuleConfiguration ds0 = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
+        when(ds0.getAutoAwareDataSourceName()).thenReturn("");
+        when(ds0.getWriteDataSourceName()).thenReturn("");
+        when(ruleConfig.getDataSources()).thenReturn(Collections.singletonList(ds0));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(AlgorithmProvidedReadwriteSplittingRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+}

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.readwritesplitting.rule.checker;
+
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
+import org.apache.shardingsphere.infra.spi.ordered.OrderedSPIRegistry;
+import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Readwrite-splitting rule configuration checker test.
+ */
+public final class ReadwriteSplittingRuleConfigurationCheckerTest {
+    static {
+        ShardingSphereServiceLoader.register(RuleConfigurationChecker.class);
+    }
+
+    @Test
+    public void assertCheckPass() {
+        ReadwriteSplittingRuleConfiguration ruleConfig = mock(ReadwriteSplittingRuleConfiguration.class);
+        ReadwriteSplittingDataSourceRuleConfiguration ds0 = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
+        when(ds0.getAutoAwareDataSourceName()).thenReturn("ds0");
+        when(ruleConfig.getDataSources()).thenReturn(Collections.singletonList(ds0));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(ReadwriteSplittingRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckNoPass() {
+        ReadwriteSplittingRuleConfiguration ruleConfig = mock(ReadwriteSplittingRuleConfiguration.class);
+        ReadwriteSplittingDataSourceRuleConfiguration ds0 = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
+        when(ds0.getAutoAwareDataSourceName()).thenReturn("");
+        when(ds0.getWriteDataSourceName()).thenReturn("");
+        when(ruleConfig.getDataSources()).thenReturn(Collections.singletonList(ds0));
+        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(Collections.singletonList(ruleConfig), RuleConfigurationChecker.class).get(ruleConfig);
+        assertNotNull(checker);
+        assertThat(checker, instanceOf(ReadwriteSplittingRuleConfigurationChecker.class));
+        checker.check("test", ruleConfig);
+    }
+}

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
For #10536.

Changes proposed in this pull request:
- Add test case for ReadwriteSplittingRuleConfigurationChecker
- Add test case for AlgorithmProvidedReadwriteSplittingRuleConfigurationChecker
- Add test case for EncryptRuleConfigurationChecker
- Add test case for AlgorithmProvidedEncryptRuleConfigurationChecker
