### PR TITLE
Add Oracle SQL - DISASSOCIATE STATISTICS

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1842,3 +1842,13 @@ defaultCostClause
 defaultSelectivityClause
     : DEFAULT SELECTIVITY defaultSelectivity
     ;
+
+disassociateStatistics
+    : DISASSOCIATE STATISTICS FROM 
+    (COLUMNS tableName DOT_ columnName (COMMA_ tableName DOT_ columnName)*
+    | FUNCTIONS function (COMMA_ function)*
+    | PACKAGES packageName (COMMA_ packageName)*
+    | TYPES typeName (COMMA_ typeName)*
+    | INDEXES indexName (COMMA_ indexName)*
+    | INDEXTYPES indexTypeName (COMMA_ indexTypeName)*) FORCE?
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -2215,6 +2215,10 @@ ASSOCIATE
     : A S S O C I A T E
     ;
 
+DISASSOCIATE
+    : D I S A S S O C I A T E
+    ;
+
 FUNCTIONS
     : F U N C T I O N S
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
@@ -53,5 +53,6 @@ execute
     | setConstraints
     | analyze
     | associateStatistics
+    | disassociateStatistics
     ) SEMI_?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
@@ -39,6 +39,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.Constr
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateDefinitionClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.CreateTableContext;
+import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DisassociateStatisticsContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropConstraintClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropIndexContext;
@@ -80,6 +81,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.Ora
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAssociateStatisticsStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDisassociateStatisticsStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDropIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleTruncateStatement;
@@ -407,6 +409,25 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
         }
         if (null != ctx.functionAssociation()) {
             for (IndexNameContext each: ctx.functionAssociation().indexName()) {
+                result.getIndexes().add((IndexSegment) visit(each));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public ASTNode visitDisassociateStatistics(final DisassociateStatisticsContext ctx) {
+        OracleDisassociateStatisticsStatement result = new OracleDisassociateStatisticsStatement();
+        if (null != ctx.tableName()) {
+            for (TableNameContext each : ctx.tableName()) {
+                result.getTables().add((SimpleTableSegment) visit(each));
+            }
+            for (ColumnNameContext each: ctx.columnName()) {
+                result.getColumns().add((ColumnSegment) visit(each));
+            }
+        }
+        if (null != ctx.indexName()) {
+            for (IndexNameContext each: ctx.indexName()) {
                 result.getIndexes().add((IndexSegment) visit(each));
             }
         }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -132,6 +132,8 @@ public enum SQLVisitorRule {
 
     ASSOCIATE_STATISTICS("AssociateStatistics", SQLStatementType.DDL),
 
+    DISASSOCIATE_STATISTICS("DisassociateStatistics", SQLStatementType.DDL),
+
     SET_CONSTRAINTS("SetConstraints", SQLStatementType.TCL),
     
     SET_TRANSACTION("SetTransaction", SQLStatementType.TCL),

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/ddl/OracleDisassociateStatisticsStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/ddl/OracleDisassociateStatisticsStatement.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.OracleStatement;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Oracle disassociate statistics statement.
+ */
+@Getter
+@Setter
+@ToString
+public final class OracleDisassociateStatisticsStatement extends AbstractSQLStatement implements DDLStatement, OracleStatement {
+
+    private List<IndexSegment> indexes = new LinkedList<>();
+    
+    private List<SimpleTableSegment> tables = new LinkedList<>();
+
+    private List<ColumnSegment> columns = new LinkedList<>();
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/DDLStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/DDLStatementAssert.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.Ora
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAlterSynonymStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAnalyzeStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleAssociateStatisticsStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDisassociateStatisticsStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.AlterIndexStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.AlterSessionStatementAssert;
@@ -42,6 +43,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.AssociateStatisticsStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.CreateIndexStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.CreateTableStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.DisassociateStatisticsStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.DropIndexStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.DropTableStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl.TruncateStatementAssert;
@@ -55,6 +57,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AssociateStatisticsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateIndexStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTableStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DisassociateStatisticsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropIndexStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.TruncateStatementTestCase;
@@ -97,6 +100,8 @@ public final class DDLStatementAssert {
             AnalyzeStatementAssert.assertIs(assertContext, (OracleAnalyzeStatement) actual, (AnalyzeStatementTestCase) expected);
         } else if (actual instanceof OracleAssociateStatisticsStatement) {
             AssociateStatisticsStatementAssert.assertIs(assertContext, (OracleAssociateStatisticsStatement) actual, (AssociateStatisticsStatementTestCase) expected);
+        } else if (actual instanceof OracleDisassociateStatisticsStatement) {
+            DisassociateStatisticsStatementAssert.assertIs(assertContext, (OracleDisassociateStatisticsStatement) actual, (DisassociateStatisticsStatementTestCase) expected);
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/DisassociateStatisticsStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/DisassociateStatisticsStatementAssert.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDisassociateStatisticsStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.column.ColumnAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.index.IndexAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DisassociateStatisticsStatementTestCase;
+
+/**
+ * Disassociate Statistics statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DisassociateStatisticsStatementAssert {
+    
+    /**
+     * Assert disassociate statistics statement is correct with expected parser result.
+     * 
+     * @param assertContext assert context
+     * @param actual actual disassociate statistics statement
+     * @param expected expected disassociate statistics statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final OracleDisassociateStatisticsStatement actual, final DisassociateStatisticsStatementTestCase expected) {
+        assertTables(assertContext, actual, expected);
+        assertColumns(assertContext, actual, expected);
+        assertIndexes(assertContext, actual, expected);
+    }
+    
+    private static void assertTables(final SQLCaseAssertContext assertContext, final OracleDisassociateStatisticsStatement actual, final DisassociateStatisticsStatementTestCase expected) {
+        if (null != expected.getTables()) {
+            TableAssert.assertIs(assertContext, actual.getTables(), expected.getTables());
+        }
+    }
+
+    private static void assertColumns(final SQLCaseAssertContext assertContext, final OracleDisassociateStatisticsStatement actual, final DisassociateStatisticsStatementTestCase expected) {
+        if (null != expected.getColumns()) {
+            int count = 0;
+            for (ColumnSegment each : actual.getColumns()) {
+                ColumnAssert.assertIs(assertContext, each, expected.getColumns().get(count));
+                count++;
+            }
+        }
+    }
+    
+    private static void assertIndexes(final SQLCaseAssertContext assertContext, final OracleDisassociateStatisticsStatement actual, final DisassociateStatisticsStatementTestCase expected) {
+        if (null != expected.getIndexes()) {
+            int count = 0;
+            for (IndexSegment each : actual.getIndexes()) {
+                IndexAssert.assertIs(assertContext, each, expected.getIndexes().get(count));
+                count++;
+            }
+        }
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -68,6 +68,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTriggerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateViewStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DisassociateStatisticsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDatabaseStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropFunctionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropIndexStatementTestCase;
@@ -350,6 +351,9 @@ public final class SQLParserTestCases {
 
     @XmlElement(name = "associate-statistics")
     private final List<AssociateStatisticsStatementTestCase> associateStatisticsTestCase = new LinkedList<>();
+
+    @XmlElement(name = "disassociate-statistics")
+    private final List<DisassociateStatisticsStatementTestCase> disassociateStatisticsTestCase = new LinkedList<>();
     
     @XmlElement(name = "add-resource")
     private final List<AddResourceStatementTestCase> addResourceTestCase = new LinkedList<>();
@@ -511,6 +515,7 @@ public final class SQLParserTestCases {
         putAll(dropSequenceTestCase, result);
         putAll(analyzeTestCase, result);
         putAll(associateStatisticsTestCase, result);
+        putAll(disassociateStatisticsTestCase, result);
         putAll(addResourceTestCase, result);
         putAll(alterDataBaseDiscoveryRuleTestCase, result);
         putAll(alterEncryptRuleTestCase, result);

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DisassociateStatisticsStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DisassociateStatisticsStatementTestCase.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.index.ExpectedIndex;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Disassociate Statistics statement test case.
+ */
+@Getter
+@Setter
+public final class DisassociateStatisticsStatementTestCase extends SQLParserTestCase {
+
+    @XmlElement(name = "index")
+    private final List<ExpectedIndex> indexes = new LinkedList<>();
+    
+    @XmlElement(name = "table")
+    private final List<ExpectedSimpleTable> tables = new LinkedList<>();
+
+    @XmlElement(name = "column")
+    private final List<ExpectedColumn> columns = new LinkedList<>();
+
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/disassociate-statistics.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/disassociate-statistics.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_column">
+        <table name="employee" start-index="37" stop-index="44" />
+        <column name="age" start-index="46" stop-index="48" />
+    </disassociate-statistics>
+
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_columns">
+        <table name="employee" start-index="37" stop-index="44" />
+        <column name="age" start-index="46" stop-index="48" />
+        <table name="employee" start-index="51" stop-index="58" />
+        <column name="salary" start-index="60" stop-index="65" />
+    </disassociate-statistics>   
+
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_index">
+        <index name="salary_index" start-index="37" stop-index="48" />
+    </disassociate-statistics>
+
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_function" />
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_package" />
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_type" />
+    <disassociate-statistics sql-case-id="disassociate_statistics_from_indextype" />
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/disassociate-statistics.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/disassociate-statistics.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="disassociate_statistics_from_column" value="DISASSOCIATE STATISTICS FROM COLUMNS employee.age" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_columns" value="DISASSOCIATE STATISTICS FROM COLUMNS employee.age, employee.salary FORCE" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_index" value="DISASSOCIATE STATISTICS FROM INDEXES salary_index" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_function" value="DISASSOCIATE STATISTICS FROM FUNCTIONS myFunction FORCE" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_package" value="DISASSOCIATE STATISTICS FROM PACKAGES emp_mgmt" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_type" value="DISASSOCIATE STATISTICS FROM TYPES example_typ" db-types="Oracle" />
+    <sql-case id="disassociate_statistics_from_indextype" value="DISASSOCIATE STATISTICS FROM INDEXTYPES indtype" db-types="Oracle" />
+</sql-cases>


### PR DESCRIPTION
Relates #10513 

Changes proposed in this pull request:

- Add Oracle SQL - [DISASSOCIATE STATISTICS](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DISASSOCIATE-STATISTICS.html#GUID-6E9A7D93-E28A-469D-97AB-2BECC2EF3C43)
- Add corresponding test cases

@wgy8283335
