### PR TITLE
Add ProcessRegistrySubscriber unit test without mock

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/process/ProcessListRegistryCenterRepositoryFixture.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/process/ProcessListRegistryCenterRepositoryFixture.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.process;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.shardingsphere.governance.repository.api.config.RegistryCenterConfiguration;
+import org.apache.shardingsphere.governance.repository.api.listener.DataChangedEventListener;
+import org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository;
+
+public final class ProcessListRegistryCenterRepositoryFixture implements RegistryCenterRepository {
+    
+    private static final Map<String, String> REGISTRY_DATA = new LinkedHashMap<>();
+    
+    @Override
+    public void init(final RegistryCenterConfiguration config) {
+    }
+    
+    @Override
+    public String get(final String key) {
+        return REGISTRY_DATA.get(key);
+    }
+    
+    @Override
+    public List<String> getChildrenKeys(final String key) {
+        return Collections.singletonList("db");
+    }
+    
+    @Override
+    public void persist(final String key, final String value) {
+        REGISTRY_DATA.put(key, value);
+    }
+    
+    @Override
+    public void persistEphemeral(final String key, final String value) {
+        REGISTRY_DATA.put(key, value);
+    }
+    
+    @Override
+    public void delete(final String key) {
+        REGISTRY_DATA.remove(key);
+    }
+    
+    @Override
+    public void watch(final String key, final DataChangedEventListener listener) {
+    }
+    
+    @Override
+    public boolean tryLock(final String key, final long time, final TimeUnit unit) {
+        return false;
+    }
+    
+    @Override
+    public void releaseLock(final String key) {
+    }
+    
+    @Override
+    public void close() {
+        REGISTRY_DATA.clear();
+    }
+    
+    @Override
+    public String getType() {
+        return "PROCESS_FIXTURE";
+    }
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/process/ProcessRegistrySubscriberTestNoMock.java
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/java/org/apache/shardingsphere/governance/core/registry/process/ProcessRegistrySubscriberTestNoMock.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.governance.core.registry.process;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import org.apache.shardingsphere.governance.core.registry.process.event.ExecuteProcessReportEvent;
+import org.apache.shardingsphere.governance.core.registry.process.event.ExecuteProcessSummaryReportEvent;
+import org.apache.shardingsphere.governance.core.registry.process.event.ExecuteProcessUnitReportEvent;
+import org.apache.shardingsphere.governance.core.registry.process.node.ProcessNode;
+import org.apache.shardingsphere.governance.core.registry.process.subscriber.ProcessRegistrySubscriber;
+import org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroup;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
+import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessUnit;
+import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
+import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessUnit;
+import org.apache.shardingsphere.infra.metadata.user.Grantee;
+import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public final class ProcessRegistrySubscriberTestNoMock {
+    
+    private final RegistryCenterRepository repository = new ProcessListRegistryCenterRepositoryFixture();
+    
+    private final ProcessRegistrySubscriber subscriber = new ProcessRegistrySubscriber(repository);
+    
+    private final ExecuteProcessContext executeProcessContext;
+    
+    private final ExecutionUnit executionUnit;
+    
+    public ProcessRegistrySubscriberTestNoMock() {
+        ExecutionUnit executionUnit = new ExecutionUnit("ds_0", new SQLUnit("sql1_0", Collections.emptyList()));
+        this.executionUnit = executionUnit;
+        executeProcessContext = createExecuteProcessContext(executionUnit);
+    }
+    
+    private ExecuteProcessContext createExecuteProcessContext(final ExecutionUnit executionUnit) {
+        Collection<ExecutionGroup<JDBCExecutionUnit>> inputGroups = new ArrayList<>();
+        inputGroups.add(new ExecutionGroup<>(Collections.singletonList(new JDBCExecutionUnit(executionUnit, ConnectionMode.MEMORY_STRICTLY, null))));
+        ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext = new ExecutionGroupContext<>(inputGroups);
+        executionGroupContext.setSchemaName("sharding_db");
+        executionGroupContext.setGrantee(new Grantee("sharding", "127.0.0.1"));
+        return new ExecuteProcessContext("sql1", executionGroupContext, ExecuteProcessConstants.EXECUTE_STATUS_START);
+    }
+    
+    @Test
+    public void assertWholeProcessCompleted() {
+        assertReportExecuteProcessSummary();
+        ExecuteProcessConstants processConstants = ExecuteProcessConstants.EXECUTE_STATUS_DONE;
+        assertReportExecuteProcessUnit(processConstants);
+        assertReportExecuteProcess(processConstants);
+    }
+    
+    @Test
+    public void assertWholeProcessUncompleted() {
+        assertReportExecuteProcessSummary();
+        ExecuteProcessConstants processConstants = ExecuteProcessConstants.EXECUTE_STATUS_START;
+        assertReportExecuteProcessUnit(processConstants);
+        assertReportExecuteProcess(processConstants);
+    }
+    
+    private void assertReportExecuteProcessSummary() {
+        subscriber.reportExecuteProcessSummary(new ExecuteProcessSummaryReportEvent(executeProcessContext));
+        String executionID = executeProcessContext.getExecutionID();
+        String executeProcessText = repository.get(ProcessNode.getExecutionPath(executionID));
+        assertNotNull(executeProcessText);
+        YamlExecuteProcessContext yamlExecuteProcessContext = YamlEngine.unmarshal(executeProcessText, YamlExecuteProcessContext.class);
+        assertEquals(executionID, yamlExecuteProcessContext.getExecutionID());
+        assertNotNull(yamlExecuteProcessContext.getStartTimeMillis());
+        assertEquals(executeProcessContext.getStartTimeMillis(), yamlExecuteProcessContext.getStartTimeMillis().longValue());
+        assertEquals("sharding_db", yamlExecuteProcessContext.getSchemaName());
+        assertEquals("sharding", yamlExecuteProcessContext.getUsername());
+        assertEquals("127.0.0.1", yamlExecuteProcessContext.getHostname());
+        assertEquals("sql1", yamlExecuteProcessContext.getSql());
+        Collection<YamlExecuteProcessUnit> unitStatuses = yamlExecuteProcessContext.getUnitStatuses();
+        assertEquals(1, unitStatuses.size());
+        YamlExecuteProcessUnit yamlExecuteProcessUnit = unitStatuses.iterator().next();
+        assertEquals(ExecuteProcessConstants.EXECUTE_STATUS_START, yamlExecuteProcessUnit.getStatus());
+    }
+    
+    private void assertReportExecuteProcessUnit(final ExecuteProcessConstants processConstants) {
+        String executionID = executeProcessContext.getExecutionID();
+        ExecuteProcessUnitReportEvent event = new ExecuteProcessUnitReportEvent(executionID, new ExecuteProcessUnit(executionUnit, processConstants));
+        subscriber.reportExecuteProcessUnit(event);
+        String executeProcessText = repository.get(ProcessNode.getExecutionPath(executionID));
+        assertNotNull(executeProcessText);
+        YamlExecuteProcessContext yamlExecuteProcessContext = YamlEngine.unmarshal(executeProcessText, YamlExecuteProcessContext.class);
+        assertEquals(executionID, yamlExecuteProcessContext.getExecutionID());
+        YamlExecuteProcessUnit yamlExecuteProcessUnit = yamlExecuteProcessContext.getUnitStatuses().iterator().next();
+        assertEquals(processConstants, yamlExecuteProcessUnit.getStatus());
+    }
+    
+    private void assertReportExecuteProcess(final ExecuteProcessConstants processConstants) {
+        String executionID = executeProcessContext.getExecutionID();
+        ExecuteProcessReportEvent event = new ExecuteProcessReportEvent(executionID);
+        subscriber.reportExecuteProcess(event);
+        String executeProcessText = repository.get(ProcessNode.getExecutionPath(executionID));
+        if (processConstants == ExecuteProcessConstants.EXECUTE_STATUS_DONE) {
+            assertNull(executeProcessText);
+        } else {
+            assertNotNull(executeProcessText);
+            YamlExecuteProcessContext yamlExecuteProcessContext = YamlEngine.unmarshal(executeProcessText, YamlExecuteProcessContext.class);
+            assertEquals(executionID, yamlExecuteProcessContext.getExecutionID());
+            YamlExecuteProcessUnit yamlExecuteProcessUnit = yamlExecuteProcessContext.getUnitStatuses().iterator().next();
+            assertEquals(processConstants, yamlExecuteProcessUnit.getStatus());
+        }
+    }
+    
+}

--- a/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/META-INF/services/org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository
+++ b/shardingsphere-governance/shardingsphere-governance-core/src/test/resources/META-INF/services/org.apache.shardingsphere.governance.repository.spi.RegistryCenterRepository
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.governance.core.registry.fixture.RegistryCenterRepositoryFixture
+org.apache.shardingsphere.governance.core.registry.process.ProcessListRegistryCenterRepositoryFixture


### PR DESCRIPTION
Since it's difficult to verify through integration test, we need to do unit test with real `RegistryCenterRepository` implementation and verify result from it.

Changes proposed in this pull request:
- Add ProcessRegistrySubscriber unit test without mock. A new `RegistryCenterRepository` is implemented, which store data in memory, and it's loaded by ServiceLoader dynamically.
