### PR TITLE
Fix AggregationProjection return expression without cleaning

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.Agg
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.AggregationProjection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.DerivedProjection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ShorthandProjection;
+import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -68,7 +69,7 @@ public final class ProjectionsContext {
      */
     public Optional<String> findAlias(final String projectionName) {
         for (Projection each : projections) {
-            if (projectionName.equalsIgnoreCase(each.getExpression())) {
+            if (projectionName.equalsIgnoreCase(SQLUtil.getExactlyValue(each.getExpression()))) {
                 return each.getAlias();
             }
         }
@@ -84,7 +85,7 @@ public final class ProjectionsContext {
     public Optional<Integer> findProjectionIndex(final String projectionName) {
         int result = 1;
         for (Projection each : projections) {
-            if (projectionName.equalsIgnoreCase(each.getExpression())) {
+            if (projectionName.equalsIgnoreCase(SQLUtil.getExactlyValue(each.getExpression()))) {
                 return Optional.of(result);
             }
             result++;

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -24,7 +24,6 @@ import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
-import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +51,7 @@ public class AggregationProjection implements Projection {
     
     @Override
     public final String getExpression() {
-        return SQLUtil.getExactlyValue(type.name() + innerExpression);
+        return type.name() + innerExpression;
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.select.projection.impl;
+
+import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class AggregationProjectionTest {
+    private final AggregationType aggregationType = AggregationType.COUNT;
+
+    private final String innerExpression = "( A.\"DIRECTION\" )";
+
+    private final String alias = "AVG_DERIVED_COUNT_0";
+
+    private final AggregationProjection aggregationProjection1 = new AggregationProjection(aggregationType, innerExpression, alias);
+
+    private final AggregationProjection aggregationProjection2 = new AggregationProjection(aggregationType, innerExpression, null);
+
+    @Test
+    public void assertGetExpression() {
+        assertThat(aggregationProjection1.getExpression(), is(aggregationType + innerExpression));
+    }
+
+    @Test
+    public void assertGetAlias() {
+        Optional<String> actual = aggregationProjection1.getAlias();
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), is(alias));
+    }
+
+    @Test
+    public void assertGetColumnLabel() {
+        assertThat(aggregationProjection1.getColumnLabel(), is(alias));
+    }
+
+    @Test
+    public void assertGetColumnLabelWithoutAlias() {
+        assertThat(aggregationProjection2.getColumnLabel(), is(aggregationType + innerExpression));
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/issues/10861

Changes proposed in this pull request:
- Fix AggregationProjection return expression without cleaning


---
- I Checked with only MySQL (5.7.34 / 8.0.25) and Postgres (10.5)
- Two databases have different column identifiers spec
- Postgres needs to double-quotes for using upper case column name.
- However, MySQL needs to change SQL mode ([ANSI_QUOTES](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes)) for using double-quotes.
- Therefore, AggregationProjection returns expression as passed from Original SQL.
