### PR TITLE
fix letter case problems as follows: table names in sql executed are …

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -171,7 +171,7 @@ public final class ShardingRule implements FeatureRule, SchemaRule, DataNodeCont
     @Override
     public Collection<String> getAllTables() {
         Collection<String> result = new HashSet<>(getTables());
-        result.addAll(getAllActualTables());
+        result.addAll(getAllActualTables().stream().map(String::toLowerCase).collect(Collectors.toList()));
         result.addAll(broadcastTables);
         return result;
     }
@@ -316,7 +316,7 @@ public final class ShardingRule implements FeatureRule, SchemaRule, DataNodeCont
         if (singleTableRuleExists(logicTableNames)) {
             return false;
         }
-        Collection<String> tableNames = new HashSet<>(logicTableNames);
+        Collection<String> tableNames = logicTableNames.stream().map(String::toLowerCase).collect(Collectors.toSet());
         Collection<String> dataSourceNames = new HashSet<>();
         dataSourceNames.addAll(tableRules.stream().filter(each -> tableNames.contains(each.getLogicTable())).flatMap(each 
             -> each.getActualDataNodes().stream()).map(DataNode::getDataSourceName).collect(Collectors.toSet()));
@@ -440,7 +440,7 @@ public final class ShardingRule implements FeatureRule, SchemaRule, DataNodeCont
      * @return sharding broadcast table names
      */
     public Collection<String> getShardingBroadcastTableNames(final Collection<String> logicTableNames) {
-        return logicTableNames.stream().filter(each -> findTableRule(each).isPresent() || broadcastTables.contains(each)).collect(Collectors.toCollection(LinkedList::new));
+        return logicTableNames.stream().filter(each -> findTableRule(each).isPresent() || broadcastTables.contains(each.toLowerCase())).collect(Collectors.toCollection(LinkedList::new));
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/single/SingleTableDataNodeLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/single/SingleTableDataNodeLoader.java
@@ -66,7 +66,7 @@ public final class SingleTableDataNodeLoader {
         }
         Map<String, SingleTableDataNode> result = new HashMap<>(tables.size(), 1);
         for (String each : tables) {
-            if (!excludedTables.contains(each)) {
+            if (!excludedTables.contains(each.toLowerCase())) {
                 result.put(each, new SingleTableDataNode(each, dataSourceName));
             }
         }


### PR DESCRIPTION

fix letter case problems as follows: table names in sql executed are upper case, and in database schema are lower case. in such case, the judgement like Collection#contains will goes wrong as the letter case is not consistent with parameter and value in collection.

the debugger info as follows:
table names in parameter `logicTableNames` are upper case which consistent with letter case in sql executed, but table names in `broadcastTables` are converted to lower case:
![ShardingRule-getShardingBroadcastTableNames](https://user-images.githubusercontent.com/20662392/128285786-bc6cc597-d481-48b0-b68f-398b007855c9.png)
![ShardingRule-getShardingBroadcastTableNames-2](https://user-images.githubusercontent.com/20662392/128286006-6465e470-d18b-4c8d-9bb0-a5c3634aa24a.png)

![ShardingRule-isAllTablesInSameDataSource](https://user-images.githubusercontent.com/20662392/128286019-fbe5e275-d287-48b5-b1bd-de65ddae6b68.png)

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
- 
-
-
