### PR TITLE
Add Oracle SQL - FLASHBACK TABLE

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -824,6 +824,10 @@ scnValue
     : literals
     ;
 
+timestampValue
+    : LP_? expr+ RP_?
+    ;
+
 scnTimestampExpr
-    : scnValue | LP_? expr+ RP_?
+    : scnValue | timestampValue
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -96,7 +96,7 @@ unreservedWord
     | BECOME | CHANGE | NOTIFICATION | PRIVILEGE | PURGE | RESUMABLE
     | SYSGUID | SYSBACKUP | SYSDBA | SYSDG | SYSKM | SYSOPER | DBA_RECYCLEBIN |SCHEMA
     | DO | DEFINER | CURRENT_USER | CASCADED | CLOSE | OPEN | NEXT | NAME | NAMES
-    | COLLATION | REAL | TYPE | FIRST | RANK | SAMPLE
+    | COLLATION | REAL | TYPE | FIRST | RANK | SAMPLE | SYSTIMESTAMP | INTERVAL | MINUTE
     ;
 
 schemaName
@@ -825,5 +825,5 @@ scnValue
     ;
 
 scnTimestampExpr
-    : scnValue | identifier
+    : scnValue | LP_? expr+ RP_?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1903,3 +1903,13 @@ scnTimestampClause
 restorePointClause
     : RESTORE POINT restorePoint
     ;
+
+flashbackTable
+    : FLASHBACK TABLE tableName TO (
+    (scnTimestampClause | restorePointClause) ((ENABLE | DISABLE) TRIGGERS)?
+    | BEFORE DROP renameToTable? )
+    ;
+
+renameToTable
+    : RENAME TO tableName
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
@@ -47,6 +47,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropCo
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropIndexContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.DropTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.FlashbackDatabaseContext;
+import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.FlashbackTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.IndexNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.InlineConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.ModifyColPropertiesContext;
@@ -91,6 +92,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.Ora
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDropIndexStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleDropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleFlashbackDatabaseStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleFlashbackTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleNoAuditStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleTruncateStatement;
 
@@ -467,5 +469,16 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
     @Override
     public ASTNode visitFlashbackDatabase(final FlashbackDatabaseContext ctx) {
         return new OracleFlashbackDatabaseStatement();
+    }
+
+    @Override
+    public ASTNode visitFlashbackTable(final FlashbackTableContext ctx) {
+        OracleFlashbackTableStatement result = new OracleFlashbackTableStatement();
+        result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+
+        if (null != ctx.renameToTable()) {
+            result.setRenameTable((SimpleTableSegment) visit(ctx.renameToTable().tableName()));
+        }
+        return result;
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -141,6 +141,8 @@ public enum SQLVisitorRule {
     COMMENT("Comment", SQLStatementType.DDL),
 
     FLASHBACK_DATABASE("FlashbackDatabase", SQLStatementType.DDL),
+
+    FLASHBACK_TABLE("FlashbackTable", SQLStatementType.DDL),
     
     SET_CONSTRAINTS("SetConstraints", SQLStatementType.TCL),
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/ddl/OracleFlashbackTableStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/oracle/ddl/OracleFlashbackTableStatement.java
@@ -15,49 +15,25 @@
  * limitations under the License.
  */
 
-grammar OracleStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, StoreProcedure;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.OracleStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createTable
-    | alterTable
-    | dropTable
-    | truncateTable
-    | createIndex
-    | dropIndex
-    | alterIndex
-    | commit
-    | rollback
-    | setTransaction
-    | savepoint
-    | grant
-    | revoke
-    | createUser
-    | dropUser
-    | alterUser
-    | createRole
-    | dropRole
-    | alterRole
-    | setRole
-    | call
-    | merge
-    | alterSynonym
-    | alterSession
-    | alterDatabase
-    | alterSystem
-    | setConstraints
-    | analyze
-    | associateStatistics
-    | disassociateStatistics
-    | audit
-    | noAudit
-    | comment
-    | flashbackDatabase
-    | flashbackTable
-    ) SEMI_?
-    ;
+/**
+ * Oracle flashback table statement.
+ */
+@Getter
+@Setter
+@ToString
+public class OracleFlashbackTableStatement extends AbstractSQLStatement implements DDLStatement, OracleStatement {
+    
+    private SimpleTableSegment table;
+
+    private SimpleTableSegment renameTable;
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/FlashbackTableStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/FlashbackTableStatementAssert.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.ddl.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleFlashbackTableStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.FlashbackTableStatementTestCase;
+
+/**
+ * Flashback table statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class FlashbackTableStatementAssert {
+    
+    /**
+     * Assert flashback table statement is correct with expected parser result.
+     * 
+     * @param assertContext assert context
+     * @param actual actual flashback table statement
+     * @param expected expected flashback table statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final OracleFlashbackTableStatement actual, final FlashbackTableStatementTestCase expected) {
+        assertTable(assertContext, actual, expected);
+        assertRenameTable(assertContext, actual, expected);
+    }
+    
+    private static void assertTable(final SQLCaseAssertContext assertContext, final OracleFlashbackTableStatement actual, final FlashbackTableStatementTestCase expected) {
+        TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
+    }
+
+    private static void assertRenameTable(final SQLCaseAssertContext assertContext, final OracleFlashbackTableStatement actual, final FlashbackTableStatementTestCase expected) {
+        if (null != expected.getRenameTable()) {
+            TableAssert.assertIs(assertContext, actual.getRenameTable(), expected.getRenameTable());
+        }
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -81,6 +81,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTriggerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropViewStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.FlashbackDatabaseStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.FlashbackTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.NoAuditStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.TruncateStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingJobListStatementTestCase;
@@ -365,12 +366,15 @@ public final class SQLParserTestCases {
 
     @XmlElement(name = "no-audit")
     private final List<NoAuditStatementTestCase> noAuditTestCase = new LinkedList<>();
-
+    
     @XmlElement(name = "comment")
     private final List<CommentStatementTestCase> commentTestCase = new LinkedList<>();
-
+    
     @XmlElement(name = "flashback-database")
     private final List<FlashbackDatabaseStatementTestCase> flashbackDatabaseTestCase = new LinkedList<>();
+    
+    @XmlElement(name = "flashback-table")
+    private final List<FlashbackTableStatementTestCase> flashbackTableTestCase = new LinkedList<>();
     
     @XmlElement(name = "add-resource")
     private final List<AddResourceStatementTestCase> addResourceTestCase = new LinkedList<>();
@@ -540,6 +544,7 @@ public final class SQLParserTestCases {
         putAll(noAuditTestCase, result);
         putAll(commentTestCase, result);
         putAll(flashbackDatabaseTestCase, result);
+        putAll(flashbackTableTestCase, result);
         putAll(addResourceTestCase, result);
         putAll(alterDataBaseDiscoveryRuleTestCase, result);
         putAll(alterEncryptRuleTestCase, result);

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/FlashbackTableStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/FlashbackTableStatementTestCase.java
@@ -15,49 +15,25 @@
  * limitations under the License.
  */
 
-grammar OracleStatement;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, StoreProcedure;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createTable
-    | alterTable
-    | dropTable
-    | truncateTable
-    | createIndex
-    | dropIndex
-    | alterIndex
-    | commit
-    | rollback
-    | setTransaction
-    | savepoint
-    | grant
-    | revoke
-    | createUser
-    | dropUser
-    | alterUser
-    | createRole
-    | dropRole
-    | alterRole
-    | setRole
-    | call
-    | merge
-    | alterSynonym
-    | alterSession
-    | alterDatabase
-    | alterSystem
-    | setConstraints
-    | analyze
-    | associateStatistics
-    | disassociateStatistics
-    | audit
-    | noAudit
-    | comment
-    | flashbackDatabase
-    | flashbackTable
-    ) SEMI_?
-    ;
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Flashback table statement test case.
+ */
+@Getter
+@Setter
+public final class FlashbackTableStatementTestCase extends SQLParserTestCase {
+
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable table;
+    
+    @XmlElement(name = "rename-table")
+    private ExpectedSimpleTable renameTable;
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/flashback-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/flashback-table.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <flashback-table sql-case-id="flashback_table_to_scn">
+        <table name="employees" start-index="16" stop-index="24" />
+    </flashback-table>
+
+    <flashback-table sql-case-id="flashback_table_to_timestamp">
+        <table name="employees_test" start-index="16" stop-index="29" />
+    </flashback-table>
+
+    <flashback-table sql-case-id="flashback_table_to_restore_point">
+        <table name="sample" start-index="16" stop-index="21" />
+    </flashback-table>
+
+    <flashback-table sql-case-id="flashback_table_to_before_drop">
+        <table name="print_media" start-index="16" stop-index="26" />
+    </flashback-table>
+
+    <flashback-table sql-case-id="flashback_table_to_before_drop_rename_to">
+        <table name="print_media" start-index="16" stop-index="26" />
+        <rename-table name="print_media_old" start-index="53" stop-index="67" />
+    </flashback-table>
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/flashback-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/flashback-table.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="flashback_table_to_scn" value="FLASHBACK TABLE employees TO SCN 1500 DISABLE TRIGGERS" db-types="Oracle" />
+    <sql-case id="flashback_table_to_timestamp" value="FLASHBACK TABLE employees_test TO TIMESTAMP (SYSTIMESTAMP - INTERVAL '1' minute)" db-types="Oracle" />
+    <sql-case id="flashback_table_to_restore_point" value="FLASHBACK TABLE sample TO RESTORE POINT good_data" db-types="Oracle" />
+    <sql-case id="flashback_table_to_before_drop" value="FLASHBACK TABLE print_media TO BEFORE DROP" db-types="Oracle" />
+    <sql-case id="flashback_table_to_before_drop_rename_to" value="FLASHBACK TABLE print_media TO BEFORE DROP RENAME TO print_media_old" db-types="Oracle" />
+</sql-cases>


### PR DESCRIPTION
Relates #10513

Changes proposed in this pull request:

- Proofread Oracle SQL - [FLASHBACK TABLE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/FLASHBACK-TABLE.html#GUID-FA9AF2FD-2DAD-4387-9E62-14AFC26EA85C)
- Add corresponding test cases

@wgy8283335