### PR TITLE
fix missing packages in 'plugins' folder of agent

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-distribution/pom.xml
+++ b/shardingsphere-agent/shardingsphere-agent-distribution/pom.xml
@@ -35,6 +35,36 @@
             <artifactId>shardingsphere-agent-bootstrap</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-metrics-prometheus</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-logging-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-tracing-jaeger</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-tracing-opentracing</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-tracing-zipkin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-agent-tracing-opentelemetry</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
     
     <build>


### PR DESCRIPTION
Fixes #11378.

Change the dependency of agent distribution and add them to pom.xml
