### PR TITLE
support table owner shorthand for mix use of sharding and encrypt

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -48,7 +48,8 @@ import java.util.Optional;
  * Projection token generator for encrypt.
  */
 @Setter
-public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGenerator implements CollectionSQLTokenGenerator<SelectStatementContext>, QueryWithCipherColumnAware, PreviousSQLTokensAware {
+public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGenerator 
+        implements CollectionSQLTokenGenerator<SelectStatementContext>, QueryWithCipherColumnAware, PreviousSQLTokensAware {
     
     private boolean queryWithCipherColumn;
     

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -29,6 +29,8 @@ import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.CollectionSQLTokenGenerator;
+import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.PreviousSQLTokensAware;
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.SubstitutableColumnNameToken;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
@@ -46,9 +48,11 @@ import java.util.Optional;
  * Projection token generator for encrypt.
  */
 @Setter
-public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGenerator implements CollectionSQLTokenGenerator<SelectStatementContext>, QueryWithCipherColumnAware {
+public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGenerator implements CollectionSQLTokenGenerator<SelectStatementContext>, QueryWithCipherColumnAware, PreviousSQLTokensAware {
     
     private boolean queryWithCipherColumn;
+    
+    private List<SQLToken> previousSQLTokens;
     
     @Override
     protected boolean isGenerateSQLTokenForEncrypt(final SQLStatementContext sqlStatementContext) {
@@ -110,6 +114,7 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
                 projections.add(new ColumnProjection(null == each.getOwner() ? null : each.getOwner(), each.getName(), null));
             }
         }
+        previousSQLTokens.removeIf(each -> each.getStartIndex() == segment.getStartIndex());
         return new SubstitutableColumnNameToken(segment.getStartIndex(), segment.getStopIndex(), projections, databaseType.getQuoteCharacter());
     }
     
@@ -131,5 +136,10 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
             }
         }
         throw new IllegalStateException(String.format("Can not find shorthand projection segment, owner is: `%s`", owner.orElse(null)));
+    }
+    
+    @Override
+    public void setPreviousSQLTokens(final List<SQLToken> previousSQLTokens) {
+        this.previousSQLTokens = previousSQLTokens;
     }
 }

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/select_for_query_with_cipher.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/select_for_query_with_cipher.xml
@@ -72,10 +72,9 @@
         <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS password, `a`.`cipher_amount` AS amount, `a`.`status`, account_id, 1+1 FROM t_account_1 a" />
     </rewrite-assertion>
 
-    <!-- FIXME #9510 should rewrite owner table as sharding table -->
-    <!--<rewrite-assertion id="select_with_table_qualified_shorthand">-->
-        <!--<input sql="SELECT t_account.* FROM t_account" />-->
-        <!--<output sql="SELECT t_account_0.account_id, t_account_0.cipher_password AS password, t_account_0.cipher_amount AS amount, t_account_0.status FROM t_account_0" />-->
-        <!--<output sql="SELECT t_account_1.account_id, t_account_1.cipher_password AS password, t_account_1.cipher_amount AS amount, t_account_1.status FROM t_account_1" />-->
-    <!--</rewrite-assertion>-->
+    <rewrite-assertion id="select_with_table_qualified_shorthand">
+        <input sql="SELECT t_account.* FROM t_account" />
+        <output sql="SELECT `t_account_0`.`account_id`, `t_account_0`.`cipher_password` AS password, `t_account_0`.`cipher_amount` AS amount, `t_account_0`.`status` FROM t_account_0" />
+        <output sql="SELECT `t_account_1`.`account_id`, `t_account_1`.`cipher_password` AS password, `t_account_1`.`cipher_amount` AS amount, `t_account_1`.`status` FROM t_account_1" />
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/select_for_query_with_plain.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/select_for_query_with_plain.xml
@@ -45,10 +45,9 @@
         <output sql="SELECT `a`.`account_id`, `a`.`plain_password` AS password, `a`.`plain_amount` AS amount, `a`.`status`, account_id, 1+1 FROM t_account_bak_1 a" />
     </rewrite-assertion>
     
-    <!-- FIXME #9510 should rewrite owner table as sharding table -->
-    <!--<rewrite-assertion id="select_with_table_qualified_shorthand">-->
-        <!--<input sql="SELECT t_account_bak.* FROM t_account_bak" />-->
-        <!--<output sql="SELECT t_account_bak_0.account_id, t_account_bak_0.plain_password AS password, t_account_bak_0.plain_amount AS amount, t_account_bak_0.status FROM t_account_bak_0" />-->
-        <!--<output sql="SELECT t_account_bak_1.account_id, t_account_bak_1.plain_password AS password, t_account_bak_1.plain_amount AS amount, t_account_bak_1.status FROM t_account_bak_1" />-->
-    <!--</rewrite-assertion>-->
+    <rewrite-assertion id="select_with_table_qualified_shorthand">
+        <input sql="SELECT t_account_bak.* FROM t_account_bak" />
+        <output sql="SELECT `t_account_bak_0`.`account_id`, `t_account_bak_0`.`plain_password` AS password, `t_account_bak_0`.`plain_amount` AS amount, `t_account_bak_0`.`status` FROM t_account_bak_0" />
+        <output sql="SELECT `t_account_bak_1`.`account_id`, `t_account_bak_1`.`plain_password` AS password, `t_account_bak_1`.`plain_amount` AS amount, `t_account_bak_1`.`status` FROM t_account_bak_1" />
+    </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Ref #9625.

Changes proposed in this pull request:
- support table owner shorthand for mix use of sharding and encrypt, like `SELECT t_account_bak.* FROM t_account_bak`
