### PR TITLE
Minor optimization in DropReadwriteSplittingRuleStatementUpdater

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/DropReadwriteSplittingRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/DropReadwriteSplittingRuleStatementUpdater.java
@@ -76,7 +76,7 @@ public final class DropReadwriteSplittingRuleStatementUpdater implements RuleDef
     }
     
     private boolean isLoadBalancerNotInUse(final ReadwriteSplittingRuleConfiguration currentRuleConfig, final String toBeDroppedLoadBalancerName) {
-        return !currentRuleConfig.getDataSources().stream().filter(each -> each.getLoadBalancerName().equals(toBeDroppedLoadBalancerName)).findAny().isPresent();
+        return !currentRuleConfig.getDataSources().stream().anyMatch(each -> each.getLoadBalancerName().equals(toBeDroppedLoadBalancerName));
     }
     
     @Override


### PR DESCRIPTION
Changes proposed in this pull request:
- Use anyMatch to replace filter & findAny & isPresent
- Tips from idea editor `The 'filter().findAny().isPresent()' chain can be replaced with 'anyMatch()' `