### PR TITLE
Support SQL execution process delayed report or no report for better performance

### DIFF
--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/server.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/server.yaml
@@ -59,3 +59,5 @@
 #  sql-show: false
 #  check-table-metadata-enabled: false
 #  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
+#  show-process-list-enabled: false
+#  show-process-list-no-report-threshold-millis: 100

--- a/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/process/GovernanceExecuteProcessReporter.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/process/GovernanceExecuteProcessReporter.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.governance.core.registry.process.event.ExecuteP
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutorDataMap;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
@@ -37,17 +38,17 @@ public final class GovernanceExecuteProcessReporter implements ExecuteProcessRep
     @Override
     public void report(final LogicSQL logicSQL, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ExecuteProcessConstants constants) {
         ExecuteProcessContext executeProcessContext = new ExecuteProcessContext(logicSQL.getSql(), executionGroupContext, constants);
-        ShardingSphereEventBus.getInstance().post(new ExecuteProcessSummaryReportEvent(executeProcessContext));
+        ShardingSphereEventBus.getInstance().post(new ExecuteProcessSummaryReportEvent(executeProcessContext, ExecutorDataMap.getValue()));
     }
     
     @Override
     public void report(final String executionID, final SQLExecutionUnit executionUnit, final ExecuteProcessConstants constants) {
         ExecuteProcessUnit executeProcessUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), constants);
-        ShardingSphereEventBus.getInstance().post(new ExecuteProcessUnitReportEvent(executionID, executeProcessUnit));
+        ShardingSphereEventBus.getInstance().post(new ExecuteProcessUnitReportEvent(executionID, executeProcessUnit, ExecutorDataMap.getValue()));
     }
     
     @Override
     public void report(final String executionID, final ExecuteProcessConstants constants) {
-        ShardingSphereEventBus.getInstance().post(new ExecuteProcessReportEvent(executionID));
+        ShardingSphereEventBus.getInstance().post(new ExecuteProcessReportEvent(executionID, ExecutorDataMap.getValue()));
     }
 }

--- a/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/process/GovernanceExecuteProcessReporter.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/process/GovernanceExecuteProcessReporter.java
@@ -54,9 +54,9 @@ public final class GovernanceExecuteProcessReporter implements ExecuteProcessRep
     }
     
     @Override
-    public void report(final String executionID, final SQLExecutionUnit executionUnit, final ExecuteProcessConstants constants) {
+    public void report(final String executionID, final SQLExecutionUnit executionUnit, final ExecuteProcessConstants constants, final Map<String, Object> dataMap) {
         ExecuteProcessUnit executeProcessUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), constants);
-        ShardingSphereEventBus.getInstance().post(new ExecuteProcessUnitReportEvent(executionID, executeProcessUnit, ExecutorDataMap.getValue()));
+        ShardingSphereEventBus.getInstance().post(new ExecuteProcessUnitReportEvent(executionID, executeProcessUnit, dataMap));
     }
     
     @Override

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessReportEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessReportEvent.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.governance.core.registry.process.event;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -28,4 +29,6 @@ import lombok.RequiredArgsConstructor;
 public final class ExecuteProcessReportEvent {
     
     private final String executionID;
+    
+    private final Map<String, Object> dataMap;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessSummaryReportEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessSummaryReportEvent.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.governance.core.registry.process.event;
 import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 
 /**
  * Execute process summary report event.
@@ -29,7 +28,7 @@ import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcess
 @Getter
 public final class ExecuteProcessSummaryReportEvent {
     
-    private final ExecuteProcessContext executeProcessContext;
+    private final String executionID;
     
     private final Map<String, Object> dataMap;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessSummaryReportEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessSummaryReportEvent.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.governance.core.registry.process.event;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
@@ -29,4 +30,6 @@ import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcess
 public final class ExecuteProcessSummaryReportEvent {
     
     private final ExecuteProcessContext executeProcessContext;
+    
+    private final Map<String, Object> dataMap;
 }

--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessUnitReportEvent.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/event/ExecuteProcessUnitReportEvent.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.governance.core.registry.process.event;
 
+import java.util.Map;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessUnit;
@@ -31,4 +32,6 @@ public final class ExecuteProcessUnitReportEvent {
     private final String executionID;
     
     private final ExecuteProcessUnit executeProcessUnit;
+    
+    private final Map<String, Object> dataMap;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/properties/ConfigurationPropertyKey.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/properties/ConfigurationPropertyKey.java
@@ -119,6 +119,11 @@ public enum ConfigurationPropertyKey implements TypedPropertyKey {
     SHOW_PROCESS_LIST_ENABLED("show-process-list-enabled", String.valueOf(false), boolean.class),
     
     /**
+     * If execution time less than this threshold, then process will not be reported.
+     */
+    SHOW_PROCESS_LIST_NO_REPORT_THRESHOLD_MILLIS("show-process-list-no-report-threshold-millis", String.valueOf(100), long.class),
+    
+    /**
      * The length of time in milliseconds an SQL waits for a global lock before giving up.
      */
     LOCK_WAIT_TIMEOUT_MILLISECONDS("lock-wait-timeout-milliseconds", String.valueOf(50000L), long.class),

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
@@ -112,7 +112,7 @@ public abstract class JDBCExecutorCallback<T> implements ExecutorCallback<JDBCEx
     
     private void finishReport(final Map<String, Object> dataMap, final SQLExecutionUnit executionUnit) {
         if (dataMap.containsKey(ExecuteProcessConstants.EXECUTE_ID.name())) {
-            ExecuteProcessEngine.finish(dataMap.get(ExecuteProcessConstants.EXECUTE_ID.name()).toString(), executionUnit);
+            ExecuteProcessEngine.finish(dataMap.get(ExecuteProcessConstants.EXECUTE_ID.name()).toString(), executionUnit, dataMap);
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/raw/callback/RawSQLExecutorCallback.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/raw/callback/RawSQLExecutorCallback.java
@@ -53,7 +53,7 @@ public final class RawSQLExecutorCallback implements ExecutorCallback<RawSQLExec
         if (dataMap.containsKey(ExecuteProcessConstants.EXECUTE_ID.name())) {
             String executionID = dataMap.get(ExecuteProcessConstants.EXECUTE_ID.name()).toString();
             for (RawSQLExecutionUnit each : inputs) {
-                ExecuteProcessEngine.finish(executionID, each);
+                ExecuteProcessEngine.finish(executionID, each, dataMap);
             }
         }
         return result;

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
@@ -24,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
+import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutorDataMap;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
@@ -59,8 +60,8 @@ public final class ExecuteProcessEngine {
     public static void initialize(final LogicSQL logicSQL, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ConfigurationProperties props) {
         SQLStatementContext<?> context = logicSQL.getSqlStatementContext();
         if (!HANDLERS.isEmpty() && ExecuteProcessStrategyEvaluator.evaluate(context, executionGroupContext, props)) {
-            //TODO put in server.yaml
-            long noReportThresholdMillis = 100;
+            long noReportThresholdMillis = props.getValue(ConfigurationPropertyKey.SHOW_PROCESS_LIST_NO_REPORT_THRESHOLD_MILLIS);
+            log.info("noReportThresholdMillis={}", noReportThresholdMillis);
             ExecuteProcessReportContext reportContext = new ExecuteProcessReportContext(executionGroupContext.getExecutionID(), noReportThresholdMillis);
             ExecutorDataMap.getValue().put(ExecuteProcessConstants.EXECUTE_ID.name(), reportContext);
             HANDLERS.iterator().next().report(logicSQL, executionGroupContext, ExecuteProcessConstants.EXECUTE_STATUS_START);

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutorDataMap;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessReportContext;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
 import org.apache.shardingsphere.infra.executor.sql.process.spi.ExecuteProcessReporter;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
@@ -54,7 +55,9 @@ public final class ExecuteProcessEngine {
     public static void initialize(final LogicSQL logicSQL, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ConfigurationProperties props) {
         SQLStatementContext<?> context = logicSQL.getSqlStatementContext();
         if (!HANDLERS.isEmpty() && ExecuteProcessStrategyEvaluator.evaluate(context, executionGroupContext, props)) {
-            ExecutorDataMap.getValue().put(ExecuteProcessConstants.EXECUTE_ID.name(), executionGroupContext.getExecutionID());
+            long noReportThresholdMillis = 100;
+            ExecuteProcessReportContext reportContext = new ExecuteProcessReportContext(executionGroupContext.getExecutionID(), noReportThresholdMillis);
+            ExecutorDataMap.getValue().put(ExecuteProcessConstants.EXECUTE_ID.name(), reportContext);
             HANDLERS.iterator().next().report(logicSQL, executionGroupContext, ExecuteProcessConstants.EXECUTE_STATUS_START);
         }
     }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessEngine.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.infra.executor.sql.process;
 
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,9 +31,10 @@ import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcess
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
 import org.apache.shardingsphere.infra.executor.sql.process.spi.ExecuteProcessReporter;
 import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
 import java.util.Collection;
-import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import java.util.Map;
 
 /**
  * Execute process engine.
@@ -61,7 +61,6 @@ public final class ExecuteProcessEngine {
         SQLStatementContext<?> context = logicSQL.getSqlStatementContext();
         if (!HANDLERS.isEmpty() && ExecuteProcessStrategyEvaluator.evaluate(context, executionGroupContext, props)) {
             long noReportThresholdMillis = props.getValue(ConfigurationPropertyKey.SHOW_PROCESS_LIST_NO_REPORT_THRESHOLD_MILLIS);
-            log.info("noReportThresholdMillis={}", noReportThresholdMillis);
             ExecuteProcessReportContext reportContext = new ExecuteProcessReportContext(executionGroupContext.getExecutionID(), noReportThresholdMillis);
             ExecutorDataMap.getValue().put(ExecuteProcessConstants.EXECUTE_ID.name(), reportContext);
             HANDLERS.iterator().next().report(logicSQL, executionGroupContext, ExecuteProcessConstants.EXECUTE_STATUS_START);

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.executor.sql.process.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Execute process report context.
+ */
+@RequiredArgsConstructor
+@Getter
+@Setter
+public final class ExecuteProcessReportContext {
+
+    private final String executionID;
+    
+    private final long showProcessListNoReportThresholdMillis;
+    
+    private volatile ExecuteProcessContext executeProcessContext;
+    
+    private volatile boolean reportToGovernanceDonePartially;
+    
+    @Override
+    public String toString() {
+        return executionID;
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.executor.sql.process.model;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
 
 /**
  * Execute process report context.
@@ -33,7 +34,7 @@ public final class ExecuteProcessReportContext {
     
     private final long showProcessListNoReportThresholdMillis;
     
-    private volatile ExecuteProcessContext executeProcessContext;
+    private volatile YamlExecuteProcessContext yamlExecuteProcessContext;
     
     private volatile boolean reportToGovernanceDonePartially;
     

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContext.java
@@ -36,7 +36,7 @@ public final class ExecuteProcessReportContext {
     
     private volatile YamlExecuteProcessContext yamlExecuteProcessContext;
     
-    private volatile boolean reportToGovernanceDonePartially;
+    private boolean reportToGovernanceDonePartially;
     
     @Override
     public String toString() {

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
@@ -35,7 +35,7 @@ public final class YamlExecuteProcessUnit {
     
     private String unitID;
     
-    private ExecuteProcessConstants status;
+    private volatile ExecuteProcessConstants status;
     
     public YamlExecuteProcessUnit(final ExecuteProcessUnit executeProcessUnit) {
         unitID = executeProcessUnit.getUnitID();

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
@@ -35,7 +35,7 @@ public final class YamlExecuteProcessUnit {
     
     private String unitID;
     
-    private volatile ExecuteProcessConstants status;
+    private ExecuteProcessConstants status;
     
     public YamlExecuteProcessUnit(final ExecuteProcessUnit executeProcessUnit) {
         unitID = executeProcessUnit.getUnitID();

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/spi/ExecuteProcessReporter.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/spi/ExecuteProcessReporter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.process.spi;
 
+import java.util.Map;
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
@@ -40,8 +41,9 @@ public interface ExecuteProcessReporter {
      * @param executionID execution ID
      * @param executionUnit execution unit
      * @param constants constants
+     * @param dataMap data map
      */
-    void report(String executionID, SQLExecutionUnit executionUnit, ExecuteProcessConstants constants);
+    void report(String executionID, SQLExecutionUnit executionUnit, ExecuteProcessConstants constants, Map<String, Object> dataMap);
     
     /**
      * Report this task on completion.

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContextTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.executor.sql.process.model;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ExecuteProcessReportContextTest {
+    
+    @Test
+    public void assertToString() {
+        String executionID = "738b1fb3-655e-4973-ae94-c15bdce2cf38";
+        ExecuteProcessReportContext context = new ExecuteProcessReportContext(executionID, 100);
+        assertThat(context.toString(), is(executionID));
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessReportContextTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ExecuteProcessReportContextTest {
+public final class ExecuteProcessReportContextTest {
     
     @Test
     public void assertToString() {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutor.java
@@ -101,6 +101,9 @@ public final class ShowProcessListExecutor implements DatabaseAdminQueryExecutor
             String statePrefix = "Executing ";
             rowValues.add(statePrefix + processDoneCount + "/" + processContext.getUnitStatuses().size());
             String sql = processContext.getSql();
+            if (null != sql && sql.length() > 100) {
+                sql = sql.substring(0, 100);
+            }
             rowValues.add(sql != null ? sql : "");
             return new MemoryQueryResultDataRow(rowValues);
         }).collect(Collectors.toList());

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutorTest.java
@@ -78,6 +78,7 @@ public final class ShowProcessListExecutorTest {
         Field childrenValuesField = showProcessListExecutor.getClass().getDeclaredField("processListData");
         childrenValuesField.setAccessible(true);
         String executionNodeValue = "executionID: f6c2336a-63ba-41bf-941e-2e3504eb2c80\n"
+            + "sql: alter table t_order add column a varchar(64) after order_id\n"
             + "startTimeMillis: 1617939785160\n"
             + "unitStatuses:\n"
             + "- status: EXECUTE_STATUS_START\n"
@@ -98,6 +99,7 @@ public final class ShowProcessListExecutorTest {
             assertThat(mergedResult.getValue(3, String.class), is("localhost:30000"));
             assertThat(mergedResult.getValue(4, String.class), is(SCHEMA_NAME));
             assertThat(mergedResult.getValue(7, String.class), is("Executing 1/2"));
+            assertThat(mergedResult.getValue(8, String.class), is("alter table t_order add column a varchar(64) after order_id"));
         }
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -60,3 +60,4 @@
 #  check-table-metadata-enabled: false
 #  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
 #  show-process-list-enabled: false
+#  show-process-list-no-report-threshold-millis: 100


### PR DESCRIPTION
Fixes #9568 part 7.

Changes proposed in this pull request:
- Add ExecuteProcessReportContext
- Add process report lock for the same execution process report, with different execution unit
- Add `show-process-list-no-report-threshold-millis` in `server.yaml`, default value: 100
- Report situations: 1) if total execution time not reach threshold, then no report, 2) else, report will be delayed to threshold or later
- Refactor `ExecuteProcessReporter.report` execution unit, use unified dataMap to report execution unit, to avoid thread local issue
- Additional: Limit show processlist `Info` column maximum length to 100
