### PR TITLE
Add synchronization for reporting execute process unit and enable DML statement reporting

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/subscriber/ProcessRegistrySubscriber.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/main/java/org/apache/shardingsphere/governance/core/registry/process/subscriber/ProcessRegistrySubscriber.java
@@ -79,16 +79,18 @@ public final class ProcessRegistrySubscriber {
      */
     @Subscribe
     public void reportExecuteProcessUnit(final ExecuteProcessUnitReportEvent event) {
-        // TODO lock on the same jvm
-        String executionPath = ProcessNode.getExecutionPath(event.getExecutionID());
-        YamlExecuteProcessContext yamlExecuteProcessContext = YamlEngine.unmarshal(repository.get(executionPath), YamlExecuteProcessContext.class);
-        ExecuteProcessUnit executeProcessUnit = event.getExecuteProcessUnit();
-        for (YamlExecuteProcessUnit unit : yamlExecuteProcessContext.getUnitStatuses()) {
-            if (unit.getUnitID().equals(executeProcessUnit.getUnitID())) {
-                unit.setStatus(executeProcessUnit.getStatus());
+        String executionID = event.getExecutionID();
+        synchronized (executionID) {
+            String executionPath = ProcessNode.getExecutionPath(executionID);
+            YamlExecuteProcessContext yamlExecuteProcessContext = YamlEngine.unmarshal(repository.get(executionPath), YamlExecuteProcessContext.class);
+            ExecuteProcessUnit executeProcessUnit = event.getExecuteProcessUnit();
+            for (YamlExecuteProcessUnit unit : yamlExecuteProcessContext.getUnitStatuses()) {
+                if (unit.getUnitID().equals(executeProcessUnit.getUnitID())) {
+                    unit.setStatus(executeProcessUnit.getStatus());
+                }
             }
+            repository.persist(executionPath, YamlEngine.marshal(yamlExecuteProcessContext));
         }
-        repository.persist(executionPath, YamlEngine.marshal(yamlExecuteProcessContext));
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessStrategyEvaluator.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessStrategyEvaluator.java
@@ -24,7 +24,9 @@ import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties
 import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DMLStatement;
 
 /**
  * Process strategy evaluator.
@@ -41,8 +43,9 @@ public final class ExecuteProcessStrategyEvaluator {
      * @return submit or not
      */
     public static boolean evaluate(final SQLStatementContext<?> context, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ConfigurationProperties props) {
-        // TODO : Add more conditions to evaluate whether to submit this process task or not
         boolean showProcessListEnabled = props.getValue(ConfigurationPropertyKey.SHOW_PROCESS_LIST_ENABLED);
-        return showProcessListEnabled && context.getSqlStatement() instanceof DDLStatement;
+        SQLStatement statement = context.getSqlStatement();
+        boolean statementEnabled = statement instanceof DDLStatement || statement instanceof DMLStatement;
+        return showProcessListEnabled && statementEnabled;
     }
 }


### PR DESCRIPTION
Fixes #9568 part 9.

Changes proposed in this pull request:
- Add synchronization for reporting execute process unit. In order to avoid process overwriting in governance when sharded sqls are executed concurrently.
- Enable DML statement reporting
