### PR TITLE
Fix dependency error in opentelemetry integration

### DIFF
--- a/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-opentelemetry/pom.xml
+++ b/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-opentelemetry/pom.xml
@@ -70,6 +70,12 @@
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP</artifactId>
+            <version>${hikari-cp.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
The integration test passed after #11273 was opened, but #11262 was merged before #11273 , resulting in errors in subsequent integration tests.

Changes proposed in this pull request:
- add HikariCP dependency in pom.
