### PR TITLE
BeanClassName may be empty

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-namespace-infra/src/main/java/org/apache/shardingsphere/spring/namespace/registry/ShardingSphereAlgorithmBeanRegistry.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-namespace-infra/src/main/java/org/apache/shardingsphere/spring/namespace/registry/ShardingSphereAlgorithmBeanRegistry.java
@@ -45,7 +45,8 @@ public final class ShardingSphereAlgorithmBeanRegistry {
         String algorithmFactoryBeanClassName = algorithmFactoryBeanClass.getName();
         Map<String, RuntimeBeanReference> result = new ManagedMap<>(beanDefinitionNames.length);
         for (String each : beanDefinitionNames) {
-            if (parserContext.getRegistry().getBeanDefinition(each).getBeanClassName().equals(algorithmFactoryBeanClassName)) {
+            String beanClassName = parserContext.getRegistry().getBeanDefinition(each).getBeanClassName();
+            if (beanClassName != null && beanClassName.equals(algorithmFactoryBeanClassName)) {
                 result.put(each, new RuntimeBeanReference(each));
             }
         }


### PR DESCRIPTION
…ClassName may be empty in the case of factory bean reference, the beanclassname needs to be judged

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
