### PR TITLE
jdbc-governance add schema name api

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactory.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/GovernanceShardingSphereDataSourceFactory.java
@@ -21,8 +21,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.driver.governance.internal.datasource.GovernanceShardingSphereDataSource;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.governance.repository.api.config.GovernanceConfiguration;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -58,6 +58,25 @@ public final class GovernanceShardingSphereDataSourceFactory {
     /**
      * Create ShardingSphere data source.
      *
+     * @param dataSourceMap data source map
+     * @param ruleConfigurations rule configurations
+     * @param governanceConfig governance configuration
+     * @param props properties for data source
+     * @param schemaName schema name configuration
+     * @return ShardingSphere data source
+     * @throws SQLException SQL exception
+     */
+    public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final Collection<RuleConfiguration> ruleConfigurations,
+                                              final Properties props, final GovernanceConfiguration governanceConfig, final String schemaName) throws SQLException {
+        if (null == ruleConfigurations || ruleConfigurations.isEmpty()) {
+            return createDataSource(governanceConfig, schemaName);
+        }
+        return new GovernanceShardingSphereDataSource(dataSourceMap, ruleConfigurations, props, governanceConfig, schemaName);
+    }
+    
+    /**
+     * Create ShardingSphere data source.
+     *
      * @param dataSource data source
      * @param ruleConfigurations rule configurations
      * @param governanceConfig governance configuration
@@ -69,7 +88,26 @@ public final class GovernanceShardingSphereDataSourceFactory {
                                               final Properties props, final GovernanceConfiguration governanceConfig) throws SQLException {
         Map<String, DataSource> dataSourceMap = new HashMap<>(1, 1);
         dataSourceMap.put(DefaultSchema.LOGIC_NAME, dataSource);
-        return createDataSource(dataSourceMap, ruleConfigurations, props, governanceConfig);
+        return createDataSource(dataSourceMap, ruleConfigurations, props, governanceConfig, DefaultSchema.LOGIC_NAME);
+    }
+    
+    /**
+     * Create ShardingSphere data source.
+     *
+     * @param dataSource data source
+     * @param ruleConfigurations rule configurations
+     * @param governanceConfig governance configuration
+     * @param props properties for data source
+     * @param schemaName schema name configuration
+     * @return ShardingSphere data source
+     * @throws SQLException SQL exception
+     */
+    public static DataSource createDataSource(final DataSource dataSource, final Collection<RuleConfiguration> ruleConfigurations,
+                                              final Properties props, final GovernanceConfiguration governanceConfig,
+                                              final String schemaName) throws SQLException {
+        Map<String, DataSource> dataSourceMap = new HashMap<>(1, 1);
+        dataSourceMap.put(schemaName, dataSource);
+        return createDataSource(dataSourceMap, ruleConfigurations, props, governanceConfig, schemaName);
     }
     
     /**
@@ -81,5 +119,17 @@ public final class GovernanceShardingSphereDataSourceFactory {
      */
     public static DataSource createDataSource(final GovernanceConfiguration governanceConfig) throws SQLException {
         return new GovernanceShardingSphereDataSource(governanceConfig);
+    }
+    
+    /**
+     * Create ShardingSphere data source.
+     *
+     * @param governanceConfig governance configuration
+     * @param schemaName schema name configuration
+     * @return ShardingSphere data source
+     * @throws SQLException SQL exception
+     */
+    public static DataSource createDataSource(final GovernanceConfiguration governanceConfig, final String schemaName) throws SQLException {
+        return new GovernanceShardingSphereDataSource(governanceConfig, schemaName);
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/yaml/YamlGovernanceShardingSphereDataSourceFactory.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/api/yaml/YamlGovernanceShardingSphereDataSourceFactory.java
@@ -53,7 +53,7 @@ public final class YamlGovernanceShardingSphereDataSourceFactory {
     public static DataSource createDataSource(final File yamlFile) throws SQLException, IOException {
         YamlGovernanceRootRuleConfigurations configurations = unmarshal(yamlFile);
         return createDataSource(new YamlDataSourceConfigurationSwapper().swapToDataSources(configurations.getDataSources()),
-                configurations, configurations.getProps(), configurations.getGovernance());
+                configurations, configurations.getProps(), configurations.getGovernance(), configurations.getSchemaName());
     }
     
     /**
@@ -67,7 +67,7 @@ public final class YamlGovernanceShardingSphereDataSourceFactory {
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final File yamlFile) throws SQLException, IOException {
         YamlGovernanceRootRuleConfigurations configurations = unmarshal(yamlFile);
-        return createDataSource(dataSourceMap, configurations, configurations.getProps(), configurations.getGovernance());
+        return createDataSource(dataSourceMap, configurations, configurations.getProps(), configurations.getGovernance(), configurations.getSchemaName());
     }
     
     /**
@@ -81,7 +81,7 @@ public final class YamlGovernanceShardingSphereDataSourceFactory {
     public static DataSource createDataSource(final byte[] yamlBytes) throws SQLException, IOException {
         YamlGovernanceRootRuleConfigurations configurations = unmarshal(yamlBytes);
         return createDataSource(new YamlDataSourceConfigurationSwapper().swapToDataSources(configurations.getDataSources()),
-                configurations, configurations.getProps(), configurations.getGovernance());
+                configurations, configurations.getProps(), configurations.getGovernance(), configurations.getSchemaName());
     }
     
     /**
@@ -95,27 +95,29 @@ public final class YamlGovernanceShardingSphereDataSourceFactory {
      */
     public static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final byte[] yamlBytes) throws SQLException, IOException {
         YamlGovernanceRootRuleConfigurations configurations = unmarshal(yamlBytes);
-        return createDataSource(dataSourceMap, configurations, configurations.getProps(), configurations.getGovernance());
+        return createDataSource(dataSourceMap, configurations, configurations.getProps(), configurations.getGovernance(), configurations.getSchemaName());
     }
     
     private static DataSource createDataSource(final Map<String, DataSource> dataSourceMap, final YamlGovernanceRootRuleConfigurations configurations,
-                                               final Properties props, final YamlGovernanceConfiguration governance) throws SQLException {
+                                               final Properties props, final YamlGovernanceConfiguration governance,
+                                               final String schemaName) throws SQLException {
         if (configurations.getRules().isEmpty() || dataSourceMap.isEmpty()) {
-            return createDataSourceWithoutRules(governance);
+            return createDataSourceWithoutRules(governance, schemaName);
         } else {
             return createDataSourceWithRules(dataSourceMap, new YamlRuleConfigurationSwapperEngine().swapToRuleConfigurations(configurations.getRules()),
-                    props, governance);
+                    props, governance, schemaName);
         }
     }
     
-    private static DataSource createDataSourceWithoutRules(final YamlGovernanceConfiguration governance) throws SQLException {
-        return new GovernanceShardingSphereDataSource(YamlGovernanceConfigurationSwapperUtil.marshal(governance));
+    private static DataSource createDataSourceWithoutRules(final YamlGovernanceConfiguration governance, final String schemaName) throws SQLException {
+        return new GovernanceShardingSphereDataSource(YamlGovernanceConfigurationSwapperUtil.marshal(governance), schemaName);
     }
     
     private static DataSource createDataSourceWithRules(final Map<String, DataSource> dataSourceMap, final Collection<RuleConfiguration> ruleConfigurations,
-                                                        final Properties props, final YamlGovernanceConfiguration governance) throws SQLException {
+                                                        final Properties props, final YamlGovernanceConfiguration governance,
+                                                        final String schemaName) throws SQLException {
         return new GovernanceShardingSphereDataSource(dataSourceMap, ruleConfigurations, props, 
-                YamlGovernanceConfigurationSwapperUtil.marshal(governance));
+                YamlGovernanceConfigurationSwapperUtil.marshal(governance), schemaName);
     }
     
     private static YamlGovernanceRootRuleConfigurations unmarshal(final File yamlFile) throws IOException {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/integrate/sharding/configWithDataSourceWithProps.yaml
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/resources/yaml/integrate/sharding/configWithDataSourceWithProps.yaml
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+schemaName: logic_db
+
 dataSources:
   db0:
     dataSourceClassName: org.apache.commons.dbcp2.BasicDataSource

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/governance/ShardingSphereGovernanceAutoConfiguration.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/governance/ShardingSphereGovernanceAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.governance.repository.api.config.GovernanceConf
 import org.apache.shardingsphere.spring.boot.datasource.DataSourceMapSetter;
 import org.apache.shardingsphere.spring.boot.governance.common.GovernanceSpringBootRootConfiguration;
 import org.apache.shardingsphere.spring.boot.governance.rule.LocalRulesCondition;
+import org.apache.shardingsphere.spring.boot.schema.SchemaNameSetter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -65,6 +66,8 @@ public class ShardingSphereGovernanceAutoConfiguration implements EnvironmentAwa
     private final GovernanceSpringBootRootConfiguration root;
     
     private final RegistryCenterConfigurationYamlSwapper swapper = new RegistryCenterConfigurationYamlSwapper();
+    
+    private String schemaName;
     
     /**
      * Get governance configuration.
@@ -109,13 +112,14 @@ public class ShardingSphereGovernanceAutoConfiguration implements EnvironmentAwa
     @Override
     public final void setEnvironment(final Environment environment) {
         dataSourceMap.putAll(DataSourceMapSetter.getDataSourceMap(environment));
+        schemaName = SchemaNameSetter.getSchemaName(environment);
     }
     
     private DataSource createDataSourceWithRules(final List<RuleConfiguration> ruleConfigs, final GovernanceConfiguration governanceConfig) throws SQLException {
-        return new GovernanceShardingSphereDataSource(dataSourceMap, ruleConfigs, root.getProps(), governanceConfig);
+        return new GovernanceShardingSphereDataSource(dataSourceMap, ruleConfigs, root.getProps(), governanceConfig, schemaName);
     }
     
     private DataSource createDataSourceWithoutRules(final GovernanceConfiguration governanceConfig) throws SQLException {
-        return new GovernanceShardingSphereDataSource(governanceConfig);
+        return new GovernanceShardingSphereDataSource(governanceConfig, schemaName);
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/java/org/apache/shardingsphere/spring/namespace/governance/constants/SchemaNameBeanDefinitionTag.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/java/org/apache/shardingsphere/spring/namespace/governance/constants/SchemaNameBeanDefinitionTag.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.namespace.governance.constants;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Schema name bean definition tag.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SchemaNameBeanDefinitionTag {
+    
+    public static final String ROOT_TAG = "schema-name";
+}

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/java/org/apache/shardingsphere/spring/namespace/governance/parser/DataSourceBeanDefinitionParser.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/java/org/apache/shardingsphere/spring/namespace/governance/parser/DataSourceBeanDefinitionParser.java
@@ -21,7 +21,9 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import org.apache.shardingsphere.driver.governance.internal.datasource.GovernanceShardingSphereDataSource;
 import org.apache.shardingsphere.governance.repository.api.config.GovernanceConfiguration;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.spring.namespace.governance.constants.DataSourceBeanDefinitionTag;
+import org.apache.shardingsphere.spring.namespace.governance.constants.SchemaNameBeanDefinitionTag;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
@@ -30,6 +32,7 @@ import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.xml.AbstractBeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
 import org.w3c.dom.Element;
 
@@ -56,9 +59,10 @@ public final class DataSourceBeanDefinitionParser extends AbstractBeanDefinition
             factory.addConstructorArgValue(parseDataSources(element));
             factory.addConstructorArgValue(parseRuleConfigurations(element));
             factory.addConstructorArgValue(parseProperties(element, parserContext));
-            factory.setDestroyMethodName("close");
         }
         factory.addConstructorArgValue(getGovernanceConfiguration(element));
+        factory.addConstructorArgValue(parseSchemaName(element));
+        factory.setDestroyMethodName("close");
     }
     
     private Map<String, RuntimeBeanReference> parseDataSources(final Element element) {
@@ -89,5 +93,10 @@ public final class DataSourceBeanDefinitionParser extends AbstractBeanDefinition
         factory.addConstructorArgReference(element.getAttribute(DataSourceBeanDefinitionTag.REG_CENTER_REF_ATTRIBUTE));
         factory.addConstructorArgValue(element.getAttribute(DataSourceBeanDefinitionTag.OVERWRITE_ATTRIBUTE));
         return factory.getBeanDefinition();
+    }
+    
+    private String parseSchemaName(final Element element) {
+        String schemaName = element.getAttribute(SchemaNameBeanDefinitionTag.ROOT_TAG);
+        return StringUtils.isEmpty(schemaName) ? DefaultSchema.LOGIC_NAME : schemaName;
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/resources/META-INF/namespace/governance.xsd
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-governance-spring/shardingsphere-jdbc-governance-spring-namespace/src/main/resources/META-INF/namespace/governance.xsd
@@ -34,6 +34,7 @@
             <xsd:attribute name="rule-refs" type="xsd:string" />
             <xsd:attribute name="config-center-ref" type="xsd:string" />
             <xsd:attribute name="overwrite" type="xsd:string" default="false" />
+            <xsd:attribute name="schema-name" type="xsd:string" />
         </xsd:complexType>
     </xsd:element>
     


### PR DESCRIPTION
For #11621 .

jdbc-governance add schema name api. include: properties、yml、xml
