### PR TITLE
Fix insert or query by precise value error when there is no db ShardingStrategy and using unique table names

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithm.java
@@ -84,8 +84,9 @@ public final class AutoIntervalShardingAlgorithm implements StandardShardingAlgo
     
     @Override
     public String doSharding(final Collection<String> availableTargetNames, final PreciseShardingValue<Comparable<?>> shardingValue) {
+        String tableNameSuffix = String.valueOf(doSharding(parseDate(shardingValue.getValue())));
         for (String each : availableTargetNames) {
-            if (each.endsWith(String.valueOf(doSharding(parseDate(shardingValue.getValue()))))) {
+            if (each.endsWith(tableNameSuffix)) {
                 return each;
             }
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.config.exception.ShardingSphereConfigurationException;
-import org.apache.shardingsphere.sharding.algorithm.sharding.ShardingAlgorithmException;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
@@ -121,9 +120,10 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     
     @Override
     public String doSharding(final Collection<String> availableTargetNames, final PreciseShardingValue<Comparable<?>> shardingValue) {
+        String tableNameSuffix = parseDateTime(shardingValue.getValue().toString()).format(tableSuffixPattern);
         return availableTargetNames.stream()
-                .filter(each -> each.endsWith(parseDateTime(shardingValue.getValue().toString()).format(tableSuffixPattern)))
-                .findFirst().orElseThrow(() -> new ShardingAlgorithmException(String.format("failed to shard value %s, and availableTables %s", shardingValue, availableTargetNames)));
+                .filter(each -> each.endsWith(tableNameSuffix))
+                .findFirst().orElse(null);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 public final class IntervalShardingAlgorithmTest {
@@ -94,6 +95,7 @@ public final class IntervalShardingAlgorithmTest {
     @Test
     public void assertPreciseDoShardingByMonth() {
         assertThat(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, new PreciseShardingValue<>("t_order", "create_time", "2020-01-01 00:00:01")), is("t_order_202001"));
+        assertNull(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, new PreciseShardingValue<>("t_order", "create_time", "2030-01-01 00:00:01")));
     }
     
     @Test

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
@@ -152,6 +152,21 @@ public abstract class AbstractRoutingEngineTest {
         return result;
     }
     
+    protected final ShardingRule createIntervalTableShardingRule() {
+        ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
+        shardingRuleConfig.getTables().add(createTableRuleConfig("t_interval_test", "ds_0.t_interval_test_202101,ds_1.t_interval_test_202102",
+                null, new StandardShardingStrategyConfiguration("create_at", "interval_test")));
+        Properties props0 = new Properties();
+        props0.setProperty("datetime-pattern", "yyyy-MM-dd HH:mm:ss");
+        props0.setProperty("datetime-lower", "2021-01-01 00:00:00");
+        props0.setProperty("datetime-upper", "2021-01-02 00:00:00");
+        props0.setProperty("sharding-suffix-pattern", "yyyyMM");
+        props0.setProperty("datetime-interval-amount", "1");
+        props0.setProperty("datetime-interval-unit", "MONTHS");
+        shardingRuleConfig.getShardingAlgorithms().put("interval_test", new ShardingSphereAlgorithmConfiguration("INTERVAL", props0));
+        return new ShardingRule(shardingRuleConfig, mock(DatabaseType.class), createDataSourceMap());
+    }
+    
     private ShardingTableRuleConfiguration createInlineTableRuleConfig(final String tableName, final String actualDataNodes, final String algorithmExpression, final String dsAlgorithmExpression) {
         return createTableRuleConfig(tableName, actualDataNodes,
             createStandardShardingStrategyConfiguration("ds_inline", dsAlgorithmExpression), createStandardShardingStrategyConfiguration(tableName + "_inline", algorithmExpression));
@@ -197,6 +212,15 @@ public abstract class AbstractRoutingEngineTest {
         ShardingCondition shardingCondition = new ShardingCondition();
         shardingCondition.getValues().add(shardingConditionValue1);
         shardingCondition.getValues().add(shardingConditionValue2);
+        result.add(shardingCondition);
+        return new ShardingConditions(result);
+    }
+    
+    protected final ShardingConditions createIntervalShardingConditions(final String tableName) {
+        List<ShardingCondition> result = new ArrayList<>(1);
+        ShardingConditionValue shardingConditionValue = new ListShardingConditionValue<>("create_at", tableName, Collections.singleton("2021-01-01 20:20:20"));
+        ShardingCondition shardingCondition = new ShardingCondition();
+        shardingCondition.getValues().add(shardingConditionValue);
         result.add(shardingCondition);
         return new ShardingConditions(result);
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngineTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngineTest.java
@@ -171,6 +171,19 @@ public final class ShardingStandardRoutingEngineTest extends AbstractRoutingEngi
         assertThat(routeUnits.get(1).getTableMappers().iterator().next().getLogicName(), is("t_hint_table_test"));
     }
     
+    @Test
+    public void assertRouteByIntervalTableShardingStrategyOnly() {
+        ShardingStandardRoutingEngine standardRoutingEngine = createShardingStandardRoutingEngine("t_interval_test", createIntervalShardingConditions("t_interval_test"));
+        RouteContext routeContext = new RouteContext();
+        standardRoutingEngine.route(routeContext, createIntervalTableShardingRule());
+        List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
+        assertThat(routeContext.getRouteUnits().size(), is(1));
+        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
+        assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getActualName(), is("t_interval_test_202101"));
+        assertThat(routeUnits.get(0).getTableMappers().iterator().next().getLogicName(), is("t_interval_test"));
+    }
+    
     private ShardingStandardRoutingEngine createShardingStandardRoutingEngine(final String logicTableName, final ShardingConditions shardingConditions) {
         return new ShardingStandardRoutingEngine(logicTableName, shardingConditions, new ConfigurationProperties(new Properties()));
     }


### PR DESCRIPTION
Fixes #10746.

Changes proposed in this pull request:
- IntervalShardingAlgorithm`s method doSharding(...) do not throw exception directly,if no matched target just return null
- Optimized code of  IntervalShardingAlgorithm and AutoIntervalShardingAlgorithm ,reduce the times of dataTime parser
