### PR TITLE
fixed #11643 Custom pool properties are lost when restarted in governance mode 

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
@@ -32,12 +32,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * Data source configuration.
@@ -63,6 +65,8 @@ public final class DataSourceConfiguration {
     private final String dataSourceClassName;
     
     private final Map<String, Object> props = new LinkedHashMap<>();
+    
+    private final Properties customPoolProps = new Properties();
     
     /**
      * Get data source configuration.
@@ -110,7 +114,9 @@ public final class DataSourceConfiguration {
     public DataSource createDataSource() {
         DataSource result = (DataSource) Class.forName(dataSourceClassName).getConstructor().newInstance();
         Method[] methods = result.getClass().getMethods();
-        for (Entry<String, Object> entry : props.entrySet()) {
+        Map<String, Object> allProps = new HashMap<>(props);
+        allProps.putAll((Map) customPoolProps);
+        for (Entry<String, Object> entry : allProps.entrySet()) {
             if (SKIPPED_PROPERTY_NAMES.contains(entry.getKey())) {
                 continue;
             }
@@ -191,5 +197,14 @@ public final class DataSourceConfiguration {
             stringBuilder.append(entry.getKey()).append(entry.getValue());
         }
         return Objects.hashCode(dataSourceClassName, stringBuilder.toString());
+    }
+    
+    /**
+     * Determine whether there are props.
+     *
+     * @return has custom pool props  
+     */
+    public boolean hasCustomPoolProps() {
+        return customPoolProps.size() > 0;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
@@ -199,12 +199,4 @@ public final class DataSourceConfiguration {
         return Objects.hashCode(dataSourceClassName, stringBuilder.toString());
     }
     
-    /**
-     * Determine whether there are props.
-     *
-     * @return has custom pool props  
-     */
-    public boolean hasCustomPoolProps() {
-        return customPoolProps.size() > 0;
-    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceConfiguration.java
@@ -48,6 +48,8 @@ import java.util.Properties;
 @Getter
 public final class DataSourceConfiguration {
     
+    public static final String CUSTOM_POOL_PROPS_KEY = "customPoolProps";
+    
     private static final String GETTER_PREFIX = "get";
     
     private static final String SETTER_PREFIX = "set";
@@ -198,5 +200,4 @@ public final class DataSourceConfiguration {
         }
         return Objects.hashCode(dataSourceClassName, stringBuilder.toString());
     }
-    
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
@@ -45,7 +45,7 @@ public final class PropertiesConverter {
      * Convert map to properties.
      *
      * @param map map to be converted
-     * @return converted properties content
+     * @return converted properties
      */
     public static Properties convertToProperties(final Map<String, String> map) {
         Properties result = new Properties();

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
@@ -21,6 +21,7 @@ import com.google.common.base.Joiner;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -38,5 +39,17 @@ public final class PropertiesConverter {
      */
     public static String convert(final Properties props) {
         return Joiner.on(",").join(props.entrySet().stream().map(each -> Joiner.on("=").join(each.getKey(), each.getValue())).collect(Collectors.toList()));
+    }
+    
+    /**
+     * Convert map to properties.
+     *
+     * @param map map to be converted
+     * @return converted properties content
+     */
+    public static Properties convertToProperties(final Map<String, String> map) {
+        Properties result = new Properties();
+        result.putAll(map);
+        return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/properties/PropertiesConverter.java
@@ -21,7 +21,6 @@ import com.google.common.base.Joiner;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
@@ -39,17 +38,5 @@ public final class PropertiesConverter {
      */
     public static String convert(final Properties props) {
         return Joiner.on(",").join(props.entrySet().stream().map(each -> Joiner.on("=").join(each.getKey(), each.getValue())).collect(Collectors.toList()));
-    }
-    
-    /**
-     * Convert map to properties.
-     *
-     * @param map map to be converted
-     * @return converted properties
-     */
-    public static Properties convertToProperties(final Map<String, String> map) {
-        Properties result = new Properties();
-        result.putAll(map);
-        return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
@@ -71,7 +71,7 @@ public final class YamlDataSourceConfigurationSwapper {
      */
     public Map<String, Object> swapToMap(final DataSourceConfiguration dataSourceConfig) {
         Map<String, Object> result = new HashMap<>(dataSourceConfig.getProps());
-        if (dataSourceConfig.getCustomPoolProps().isEmpty()) {
+        if (!dataSourceConfig.getCustomPoolProps().isEmpty()) {
             result.put(DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY, dataSourceConfig.getCustomPoolProps());
         }
         result.put(DATA_SOURCE_CLASS_NAME_KEY, dataSourceConfig.getDataSourceClassName());

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
@@ -73,7 +73,7 @@ public final class YamlDataSourceConfigurationSwapper {
      */
     public Map<String, Object> swapToMap(final DataSourceConfiguration dataSourceConfig) {
         Map<String, Object> result = new HashMap<>(dataSourceConfig.getProps());
-        if (dataSourceConfig.hasCustomPoolProps()) {
+        if (dataSourceConfig.getCustomPoolProps().isEmpty()) {
             result.put(CUSTOM_POOL_PROPS_KEY, dataSourceConfig.getCustomPoolProps());
         }
         result.put(DATA_SOURCE_CLASS_NAME_KEY, dataSourceConfig.getDataSourceClassName());

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
@@ -34,8 +34,6 @@ public final class YamlDataSourceConfigurationSwapper {
     
     private static final String DATA_SOURCE_CLASS_NAME_KEY = "dataSourceClassName";
     
-    private static final String CUSTOM_POOL_PROPS_KEY = "customPoolProps";
-    
     /**
      * Swap to data sources from YAML data sources.
      *
@@ -57,9 +55,9 @@ public final class YamlDataSourceConfigurationSwapper {
         Map<String, Object> newDataSourceMap = new HashMap<>(yamlConfig);
         newDataSourceMap.remove(DATA_SOURCE_CLASS_NAME_KEY);
         DataSourceConfiguration result = new DataSourceConfiguration(yamlConfig.get(DATA_SOURCE_CLASS_NAME_KEY).toString());
-        if (null != newDataSourceMap.get(CUSTOM_POOL_PROPS_KEY)) {
-            result.getCustomPoolProps().putAll((Map) newDataSourceMap.get(CUSTOM_POOL_PROPS_KEY));
-            newDataSourceMap.remove(CUSTOM_POOL_PROPS_KEY);
+        if (null != newDataSourceMap.get(DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY)) {
+            result.getCustomPoolProps().putAll((Map) newDataSourceMap.get(DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY));
+            newDataSourceMap.remove(DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY);
         }
         result.getProps().putAll(newDataSourceMap);
         return result;
@@ -74,7 +72,7 @@ public final class YamlDataSourceConfigurationSwapper {
     public Map<String, Object> swapToMap(final DataSourceConfiguration dataSourceConfig) {
         Map<String, Object> result = new HashMap<>(dataSourceConfig.getProps());
         if (dataSourceConfig.getCustomPoolProps().isEmpty()) {
-            result.put(CUSTOM_POOL_PROPS_KEY, dataSourceConfig.getCustomPoolProps());
+            result.put(DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY, dataSourceConfig.getCustomPoolProps());
         }
         result.put(DATA_SOURCE_CLASS_NAME_KEY, dataSourceConfig.getDataSourceClassName());
         return result;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
@@ -34,6 +34,8 @@ public final class YamlDataSourceConfigurationSwapper {
     
     private static final String DATA_SOURCE_CLASS_NAME_KEY = "dataSourceClassName";
     
+    private static final String CUSTOM_POOL_PROPS_KEY = "customPoolProps";
+    
     /**
      * Swap to data sources from YAML data sources.
      *
@@ -55,6 +57,10 @@ public final class YamlDataSourceConfigurationSwapper {
         Map<String, Object> newDataSourceMap = new HashMap<>(yamlConfig);
         newDataSourceMap.remove(DATA_SOURCE_CLASS_NAME_KEY);
         DataSourceConfiguration result = new DataSourceConfiguration(yamlConfig.get(DATA_SOURCE_CLASS_NAME_KEY).toString());
+        if (null != newDataSourceMap.get(CUSTOM_POOL_PROPS_KEY)) {
+            result.getCustomPoolProps().putAll((Map) newDataSourceMap.get(CUSTOM_POOL_PROPS_KEY));
+            newDataSourceMap.remove(CUSTOM_POOL_PROPS_KEY);
+        }
         result.getProps().putAll(newDataSourceMap);
         return result;
     }
@@ -67,6 +73,9 @@ public final class YamlDataSourceConfigurationSwapper {
      */
     public Map<String, Object> swapToMap(final DataSourceConfiguration dataSourceConfig) {
         Map<String, Object> result = new HashMap<>(dataSourceConfig.getProps());
+        if (dataSourceConfig.hasCustomPoolProps()) {
+            result.put(CUSTOM_POOL_PROPS_KEY, dataSourceConfig.getCustomPoolProps());
+        }
         result.put(DATA_SOURCE_CLASS_NAME_KEY, dataSourceConfig.getDataSourceClassName());
         return result;
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
@@ -36,8 +36,6 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DataSourceParameterConverter {
     
-    private static final String CUSTOM_POOL_PROPS_KEY = "customPoolProps";
-    
     /**
      * Get data source parameter map.
      *
@@ -65,7 +63,8 @@ public final class DataSourceParameterConverter {
         DataSourceParameter result = new DataSourceParameter();
         for (Field each : result.getClass().getDeclaredFields()) {
             try {
-                Object dataSourceConfigProp = !CUSTOM_POOL_PROPS_KEY.equals(each.getName()) ? dataSourceConfig.getProps().get(each.getName()) : dataSourceConfig.getCustomPoolProps();
+                Object dataSourceConfigProp =
+                        DataSourceConfiguration.CUSTOM_POOL_PROPS_KEY.equals(each.getName()) ? dataSourceConfig.getCustomPoolProps() : dataSourceConfig.getProps().get(each.getName());
                 if (null == dataSourceConfigProp) {
                     continue;
                 }

--- a/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-common/src/main/java/org/apache/shardingsphere/proxy/config/util/DataSourceParameterConverter.java
@@ -72,7 +72,7 @@ public final class DataSourceParameterConverter {
                     continue;
                 }
                 each.setAccessible(true);
-                if (each.getName().equals(KEY_CUSTOM_POOL_PROPS)) {
+                if (KEY_CUSTOM_POOL_PROPS.equals(each.getName())) {
                     dataSourceConfigProp = PropertiesConverter.convertToProperties((Map) dataSourceConfigProp);
                 }
                 setDataSourceParameterField(each, result, dataSourceConfigProp);


### PR DESCRIPTION
Fixes #11643.

Changes proposed in this pull request:
- Fixed custom pool properties are lost when restarted in governance mode 
