### PR TITLE
Remove duplicate code of setting 'useServerPrepStmts' property (#11398)

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/datasource/decorator/HikariJDBCParameterDecorator.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/datasource/decorator/HikariJDBCParameterDecorator.java
@@ -33,7 +33,6 @@ public final class HikariJDBCParameterDecorator implements JDBCParameterDecorato
     public HikariDataSource decorate(final HikariDataSource dataSource) {
         Map<String, String> urlProps = new ConnectionUrlParser(dataSource.getJdbcUrl()).getQueryMap();
         addJDBCProperty(dataSource, urlProps, "useServerPrepStmts", Boolean.TRUE.toString());
-        addJDBCProperty(dataSource, urlProps, "useServerPrepStmts", Boolean.TRUE.toString());
         addJDBCProperty(dataSource, urlProps, "cachePrepStmts", Boolean.TRUE.toString());
         addJDBCProperty(dataSource, urlProps, "prepStmtCacheSize", "200000");
         addJDBCProperty(dataSource, urlProps, "prepStmtCacheSqlLimit", "2048");


### PR DESCRIPTION
Fixes #11398.

Changes proposed in this pull request:
- Remove duplicate code of setting 'useServerPrepStmts' property in 'HikariJDBCParameterDecorator' class.
-
-
