### PR TITLE
实现自定义权限，可按照proxy用户分配schema权限

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/CustomPrivilegesPermittedAuthorityProviderAlgorithm.java
+++ b/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/CustomPrivilegesPermittedAuthorityProviderAlgorithm.java
@@ -1,0 +1,54 @@
+package org.apache.shardingsphere.authority.provider.custom;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
+import org.apache.shardingsphere.authority.provider.custom.builder.CustomPrivilegeBuilder;
+import org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.user.Grantee;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+
+public final class CustomPrivilegesPermittedAuthorityProviderAlgorithm implements AuthorityProvideAlgorithm {
+
+    private final Map<ShardingSphereUser, ShardingSpherePrivileges> userPrivilegeMap = new ConcurrentHashMap<>();
+
+    public static final String PROP_USER_SCHEMA_MAPPINGS = "user-schema-mappings";
+    
+	private Properties props;
+	
+	@Override
+	public void setProps(Properties props) {
+		this.props = props;
+	}
+
+	@Override
+	public Properties getProps() {
+		return this.props;
+	}
+
+	@Override
+	public void init(Map<String, ShardingSphereMetaData> mataDataMap, Collection<ShardingSphereUser> users) {
+		this.userPrivilegeMap.putAll(CustomPrivilegeBuilder.build(users, props));
+	}
+
+	@Override
+	public void refresh(Map<String, ShardingSphereMetaData> mataDataMap, Collection<ShardingSphereUser> users) {
+		this.userPrivilegeMap.putAll(CustomPrivilegeBuilder.build(users, props));
+	}
+
+	@Override
+	public Optional<ShardingSpherePrivileges> findPrivileges(Grantee grantee) {
+		 return userPrivilegeMap.keySet().stream().filter(each -> each.getGrantee().equals(grantee)).findFirst().map(userPrivilegeMap::get);
+	}
+	
+	@Override
+	public String getType() {
+		return "CUSTOM_PRIVILEGES_PERMITTED";
+	}
+	
+}

--- a/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/builder/CustomPrivilegeBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/builder/CustomPrivilegeBuilder.java
@@ -1,0 +1,39 @@
+package org.apache.shardingsphere.authority.provider.custom.builder;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
+import org.apache.shardingsphere.authority.provider.custom.CustomPrivilegesPermittedAuthorityProviderAlgorithm;
+import org.apache.shardingsphere.authority.provider.custom.model.privilege.CustomPrivilegesPermittedShardingSpherePrivileges;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomPrivilegeBuilder {
+
+	public static Map<ShardingSphereUser, ShardingSpherePrivileges> build(final Collection<ShardingSphereUser> users, final Properties props){
+		
+		Map<ShardingSphereUser, ShardingSpherePrivileges> result = new HashMap<>();
+		
+		Map<String, Set<String>> userSchemaMappings = new HashMap<>();
+		String[] mappings = StringUtils.split(props.getProperty(CustomPrivilegesPermittedAuthorityProviderAlgorithm.PROP_USER_SCHEMA_MAPPINGS, ""), ",");
+		for(String mapping : mappings){
+			String[] userSchemaPair = StringUtils.split(mapping.trim(), "=");
+			Set<String> schemas = userSchemaMappings.getOrDefault(userSchemaPair[0], new HashSet<>());
+			schemas.add(userSchemaPair[1]);
+			userSchemaMappings.putIfAbsent(userSchemaPair[0], schemas);
+		}
+		users.forEach(each -> result.put(each, new CustomPrivilegesPermittedShardingSpherePrivileges(userSchemaMappings.getOrDefault(each.getGrantee().getUsername(), Collections.emptySet()))));
+		return result;
+	}
+	
+}

--- a/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/model/privilege/CustomPrivilegesPermittedShardingSpherePrivileges.java
+++ b/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/java/org/apache/shardingsphere/authority/provider/custom/model/privilege/CustomPrivilegesPermittedShardingSpherePrivileges.java
@@ -1,0 +1,41 @@
+package org.apache.shardingsphere.authority.provider.custom.model.privilege;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.shardingsphere.authority.model.AccessSubject;
+import org.apache.shardingsphere.authority.model.PrivilegeType;
+import org.apache.shardingsphere.authority.model.ShardingSpherePrivileges;
+import org.apache.shardingsphere.authority.provider.natived.model.subject.SchemaAccessSubject;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class CustomPrivilegesPermittedShardingSpherePrivileges implements ShardingSpherePrivileges{
+
+	private Set<String> schemas;
+	
+	@Override
+	public void setSuperPrivilege() {
+		
+	}
+
+	@Override
+	public boolean hasPrivileges(String schema) {
+		return schemas.contains(schema);
+	}
+
+	@Override
+	public boolean hasPrivileges(Collection<PrivilegeType> privileges) {
+		return true;
+	}
+
+	@Override
+	public boolean hasPrivileges(AccessSubject accessSubject, Collection<PrivilegeType> privileges) {
+		if (accessSubject instanceof SchemaAccessSubject) {
+			return hasPrivileges(((SchemaAccessSubject) accessSubject).getSchema());
+		}
+		throw new UnsupportedOperationException(accessSubject.getClass().getCanonicalName());
+	}
+
+}

--- a/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/resources/META-INF/services/org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm
+++ b/shardingsphere-infra/shardingsphere-infra-authority/shardingsphere-infra-authority-common/src/main/resources/META-INF/services/org.apache.shardingsphere.authority.spi.AuthorityProvideAlgorithm
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.authority.provider.natived.NativeAuthorityProviderAlgorithm
 org.apache.shardingsphere.authority.provider.simple.AllPrivilegesPermittedAuthorityProviderAlgorithm
+org.apache.shardingsphere.authority.provider.custom.CustomPrivilegesPermittedAuthorityProviderAlgorithm

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutor.java
@@ -17,10 +17,14 @@
 
 package org.apache.shardingsphere.proxy.backend.text.admin.mysql.executor;
 
-import lombok.Getter;
+import java.sql.Types;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+
+import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.executor.check.SQLCheckEngine;
 import org.apache.shardingsphere.infra.executor.check.SQLCheckException;
-import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.metadata.RawQueryResultColumnMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.raw.metadata.RawQueryResultMetaData;
@@ -32,11 +36,7 @@ import org.apache.shardingsphere.proxy.backend.text.admin.executor.DatabaseAdmin
 import org.apache.shardingsphere.sharding.merge.dal.common.SingleLocalDataMergedResult;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLShowDatabasesStatement;
 
-import java.sql.Types;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
+import lombok.Getter;
 
 /**
  * Show databases executor.
@@ -56,16 +56,16 @@ public final class ShowDatabasesExecutor implements DatabaseAdminQueryExecutor {
             MetaDataContexts contexts = ProxyContext.getInstance().getMetaDataContexts();
             SQLCheckEngine.check(new MySQLShowDatabasesStatement(), Collections.emptyList(), 
                     contexts.getGlobalRuleMetaData().getRules(), backendConnection.getSchemaName(), contexts.getMetaDataMap(), backendConnection.getGrantee());
-            return new ArrayList<>(ProxyContext.getInstance().getAllSchemaNames());
         } catch (final SQLCheckException ex) {
-            Collection<Object> result = new LinkedList<>();
-            for (String each : ProxyContext.getInstance().getAllSchemaNames()) {
-                if (SQLCheckEngine.check(each, getRules(each), backendConnection.getGrantee())) {
-                    result.add(each);
-                }
-            }
-            return result;
+            //ignore
         }
+        Collection<Object> result = new LinkedList<>();
+        for (String each : ProxyContext.getInstance().getAllSchemaNames()) {
+            if (SQLCheckEngine.check(each, getRules(each), backendConnection.getGrantee())) {
+                result.add(each);
+            }
+        }
+        return result;
     }
     
     private Collection<ShardingSphereRule> getRules(final String schemaName) {


### PR DESCRIPTION
权限增强，配置样例如下：
rules:
  - !AUTHORITY
    users:
      - root@:root
      - root1@:root1
    provider:
      type: CUSTOM_PRIVILEGES_PERMITTED
      props: 
        user-schema-mappings: root=test, root1=db_dal_admin, root1=test
使用root用户登录proxy，可以看到数据库(也就是schema)test
使用root1用户登录proxy，可以看到数据库(也就是schema)test和db_dal_admin

