### PR TITLE
change og's default behaviour when DN node can't reachable, throw exception and don't return 1

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/sane/postgresql/OpenGaussSaneQueryResultEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/sane/postgresql/OpenGaussSaneQueryResultEngine.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.postgresql;
+
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.SaneQueryResultEngine;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.ExecuteResult;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+
+import java.util.Optional;
+
+/**
+ * Sane query result engine for PostgreSQL.
+ */
+public final class OpenGaussSaneQueryResultEngine implements SaneQueryResultEngine {
+    
+    @Override
+    public Optional<ExecuteResult> getSaneQueryResult(final SQLStatement sqlStatement) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public String getType() {
+        return "OpenGauss";
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.SaneQueryResultEngine
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.SaneQueryResultEngine
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.mysql.MySQLSaneQueryResultEngine
 org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.postgresql.PostgreSQLSaneQueryResultEngine
+org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.sane.postgresql.OpenGaussSaneQueryResultEngine


### PR DESCRIPTION
change og' default  behaviour  when DN not reachable. It's same with pg database。
Fixes #11239.

Changes proposed in this pull request:
- add a new OpenGaussSaneQueryResultEngine to deal with default result
- the OpenGaussSaneQueryResultEngine  copy from PostgreSQLSaneQueryResultEngine and set databaseType is OpenGauss
