### PR TITLE
support subquery aggregation and partial distinct aggregation

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/impl/ShardingSelectStatementValidator.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/dml/impl/ShardingSelectStatementValidator.java
@@ -45,7 +45,7 @@ public final class ShardingSelectStatementValidator extends ShardingDMLStatement
     @Override
     public void postValidate(final ShardingRule shardingRule, final SQLStatementContext<SelectStatement> sqlStatementContext, 
                              final RouteContext routeContext, final ShardingSphereSchema schema) {
-        if (needCheckDatabaseInstance) {
+        if (!routeContext.isFederated() && needCheckDatabaseInstance) {
             Preconditions.checkState(routeContext.isSingleRouting(), "Sharding value must same with subquery.");
         }
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/AbstractSQLRouteTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/AbstractSQLRouteTest.java
@@ -24,8 +24,8 @@ import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
 import org.apache.shardingsphere.infra.metadata.rule.ShardingSphereRuleMetaData;
-import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.parser.sql.SQLStatementParserEngine;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
@@ -49,6 +49,10 @@ import static org.mockito.Mockito.mock;
 public abstract class AbstractSQLRouteTest extends AbstractRoutingEngineTest {
     
     protected final RouteContext assertRoute(final String sql, final List<Object> parameters) {
+        return assertRoute(sql, parameters, 1);
+    }
+    
+    protected final RouteContext assertRoute(final String sql, final List<Object> parameters, final int routeUnitSize) {
         ShardingRule shardingRule = createAllShardingRule();
         ShardingSphereSchema schema = buildSchema();
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
@@ -58,7 +62,7 @@ public abstract class AbstractSQLRouteTest extends AbstractRoutingEngineTest {
         ShardingSphereRuleMetaData ruleMetaData = new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(shardingRule));
         ShardingSphereMetaData metaData = new ShardingSphereMetaData("sharding_db", mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), ruleMetaData, schema);
         RouteContext result = new SQLRouteEngine(Collections.singletonList(shardingRule), props).route(logicSQL, metaData);
-        assertThat(result.getRouteUnits().size(), is(1));
+        assertThat(result.getRouteUnits().size(), is(routeUnitSize));
         return result;
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/SubqueryRouteTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/SubqueryRouteTest.java
@@ -26,30 +26,30 @@ import java.util.List;
 public final class SubqueryRouteTest extends AbstractSQLRouteTest {
     
     @Test
-    public void assertOneTableError() {
+    public void assertOneTableDifferentConditionWithFederate() {
         String sql = "select (select max(id) from t_order b where b.user_id =? ) from t_order a where user_id = ? ";
         List<Object> parameters = new LinkedList<>();
         parameters.add(3);
         parameters.add(2);
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
     @Test
-    public void assertOneTable() {
+    public void assertOneTableSameConditionWithFederate() {
         String sql = "select (select max(id) from t_order b where b.user_id = ? and b.user_id = a.user_id) from t_order a where user_id = ? ";
         List<Object> parameters = new LinkedList<>();
         parameters.add(1);
         parameters.add(1);
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
     @Test
-    public void assertBindingTable() {
+    public void assertBindingTableWithFederate() {
         String sql = "select (select max(id) from t_order_item b where b.user_id = ?) from t_order a where user_id = ? ";
         List<Object> parameters = new LinkedList<>();
         parameters.add(1);
         parameters.add(1);
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
     @Test
@@ -62,33 +62,33 @@ public final class SubqueryRouteTest extends AbstractSQLRouteTest {
     }
     
     @Test
-    public void assertBindingTableWithDifferentValue() {
+    public void assertBindingTableWithDifferentValueWithFederate() {
         String sql = "select (select max(id) from t_order_item b where b.user_id = ? ) from t_order a where user_id = ? ";
         List<Object> parameters = new LinkedList<>();
         parameters.add(2);
         parameters.add(3);
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
-    @Test(expected = IllegalStateException.class)
-    public void assertTwoTableWithDifferentOperator() {
+    @Test
+    public void assertTwoTableWithDifferentOperatorWithFederate() {
         List<Object> parameters = new LinkedList<>();
         parameters.add(1);
         parameters.add(2);
         parameters.add(1);
         String sql = "select (select max(id) from t_order_item b where b.user_id in(?,?)) from t_order a where user_id = ? ";
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
-    @Test(expected = IllegalStateException.class)
-    public void assertTwoTableWithIn() {
+    @Test
+    public void assertTwoTableWithInWithFederate() {
         List<Object> parameters = new LinkedList<>();
         parameters.add(1);
         parameters.add(2);
         parameters.add(1);
         parameters.add(3);
         String sql = "select (select max(id) from t_order_item b where b.user_id in(?,?)) from t_order a where user_id in(?,?) ";
-        assertRoute(sql, parameters);
+        assertRoute(sql, parameters, 2);
     }
     
     @Test

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.infra.binder.type.TableAvailable;
 import org.apache.shardingsphere.infra.binder.type.WhereAvailable;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.sql.parser.sql.common.extractor.TableExtractor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.ColumnOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.ExpressionOrderByItemSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.IndexOrderByItemSegment;
@@ -78,7 +79,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
     
     private final int generateOrderByStartIndex;
     
-    private final boolean containsHaving;
+    private final boolean containsSubqueyAggregation;
 
     // TODO to be remove, for test case only
     public SelectStatementContext(final SelectStatement sqlStatement, final GroupByContext groupByContext,
@@ -91,7 +92,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
         this.paginationContext = paginationContext;
         containsSubquery = containsSubquery();
         generateOrderByStartIndex = generateOrderByStartIndex();
-        containsHaving = sqlStatement.getHaving().isPresent();
+        containsSubqueyAggregation = containsSubqueyAggregation();
     }
     
     public SelectStatementContext(final ShardingSphereSchema schema, final List<Object> parameters, final SelectStatement sqlStatement) {
@@ -103,11 +104,16 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
         paginationContext = new PaginationContextEngine().createPaginationContext(sqlStatement, projectionsContext, parameters);
         containsSubquery = containsSubquery();
         generateOrderByStartIndex = generateOrderByStartIndex();
-        containsHaving = sqlStatement.getHaving().isPresent();
+        containsSubqueyAggregation = containsSubqueyAggregation();
     }
     
     private boolean containsSubquery() {
         return !SubqueryExtractUtil.getSubquerySegments(getSqlStatement()).isEmpty();
+    }
+    
+    private boolean containsSubqueyAggregation() {
+        return SubqueryExtractUtil.getSubquerySegments(getSqlStatement()).stream().flatMap(each 
+            -> each.getSelect().getProjections().getProjections().stream()).anyMatch(each -> each instanceof AggregationProjectionSegment);
     }
     
     private int generateOrderByStartIndex() {
@@ -128,12 +134,31 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
     }
     
     /**
-     * Whether it contain join query.
+     * Judge whether contains join query or not.
      *
-     * @return contain join query or not
+     * @return whether contains join query or not
      */
     public boolean isContainsJoinQuery() {
         return getSqlStatement().getFrom() instanceof JoinTableSegment;
+    }
+    
+    /**
+     * Judge whether contains having or not.
+     *
+     * @return whether contains having or not
+     */
+    public boolean isContainsHaving() {
+        return getSqlStatement().getHaving().isPresent();
+    }
+    
+    /**
+     * Judge whether contains partial distinct aggregation.
+     *
+     * @return whether contains partial distinct aggregation
+     */
+    public boolean isContainsPartialDistinctAggregation() {
+        return projectionsContext.getAggregationProjections().size() > 1 && projectionsContext.getAggregationDistinctProjections().size() > 0 
+                && projectionsContext.getAggregationProjections().size() != projectionsContext.getAggregationDistinctProjections().size();
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -157,8 +157,9 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
      * @return whether contains partial distinct aggregation
      */
     public boolean isContainsPartialDistinctAggregation() {
-        return projectionsContext.getAggregationProjections().size() > 1 && projectionsContext.getAggregationDistinctProjections().size() > 0 
-                && projectionsContext.getAggregationProjections().size() != projectionsContext.getAggregationDistinctProjections().size();
+        Collection<Projection> aggregationProjections = projectionsContext.getProjections().stream().filter(each -> each instanceof AggregationProjection).collect(Collectors.toList());
+        return aggregationProjections.size() > 1 && projectionsContext.getAggregationDistinctProjections().size() > 0 
+                && aggregationProjections.size() != projectionsContext.getAggregationDistinctProjections().size();
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/SelectStatementContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/SelectStatementContextTest.java
@@ -416,6 +416,7 @@ public final class SelectStatementContextTest {
         when(projectionSegment.getSubquery().getSelect().getWhere()).thenReturn(Optional.of(mock(WhereSegment.class)));
         WhereSegment whereSegment = new WhereSegment(0, 0, null);
         subSelectStatement.setWhere(whereSegment);
+        subSelectStatement.setProjections(new ProjectionsSegment(0, 0));
         SubquerySegment subquerySegment = new SubquerySegment(0, 0, subSelectStatement);
         when(projectionSegment.getSubquery()).thenReturn(subquerySegment);
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
@@ -457,6 +458,7 @@ public final class SelectStatementContextTest {
         BinaryOperationExpression expression = new BinaryOperationExpression(0, 0, left, right, "=", null);
         WhereSegment subWhereSegment = new WhereSegment(0, 0, expression);
         subSelectStatement.setWhere(subWhereSegment);
+        subSelectStatement.setProjections(new ProjectionsSegment(0, 0));
         SubqueryExpressionSegment subqueryExpressionSegment = new SubqueryExpressionSegment(new SubquerySegment(0, 0, subSelectStatement));
         SubqueryProjectionSegment projectionSegment = mock(SubqueryProjectionSegment.class);
         WhereSegment whereSegment = new WhereSegment(0, 0, subqueryExpressionSegment);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/FederateStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/FederateStatementTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
@@ -65,6 +66,15 @@ public final class FederateStatementTest extends AbstractShardingSphereDataSourc
     private static final String SELECT_SQL_BY_ID_ACROSS_TWO_SHARDING_TABLES =
             "select o.order_id_sharding, i.order_id from t_order_federate_sharding o, t_order_item_federate_sharding i "
                     + "where o.order_id_sharding = i.item_id";
+    
+    private static final String SELECT_HAVING_SQL_FOR_SHARDING_TABLE =
+            "SELECT user_id, SUM(order_id_sharding) FROM t_order_federate_sharding GROUP BY user_id HAVING SUM(order_id_sharding) > 1000";
+    
+    private static final String SELECT_SUBQUEY_AGGREGATION_SQL_FOR_SHARDING_TABLE =
+            "SELECT (SELECT MAX(user_id) FROM t_order_federate_sharding) max_user_id, order_id_sharding, status FROM t_order_federate_sharding WHERE order_id_sharding > 1100";
+    
+    private static final String SELECT_PARTIAL_DISTINCT_AGGREGATION_SQL_FOR_SHARDING_TABLE =
+            "SELECT SUM(DISTINCT user_id), SUM(order_id_sharding) FROM t_order_federate_sharding WHERE order_id_sharding > 1000";
     
     @Test
     public void assertQueryWithFederateInSingleTablesByExecuteQuery() throws SQLException {
@@ -290,5 +300,70 @@ public final class FederateStatementTest extends AbstractShardingSphereDataSourc
         assertThat(resultSet.getInt(1), is(1011));
         assertThat(resultSet.getInt(2), is(10001));
         assertFalse(resultSet.next());
+    }
+    
+    @Test
+    public void assertHavingForShardingTableWithFederateByExecuteQuery() throws SQLException {
+        assertHavingForShardingTableWithFederate(true);
+    }
+    
+    @Test
+    public void assertHavingForShardingTableWithFederateByExecute() throws SQLException {
+        assertHavingForShardingTableWithFederate(false);
+    }
+    
+    private void assertHavingForShardingTableWithFederate(final boolean executeQuery) throws SQLException {
+        Statement statement = getShardingSphereDataSource().getConnection().createStatement();
+        ResultSet resultSet = getResultSet(statement, SELECT_HAVING_SQL_FOR_SHARDING_TABLE, executeQuery);
+        assertNotNull(resultSet);
+        assertTrue(resultSet.next());
+        assertThat(resultSet.getInt(1), is(10));
+        assertThat(resultSet.getInt(2), is(2110));
+        assertNotNull(resultSet);
+        assertTrue(resultSet.next());
+        assertThat(resultSet.getInt(1), is(11));
+        assertThat(resultSet.getInt(2), is(2112));
+        assertFalse(resultSet.next());
+    }
+    
+    @Test
+    public void assertSubqueyAggregationForShardingTableWithFederateByExecuteQuery() throws SQLException {
+        assertSubqueyAggregationForShardingTableWithFederate(true);
+    }
+    
+    @Test
+    public void assertSubqueyAggregationForShardingTableWithFederateByExecute() throws SQLException {
+        assertSubqueyAggregationForShardingTableWithFederate(false);
+    }
+    
+    private void assertSubqueyAggregationForShardingTableWithFederate(final boolean executeQuery) throws SQLException {
+        Statement statement = getShardingSphereDataSource().getConnection().createStatement();
+        ResultSet resultSet = getResultSet(statement, SELECT_SUBQUEY_AGGREGATION_SQL_FOR_SHARDING_TABLE, executeQuery);
+        assertNotNull(resultSet);
+        assertTrue(resultSet.next());
+        assertThat(resultSet.getInt(1), is(11));
+        assertThat(resultSet.getInt(2), is(1101));
+        assertThat(resultSet.getString(3), is("init"));
+        assertNotNull(resultSet);
+    }
+    
+    @Test
+    public void assertPartialDistinctAggregationForShardingTableWithFederateByExecuteQuery() throws SQLException {
+        assertPartialDistinctAggregationForShardingTableWithFederate(true);
+    }
+    
+    @Test
+    public void assertPartialDistinctAggregationForShardingTableWithFederateByExecute() throws SQLException {
+        assertPartialDistinctAggregationForShardingTableWithFederate(false);
+    }
+    
+    private void assertPartialDistinctAggregationForShardingTableWithFederate(final boolean executeQuery) throws SQLException {
+        Statement statement = getShardingSphereDataSource().getConnection().createStatement();
+        ResultSet resultSet = getResultSet(statement, SELECT_PARTIAL_DISTINCT_AGGREGATION_SQL_FOR_SHARDING_TABLE, executeQuery);
+        assertNotNull(resultSet);
+        assertTrue(resultSet.next());
+        assertThat(resultSet.getInt(1), is(21));
+        assertThat(resultSet.getInt(2), is(4222));
+        assertNotNull(resultSet);
     }
 }

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/select.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/select.xml
@@ -35,7 +35,7 @@
 
     <rewrite-assertion id="select_with_sum_fun">
         <input sql="SELECT SUM(DISTINCT account_id), SUM(account_id) FROM t_account WHERE account_id = 100" />
-        <output sql="SELECT SUM(DISTINCT account_id), SUM(account_id) FROM t_account_0 WHERE account_id = 100" />
+        <output sql="SELECT SUM(DISTINCT account_id), SUM(account_id) FROM t_account WHERE account_id = 100" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_avg_fun">


### PR DESCRIPTION
Fixes #10565 #10564.

Changes proposed in this pull request:
- support subquery aggregation by calcite
- support partial distinct aggregation when statement include multi aggregation by calcite
- add test cases for `having` statement, `subquery aggregation` statement and `partial distinct aggregation` statement
