### PR TITLE
correct wrong result when metadata refresh with encrypt in multi dataSources

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilder.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilder.java
@@ -44,9 +44,9 @@ public final class EncryptTableMetaDataBuilder implements RuleBasedTableMetaData
     @Override
     public Optional<TableMetaData> load(final String tableName, final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final DataNodes dataNodes,
                                         final EncryptRule encryptRule, final ConfigurationProperties props) throws SQLException {
-        DataNode dataNode = dataNodes.getDataNodes(tableName).iterator().next();
+        String dataSourceName = dataNodes.getDataNodes(tableName).stream().map(DataNode::getDataSourceName).findFirst().orElseGet(() -> dataSourceMap.keySet().iterator().next());
         return encryptRule.findEncryptTable(tableName).isPresent() 
-                ? TableMetaDataLoader.load(dataSourceMap.get(dataNode.getDataSourceName()), dataNode.getTableName(), databaseType) : Optional.empty();
+                ? TableMetaDataLoader.load(dataSourceMap.get(dataSourceName), tableName, databaseType) : Optional.empty();
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilder.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilder.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.datanode.DataNodes;
 import org.apache.shardingsphere.infra.metadata.schema.builder.loader.TableMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.schema.builder.spi.RuleBasedTableMetaDataBuilder;
@@ -43,7 +44,9 @@ public final class EncryptTableMetaDataBuilder implements RuleBasedTableMetaData
     @Override
     public Optional<TableMetaData> load(final String tableName, final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final DataNodes dataNodes,
                                         final EncryptRule encryptRule, final ConfigurationProperties props) throws SQLException {
-        return encryptRule.findEncryptTable(tableName).isPresent() ? TableMetaDataLoader.load(dataSourceMap.values().iterator().next(), tableName, databaseType) : Optional.empty();
+        DataNode dataNode = dataNodes.getDataNodes(tableName).iterator().next();
+        return encryptRule.findEncryptTable(tableName).isPresent() 
+                ? TableMetaDataLoader.load(dataSourceMap.get(dataNode.getDataSourceName()), dataNode.getTableName(), databaseType) : Optional.empty();
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/MetadataRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/MetadataRefresher.java
@@ -17,9 +17,26 @@
 
 package org.apache.shardingsphere.infra.metadata;
 
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 /**
  * Metadata refresher.
  *
  */
 public interface MetadataRefresher {
+    
+    /**
+     * Find ShardingSphereRule collection by class.
+     *
+     * @param rules ShardingSphereRule collection
+     * @param clazz target class
+     * @param <R> type of target class
+     * @return ShardingSphereRule collection of target class
+     */
+    default <R extends ShardingSphereRule> Collection<R> findShardingSphereRulesByClass(final Collection<ShardingSphereRule> rules, final Class<R> clazz) {
+        return rules.stream().filter(each -> clazz.isAssignableFrom(each.getClass())).map(clazz::cast).collect(Collectors.toList());
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -23,10 +23,9 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.TableMetaDataBuil
 import org.apache.shardingsphere.infra.metadata.schema.builder.loader.TableMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.refresher.SchemaRefresher;
-import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.infra.rule.single.SingleTableRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
+import org.apache.shardingsphere.infra.rule.single.SingleTableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
 
 import java.sql.SQLException;
@@ -41,6 +40,9 @@ public final class CreateTableStatementSchemaRefresher implements SchemaRefreshe
     public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, 
                         final CreateTableStatement sqlStatement, final SchemaBuilderMaterials materials) throws SQLException {
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
+        if (!containsInDataNodeContainedRule(tableName, materials)) {
+            findShardingSphereRulesByClass(materials.getRules(), SingleTableRule.class).forEach(each -> each.addSingleTableDataNode(tableName, logicDataSourceNames.iterator().next()));
+        }
         TableMetaData tableMetaData;
         if (containsInTableContainedRule(tableName, materials)) {
             tableMetaData = TableMetaDataBuilder.build(tableName, materials).orElseGet(TableMetaData::new);
@@ -48,22 +50,13 @@ public final class CreateTableStatementSchemaRefresher implements SchemaRefreshe
             tableMetaData = TableMetaDataLoader.load(tableName, logicDataSourceNames, materials).orElseGet(TableMetaData::new);
         }
         schema.put(tableName, tableMetaData);
-        if (isSingleTable(tableName, materials)) {
-            materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each 
-                -> (SingleTableRule) each).findFirst().ifPresent(rule -> rule.addSingleTableDataNode(tableName, logicDataSourceNames.iterator().next()));
-        }
     }
     
-    private boolean isSingleTable(final String tableName, final SchemaBuilderMaterials materials) {
-        return materials.getRules().stream().noneMatch(each -> each instanceof DataNodeContainedRule && ((DataNodeContainedRule) each).getAllTables().contains(tableName));
+    private boolean containsInDataNodeContainedRule(final String tableName, final SchemaBuilderMaterials materials) {
+        return findShardingSphereRulesByClass(materials.getRules(), DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     private boolean containsInTableContainedRule(final String tableName, final SchemaBuilderMaterials materials) {
-        for (ShardingSphereRule each : materials.getRules()) {
-            if (each instanceof TableContainedRule && ((TableContainedRule) each).getTables().contains(tableName)) {
-                return true;
-            }
-        }
-        return false;
+        return findShardingSphereRulesByClass(materials.getRules(), TableContainedRule.class).stream().anyMatch(each -> each.getTables().contains(tableName));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -37,13 +37,12 @@ public final class CreateViewStatementSchemaRefresher implements SchemaRefresher
         String viewName = sqlStatement.getView().getTableName().getIdentifier().getValue();
         TableMetaData tableMetaData = new TableMetaData();
         schema.put(viewName, tableMetaData);
-        if (isSingleTable(viewName, materials)) {
-            materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each 
-                -> (SingleTableRule) each).findFirst().ifPresent(rule -> rule.addSingleTableDataNode(viewName, logicDataSourceNames.iterator().next()));
+        if (!containsInDataNodeContainedRule(viewName, materials)) {
+            findShardingSphereRulesByClass(materials.getRules(), SingleTableRule.class).forEach(each -> each.addSingleTableDataNode(viewName, logicDataSourceNames.iterator().next()));
         }
     }
     
-    private boolean isSingleTable(final String tableName, final SchemaBuilderMaterials materials) {
-        return materials.getRules().stream().noneMatch(each -> each instanceof DataNodeContainedRule && ((DataNodeContainedRule) each).getAllTables().contains(tableName));
+    private boolean containsInDataNodeContainedRule(final String tableName, final SchemaBuilderMaterials materials) {
+        return findShardingSphereRulesByClass(materials.getRules(), DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Sim
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropTableStatement;
 
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * ShardingSphere schema refresher for drop table statement.
@@ -35,9 +34,9 @@ public final class DropTableStatementSchemaRefresher implements SchemaRefresher<
     @Override
     public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final DropTableStatement sqlStatement, final SchemaBuilderMaterials materials) {
         sqlStatement.getTables().forEach(each -> schema.remove(each.getTableName().getIdentifier().getValue()));
-        Optional<SingleTableRule> singleTableRule = materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
+        Collection<SingleTableRule> rules = findShardingSphereRulesByClass(materials.getRules(), SingleTableRule.class);
         for (SimpleTableSegment each : sqlStatement.getTables()) {
-            singleTableRule.ifPresent(rule -> rule.dropSingleTableDataNode(each.getTableName().getIdentifier().getValue()));
+            rules.forEach(rule -> rule.dropSingleTableDataNode(each.getTableName().getIdentifier().getValue()));
         }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Sim
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropViewStatement;
 
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * ShardingSphere schema refresher for drop view statement.
@@ -35,9 +34,9 @@ public final class DropViewStatementSchemaRefresher implements SchemaRefresher<D
     @Override
     public void refresh(final ShardingSphereSchema schema, final Collection<String> logicDataSourceNames, final DropViewStatement sqlStatement, final SchemaBuilderMaterials materials) {
         sqlStatement.getViews().forEach(each -> schema.remove(each.getTableName().getIdentifier().getValue()));
-        Optional<SingleTableRule> singleTableRule = materials.getRules().stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
+        Collection<SingleTableRule> rules = findShardingSphereRulesByClass(materials.getRules(), SingleTableRule.class);
         for (SimpleTableSegment each : sqlStatement.getViews()) {
-            singleTableRule.ifPresent(rule -> rule.dropSingleTableDataNode(each.getTableName().getIdentifier().getValue()));
+            rules.forEach(rule -> rule.dropSingleTableDataNode(each.getTableName().getIdentifier().getValue()));
         }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/level/KernelRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/level/KernelRule.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.infra.rule.identifier.level;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
 /**
- * Kernel rule which for level-1 of pluggable platform..
+ * Kernel rule which for level-1 of pluggable platform.
  */
 public interface KernelRule extends ShardingSphereRule {
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/single/SingleTableRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/single/SingleTableRule.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.rule.single;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.level.KernelRule;
 import org.apache.shardingsphere.infra.rule.identifier.scope.SchemaRule;
@@ -27,11 +28,14 @@ import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedR
 
 import javax.sql.DataSource;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,7 +43,7 @@ import java.util.stream.Collectors;
  * Single table rule.
  */
 @Getter
-public final class SingleTableRule implements KernelRule, SchemaRule {
+public final class SingleTableRule implements KernelRule, SchemaRule, DataNodeContainedRule {
     
     private final Collection<String> dataSourceNames;
     
@@ -120,5 +124,42 @@ public final class SingleTableRule implements KernelRule, SchemaRule {
     
     private Collection<String> getExcludedTables(final Collection<ShardingSphereRule> rules) {
         return rules.stream().filter(each -> each instanceof DataNodeContainedRule).flatMap(each -> ((DataNodeContainedRule) each).getAllTables().stream()).collect(Collectors.toList());
+    }
+    
+    @Override
+    public Map<String, Collection<DataNode>> getAllDataNodes() {
+        Map<String, Collection<DataNode>> result = new LinkedHashMap<>();
+        singleTableDataNodes.forEach((key, value) -> result.put(key, Collections.singleton(new DataNode(value.getDataSourceName(), value.getTableName()))));
+        return result;
+    }
+    
+    @Override
+    public Collection<String> getAllActualTables() {
+        return Collections.emptyList();
+    }
+    
+    @Override
+    public Optional<String> findFirstActualTable(final String logicTable) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public boolean isNeedAccumulate(final Collection<String> tables) {
+        return false;
+    }
+    
+    @Override
+    public Optional<String> findLogicTableByActualTable(final String actualTable) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<String> findActualTableByCatalog(final String catalog, final String logicTable) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Collection<String> getAllTables() {
+        return singleTableDataNodes.keySet();
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/AlterTableStatementFederateRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/AlterTableStatementFederateRefresher.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.loader.TableMetaD
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.optimize.core.metadata.FederateSchemaMetadata;
 import org.apache.shardingsphere.infra.optimize.core.metadata.refresher.FederateRefresher;
-import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterTableStatement;
 
@@ -60,11 +59,6 @@ public final class AlterTableStatementFederateRefresher implements FederateRefre
     }
 
     private boolean containsInTableContainedRule(final String tableName, final SchemaBuilderMaterials materials) {
-        for (ShardingSphereRule each : materials.getRules()) {
-            if (each instanceof TableContainedRule && ((TableContainedRule) each).getTables().contains(tableName)) {
-                return true;
-            }
-        }
-        return false;
+        return findShardingSphereRulesByClass(materials.getRules(), TableContainedRule.class).stream().anyMatch(each -> each.getTables().contains(tableName));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/CreateTableStatementFederateRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/core/metadata/refresher/type/CreateTableStatementFederateRefresher.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.loader.TableMetaD
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.optimize.core.metadata.FederateSchemaMetadata;
 import org.apache.shardingsphere.infra.optimize.core.metadata.refresher.FederateRefresher;
-import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
 
@@ -49,11 +48,6 @@ public final class CreateTableStatementFederateRefresher implements FederateRefr
     }
     
     private boolean containsInTableContainedRule(final String tableName, final SchemaBuilderMaterials materials) {
-        for (ShardingSphereRule each : materials.getRules()) {
-            if (each instanceof TableContainedRule && ((TableContainedRule) each).getTables().contains(tableName)) {
-                return true;
-            }
-        }
-        return false;
+        return findShardingSphereRulesByClass(materials.getRules(), TableContainedRule.class).stream().anyMatch(each -> each.getTables().contains(tableName));
     }
 }


### PR DESCRIPTION
Ref #10996.

Changes proposed in this pull request:
- add DataNodeContainedRule interface for SingleTableRule
- optimize duplicate code in schema refresher and federate refresher
- optimize logic of EncryptTableMetaDataBuilder load method
