### PR TITLE
add feature of encrypt password in config file

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/properties/ConfigurationPropertyKey.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/properties/ConfigurationPropertyKey.java
@@ -132,8 +132,20 @@ public enum ConfigurationPropertyKey implements TypedPropertyKey {
      * Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
      * The default value is -1, which means set the minimum value for different JDBC drivers.
      */
-    PROXY_BACKEND_QUERY_FETCH_SIZE("proxy-backend-query-fetch-size", "-1", int.class);
-    
+    PROXY_BACKEND_QUERY_FETCH_SIZE("proxy-backend-query-fetch-size", "-1", int.class),
+
+    /**
+     * Proxy backend password encrypt/decrypt algorithm
+     * The default value is NONE, which means no algorithm will be run.
+     */
+    PROXY_BACKEND_ALGORITHM("proxy-backend-algorithm", "NONE", String.class),
+
+    /**
+     * Proxy frontend password encrypt/decrypt algorithm
+     * The default value is NONE, which means no algorithm will be run.
+     */
+    PROXY_FRONTEND_ALGORITHM("proxy-frontend-algorithm", "NONE", String.class);
+
     private final String key;
     
     private final String defaultValue;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/ShardingSphereUser.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/ShardingSphereUser.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.metadata.user;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.apache.shardingsphere.infra.security.AlgorithmSecureFactory;
 
 /**
  * ShardingSphere user.
@@ -34,5 +35,19 @@ public final class ShardingSphereUser {
     public ShardingSphereUser(final String username, final String password, final String hostname) {
         grantee = new Grantee(username, hostname);
         this.password = password;
+    }
+
+    /**
+     * get decrypt password.
+     * @return String the decrypt password
+     */
+    public String getPassword() {
+        try {
+            return AlgorithmSecureFactory.getInstance().decryptFrontend(password);
+            // CHECKSTYLE:OFF
+        } catch (Exception e) {
+            //checkstyle:ON
+            return null;
+        }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AesAlgorithmSecure.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AesAlgorithmSecure.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.security;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * this is Aes Security Utils for encrypt or decrypt password
+ * NOTICE:
+ * in encrypt, we random get iv and key in 16-bytes to encrypt password, but in return value, we combain
+ * iv + key + encrypt(passwd) as a string, this is not SAFE!!! iv and key must save other security file or database!
+ * if you need more security, please implements AlgorithmSecure youself.
+ * in decrypt, we first extract iv and key in 16 bytes, then use it to decrypt password.
+ */
+public class AesAlgorithmSecure implements AlgorithmSecure {
+    // the iv and key lenght
+    private static final int KEY_PART_LENGTH = 16;
+
+    // the default encrypt / decrypt algorithm
+    private static final String DEFAULT_ALGORITHM = "AES/CBC/PKCS5PADDING";
+
+    // the default key generator algorithm
+    private static final String DEFAULT_KEY_ALGORITHM = "AES";
+
+    @Override
+    public String encrypt(final byte[] content) throws Exception {
+        byte[] ivBytes = getRandom();
+        byte[] secretKeyBytes = getRandom();
+        byte[] encryptBytes = runAesAlgorithm(content,
+                ivBytes,
+                secretKeyBytes,
+                Cipher.ENCRYPT_MODE);
+        byte[] results = mergeAllBytes(ivBytes, secretKeyBytes, encryptBytes);
+        return Base64.getEncoder().encodeToString(results);
+    }
+
+    @Override
+    public String decrypt(final String input, final String charsetName) throws Exception {
+        byte[] base64Bytes = Base64.getDecoder().decode(input);
+        List<byte[]> splitTotalBytes = splitInputBytes(base64Bytes, KEY_PART_LENGTH, KEY_PART_LENGTH);
+        byte[] ivBytes = splitTotalBytes.get(0);
+        byte[] secretBytes = splitTotalBytes.get(1);
+        byte[] content = splitTotalBytes.get(2);
+        byte[] decrypt = runAesAlgorithm(content, ivBytes, secretBytes, Cipher.DECRYPT_MODE);
+        return new String(decrypt, charsetName);
+    }
+
+    @Override
+    public String getType() {
+        return "AES";
+    }
+
+    private byte[] runAesAlgorithm(final byte[] content, final byte[] iv, final byte[] key, final int mode) throws Exception {
+        Cipher cipher = Cipher.getInstance(DEFAULT_ALGORITHM);
+        cipher.init(mode,
+                new SecretKeySpec(key, DEFAULT_KEY_ALGORITHM),
+                new IvParameterSpec(iv));
+        return cipher.doFinal(content);
+    }
+
+    private static byte[] getRandom() {
+        byte[] output = new byte[KEY_PART_LENGTH];
+        SecureRandom random = new SecureRandom();
+        random.setSeed(System.nanoTime());
+        random.nextBytes(output);
+        return output;
+    }
+
+    private byte[] mergeAllBytes(final byte[]... args) {
+        int total = Arrays.stream(args).mapToInt(arr -> arr.length).sum();
+        byte[] results = new byte[total];
+        int curPos = 0;
+        for (byte[] arr: args) {
+            System.arraycopy(arr, 0, results, curPos, arr.length);
+            curPos += arr.length;
+        }
+        return results;
+    }
+
+    private List<byte[]> splitInputBytes(final byte[] input, final int... args) {
+        List<byte[]> result = new ArrayList<>(args.length + 1);
+        int curPos = 0;
+        for (int len: args) {
+            result.add(Arrays.copyOfRange(input, curPos, curPos + len));
+            curPos += len;
+        }
+        if (curPos != input.length) {
+            result.add(Arrays.copyOfRange(input, curPos, input.length));
+        }
+        return result;
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AlgorithmSecure.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AlgorithmSecure.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.security;
+
+import org.apache.shardingsphere.infra.spi.typed.TypedSPI;
+
+/**
+ * Typed of Secure.
+ */
+public interface AlgorithmSecure extends TypedSPI {
+    
+    /**
+     * encrypt input.
+     *
+     * @param input the input password
+     * @param charsetName the password' charset
+     * @return String the encrypted password
+     * @throws Exception when encrypt failed throw this exception
+     */
+    default String encrypt(final String input, final String charsetName) throws Exception {
+        return encrypt(input.getBytes(charsetName));
+    }
+
+    /**
+     * encrypt input.
+     *
+     * @param input the input password
+     * @return String the encrypted password
+     * @throws Exception when encrypt failed throw this exception
+     */
+    default String encrypt(final String input) throws Exception {
+        return encrypt(input, "UTF-8");
+    }
+
+    /**
+     * encrypt input.
+     *
+     * @param content the password byte array
+     * @return String the encrypted password
+     * @throws Exception when encrypt failed throw this exception
+     */
+    String encrypt(byte[] content) throws Exception;
+
+    /**
+     * decrypt input.
+     * @param input the encrypt returned result
+     * @param charsetName the decrypted password's charsetName
+     * @return String the decrypted password
+     * @throws Exception when decrypt failed throw this exception
+     */
+    String decrypt(String input, String charsetName) throws Exception;
+
+    /**
+     * decrypt input.
+     * @param input the encrypt returned result
+     * @return String the decrypted password
+     * @throws Exception when decrypt failed throw this exception
+     */
+    default String decrypt(final String input) throws Exception {
+        return decrypt(input, "UTF-8");
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AlgorithmSecureFactory.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/AlgorithmSecureFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.security;
+
+import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.spi.ShardingSphereServiceLoader;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * ShardingSphere algorithm secure factory.
+ */
+public final class AlgorithmSecureFactory {
+    private static AlgorithmSecureFactory instance = new AlgorithmSecureFactory();
+
+    private Map<String, AlgorithmSecure> algorithms = new ConcurrentHashMap<>(2);
+
+    private Map<String, String> secure2AlgType = new ConcurrentHashMap<>(2);
+
+    private boolean isInited = false;
+
+    static {
+        ShardingSphereServiceLoader.register(AlgorithmSecure.class);
+    }
+
+    private AlgorithmSecureFactory() {
+        algorithms.put("NONE", new NoneAlgorithmSecure());
+    }
+
+    /**
+     *  get singleton algorithm secure factory instance.
+     * @return the factory
+     */
+    public static AlgorithmSecureFactory getInstance() {
+        return instance;
+    }
+
+    /**
+     * init all security algorithm by server.yaml config.
+     * @param props the server.yaml prop config, use PROXY_FRONTEND_ALGORITHM and PROXY_BACKEND_ALGORITHM params
+     */
+    public void init(final Properties props) {
+        String[] keys = {ConfigurationPropertyKey.PROXY_FRONTEND_ALGORITHM.getKey(),
+                ConfigurationPropertyKey.PROXY_BACKEND_ALGORITHM.getKey()};
+        for (String key: keys) {
+            secure2AlgType.put(key, props.getOrDefault(key, "NONE").toString().trim());
+        }
+        Collection<AlgorithmSecure> tmpAlgs = ShardingSphereServiceLoader.newServiceInstances(AlgorithmSecure.class);
+        for (AlgorithmSecure alg: tmpAlgs) {
+            algorithms.put(alg.getType(), alg);
+        }
+        isInited = true;
+    }
+
+    /**
+     * decrypt password for frontend of connect database password.
+     * @param encrypt  the encrypt password
+     * @return String the decrypt password
+     * @throws Exception when decrypt with exception, such as iv and key not right
+     */
+    public String decryptFrontend(final String encrypt) throws Exception {
+        return getAlgorithm(ConfigurationPropertyKey.PROXY_FRONTEND_ALGORITHM.getKey()).decrypt(encrypt);
+    }
+
+    /**
+     * decrypt password for backend of connect database password.
+     * @param encrypt  the encrypt password
+     * @return String the decrypt password
+     * @throws Exception when decrypt with exception, such as iv and key not right
+     */
+    public String decryptBackend(final String encrypt) throws Exception {
+        return getAlgorithm(ConfigurationPropertyKey.PROXY_BACKEND_ALGORITHM.getKey()).decrypt(encrypt);
+    }
+
+    private AlgorithmSecure getAlgorithm(final String secureType) {
+        return algorithms.get(secure2AlgType.getOrDefault(secureType, "NONE"));
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/NoneAlgorithmSecure.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/security/NoneAlgorithmSecure.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.security;
+
+/**
+ * this is default Security Utils for encrypt or decrypt password.
+ * no algorithm running.
+ */
+public class NoneAlgorithmSecure implements AlgorithmSecure {
+    @Override
+    public String encrypt(final String input, final String charsetName) throws Exception {
+        return input;
+    }
+
+    @Override
+    public String encrypt(final byte[] content) throws Exception {
+        throw new Exception("None algorithm not support encrypt byte[]");
+    }
+
+    @Override
+    public String decrypt(final String input, final String charsetName) throws Exception {
+        return input;
+    }
+
+    @Override
+    public String getType() {
+        return "NONE";
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.security.AlgorithmSecure
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.security.AlgorithmSecure
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.infra.security.NoneAlgorithmSecure
+org.apache.shardingsphere.infra.security.AesAlgorithmSecure

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/impl/AbstractBootstrapInitializer.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/impl/AbstractBootstrapInitializer.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKe
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContextsBuilder;
 import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
+import org.apache.shardingsphere.infra.security.AlgorithmSecureFactory;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.datasource.factory.JDBCRawBackendDataSourceFactory;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.config.ProxyConfiguration;
@@ -57,6 +58,7 @@ public abstract class AbstractBootstrapInitializer implements BootstrapInitializ
     @Override
     public final void init(final YamlProxyConfiguration yamlConfig, final int port) throws SQLException {
         ProxyConfiguration proxyConfig = getProxyConfiguration(yamlConfig);
+        AlgorithmSecureFactory.getInstance().init(proxyConfig.getProps());
         MetaDataContexts metaDataContexts = decorateMetaDataContexts(createMetaDataContexts(proxyConfig));
         String xaTransactionMangerType = metaDataContexts.getProps().getValue(ConfigurationPropertyKey.XA_TRANSACTION_MANAGER_TYPE);
         TransactionContexts transactionContexts = decorateTransactionContexts(createTransactionContexts(metaDataContexts), xaTransactionMangerType);

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -1,173 +1,213 @@
-#
-# Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-######################################################################################################
-# 
-# Here you can configure the rules for the proxy.
-# This example is configuration of sharding rule.
-# 
-######################################################################################################
-#
-#schemaName: sharding_db
-#
-#dataSources:
-#  ds_0:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0?serverTimezone=UTC&useSSL=false
-#    username: postgres
-#    password: postgres
-#    connectionTimeoutMilliseconds: 30000
-#    idleTimeoutMilliseconds: 60000
-#    maxLifetimeMilliseconds: 1800000
-#    maxPoolSize: 50
-#    minPoolSize: 1
-#  ds_1:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
-#    username: postgres
-#    password: postgres
-#    connectionTimeoutMilliseconds: 30000
-#    idleTimeoutMilliseconds: 60000
-#    maxLifetimeMilliseconds: 1800000
-#    maxPoolSize: 50
-#    minPoolSize: 1
-#
-#rules:
-#- !SHARDING
-#  tables:
-#    t_order:
-#      actualDataNodes: ds_${0..1}.t_order_${0..1}
-#      tableStrategy:
-#        standard:
-#          shardingColumn: order_id
-#          shardingAlgorithmName: t_order_inline
-#      keyGenerateStrategy:
-#          column: order_id
-#          keyGeneratorName: snowflake
-#    t_order_item:
-#      actualDataNodes: ds_${0..1}.t_order_item_${0..1}
-#      tableStrategy:
-#        standard:
-#          shardingColumn: order_id
-#          shardingAlgorithmName: t_order_item_inline
-#      keyGenerateStrategy:
-#        column: order_item_id
-#        keyGeneratorName: snowflake
-#  bindingTables:
-#    - t_order,t_order_item
-#  defaultDatabaseStrategy:
-#    standard:
-#      shardingColumn: user_id
-#      shardingAlgorithmName: database_inline
-#  defaultTableStrategy:
-#    none:
-#  
-#  shardingAlgorithms:
-#    database_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: ds_${user_id % 2}
-#    t_order_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: t_order_${order_id % 2}
-#    t_order_item_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: t_order_item_${order_id % 2}
-#  
-#  keyGenerators:
-#    snowflake:
-#      type: SNOWFLAKE
-#      props:
-#        worker-id: 123
-
-######################################################################################################
-#
-# If you want to connect to MySQL, you should manually copy MySQL driver to lib directory.
-#
-######################################################################################################
-
-#schemaName: sharding_db
-#
-#dataSources:
-#  ds_0:
-#    url: jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false
-#    username: root
-#    password:
-#    connectionTimeoutMilliseconds: 30000
-#    idleTimeoutMilliseconds: 60000
-#    maxLifetimeMilliseconds: 1800000
-#    maxPoolSize: 50
-#    minPoolSize: 1
-#  ds_1:
-#    url: jdbc:mysql://127.0.0.1:3306/demo_ds_1?serverTimezone=UTC&useSSL=false
-#    username: root
-#    password:
-#    connectionTimeoutMilliseconds: 30000
-#    idleTimeoutMilliseconds: 60000
-#    maxLifetimeMilliseconds: 1800000
-#    maxPoolSize: 50
-#    minPoolSize: 1
-#
-#rules:
-#- !SHARDING
-#  tables:
-#    t_order:
-#      actualDataNodes: ds_${0..1}.t_order_${0..1}
-#      tableStrategy:
-#        standard:
-#          shardingColumn: order_id
-#          shardingAlgorithmName: t_order_inline
-#      keyGenerateStrategy:
-#        column: order_id
-#        keyGeneratorName: snowflake
-#    t_order_item:
-#      actualDataNodes: ds_${0..1}.t_order_item_${0..1}
-#      tableStrategy:
-#        standard:
-#          shardingColumn: order_id
-#          shardingAlgorithmName: t_order_item_inline
-#      keyGenerateStrategy:
-#        column: order_item_id
-#        keyGeneratorName: snowflake
-#  bindingTables:
-#    - t_order,t_order_item
-#  defaultDatabaseStrategy:
-#    standard:
-#      shardingColumn: user_id
-#      shardingAlgorithmName: database_inline
-#  defaultTableStrategy:
-#    none:
-#  
-#  shardingAlgorithms:
-#    database_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: ds_${user_id % 2}
-#    t_order_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: t_order_${order_id % 2}
-#    t_order_item_inline:
-#      type: INLINE
-#      props:
-#        algorithm-expression: t_order_item_${order_id % 2}
-#  
-#  keyGenerators:
-#    snowflake:
-#      type: SNOWFLAKE
-#      props:
-#        worker-id: 123
+dataSources:
+  ds_0:
+    connectionTimeoutMilliseconds: 30000
+    idleTimeoutMilliseconds: 60000
+    maxLifetimeMilliseconds: 1800000
+    maxPoolSize: 4096
+    minPoolSize: 10
+    password: hVsHb4O2LwO35UxDYJ5aAPDgCPkjQSyDzoXIZSLrtp0Us96MVrf3xly4qD54OA1o
+    url: jdbc:postgresql://192.168.0.34:40100/ds_0?serverTimezone=UTC&useSSL=false
+    username: test
+rules:
+- !SHARDING
+    bindingTables:
+      - bmsql_warehouse, bmsql_customer
+      - bmsql_stock, bmsql_district, bmsql_order_line
+    defaultDatabaseStrategy:
+      none: null
+    defaultTableStrategy:
+      none: null
+    keyGenerators:
+      snowflake:
+        props:
+          worker-id: 123
+        type: SNOWFLAKE
+    shardingAlgorithms:
+      database_inline:
+        props:
+          algorithm-expression: ds_${user_id % 2}
+        type: INLINE
+      ds_bmsql_config_inline:
+        props:
+          algorithm-expression: ds_${cfg_id % 1}
+        type: INLINE
+      ds_bmsql_customer_inline:
+        props:
+          algorithm-expression: ds_${c_w_id % 1}
+        type: INLINE
+      ds_bmsql_district_inline:
+        props:
+          algorithm-expression: ds_${d_w_id % 1}
+        type: INLINE
+      ds_bmsql_history_inline:
+        props:
+          algorithm-expression: ds_${h_w_id % 1}
+        type: INLINE
+      ds_bmsql_item_inline:
+        props:
+          algorithm-expression: ds_${i_id % 1}
+        type: INLINE
+      ds_bmsql_new_order_inline:
+        props:
+          algorithm-expression: ds_${no_w_id % 1}
+        type: INLINE
+      ds_bmsql_oorder_inline:
+        props:
+          algorithm-expression: ds_${o_w_id % 1}
+        type: INLINE
+      ds_bmsql_order_line_inline:
+        props:
+          algorithm-expression: ds_${ol_w_id % 1}
+        type: INLINE
+      ds_bmsql_stock_inline:
+        props:
+          algorithm-expression: ds_${s_w_id % 1}
+        type: INLINE
+      ds_bmsql_warehouse_inline:
+        props:
+          algorithm-expression: ds_${w_id % 1}
+        type: INLINE
+      tb_bmsql_config_inline:
+        props:
+          algorithm-expression: bmsql_config_${cfg_id % 1}
+        type: INLINE
+      tb_bmsql_customer_inline:
+        props:
+          algorithm-expression: bmsql_customer_${c_w_id % 1}
+        type: INLINE
+      tb_bmsql_district_inline:
+        props:
+          algorithm-expression: bmsql_district_${d_w_id % 1}
+        type: INLINE
+      tb_bmsql_history_inline:
+        props:
+          algorithm-expression: bmsql_history_${h_w_id % 1}
+        type: INLINE
+      tb_bmsql_item_inline:
+        props:
+          algorithm-expression: bmsql_item_${i_id % 1}
+        type: INLINE
+      tb_bmsql_new_order_inline:
+        props:
+          algorithm-expression: bmsql_new_order_${no_w_id % 1}
+        type: INLINE
+      tb_bmsql_oorder_inline:
+        props:
+          algorithm-expression: bmsql_oorder_${o_w_id % 1}
+        type: INLINE
+      tb_bmsql_order_line_inline:
+        props:
+          algorithm-expression: bmsql_order_line_${ol_w_id % 1}
+        type: INLINE
+      tb_bmsql_stock_inline:
+        props:
+          algorithm-expression: bmsql_stock_${s_w_id % 1}
+        type: INLINE
+      tb_bmsql_warehouse_inline:
+        props:
+          algorithm-expression: bmsql_warehouse_${w_id % 1}
+        type: INLINE
+    tables:
+      bmsql_config:
+        actualDataNodes: ds_${0..0}.bmsql_config_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_config_inline
+            shardingColumn: cfg_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_config_inline
+            shardingColumn: cfg_id
+      bmsql_customer:
+        actualDataNodes: ds_${0..0}.bmsql_customer_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_customer_inline
+            shardingColumn: c_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_customer_inline
+            shardingColumn: c_w_id
+      bmsql_district:
+        actualDataNodes: ds_${0..0}.bmsql_district_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_district_inline
+            shardingColumn: d_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_district_inline
+            shardingColumn: d_w_id
+      bmsql_history:
+        actualDataNodes: ds_${0..0}.bmsql_history_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_history_inline
+            shardingColumn: h_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_history_inline
+            shardingColumn: h_w_id
+      bmsql_item:
+        actualDataNodes: ds_${0..0}.bmsql_item_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_item_inline
+            shardingColumn: i_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_item_inline
+            shardingColumn: i_id
+      bmsql_new_order:
+        actualDataNodes: ds_${0..0}.bmsql_new_order_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_new_order_inline
+            shardingColumn: no_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_new_order_inline
+            shardingColumn: no_w_id
+      bmsql_oorder:
+        actualDataNodes: ds_${0..0}.bmsql_oorder_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_oorder_inline
+            shardingColumn: o_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_oorder_inline
+            shardingColumn: o_w_id
+      bmsql_order_line:
+        actualDataNodes: ds_${0..0}.bmsql_order_line_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_order_line_inline
+            shardingColumn: ol_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_order_line_inline
+            shardingColumn: ol_w_id
+      bmsql_stock:
+        actualDataNodes: ds_${0..0}.bmsql_stock_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_stock_inline
+            shardingColumn: s_w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_stock_inline
+            shardingColumn: s_w_id
+      bmsql_warehouse:
+        actualDataNodes: ds_${0..0}.bmsql_warehouse_${0..0}
+        databaseStrategy:
+          standard:
+            shardingAlgorithmName: ds_bmsql_warehouse_inline
+            shardingColumn: w_id
+        tableStrategy:
+          standard:
+            shardingAlgorithmName: tb_bmsql_warehouse_inline
+            shardingColumn: w_id
+      test_order:
+        actualDataNodes: ds_0.test_order
+schemaName: sharding_db


### PR DESCRIPTION
Fixes #11434.

Changes proposed in this pull request:
- add prop PROXY_BACKEND_ALGORITHM and PROXY_FRONTEND_ALGORITHM to config password encrypt algorithm, default is NONE, that mains nothing to do
- add AES password encrypt algorithm
- anyone can implements AlgorithmSecure interface for new algorithm

examples:
add server.yaml config in props:
  proxy-backend-algorithm: AES  --this is for config-sharding.yaml's dataSource password encrypt
  proxy-frontend-algorithm: AES  -- this is for server.yaml rule's authority password encrypt
![image](https://user-images.githubusercontent.com/12265143/126469682-c74cc686-1bb2-4bf0-b25f-249b569eada0.png)

in config file like this:
for backend algorithm:
![image](https://user-images.githubusercontent.com/12265143/126469195-56ec4d13-5582-4ecb-9c3e-f46045dda3e7.png)
for frontend algorithm:
 
![image](https://user-images.githubusercontent.com/12265143/126469355-a32e799a-4e52-4787-8174-726f2f790e69.png)

to get password, you can simple run algorithm:
---
import org.apache.shardingsphere.infra.security.AesAlgorithmSecure;

public class Main {
    public static void main(String ... args) throws Exception {
        String plaint = "sharding";
        AesAlgorithmSecure util = new AesAlgorithmSecure();

        String encryptStr = util.encrypt(plaint);
        System.out.println("Encrypt: " + encryptStr);

        String decrypt = util.decrypt(encryptStr);
        System.out.println("Decrypt: " + decrypt);
    }
}
---
result:
Encrypt: TXdQa74U8xed9457/sfIuDnuu7PI8I6hL4IWCy/B0PVopdKwEhZCacukz9k0vhaL
Decrypt: sharding