### PR TITLE
Add Oracle SQL - Delete statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -114,23 +114,12 @@ assignmentValue
     ;
 
 delete
-    : DELETE deleteSpecification? (singleTableClause | multipleTablesClause) whereClause?
+    : DELETE hint? FROM? deleteSpecification alias? whereClause? returningClause? errorLoggingClause?
     ;
 
 deleteSpecification
-    : ONLY
-    ;
-
-singleTableClause
-    : FROM? LP_? tableName RP_? (AS? alias)?
-    ;
-
-multipleTablesClause
-    : multipleTableNames FROM tableReferences | FROM multipleTableNames USING tableReferences
-    ;
-
-multipleTableNames
-    : tableName DOT_ASTERISK_? (COMMA_ tableName DOT_ASTERISK_?)*
+    : dmlTableExprClause
+    | ONLY LP_ dmlTableExprClause RP_
     ;
 
 select

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/DeleteStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/DeleteStatementAssert.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OutputSeg
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.DeleteMultiTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DeleteStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.dml.DeleteStatementHandler;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
@@ -89,6 +90,9 @@ public final class DeleteStatementAssert {
                 actualTableSegments.addAll(deleteMultiTableSegment.getActualDeleteTables());
             }
             TableAssert.assertIs(assertContext, actualTableSegments, expected.getTables());
+        } else if (null != expected.getSubqueryTable()) {
+            assertNotNull(assertContext.getText("Actual subquery table segment should exist."), actual.getTableSegment());
+            TableAssert.assertIs(assertContext, (SubqueryTableSegment) actual.getTableSegment(), expected.getSubqueryTable());
         } else {
             assertNull(assertContext.getText("Actual table should not exist."), actual.getTableSegment());
         }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/DeleteStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/DeleteStatementTestCase.java
@@ -22,8 +22,9 @@ import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.limit.ExpectedLimitClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.orderby.ExpectedOrderByClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.output.ExpectedOutputClause;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.where.ExpectedWhereClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSubqueryTable;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.where.ExpectedWhereClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.with.ExpectedWithClause;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
@@ -55,4 +56,7 @@ public final class DeleteStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "limit")
     private ExpectedLimitClause limitClause;
+    
+    @XmlElement(name = "subquery-table")
+    private ExpectedSubqueryTable subqueryTable;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/delete.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/delete.xml
@@ -104,39 +104,39 @@
         </where>
     </delete>
 
-    <delete sql-case-id="delete_with_special_comments_return_without_sharding_value">
-        <table name="t_order" start-index="33" stop-index="39" />
-        <where start-index="41" stop-index="54">
-            <expr>
-                <binary-operation-expression start-index="47" stop-index="54">
-                    <left>
-                        <column name="status" start-index="47" stop-index="52" />
-                    </left>
-                    <operator>=</operator>
-                    <right>
-                        <literal-expression value="1" start-index="54" stop-index="54" />
-                    </right>
-                </binary-operation-expression>
-            </expr>
-        </where>
-    </delete>
+<!--    <delete sql-case-id="delete_with_special_comments_return_without_sharding_value">-->
+<!--        <table name="t_order" start-index="33" stop-index="39" />-->
+<!--        <where start-index="41" stop-index="54">-->
+<!--            <expr>-->
+<!--                <binary-operation-expression start-index="47" stop-index="54">-->
+<!--                    <left>-->
+<!--                        <column name="status" start-index="47" stop-index="52" />-->
+<!--                    </left>-->
+<!--                    <operator>=</operator>-->
+<!--                    <right>-->
+<!--                        <literal-expression value="1" start-index="54" stop-index="54" />-->
+<!--                    </right>-->
+<!--                </binary-operation-expression>-->
+<!--            </expr>-->
+<!--        </where>-->
+<!--    </delete>-->
 
-    <delete sql-case-id="delete_with_special_comments_returning_without_sharding_value">
-        <table name="t_order" start-index="34" stop-index="40" />
-        <where start-index="43" stop-index="56">
-            <expr>
-                <binary-operation-expression start-index="49" stop-index="56">
-                    <left>
-                        <column name="status" start-index="49" stop-index="54" />
-                    </left>
-                    <operator>=</operator>
-                    <right>
-                        <literal-expression value="1" start-index="56" stop-index="56" />
-                    </right>
-                </binary-operation-expression>
-            </expr>
-        </where>
-    </delete>
+<!--    <delete sql-case-id="delete_with_special_comments_returning_without_sharding_value">-->
+<!--        <table name="t_order" start-index="34" stop-index="40" />-->
+<!--        <where start-index="43" stop-index="56">-->
+<!--            <expr>-->
+<!--                <binary-operation-expression start-index="49" stop-index="56">-->
+<!--                    <left>-->
+<!--                        <column name="status" start-index="49" stop-index="54" />-->
+<!--                    </left>-->
+<!--                    <operator>=</operator>-->
+<!--                    <right>-->
+<!--                        <literal-expression value="1" start-index="56" stop-index="56" />-->
+<!--                    </right>-->
+<!--                </binary-operation-expression>-->
+<!--            </expr>-->
+<!--        </where>-->
+<!--    </delete>-->
 
     <delete sql-case-id="delete_with_alias" parameters="'init'">
         <table name="t_order" alias="o" start-index="12" stop-index="23" />
@@ -152,6 +152,38 @@
                         <parameter-marker-expression value="0" start-index="38" stop-index="38" />
                     </right>
                 </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_alias_without_as">
+        <table name="product_price_history" alias="pp" start-index="7" stop-index="30" />
+        <where start-index="32" stop-index="211">
+            <expr>
+                <in-expression start-index="38" stop-index="211">
+                    <not>false</not>
+                    <left>
+                        <common-expression text="(product_id,currency_code,effective_from_date)" start-index="38" stop-index="85"/>
+                    </left>
+                    <right>
+                        <subquery start-index="90" stop-index="211">
+                            <select>
+                                <from start-index="155" stop-index="175">
+                                    <simple-table name="product_price_history" start-index="155" stop-index="175"/>
+                                </from>
+                                <projections start-index="98" stop-index="148">
+                                    <column-projection name="product_id" start-index="98" stop-index="107"/>
+                                    <column-projection name="currency_code" start-index="110" stop-index="122"/>
+                                    <aggregation-projection type="MAX" inner-expression="(effective_from_date)" start-index="125" stop-index="148" />
+                                </projections>
+                                <group-by>
+                                    <column-item name="product_id" start-index="186" stop-index="195" />
+                                    <column-item name="currency_code" start-index="198" stop-index="210" />
+                                </group-by>
+                            </select>
+                        </subquery>
+                    </right>
+                </in-expression>
             </expr>
         </where>
     </delete>
@@ -513,5 +545,175 @@
                 </binary-operation-expression>
             </expr>
         </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_simple_table">
+        <table name="product_descriptions" start-index="12" stop-index="31" />
+        <where start-index="33" stop-index="56">
+            <expr>
+                <binary-operation-expression start-index="39" stop-index="56">
+                    <left>
+                        <column name="language_id" start-index="39" stop-index="49" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="AR" start-index="53" stop-index="56" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_simple_subquery">
+        <subquery-table>
+            <subquery>
+                <select>
+                    <from start-index="27" stop-index="35">
+                        <simple-table name="employees" start-index="27" stop-index="35"/>
+                    </from>
+                    <projections start-index="20" stop-index="20">
+                        <shorthand-projection start-index="20" stop-index="20"/>
+                    </projections>
+                </select>
+            </subquery>
+        </subquery-table>
+        <where start-index="38" stop-index="85">
+            <expr>
+                <binary-operation-expression start-index="44" stop-index="85">
+                    <left>
+                        <binary-operation-expression start-index="44" stop-index="60">
+                            <left>
+                                <column name="job_id" start-index="44" stop-index="49"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="SA_REP" start-index="53" stop-index="60"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="66" stop-index="85">
+                            <left>
+                                <column name="commission_pct" start-index="66" stop-index="79"/>
+                            </left>
+                            <operator>&lt;</operator>
+                            <right>
+                                <literal-expression value="0.2" start-index="83" stop-index="85"/>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_simple_subquery_without_from">
+        <subquery-table>
+            <subquery>
+                <select>
+                    <from start-index="27" stop-index="35">
+                        <simple-table name="product_price_history" start-index="22" stop-index="42"/>
+                    </from>
+                    <projections start-index="15" stop-index="15">
+                        <shorthand-projection start-index="15" stop-index="15"/>
+                    </projections>
+                </select>
+            </subquery>
+        </subquery-table>
+        <where start-index="45" stop-index="71">
+            <expr>
+                <binary-operation-expression start-index="51" stop-index="71">
+                    <left>
+                        <column name="currency_code" start-index="51" stop-index="63"/>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="EUR" start-index="67" stop-index="71"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_remote_database_table">
+        <table name="locations" start-index="12" stop-index="23">
+            <owner name="hr" start-index="12" stop-index="13" />
+        </table>
+        <where start-index="32" stop-index="55">
+            <expr>
+                <binary-operation-expression start-index="38" stop-index="55">
+                    <left>
+                        <column name="location_id" start-index="38" stop-index="48" />
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="3000" start-index="52" stop-index="55" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_returning_into">
+        <table name="employees" start-index="12" stop-index="20" />
+        <where start-index="22" stop-index="93">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="93">
+                    <left>
+                        <binary-operation-expression start-index="28" stop-index="44">
+                            <left>
+                                <column name="job_id" start-index="28" stop-index="33"/>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="SA_REP" start-index="37" stop-index="44"/>
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="50" stop-index="93">
+                            <left>
+                                <binary-operation-expression start-index="50" stop-index="83">
+                                    <left>
+                                        <column name="hire_date" start-index="50" stop-index="58"/>
+                                    </left>
+                                    <operator>+</operator>
+                                    <right>
+                                        <expression-projection text="TO_YMINTERVAL('01-00')" start-index="62" stop-index="83"/>
+                                    </right>
+                                </binary-operation-expression>
+                            </left>
+                            <operator>&lt;</operator>
+                            <right>
+                                <column name="SYSDATE" start-index="87" stop-index="93"/>
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_partition">
+        <table name="sales" start-index="12" stop-index="16" />
+        <where start-index="44" stop-index="67">
+            <expr>
+                <binary-operation-expression start-index="50" stop-index="67">
+                    <left>
+                        <column name="amount_sold" start-index="50" stop-index="60" />
+                    </left>
+                    <operator>&gt;</operator>
+                    <right>
+                        <literal-expression value="1000" start-index="64" stop-index="67" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </delete>
+
+    <delete sql-case-id="delete_with_table">
+        <table name="product_price_history" start-index="7" stop-index="27" />
     </delete>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/delete.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/delete.xml
@@ -104,40 +104,6 @@
         </where>
     </delete>
 
-<!--    <delete sql-case-id="delete_with_special_comments_return_without_sharding_value">-->
-<!--        <table name="t_order" start-index="33" stop-index="39" />-->
-<!--        <where start-index="41" stop-index="54">-->
-<!--            <expr>-->
-<!--                <binary-operation-expression start-index="47" stop-index="54">-->
-<!--                    <left>-->
-<!--                        <column name="status" start-index="47" stop-index="52" />-->
-<!--                    </left>-->
-<!--                    <operator>=</operator>-->
-<!--                    <right>-->
-<!--                        <literal-expression value="1" start-index="54" stop-index="54" />-->
-<!--                    </right>-->
-<!--                </binary-operation-expression>-->
-<!--            </expr>-->
-<!--        </where>-->
-<!--    </delete>-->
-
-<!--    <delete sql-case-id="delete_with_special_comments_returning_without_sharding_value">-->
-<!--        <table name="t_order" start-index="34" stop-index="40" />-->
-<!--        <where start-index="43" stop-index="56">-->
-<!--            <expr>-->
-<!--                <binary-operation-expression start-index="49" stop-index="56">-->
-<!--                    <left>-->
-<!--                        <column name="status" start-index="49" stop-index="54" />-->
-<!--                    </left>-->
-<!--                    <operator>=</operator>-->
-<!--                    <right>-->
-<!--                        <literal-expression value="1" start-index="56" stop-index="56" />-->
-<!--                    </right>-->
-<!--                </binary-operation-expression>-->
-<!--            </expr>-->
-<!--        </where>-->
-<!--    </delete>-->
-
     <delete sql-case-id="delete_with_alias" parameters="'init'">
         <table name="t_order" alias="o" start-index="12" stop-index="23" />
         <where start-index="25" stop-index="38" literal-stop-index="43">

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/delete.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/delete.xml
@@ -20,9 +20,10 @@
     <sql-case id="delete_with_sharding_value" value="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status=?" />
     <sql-case id="delete_without_sharding_value" value="DELETE FROM t_order WHERE status=?" />
     <sql-case id="delete_with_special_character_without_sharding_value" value="DELETE FROM `t_order` WHERE `status`='init'" db-types="MySQL" />
-    <sql-case id="delete_with_special_comments_return_without_sharding_value" value="DELETE /*+ index(status) */ ONLY t_order WHERE status=1 RETURN * LOG ERRORS INTO TABLE_LOG" db-types="Oracle" />
-    <sql-case id="delete_with_special_comments_returning_without_sharding_value" value="DELETE /*+ index(status) */ ONLY (t_order) WHERE status=1 RETURNING *" db-types="Oracle" />
-    <sql-case id="delete_with_alias" value="DELETE FROM t_order AS o WHERE status=?" db-types="MySQL,Oracle,SQLServer"/>
+<!--    <sql-case id="delete_with_special_comments_return_without_sharding_value" value="DELETE /*+ index(status) */ ONLY t_order WHERE status=1 RETURN * LOG ERRORS INTO TABLE_LOG" db-types="Oracle" />-->
+<!--    <sql-case id="delete_with_special_comments_returning_without_sharding_value" value="DELETE /*+ index(status) */ ONLY (t_order) WHERE status=1 RETURNING *" db-types="Oracle" />-->
+    <sql-case id="delete_with_alias" value="DELETE FROM t_order AS o WHERE status=?" db-types="MySQL,SQLServer"/>
+    <sql-case id="delete_with_alias_without_as" value="DELETE product_price_history pp WHERE (product_id, currency_code, effective_from_date) IN (SELECT product_id, currency_code, MAX(effective_from_date) FROM product_price_history GROUP BY product_id, currency_code)" db-types="Oracle" />
     <sql-case id="delete_with_order_by_row_count" value="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status=? ORDER BY order_id LIMIT ?" db-types="MySQL"/>
     <sql-case id="delete_with_output_clause" value="DELETE FROM t_order OUTPUT DELETED.order_id, DELETED.user_id INTO @MyTableVar (temp_order_id, temp_user_id) WHERE order_id = ?" db-types="SQLServer" />
     <sql-case id="delete_with_output_clause_without_output_table_columns" value="DELETE FROM t_order OUTPUT DELETED.order_id, DELETED.user_id INTO @MyTableVar WHERE order_id = ?" db-types="SQLServer" />
@@ -35,4 +36,11 @@
     <sql-case id="delete_multi_tables" value="DELETE t_order, t_order_item from t_order, t_order_item where t_order.order_id = t_order_item.order_id and t_order.status = ?" db-types="MySQL"/>
     <sql-case id="delete_multi_tables_with_using" value="DELETE from t_order, t_order_item using t_order left join t_order_item on t_order.order_id = t_order_item.order_id where t_order.status = ?" db-types="MySQL"/>
     <sql-case id="delete_with_query_hint" value="DELETE FROM t_order WHERE order_id = ? HASH GROUP" db-types="SQLServer" />
+    <sql-case id="delete_with_simple_table" value="DELETE FROM product_descriptions WHERE language_id = 'AR'" db-types="Oracle" />
+    <sql-case id="delete_with_simple_subquery" value="DELETE FROM (SELECT * FROM employees) WHERE job_id = 'SA_REP' AND commission_pct &lt; 0.2" db-types="Oracle" />
+    <sql-case id="delete_with_simple_subquery_without_from" value="DELETE (SELECT * FROM product_price_history) WHERE currency_code = 'EUR'" db-types="Oracle" />
+    <sql-case id="delete_with_remote_database_table" value="DELETE FROM hr.locations@remote WHERE location_id > 3000" db-types="Oracle" />
+    <sql-case id="delete_with_returning_into" value="DELETE FROM employees WHERE job_id = 'SA_REP' AND hire_date + TO_YMINTERVAL('01-00') &lt; SYSDATE RETURNING salary INTO bnd1" db-types="Oracle" />
+    <sql-case id="delete_with_partition" value="DELETE FROM sales PARTITION (sales_q1_1998) WHERE amount_sold > 1000" db-types="Oracle" />
+    <sql-case id="delete_with_table" value="DELETE product_price_history" db-types="Oracle" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/delete.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/delete.xml
@@ -20,8 +20,6 @@
     <sql-case id="delete_with_sharding_value" value="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status=?" />
     <sql-case id="delete_without_sharding_value" value="DELETE FROM t_order WHERE status=?" />
     <sql-case id="delete_with_special_character_without_sharding_value" value="DELETE FROM `t_order` WHERE `status`='init'" db-types="MySQL" />
-<!--    <sql-case id="delete_with_special_comments_return_without_sharding_value" value="DELETE /*+ index(status) */ ONLY t_order WHERE status=1 RETURN * LOG ERRORS INTO TABLE_LOG" db-types="Oracle" />-->
-<!--    <sql-case id="delete_with_special_comments_returning_without_sharding_value" value="DELETE /*+ index(status) */ ONLY (t_order) WHERE status=1 RETURNING *" db-types="Oracle" />-->
     <sql-case id="delete_with_alias" value="DELETE FROM t_order AS o WHERE status=?" db-types="MySQL,SQLServer"/>
     <sql-case id="delete_with_alias_without_as" value="DELETE product_price_history pp WHERE (product_id, currency_code, effective_from_date) IN (SELECT product_id, currency_code, MAX(effective_from_date) FROM product_price_history GROUP BY product_id, currency_code)" db-types="Oracle" />
     <sql-case id="delete_with_order_by_row_count" value="DELETE FROM t_order WHERE order_id = ? AND user_id = ? AND status=? ORDER BY order_id LIMIT ?" db-types="MySQL"/>


### PR DESCRIPTION
#10111 

Hi @wgy8283335, I've added SQL definition for Oracle [DELETE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DELETE.html#GUID-156845A5-B626-412B-9F95-8869B988ABD7) statement. Please check it.

Changes proposed in this pull request:
- Add Oracle `DELETE` statement.
- Add test cases.
- I removed Oracle DB-type for SQL case `delete_with_alias` as it has `AS` keyword with the alias.
- I commented out two SQL case ids `delete_with_special_comments_return_without_sharding_value`, and `delete_with_special_comments_returning_without_sharding_value` as they aren't aligned with Oracle SQL. The SQL parsing fails because of `returningCluase`. Previous Oracle `DELETE` rule, didn't have support for  `returningCluase`. So, it didn't parse. The below image specifies the SQL parsing using previous `DELETE` rule for `delete_with_special_comments_return_without_sharding_value` SQL case id :

![PreviousDeleteStatement](https://user-images.githubusercontent.com/48581379/126044994-8144e109-6e14-411b-81df-2a591b35efd8.png)

- The below image specifies SQL parsing using new `DELETE` rule:
![NewDeleteStatement](https://user-images.githubusercontent.com/48581379/126045088-959d0205-960f-4c93-9c77-e790225c2ca4.png)

The above SQL case ids don't have required `INTO` keyword with their `returningClause` as well.
