### PR TITLE
fix(transaction):fix transaction statement commit error while using shared thread pool and local transaction manager

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/BackendConnection.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/BackendConnection.java
@@ -307,7 +307,6 @@ public final class BackendConnection implements ExecutorJDBCManager {
         }
         cachedConnections.clear();
         connectionPostProcessors.clear();
-        connectionStatus.switchToReleased();
         return result;
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/BackendConnectionTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/BackendConnectionTest.java
@@ -274,7 +274,6 @@ public final class BackendConnectionTest {
         verify(connection, times(1)).close();
         assertTrue(cachedConnections.isEmpty());
         verifyConnectionPostProcessorsEmpty();
-        verify(connectionStatus, times(1)).switchToReleased();
     }
     
     @Test
@@ -285,7 +284,6 @@ public final class BackendConnectionTest {
         Connection connection = prepareCachedConnections();
         backendConnection.closeConnections(true);
         verify(connection, never()).rollback();
-        verify(connectionStatus, times(1)).switchToReleased();
     }
     
     @Test
@@ -296,7 +294,6 @@ public final class BackendConnectionTest {
         Connection connection = prepareCachedConnections();
         backendConnection.closeConnections(true);
         verify(connection, times(1)).rollback();
-        verify(connectionStatus, times(1)).switchToReleased();
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTask.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTask.java
@@ -84,6 +84,7 @@ public final class CommandExecutorTask implements Runnable {
             if (!backendConnection.getTransactionStatus().isInConnectionHeldTransaction()) {
                 exceptions.addAll(backendConnection.closeDatabaseCommunicationEngines(true));
                 exceptions.addAll(backendConnection.closeConnections(false));
+                backendConnection.getConnectionStatus().switchToReleased();
             }
             processClosedExceptions(exceptions);
         }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTaskTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTaskTest.java
@@ -44,6 +44,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,6 +106,7 @@ public final class CommandExecutorTaskTest {
         actual.run();
         verify(connectionStatus).waitUntilConnectionRelease();
         verify(connectionStatus).switchToUsing();
+        verify(connectionStatus).switchToReleased();
         verify(queryCommandExecutor).close();
         verify(backendConnection).closeDatabaseCommunicationEngines(true);
     }
@@ -124,6 +126,7 @@ public final class CommandExecutorTaskTest {
         actual.run();
         verify(connectionStatus).waitUntilConnectionRelease();
         verify(connectionStatus).switchToUsing();
+        verify(connectionStatus).switchToReleased();
         verify(handlerContext).write(databasePacket);
         verify(handlerContext).flush();
         verify(engine.getCommandExecuteEngine()).writeQueryData(handlerContext, backendConnection, queryCommandExecutor, 1);
@@ -147,6 +150,7 @@ public final class CommandExecutorTaskTest {
         actual.run();
         verify(connectionStatus).waitUntilConnectionRelease();
         verify(connectionStatus).switchToUsing();
+        verify(connectionStatus).switchToReleased();
         verify(handlerContext).write(databasePacket);
         verify(handlerContext).flush();
         verify(commandExecutor).close();
@@ -156,7 +160,8 @@ public final class CommandExecutorTaskTest {
     @Test
     public void assertRunWithError() {
         RuntimeException mockException = new RuntimeException("mock");
-        when(backendConnection.getConnectionStatus()).thenThrow(mockException);
+        when(backendConnection.getConnectionStatus()).thenReturn(connectionStatus);
+        doThrow(mockException).when(connectionStatus).switchToUsing();
         when(engine.getCodecEngine().createPacketPayload(message)).thenReturn(payload);
         when(engine.getCommandExecuteEngine().getErrorPacket(mockException, backendConnection)).thenReturn(databasePacket);
         when(engine.getCommandExecuteEngine().getOtherPacket(backendConnection)).thenReturn(Optional.of(databasePacket));


### PR DESCRIPTION
Fixes #11583.

Changes proposed in this pull request:
- move code backendConnection.getConnectionStatus().switchToReleased() in BackendConnection method:closeConnections to the finally code block of CommandExecutorTask`s method  "run" to avoid switchToRelease when begin statement is called.
