### PR TITLE
Fixes #10673, execute DCL without use schema.

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/SQLStatementEventMapperFactory.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/SQLStatementEventMapperFactory.java
@@ -20,9 +20,11 @@ package org.apache.shardingsphere.infra.metadata.mapper;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.metadata.mapper.type.CreateUserStatementEventMapper;
+import org.apache.shardingsphere.infra.metadata.mapper.type.DropUserStatementEventMapper;
 import org.apache.shardingsphere.infra.metadata.mapper.type.GrantStatementEventMapper;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropUserStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.GrantStatement;
 
 import java.util.HashMap;
@@ -41,6 +43,7 @@ public final class SQLStatementEventMapperFactory {
     static {
         REGISTRY.put(GrantStatement.class, new GrantStatementEventMapper());
         REGISTRY.put(CreateUserStatement.class, new CreateUserStatementEventMapper());
+        REGISTRY.put(DropUserStatement.class, new DropUserStatementEventMapper());
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/event/dcl/impl/DropUserStatementEvent.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/event/dcl/impl/DropUserStatementEvent.java
@@ -15,19 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
+package org.apache.shardingsphere.infra.metadata.mapper.event.dcl.impl;
 
 import lombok.Getter;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.metadata.mapper.event.dcl.DCLStatementEvent;
 
 import java.util.Collection;
-import java.util.LinkedList;
 
 /**
- * Drop user statement.
+ * Drop user statement event.
  */
+@RequiredArgsConstructor
 @Getter
-public abstract class DropUserStatement extends AbstractSQLStatement implements DCLStatement {
+public final class DropUserStatementEvent implements DCLStatementEvent {
     
-    private final Collection<String> users = new LinkedList<>();
+    private final Collection<String> users;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/type/CreateUserStatementEventMapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/type/CreateUserStatementEventMapper.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
- * Create user statement event.
+ * Create user statement event mapper.
  */
 public final class CreateUserStatementEventMapper implements SQLStatementEventMapper {
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/type/DropUserStatementEventMapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/mapper/type/DropUserStatementEventMapper.java
@@ -15,19 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.common.statement.dcl;
+package org.apache.shardingsphere.infra.metadata.mapper.type;
 
-import lombok.Getter;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.infra.metadata.mapper.SQLStatementEventMapper;
+import org.apache.shardingsphere.infra.metadata.mapper.event.dcl.impl.DropUserStatementEvent;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropUserStatement;
 
 import java.util.Collection;
-import java.util.LinkedList;
 
 /**
- * Drop user statement.
+ * Drop user statement event mapper.
  */
-@Getter
-public abstract class DropUserStatement extends AbstractSQLStatement implements DCLStatement {
+public final class DropUserStatementEventMapper implements SQLStatementEventMapper {
     
-    private final Collection<String> users = new LinkedList<>();
+    @Override
+    public DropUserStatementEvent map(final SQLStatement sqlStatement) {
+        return new DropUserStatementEvent(getUsers((DropUserStatement) sqlStatement));
+    }
+    
+    private Collection<String> getUsers(final DropUserStatement sqlStatement) {
+        return sqlStatement.getUsers();
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/CreateUserStatementEventMapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/CreateUserStatementEventMapperTest.java
@@ -48,5 +48,4 @@ public final class CreateUserStatementEventMapperTest {
         result.getUsers().add(userSegment);
         return result;
     }
-    
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/CreateUserStatementEventMapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/CreateUserStatementEventMapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.mapper;
+
+import org.apache.shardingsphere.infra.metadata.mapper.event.dcl.impl.CreateUserStatementEvent;
+import org.apache.shardingsphere.infra.metadata.mapper.type.CreateUserStatementEventMapper;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.CreateUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLCreateUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.UserSegment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class CreateUserStatementEventMapperTest {
+    
+    @Test
+    public void assertMapToCreateUserStatementEvent() {
+        CreateUserStatementEventMapper createUserStatementEventMapper = new CreateUserStatementEventMapper();
+        CreateUserStatementEvent createUserStatementEvent = createUserStatementEventMapper.map(getCreateUserStatement());
+        assertThat(createUserStatementEvent.getUsers().size(), is(1));
+        assertThat(createUserStatementEvent.getUsers().iterator().next().getGrantee().getUsername(), is("test"));
+    }
+    
+    private CreateUserStatement getCreateUserStatement() {
+        UserSegment userSegment = new UserSegment();
+        userSegment.setUser("test");
+        userSegment.setAuth("123456");
+        MySQLCreateUserStatement result = new MySQLCreateUserStatement();
+        result.getUsers().add(userSegment);
+        return result;
+    }
+    
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/DropUserStatementEventMapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/DropUserStatementEventMapperTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.mapper;
+
+import org.apache.shardingsphere.infra.metadata.mapper.event.dcl.impl.DropUserStatementEvent;
+import org.apache.shardingsphere.infra.metadata.mapper.type.DropUserStatementEventMapper;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DropUserStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dcl.MySQLDropUserStatement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DropUserStatementEventMapperTest {
+    
+    @Test
+    public void assertMapToDropUserStatementEvent() {
+        DropUserStatementEventMapper dropUserStatementEventMapper = new DropUserStatementEventMapper();
+        DropUserStatementEvent dropUserStatementEvent = dropUserStatementEventMapper.map(getDropUserStatement());
+        assertThat(dropUserStatementEvent.getUsers().size(), is(1));
+        assertThat(dropUserStatementEvent.getUsers().iterator().next(), is("test"));
+    }
+    
+    private DropUserStatement getDropUserStatement() {
+        MySQLDropUserStatement result = new MySQLDropUserStatement();
+        result.getUsers().add("test");
+        return result;
+    }
+    
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/DropUserStatementEventMapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/mapper/DropUserStatementEventMapperTest.java
@@ -44,5 +44,4 @@ public final class DropUserStatementEventMapperTest {
         result.getUsers().add("test");
         return result;
     }
-    
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/DatabaseBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/DatabaseBackendHandlerFactory.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.proxy.backend.text.data.impl.SchemaAssignedData
 import org.apache.shardingsphere.proxy.backend.text.data.impl.UnicastDatabaseBackendHandler;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SetStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 
@@ -45,7 +46,7 @@ public final class DatabaseBackendHandlerFactory {
      */
     public static DatabaseBackendHandler newInstance(final SQLStatementContext<?> sqlStatementContext, final String sql, final BackendConnection backendConnection) {
         SQLStatement sqlStatement = sqlStatementContext.getSqlStatement();
-        if (sqlStatement instanceof SetStatement) {
+        if (sqlStatement instanceof SetStatement || sqlStatement instanceof DCLStatement) {
             return new BroadcastDatabaseBackendHandler(sqlStatementContext, sql, backendConnection);
         }
         if (sqlStatement instanceof DALStatement || (sqlStatement instanceof SelectStatement && null == ((SelectStatement) sqlStatement).getFrom())) {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/DatabaseBackendHandlerFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/DatabaseBackendHandlerFactoryTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.proxy.backend.text.data.impl.UnicastDatabaseBac
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SetStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 import org.junit.Test;
 
@@ -69,5 +70,14 @@ public final class DatabaseBackendHandlerFactoryTest {
         when(context.getSqlStatement()).thenReturn(mock(SQLStatement.class));
         DatabaseBackendHandler actual = DatabaseBackendHandlerFactory.newInstance(context, sql, mock(BackendConnection.class));
         assertThat(actual, instanceOf(SchemaAssignedDatabaseBackendHandler.class));
+    }
+    
+    @Test
+    public void assertNewInstanceWithDCLStatement() {
+        String sql = "CREATE USER test IDENTIFIED BY '123456'";
+        SQLStatementContext<DCLStatement> context = mock(SQLStatementContext.class);
+        when(context.getSqlStatement()).thenReturn(mock(DCLStatement.class));
+        DatabaseBackendHandler actual = DatabaseBackendHandlerFactory.newInstance(context, sql, mock(BackendConnection.class));
+        assertThat(actual, instanceOf(BroadcastDatabaseBackendHandler.class));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDCLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDCLStatementSQLVisitor.java
@@ -117,6 +117,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.UserSegment;
 
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 /**
  * DCL Statement SQL visitor for MySQL.
@@ -728,9 +729,7 @@ public final class MySQLDCLStatementSQLVisitor extends MySQLStatementSQLVisitor 
     @Override
     public ASTNode visitDropUser(final DropUserContext ctx) {
         MySQLDropUserStatement result = new MySQLDropUserStatement();
-        for (UserNameContext each : ctx.userName()) {
-            result.getUsers().add(each.getText());
-        }
+        result.getUsers().addAll(ctx.userName().stream().map(UserNameContext::getText).collect(Collectors.toList()));
         return result;
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDCLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDCLStatementSQLVisitor.java
@@ -727,7 +727,11 @@ public final class MySQLDCLStatementSQLVisitor extends MySQLStatementSQLVisitor 
     
     @Override
     public ASTNode visitDropUser(final DropUserContext ctx) {
-        return new MySQLDropUserStatement();
+        MySQLDropUserStatement result = new MySQLDropUserStatement();
+        for (UserNameContext each : ctx.userName()) {
+            result.getUsers().add(each.getText());
+        }
+        return result;
     }
     
     @Override


### PR DESCRIPTION
Fixes #10673.

Changes proposed in this pull request:
The DCL statements will take the broadcast route without checking the current schema.  For now, DCL statements Include:
- AlterRoleStatement
- AlterUserStatement
- CreateRoleStatement
- CreateUserStatement
- DropRoleStatement
- DropUserStatement
- GrantStatement
- RevokeStatement
- SetRoleStatement