### PR TITLE
fix single table metadata refresh when use readwrite-splitting rule

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoader.java
@@ -20,13 +20,18 @@ package org.apache.shardingsphere.infra.metadata.schema.builder.loader;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.schema.builder.SchemaBuilderMaterials;
 import org.apache.shardingsphere.infra.metadata.schema.builder.loader.adapter.MetaDataLoaderConnectionAdapter;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.rule.type.DataSourceContainedRule;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -54,9 +59,38 @@ public final class TableMetaDataLoader {
         }
     }
     
+    /**
+     * Load table meta data.
+     *
+     * @param tableName table name
+     * @param logicDataSourceNames logic data source names
+     * @param materials materials
+     * @return table meta data
+     * @throws SQLException SQL exception
+     */
+    public static Optional<TableMetaData> load(final String tableName, final Collection<String> logicDataSourceNames, final SchemaBuilderMaterials materials) throws SQLException {
+        for (String each : logicDataSourceNames) {
+            DataSource dataSource = materials.getDataSourceMap().get(getActualDataSourceName(materials, each));
+            if (Objects.isNull(dataSource)) {
+                continue;
+            }
+            return load(dataSource, tableName, materials.getDatabaseType());
+        }
+        return Optional.empty();
+    }
+    
     private static boolean isTableExist(final Connection connection, final String tableNamePattern) throws SQLException {
         try (ResultSet resultSet = connection.getMetaData().getTables(connection.getCatalog(), connection.getSchema(), tableNamePattern, null)) {
             return resultSet.next();
         }
+    }
+    
+    private static String getActualDataSourceName(final SchemaBuilderMaterials materials, final String logicDataSourceName) {
+        for (ShardingSphereRule each : materials.getRules()) {
+            if (each instanceof DataSourceContainedRule && ((DataSourceContainedRule) each).getDataSourceMapper().containsKey(logicDataSourceName)) {
+                return ((DataSourceContainedRule) each).getDataSourceMapper().get(logicDataSourceName).iterator().next();
+            }
+        }
+        return logicDataSourceName;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/SchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/SchemaRefresher.java
@@ -36,10 +36,10 @@ public interface SchemaRefresher<T extends SQLStatement> extends MetadataRefresh
      * Refresh ShardingSphere schema.
      *
      * @param schema ShardingSphere schema to be refreshed
-     * @param routeDataSourceNames route dataSource names
+     * @param logicDataSourceNames route dataSource names
      * @param sqlStatement SQL statement
      * @param materials schema builder materials
      * @throws SQLException SQL exception
      */
-    void refresh(ShardingSphereSchema schema, Collection<String> routeDataSourceNames, T sqlStatement, SchemaBuilderMaterials materials) throws SQLException;
+    void refresh(ShardingSphereSchema schema, Collection<String> logicDataSourceNames, T sqlStatement, SchemaBuilderMaterials materials) throws SQLException;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/AlterIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/AlterIndexStatementSchemaRefresher.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 public final class AlterIndexStatementSchemaRefresher implements SchemaRefresher<AlterIndexStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final AlterIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final AlterIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
         Optional<IndexSegment> renameIndex = AlterIndexStatementHandler.getRenameIndexSegment(sqlStatement);
         if (!sqlStatement.getIndex().isPresent() || !renameIndex.isPresent()) {
             return;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateIndexStatementSchemaRefresher.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 public final class CreateIndexStatementSchemaRefresher implements SchemaRefresher<CreateIndexStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final CreateIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final CreateIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
         String indexName = null != sqlStatement.getIndex() ? sqlStatement.getIndex().getIdentifier().getValue() : IndexMetaDataUtil.getGeneratedLogicIndexName(sqlStatement.getColumns());
         if (Strings.isNullOrEmpty(indexName)) {
             return;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -33,13 +33,13 @@ import java.util.Collection;
 public final class CreateViewStatementSchemaRefresher implements SchemaRefresher<CreateViewStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final CreateViewStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final CreateViewStatement sqlStatement, final SchemaBuilderMaterials materials) {
         String viewName = sqlStatement.getView().getTableName().getIdentifier().getValue();
         TableMetaData tableMetaData = new TableMetaData();
         schema.put(viewName, tableMetaData);
         if (isSingleTable(viewName, materials)) {
             materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each 
-                -> (SingleTableRule) each).findFirst().ifPresent(rule -> rule.addSingleTableDataNode(viewName, routeDataSourceNames.iterator().next()));
+                -> (SingleTableRule) each).findFirst().ifPresent(rule -> rule.addSingleTableDataNode(viewName, logicDataSourceNames.iterator().next()));
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropIndexStatementSchemaRefresher.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 public final class DropIndexStatementSchemaRefresher implements SchemaRefresher<DropIndexStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final DropIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final DropIndexStatement sqlStatement, final SchemaBuilderMaterials materials) {
         Collection<String> indexNames = getIndexNames(sqlStatement);
         Optional<SimpleTableSegment> simpleTableSegment = DropIndexStatementHandler.getSimpleTableSegment(sqlStatement);
         String tableName = simpleTableSegment.map(tableSegment -> tableSegment.getTableName().getIdentifier().getValue()).orElse("");

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 public final class DropTableStatementSchemaRefresher implements SchemaRefresher<DropTableStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final DropTableStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final DropTableStatement sqlStatement, final SchemaBuilderMaterials materials) {
         sqlStatement.getTables().forEach(each -> schema.remove(each.getTableName().getIdentifier().getValue()));
         Optional<SingleTableRule> singleTableRule = materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         for (SimpleTableSegment each : sqlStatement.getTables()) {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
@@ -33,7 +33,7 @@ import java.util.Optional;
 public final class DropViewStatementSchemaRefresher implements SchemaRefresher<DropViewStatement> {
     
     @Override
-    public void refresh(final ShardingSphereSchema schema, final Collection<String> routeDataSourceNames, final DropViewStatement sqlStatement, final SchemaBuilderMaterials materials) {
+    public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final DropViewStatement sqlStatement, final SchemaBuilderMaterials materials) {
         sqlStatement.getViews().forEach(each -> schema.remove(each.getTableName().getIdentifier().getValue()));
         Optional<SingleTableRule> singleTableRule = materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         for (SimpleTableSegment each : sqlStatement.getViews()) {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoaderTest.java
@@ -129,7 +129,7 @@ public final class TableMetaDataLoaderTest {
     }
     
     @Test
-    public void assertLoadWithExistedTable2() throws SQLException {
+    public void assertLoadFromLogicDataSourceWithExistedTable() throws SQLException {
         DataSourceContainedRule rule = mock(DataSourceContainedRule.class, RETURNS_DEEP_STUBS);
         when(rule.getDataSourceMapper().containsKey("pr_ds")).thenReturn(true);
         when(rule.getDataSourceMapper().get("pr_ds")).thenReturn(Arrays.asList("write_ds", "read_ds_0", "read_ds_1"));
@@ -151,7 +151,7 @@ public final class TableMetaDataLoaderTest {
     }
     
     @Test
-    public void assertLoadWithNotExistedTable2() throws SQLException {
+    public void assertLoadFromLogicDataSourceWithNotExistedTable() throws SQLException {
         assertFalse(TableMetaDataLoader.load(TEST_TABLE, Collections.singletonList("pr_ds"), mock(SchemaBuilderMaterials.class)).isPresent());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/TableMetaDataLoaderTest.java
@@ -18,9 +18,11 @@
 package org.apache.shardingsphere.infra.metadata.schema.builder.loader;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.metadata.schema.builder.SchemaBuilderMaterials;
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.infra.rule.type.DataSourceContainedRule;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +35,8 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 
@@ -60,9 +64,6 @@ public final class TableMetaDataLoaderTest {
     
     @Mock
     private ResultSet tableExistResultSet;
-    
-    @Mock
-    private ResultSet tableNotExistResultSet;
     
     @Mock
     private ResultSet columnResultSet;
@@ -125,5 +126,32 @@ public final class TableMetaDataLoaderTest {
     @Test
     public void assertLoadWithNotExistedTable() throws SQLException {
         assertFalse(TableMetaDataLoader.load(dataSource, TEST_TABLE, mock(DatabaseType.class)).isPresent());
+    }
+    
+    @Test
+    public void assertLoadWithExistedTable2() throws SQLException {
+        DataSourceContainedRule rule = mock(DataSourceContainedRule.class, RETURNS_DEEP_STUBS);
+        when(rule.getDataSourceMapper().containsKey("pr_ds")).thenReturn(true);
+        when(rule.getDataSourceMapper().get("pr_ds")).thenReturn(Arrays.asList("write_ds", "read_ds_0", "read_ds_1"));
+        SchemaBuilderMaterials materials = mock(SchemaBuilderMaterials.class, RETURNS_DEEP_STUBS);
+        when(materials.getRules()).thenReturn(Collections.singletonList(rule));
+        DatabaseType databaseType = mock(DatabaseType.class, RETURNS_DEEP_STUBS);
+        when(databaseType.formatTableNamePattern(TEST_TABLE)).thenReturn(TEST_TABLE);
+        when(materials.getDatabaseType()).thenReturn(databaseType);
+        when(materials.getDataSourceMap().get("write_ds")).thenReturn(dataSource);
+        Optional<TableMetaData> actual = TableMetaDataLoader.load(TEST_TABLE, Collections.singletonList("pr_ds"), materials);
+        assertTrue(actual.isPresent());
+        Map<String, ColumnMetaData> columnMetaDataMap = actual.get().getColumns();
+        assertThat(columnMetaDataMap.size(), is(2));
+        assertColumnMetaData(columnMetaDataMap.get("pk_col"), "pk_col", Types.INTEGER, true, true);
+        assertColumnMetaData(columnMetaDataMap.get("col"), "col", Types.VARCHAR, false, false);
+        Map<String, IndexMetaData> indexMetaDataMap = actual.get().getIndexes();
+        assertThat(indexMetaDataMap.size(), is(1));
+        assertTrue(indexMetaDataMap.containsKey("my_index"));
+    }
+    
+    @Test
+    public void assertLoadWithNotExistedTable2() throws SQLException {
+        assertFalse(TableMetaDataLoader.load(TEST_TABLE, Collections.singletonList("pr_ds"), mock(SchemaBuilderMaterials.class)).isPresent());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/metadata/refresher/MetadataRefreshEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/metadata/refresher/MetadataRefreshEngine.java
@@ -56,13 +56,13 @@ public final class MetadataRefreshEngine {
      * Refresh.
      *
      * @param sqlStatement SQL statement
-     * @param routeDataSourceNames route data source names
+     * @param logicDataSourceNames logic data source names
      * @throws SQLException SQL exception
      */
-    public void refresh(final SQLStatement sqlStatement, final Collection<String> routeDataSourceNames) throws SQLException {
+    public void refresh(final SQLStatement sqlStatement, final Collection<String> logicDataSourceNames) throws SQLException {
         Collection<MetadataRefresher> metadataRefreshers = MetadataRefresherFactory.newInstance(sqlStatement);
         if (!metadataRefreshers.isEmpty()) {
-            refresh(sqlStatement, routeDataSourceNames, metadataRefreshers);
+            refresh(sqlStatement, logicDataSourceNames, metadataRefreshers);
         }
         Optional<SQLStatementEventMapper> sqlStatementEventMapper = SQLStatementEventMapperFactory.newInstance(sqlStatement);
         if (sqlStatementEventMapper.isPresent()) {
@@ -72,13 +72,13 @@ public final class MetadataRefreshEngine {
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private void refresh(final SQLStatement sqlStatement, final Collection<String> routeDataSourceNames, final Collection<MetadataRefresher> refreshers) throws SQLException {
+    private void refresh(final SQLStatement sqlStatement, final Collection<String> logicDataSourceNames, final Collection<MetadataRefresher> refreshers) throws SQLException {
         for (MetadataRefresher each : refreshers) {
             if (each instanceof SchemaRefresher) {
-                ((SchemaRefresher) each).refresh(schemaMetadata.getSchema(), routeDataSourceNames, sqlStatement, materials);
+                ((SchemaRefresher) each).refresh(schemaMetadata.getSchema(), logicDataSourceNames, sqlStatement, materials);
             }
             if (each instanceof FederateRefresher) {
-                ((FederateRefresher) each).refresh(federateMetadata, routeDataSourceNames, sqlStatement, materials);
+                ((FederateRefresher) each).refresh(federateMetadata, logicDataSourceNames, sqlStatement, materials);
             }
         }
         ShardingSphereEventBus.getInstance().post(new SchemaAlteredEvent(schemaMetadata.getName(), schemaMetadata.getSchema()));

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/FederateRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/FederateRefresher.java
@@ -36,10 +36,10 @@ public interface FederateRefresher<T extends SQLStatement> extends MetadataRefre
      * Refresh federate schema.
      *
      * @param schema Federate schema to be refreshed
-     * @param routeDataSourceNames route dataSource names
+     * @param logicDataSourceNames logic dataSource names
      * @param sqlStatement SQL statement
      * @param materials schema builder materials
      * @throws SQLException SQL exception
      */
-    void refresh(FederateSchemaMetadata schema, Collection<String> routeDataSourceNames, T sqlStatement, SchemaBuilderMaterials materials) throws SQLException;
+    void refresh(FederateSchemaMetadata schema, Collection<String> logicDataSourceNames, T sqlStatement, SchemaBuilderMaterials materials) throws SQLException;
 }

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/DropTableStatementFederateRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/DropTableStatementFederateRefresher.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 public final class DropTableStatementFederateRefresher implements FederateRefresher<DropTableStatement> {
 
     @Override
-    public void refresh(final FederateSchemaMetadata schema, final Collection<String> routeDataSourceNames, final DropTableStatement sqlStatement, final SchemaBuilderMaterials materials)
+    public void refresh(final FederateSchemaMetadata schema, final Collection<String> logicDataSourceNames, final DropTableStatement sqlStatement, final SchemaBuilderMaterials materials)
             throws SQLException {
         sqlStatement.getTables().forEach(each -> schema.remove(each.getTableName().getIdentifier().getValue()));
     }


### PR DESCRIPTION
Ref #10996.

Changes proposed in this pull request:
- fix single table metadata refresh when use readwrite-splitting rule
- transform logic data source to actual data source
- extract common logic to TableMetaDataLoader class
- add test case for TableMetaDataLoader
