### PR TITLE
For #11247, make datasource configuration match the Hikari properties.

### DIFF
--- a/docs/document/content/features/dist-sql/syntax/rql/rql-resource.cn.md
+++ b/docs/document/content/features/dist-sql/syntax/rql/rql-resource.cn.md
@@ -27,8 +27,8 @@ mysql> show resources;
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | name | type  | host      | port | db   | attribute                                                                                                                                                                                           |
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ds_0 | MySQL | 127.0.0.1 | 3306 | ds_0 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50,"maintenanceIntervalMilliseconds":30000} |
-| ds_1 | MySQL | 127.0.0.1 | 3306 | ds_1 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50,"maintenanceIntervalMilliseconds":30000} |
+| ds_0 | MySQL | 127.0.0.1 | 3306 | ds_0 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50} |
+| ds_1 | MySQL | 127.0.0.1 | 3306 | ds_1 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50} |
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 2 rows in set (0.84 sec)
 ```

--- a/docs/document/content/features/dist-sql/syntax/rql/rql-resource.en.md
+++ b/docs/document/content/features/dist-sql/syntax/rql/rql-resource.en.md
@@ -27,8 +27,8 @@ mysql> show resources;
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | name | type  | host      | port | db   | attribute                                                                                                                                                                                           |
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ds_0 | MySQL | 127.0.0.1 | 3306 | ds_0 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50,"maintenanceIntervalMilliseconds":30000} |
-| ds_1 | MySQL | 127.0.0.1 | 3306 | ds_1 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50,"maintenanceIntervalMilliseconds":30000} |
+| ds_0 | MySQL | 127.0.0.1 | 3306 | ds_0 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50} |
+| ds_1 | MySQL | 127.0.0.1 | 3306 | ds_1 | {"minPoolSize":1,"connectionTimeoutMilliseconds":30000,"maxLifetimeMilliseconds":1800000,"readOnly":false,"idleTimeoutMilliseconds":60000,"maxPoolSize":50} |
 +------+-------+-----------+------+------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 2 rows in set (0.84 sec)
 ```

--- a/docs/document/content/features/governance/management/registry-center.cn.md
+++ b/docs/document/content/features/governance/management/registry-center.cn.md
@@ -78,7 +78,6 @@ ds_0:
     url: jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false
     password: null
     maxPoolSize: 50
-    maintenanceIntervalMilliseconds: 30000
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     minPoolSize: 1
@@ -90,7 +89,6 @@ ds_1:
     url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
     password: null
     maxPoolSize: 50
-    maintenanceIntervalMilliseconds: 30000
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     minPoolSize: 1

--- a/docs/document/content/features/governance/management/registry-center.en.md
+++ b/docs/document/content/features/governance/management/registry-center.en.md
@@ -78,7 +78,6 @@ ds_0:
     url: jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false
     password: null
     maxPoolSize: 50
-    maintenanceIntervalMilliseconds: 30000
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     minPoolSize: 1
@@ -90,7 +89,6 @@ ds_1:
     url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
     password: null
     maxPoolSize: 50
-    maintenanceIntervalMilliseconds: 30000
     connectionTimeoutMilliseconds: 30000
     idleTimeoutMilliseconds: 60000
     minPoolSize: 1

--- a/docs/document/content/features/test-engine/performance-test-sysbench.cn.md
+++ b/docs/document/content/features/test-engine/performance-test-sysbench.cn.md
@@ -338,7 +338,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://${host-mysql-2}:3306/sbtest?serverTimezone=UTC&useSSL=false
     username: root
@@ -348,7 +347,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING
@@ -516,7 +514,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 128
     minPoolSize: 128
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !READWRITE_SPLITTING
@@ -543,7 +540,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
   primary_ds_1:
     url: jdbc:mysql://${host-mysql-2}:3306/sbtest?serverTimezone=UTC&useSSL=false
     username: root
@@ -553,7 +549,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING
@@ -735,7 +730,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/docs/document/content/features/test-engine/performance-test-sysbench.en.md
+++ b/docs/document/content/features/test-engine/performance-test-sysbench.en.md
@@ -338,7 +338,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://${host-mysql-2}:3306/sbtest?serverTimezone=UTC&useSSL=false
     username: root
@@ -348,7 +347,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING
@@ -516,7 +514,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 128
     minPoolSize: 128
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !READWRITE_SPLITTING
@@ -543,7 +540,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
   primary_ds_1:
     url: jdbc:mysql://${host-mysql-2}:3306/sbtest?serverTimezone=UTC&useSSL=false
     username: root
@@ -553,7 +549,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING
@@ -735,7 +730,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 256
     minPoolSize: 256
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/examples/shardingsphere-proxy-example/shardingsphere-proxy-boot-mybatis-example/src/main/resources/conf/config-readwrite-splitting.yaml
+++ b/examples/shardingsphere-proxy-example/shardingsphere-proxy-boot-mybatis-example/src/main/resources/conf/config-readwrite-splitting.yaml
@@ -34,7 +34,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_0?serverTimezone=UTC&useSSL=false
     username: root
@@ -44,7 +43,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -54,7 +52,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !READWRITE_SPLITTING

--- a/examples/shardingsphere-proxy-example/shardingsphere-proxy-boot-mybatis-example/src/main/resources/conf/config-sharding.yaml
+++ b/examples/shardingsphere-proxy-example/shardingsphere-proxy-boot-mybatis-example/src/main/resources/conf/config-sharding.yaml
@@ -34,7 +34,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -44,7 +43,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-databases-only.yaml
+++ b/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-databases-only.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://localhost:3306/demo_ds_1?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-databases-tables.yaml
+++ b/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-databases-tables.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://localhost:3306/demo_ds_1?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-write-only.yaml
+++ b/examples/shardingsphere-proxy-example/shardingsphere-proxy-hint-example/src/main/resources/conf/config-write-only.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:mysql://localhost:3306/demo_read_ds_0?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:mysql://localhost:3306/demo_read_ds_1?serverTimezone=UTC&useSSL=false&useUnicode=true&characterEncoding=UTF-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !READWRITE_SPLITTING

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-database-discovery.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-database-discovery.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_0:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -54,7 +52,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !DB_DISCOVERY
@@ -91,7 +88,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -101,7 +97,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_2:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -111,7 +106,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !DB_DISCOVERY

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-encrypt.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-encrypt.yaml
@@ -33,7 +33,6 @@
 #  maxLifetimeMilliseconds: 1800000
 #  maxPoolSize: 50
 #  minPoolSize: 1
-#  maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !ENCRYPT
@@ -72,7 +71,6 @@
 #  maxLifetimeMilliseconds: 1800000
 #  maxPoolSize: 50
 #  minPoolSize: 1
-#  maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !ENCRYPT

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-readwrite-splitting.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_0:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -54,7 +52,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !READWRITE_SPLITTING
@@ -83,7 +80,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  read_ds_0:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_0?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -93,7 +89,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  read_ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -103,7 +98,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !READWRITE_SPLITTING

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-shadow.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-shadow.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  shadow_ds:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHADOW
@@ -73,7 +71,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  shadow_ds:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -83,7 +80,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHADOW

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/conf/config-sharding.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHARDING
@@ -114,7 +112,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -124,7 +121,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHARDING

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceParameter.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceParameter.java
@@ -41,13 +41,11 @@ public final class DataSourceParameter {
     
     private long idleTimeoutMilliseconds = 60 * 1000L;
     
-    private long maxLifetimeMilliseconds;
+    private long maxLifetimeMilliseconds = 30 * 60 * 1000L;
     
     private int maxPoolSize = 50;
     
     private int minPoolSize = 1;
-    
-    private long maintenanceIntervalMilliseconds = 30 * 1000L;
     
     private boolean readOnly;
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/DataSourceConfigurationTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/DataSourceConfigurationTest.java
@@ -69,6 +69,9 @@ public final class DataSourceConfigurationTest {
         props.put("username", "root");
         props.put("password", "root");
         props.put("loginTimeout", "5000");
+        props.put("maximumPoolSize", "50");
+        props.put("minimumIdle", "1");
+        props.put("maxLifetime", "60000");
         props.put("test", "test");
         DataSourceConfiguration dataSourceConfig = new DataSourceConfiguration(HikariDataSource.class.getName());
         dataSourceConfig.getProps().putAll(props);
@@ -77,6 +80,9 @@ public final class DataSourceConfigurationTest {
         assertThat(actual.getJdbcUrl(), is("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL"));
         assertThat(actual.getUsername(), is("root"));
         assertThat(actual.getPassword(), is("root"));
+        assertThat(actual.getMaximumPoolSize(), is(50));
+        assertThat(actual.getMinimumIdle(), is(1));
+        assertThat(actual.getMaxLifetime(), is(60000L));
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSet.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSet.java
@@ -80,7 +80,6 @@ public final class DataSourceQueryResultSet implements DistSQLResultSet {
         result.put("maxLifetimeMilliseconds", dataSourceParameter.getMaxLifetimeMilliseconds());
         result.put("maxPoolSize", dataSourceParameter.getMaxPoolSize());
         result.put("minPoolSize", dataSourceParameter.getMinPoolSize());
-        result.put("maintenanceIntervalMilliseconds", dataSourceParameter.getMaintenanceIntervalMilliseconds());
         result.put("readOnly", dataSourceParameter.isReadOnly());
         return result;
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-database-discovery.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-database-discovery.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_0:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -54,7 +52,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !DB_DISCOVERY
@@ -91,7 +88,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -101,7 +97,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_2:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -111,7 +106,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !DB_DISCOVERY

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-encrypt.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-encrypt.yaml
@@ -33,7 +33,6 @@
 #  maxLifetimeMilliseconds: 1800000
 #  maxPoolSize: 50
 #  minPoolSize: 1
-#  maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !ENCRYPT
@@ -72,7 +71,6 @@
 #  maxLifetimeMilliseconds: 1800000
 #  maxPoolSize: 50
 #  minPoolSize: 1
-#  maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !ENCRYPT

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-readwrite-splitting.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_0:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  replica_ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -54,7 +52,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !READWRITE_SPLITTING
@@ -83,7 +80,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  read_ds_0:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_0?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -93,7 +89,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  read_ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_read_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -103,7 +98,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !READWRITE_SPLITTING

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-shadow.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-shadow.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  shadow_ds:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,8 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
-#
 #
 #rules:
 #- !SHADOW
@@ -74,7 +71,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  shadow_ds:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -84,7 +80,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHADOW

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -34,7 +34,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: postgres
@@ -44,7 +43,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHARDING
@@ -114,7 +112,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #  ds_1:
 #    url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
 #    username: root
@@ -124,7 +121,6 @@
 #    maxLifetimeMilliseconds: 1800000
 #    maxPoolSize: 50
 #    minPoolSize: 1
-#    maintenanceIntervalMilliseconds: 30000
 #
 #rules:
 #- !SHARDING

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
@@ -78,7 +78,6 @@ public final class DataSourceParameterConverter {
         DataSourceParameter result = new DataSourceParameter();
         result.setConnectionTimeoutMilliseconds(yamlDataSourceParameter.getConnectionTimeoutMilliseconds());
         result.setIdleTimeoutMilliseconds(yamlDataSourceParameter.getIdleTimeoutMilliseconds());
-        result.setMaintenanceIntervalMilliseconds(yamlDataSourceParameter.getMaintenanceIntervalMilliseconds());
         result.setMaxLifetimeMilliseconds(yamlDataSourceParameter.getMaxLifetimeMilliseconds());
         result.setMaxPoolSize(yamlDataSourceParameter.getMaxPoolSize());
         result.setMinPoolSize(yamlDataSourceParameter.getMinPoolSize());
@@ -98,6 +97,8 @@ public final class DataSourceParameterConverter {
         dataSourceConfig.addPropertySynonym("connectionTimeout", "connectionTimeoutMilliseconds");
         dataSourceConfig.addPropertySynonym("maxLifetime", "maxLifetimeMilliseconds");
         dataSourceConfig.addPropertySynonym("idleTimeout", "idleTimeoutMilliseconds");
+        dataSourceConfig.addPropertySynonym("maxPoolSize", "maximumPoolSize");
+        dataSourceConfig.addPropertySynonym("minPoolSize", "minimumIdle");
     }
     
     /**
@@ -119,9 +120,8 @@ public final class DataSourceParameterConverter {
         result.getProps().put("connectionTimeout", dataSourceParameter.getConnectionTimeoutMilliseconds());
         result.getProps().put("idleTimeout", dataSourceParameter.getIdleTimeoutMilliseconds());
         result.getProps().put("maxLifetime", dataSourceParameter.getMaxLifetimeMilliseconds());
-        result.getProps().put("maxPoolSize", dataSourceParameter.getMaxPoolSize());
-        result.getProps().put("minPoolSize", dataSourceParameter.getMinPoolSize());
-        result.getProps().put("maintenanceIntervalMilliseconds", dataSourceParameter.getMaintenanceIntervalMilliseconds());
+        result.getProps().put("maximumPoolSize", dataSourceParameter.getMaxPoolSize());
+        result.getProps().put("minimumIdle", dataSourceParameter.getMinPoolSize());
         result.getProps().put("readOnly", dataSourceParameter.isReadOnly());
         if (null != dataSourceParameter.getCustomPoolProps()) {
             result.getProps().putAll(new HashMap(dataSourceParameter.getCustomPoolProps()));

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/yaml/YamlDataSourceParameter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/yaml/YamlDataSourceParameter.java
@@ -48,8 +48,6 @@ public final class YamlDataSourceParameter implements YamlConfiguration {
     
     private int minPoolSize;
     
-    private long maintenanceIntervalMilliseconds;
-    
     private boolean readOnly;
     
     private Properties customPoolProps;

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/converter/AddResourcesStatementConverter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/converter/AddResourcesStatementConverter.java
@@ -53,7 +53,7 @@ public final class AddResourcesStatementConverter {
             dataSource.setMaxPoolSize(parameter.getMaxPoolSize());
             dataSource.setConnectionTimeoutMilliseconds(parameter.getConnectionTimeoutMilliseconds());
             dataSource.setIdleTimeoutMilliseconds(parameter.getIdleTimeoutMilliseconds());
-            dataSource.setMaintenanceIntervalMilliseconds(parameter.getMaintenanceIntervalMilliseconds());
+            dataSource.setMaxLifetimeMilliseconds(parameter.getMaxLifetimeMilliseconds());
             dataSource.setCustomPoolProps(each.getProperties());
             result.put(each.getName(), dataSource);
         }

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverterTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverterTest.java
@@ -68,12 +68,11 @@ public final class DataSourceParameterConverterTest {
     
     private void assertParameter(final DataSourceConfiguration actual) {
         Map<String, Object> props = actual.getProps();
-        assertThat(props.get("maxPoolSize"), is(50));
-        assertThat(props.get("minPoolSize"), is(1));
+        assertThat(props.get("maximumPoolSize"), is(50));
+        assertThat(props.get("minimumIdle"), is(1));
         assertThat(props.get("connectionTimeout"), is(30 * 1000L));
         assertThat(props.get("idleTimeout"), is(60 * 1000L));
-        assertThat(props.get("maxLifetime"), is(0L));
-        assertThat(props.get("maintenanceIntervalMilliseconds"), is(30 * 1000L));
+        assertThat(props.get("maxLifetime"), is(30 * 60 * 1000L));
         assertThat(props.get("jdbcUrl"), is("jdbc:mysql://localhost:3306/demo_ds"));
         assertThat(props.get("username"), is("root"));
         assertThat(props.get("password"), is("root"));
@@ -106,7 +105,6 @@ public final class DataSourceParameterConverterTest {
         yamlDataSourceParameter.setConnectionTimeoutMilliseconds(30 * 1000L);
         yamlDataSourceParameter.setIdleTimeoutMilliseconds(60 * 1000L);
         yamlDataSourceParameter.setMaxLifetimeMilliseconds(0L);
-        yamlDataSourceParameter.setMaintenanceIntervalMilliseconds(30 * 1000L);
         yamlDataSourceParameter.setUsername("root");
         yamlDataSourceParameter.setPassword("root");
     }
@@ -117,7 +115,6 @@ public final class DataSourceParameterConverterTest {
         assertThat(dataSourceParameter.getConnectionTimeoutMilliseconds(), is(30 * 1000L));
         assertThat(dataSourceParameter.getIdleTimeoutMilliseconds(), is(60 * 1000L));
         assertThat(dataSourceParameter.getMaxLifetimeMilliseconds(), is(0L));
-        assertThat(dataSourceParameter.getMaintenanceIntervalMilliseconds(), is(30 * 1000L));
         assertThat(dataSourceParameter.getUsername(), is("root"));
         assertThat(dataSourceParameter.getPassword(), is("root"));
         assertThat(dataSourceParameter.getCustomPoolProps().size(), is(2));

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/java/org/apache/shardingsphere/proxy/config/yaml/swapper/YamlProxyConfigurationSwapperTest.java
@@ -82,7 +82,6 @@ public final class YamlProxyConfigurationSwapperTest {
         assertThat(dataSourceParameter.getMaxLifetimeMilliseconds(), is(3L));
         assertThat(dataSourceParameter.getMaxPoolSize(), is(4));
         assertThat(dataSourceParameter.getMinPoolSize(), is(5));
-        assertThat(dataSourceParameter.getMaintenanceIntervalMilliseconds(), is(6L));
         assertTrue(dataSourceParameter.isReadOnly());
     }
     
@@ -172,7 +171,6 @@ public final class YamlProxyConfigurationSwapperTest {
         when(yamlDataSourceParameter.getMaxLifetimeMilliseconds()).thenReturn(3L);
         when(yamlDataSourceParameter.getMaxPoolSize()).thenReturn(4);
         when(yamlDataSourceParameter.getMinPoolSize()).thenReturn(5);
-        when(yamlDataSourceParameter.getMaintenanceIntervalMilliseconds()).thenReturn(6L);
         when(yamlDataSourceParameter.isReadOnly()).thenReturn(true);
         Map<String, YamlDataSourceParameter> dataSources = new HashMap<>(1, 1);
         dataSources.put("ds1", yamlDataSourceParameter);
@@ -190,7 +188,6 @@ public final class YamlProxyConfigurationSwapperTest {
         when(yamlDataSourceParameter.getMaxLifetimeMilliseconds()).thenReturn(3L);
         when(yamlDataSourceParameter.getMaxPoolSize()).thenReturn(4);
         when(yamlDataSourceParameter.getMinPoolSize()).thenReturn(5);
-        when(yamlDataSourceParameter.getMaintenanceIntervalMilliseconds()).thenReturn(6L);
         when(yamlDataSourceParameter.isReadOnly()).thenReturn(true);
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-encrypt.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-encrypt.yaml
@@ -26,7 +26,6 @@ dataSource:
   maxLifetimeMilliseconds: 1800000
   maxPoolSize: 50
   minPoolSize: 1
-  maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:mysql://127.0.0.1:3306/read_ds_0
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:mysql://127.0.0.1:3306/read_ds_1
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !READWRITE_SPLITTING

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/test/resources/conf/config-sharding.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://127.0.0.1:3306/ds_1
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 50
     minPoolSize: 1
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-metrics/src/test/resources/docker/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-metrics/src/test/resources/docker/proxy/conf/config-db.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 10
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://mysql.agent.metrics.host:3306/agent_metrics_db_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 10
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
   - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-opentelemetry/src/test/resources/docker/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-agent-test/shardingsphere-integration-agent-test-plugins/shardingsphere-integration-agent-test-opentelemetry/src/test/resources/docker/proxy/conf/config-db.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 10
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://mysql.agent.tracing.opentelemetry.host:3306/agent_opentelemetry_db_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 10
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
   - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/h2/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/h2/proxy/conf/config-db.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://mysql.db.host:3306/db_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_2:
     url: jdbc:mysql://mysql.db.host:3306/db_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_3:
     url: jdbc:mysql://mysql.db.host:3306/db_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_4:
     url: jdbc:mysql://mysql.db.host:3306/db_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_5:
     url: jdbc:mysql://mysql.db.host:3306/db_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_6:
     url: jdbc:mysql://mysql.db.host:3306/db_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_7:
     url: jdbc:mysql://mysql.db.host:3306/db_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_8:
     url: jdbc:mysql://mysql.db.host:3306/db_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_9:
     url: jdbc:mysql://mysql.db.host:3306/db_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/mysql/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/mysql/proxy/conf/config-db.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:mysql://mysql.db.host:3306/db_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_2:
     url: jdbc:mysql://mysql.db.host:3306/db_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_3:
     url: jdbc:mysql://mysql.db.host:3306/db_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_4:
     url: jdbc:mysql://mysql.db.host:3306/db_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_5:
     url: jdbc:mysql://mysql.db.host:3306/db_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_6:
     url: jdbc:mysql://mysql.db.host:3306/db_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_7:
     url: jdbc:mysql://mysql.db.host:3306/db_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_8:
     url: jdbc:mysql://mysql.db.host:3306/db_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_9:
     url: jdbc:mysql://mysql.db.host:3306/db_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/postgresql/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/postgresql/proxy/conf/config-db.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_1:
     url: jdbc:postgresql://postgresql.db.host:5432/db_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_2:
     url: jdbc:postgresql://postgresql.db.host:5432/db_2?serverTimezone=UTC&useSSL=false
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_3:
     url: jdbc:postgresql://postgresql.db.host:5432/db_3?serverTimezone=UTC&useSSL=false
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_4:
     url: jdbc:postgresql://postgresql.db.host:5432/db_4?serverTimezone=UTC&useSSL=false
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_5:
     url: jdbc:postgresql://postgresql.db.host:5432/db_5?serverTimezone=UTC&useSSL=false
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_6:
     url: jdbc:postgresql://postgresql.db.host:5432/db_6?serverTimezone=UTC&useSSL=false
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_7:
     url: jdbc:postgresql://postgresql.db.host:5432/db_7?serverTimezone=UTC&useSSL=false
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_8:
     url: jdbc:postgresql://postgresql.db.host:5432/db_8?serverTimezone=UTC&useSSL=false
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   ds_9:
     url: jdbc:postgresql://postgresql.db.host:5432/db_9?serverTimezone=UTC&useSSL=false
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/h2/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/h2/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/mysql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/mysql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/write_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting.host:3306/read_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_2?serverTimezone=UTC&useSSL=false
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_3?serverTimezone=UTC&useSSL=false
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_4?serverTimezone=UTC&useSSL=false
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_5?serverTimezone=UTC&useSSL=false
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_6?serverTimezone=UTC&useSSL=false
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_7?serverTimezone=UTC&useSSL=false
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_8?serverTimezone=UTC&useSSL=false
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   write_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_9?serverTimezone=UTC&useSSL=false
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_0:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_0?serverTimezone=UTC&useSSL=false
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_2?serverTimezone=UTC&useSSL=false
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_3?serverTimezone=UTC&useSSL=false
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_4?serverTimezone=UTC&useSSL=false
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_5?serverTimezone=UTC&useSSL=false
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_6?serverTimezone=UTC&useSSL=false
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_7?serverTimezone=UTC&useSSL=false
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_8?serverTimezone=UTC&useSSL=false
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_9?serverTimezone=UTC&useSSL=false
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/h2/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/h2/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_0:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/mysql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/mysql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_write_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_0:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_1:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_2:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_3:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_4:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_5:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_6:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_7:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_8:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_9:
     url: jdbc:mysql://mysql.dbtbl_with_readwrite_splitting_and_encrypt.host:3306/encrypt_read_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_2?serverTimezone=UTC&useSSL=false
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_3?serverTimezone=UTC&useSSL=false
     username: root
@@ -57,7 +54,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_4?serverTimezone=UTC&useSSL=false
     username: root
@@ -67,7 +63,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_5?serverTimezone=UTC&useSSL=false
     username: root
@@ -77,7 +72,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_6?serverTimezone=UTC&useSSL=false
     username: root
@@ -87,7 +81,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_7?serverTimezone=UTC&useSSL=false
     username: root
@@ -97,7 +90,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_8?serverTimezone=UTC&useSSL=false
     username: root
@@ -107,7 +99,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_write_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_9?serverTimezone=UTC&useSSL=false
     username: root
@@ -117,7 +108,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_0:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_0?serverTimezone=UTC&useSSL=false
     username: root
@@ -127,7 +117,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_1:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -137,7 +126,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_2:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_2?serverTimezone=UTC&useSSL=false
     username: root
@@ -147,7 +135,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_3:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_3?serverTimezone=UTC&useSSL=false
     username: root
@@ -157,7 +144,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_4:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_4?serverTimezone=UTC&useSSL=false
     username: root
@@ -167,7 +153,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_5:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_5?serverTimezone=UTC&useSSL=false
     username: root
@@ -177,7 +162,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_6:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_6?serverTimezone=UTC&useSSL=false
     username: root
@@ -187,7 +171,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_7:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_7?serverTimezone=UTC&useSSL=false
     username: root
@@ -197,7 +180,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_8:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_8?serverTimezone=UTC&useSSL=false
     username: root
@@ -207,7 +189,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   encrypt_read_ds_9:
     url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_9?serverTimezone=UTC&useSSL=false
     username: root
@@ -217,7 +198,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/h2/proxy/conf/config-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/h2/proxy/conf/config-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/mysql/proxy/conf/config-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/mysql/proxy/conf/config-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/postgresql/proxy/conf/config-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/postgresql/proxy/conf/config-encrypt.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !ENCRYPT

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/h2/proxy/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/h2/proxy/conf/config-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_0:
     url: jdbc:mysql://mysql.db.readwrite_splitting:3306/read_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_1:
     url: jdbc:mysql://mysql.db.readwrite_splitting:3306/read_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/mysql/proxy/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/mysql/proxy/conf/config-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_0:
     url: jdbc:mysql://mysql.readwrite_splitting.host:3306/read_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_1:
     url: jdbc:mysql://mysql.readwrite_splitting.host:3306/read_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/postgresql/proxy/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/postgresql/proxy/conf/config-readwrite-splitting.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_0:
     url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_0?serverTimezone=UTC&useSSL=false
     username: root
@@ -37,7 +36,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
   read_1:
     url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_1?serverTimezone=UTC&useSSL=false
     username: root
@@ -47,7 +45,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/h2/proxy/conf/config-sharding-governance.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/h2/proxy/conf/config-sharding-governance.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/mysql/proxy/conf/config-sharding-governance.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/mysql/proxy/conf/config-sharding-governance.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/postgresql/proxy/conf/config-sharding-governance.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/postgresql/proxy/conf/config-sharding-governance.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/h2/proxy/conf/config-tbl.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/h2/proxy/conf/config-tbl.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/mysql/proxy/conf/config-tbl.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/mysql/proxy/conf/config-tbl.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/postgresql/proxy/conf/config-tbl.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/postgresql/proxy/conf/config-tbl.yaml
@@ -27,7 +27,6 @@ dataSources:
     maxLifetimeMilliseconds: 1800000
     maxPoolSize: 2
     minPoolSize: 2
-    maintenanceIntervalMilliseconds: 30000
 
 rules:
 - !SHARDING


### PR DESCRIPTION
Fixes #11247.

Changes proposed in this pull request:

remove useless config 'maintenanceIntervalMilliseconds';
rename 'maxPoolSize' and 'minPoolSize' to 'maximumPoolSize' and 'minimumIdle'.
add default value for 'maxLifetimeMilliseconds', otherwise, it will be ZERO;