### PR TITLE
Modification #11317

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/usage/startup.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/usage/startup.cn.md
@@ -25,7 +25,7 @@ weight = 1
 
 1. 实现 `ShardingAlgorithm` 接口定义的算法实现类。
 1. 将上述 Java 文件打包成 jar 包。
-1. 将上述 jar 包拷贝至 ShardingSphere-Proxy 解压后的 `conf/lib-ext` 目录。
+1. 将上述 jar 包拷贝至 ShardingSphere-Proxy 解压后的 `ext-lib/` 目录。
 1. 将上述自定义算法实现类的 Java 文件引用配置在 YAML 文件中，具体可参考[配置规则](/cn/user-manual/shardingsphere-proxy/configuration/)。
 
 ## 注意事项

--- a/docs/document/content/user-manual/shardingsphere-proxy/usage/startup.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/usage/startup.en.md
@@ -25,7 +25,7 @@ When developer need to use user-defined sharding algorithm, it can not configure
 
 1. Implement `ShardingAlgorithm` interface.
 1. Package Java file to jar.
-1. Copy jar to ShardingSphere-Proxy's `conf/lib-ext` folder.
+1. Copy jar to ShardingSphere-Proxy's `ext-lib/` folder.
 1. Configure user-defined Java class into YAML file. Please refer to [Configuration Manual](/en/user-manual/shardingsphere-proxy/configuration/) for more details.
 
 ## Notices


### PR DESCRIPTION
Modify the "ext-lib" directory in ShardingSphere-Proxy, because the definition in the start.sh file is "EXT_LIB=${DEPLOY_DIR}/ext-lib"