### PR TITLE
Delete the common configuration, adjust the position of datasource.driver-class-name and type, because the code in #8355 has deleted the reading of the common configuration

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/configuration/spring-boot-starter/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/configuration/spring-boot-starter/_index.cn.md
@@ -11,10 +11,10 @@ ShardingSphere-JDBC 提供官方的 Spring Boot Starter，使开发者可以非�
 
 ```properties
 spring.shardingsphere.datasource.names= # 数据源名称，多数据源以逗号分隔
-spring.shardingsphere.datasource.common.type=  # 数据库连接池类名称
-spring.shardingsphere.datasource.common.driver-class-name= # 数据库驱动类名
 
-spring.shardingsphere.datasource.<datasource-name>.url= # 数据库 URL 连接
+spring.shardingsphere.datasource.<datasource-name>.type= # 数据库连接池类名称
+spring.shardingsphere.datasource.<datasource-name>.driver-class-name= # 数据库驱动类名
+spring.shardingsphere.datasource.<datasource-name>.jdbc-url= # 数据库 URL 连接
 spring.shardingsphere.datasource.<datasource-name>.username= # 数据库用户名
 spring.shardingsphere.datasource.<datasource-name>.password= # 数据库密码
 spring.shardingsphere.datasource.<datasource-name>.xxx=  # 数据库连接池的其它属性

--- a/docs/document/content/user-manual/shardingsphere-jdbc/configuration/spring-boot-starter/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/configuration/spring-boot-starter/_index.en.md
@@ -11,10 +11,10 @@ ShardingSphere-JDBC provides official Spring Boot Starter to make convenient for
 
 ```properties
 spring.shardingsphere.datasource.names= # Data source name, multiple data sources are separated by commas
-spring.shardingsphere.datasource.common.type= # Database connection pool type name
-spring.shardingsphere.datasource.common.driver-class-name= # Database driver class name
 
-spring.shardingsphere.datasource.<datasource-name>.url= # Database URL connection
+spring.shardingsphere.datasource.<datasource-name>.type= # Database connection pool type name
+spring.shardingsphere.datasource.<datasource-name>.driver-class-name= # Database driver class name
+spring.shardingsphere.datasource.<datasource-name>.jdbc-url= # Database URL connection
 spring.shardingsphere.datasource.<datasource-name>.username= # Database username
 spring.shardingsphere.datasource.<datasource-name>.password= # Database password
 spring.shardingsphere.datasource.<datasource-name>.xxx= # Other properties of database connection pool


### PR DESCRIPTION
Delete the common configuration, adjust the position of datasource.driver-class-name and type, because the code in #8355 has deleted the reading of the common configuration