### PR TITLE
Jdbc-governance module remove getDefaultMetaData()

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-context/src/test/java/org/apache/shardingsphere/governance/context/metadata/GovernanceMetaDataContextsTest.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/test/java/org/apache/shardingsphere/governance/context/metadata/GovernanceMetaDataContextsTest.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.governance.core.schema.GovernanceSchema;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.persist.DistMetaDataPersistService;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
@@ -121,7 +122,7 @@ public final class GovernanceMetaDataContextsTest {
     
     @Test
     public void assertGetDefaultMetaData() {
-        assertNull(governanceMetaDataContexts.getDefaultMetaData());
+        assertNull(governanceMetaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/DriverState.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/DriverState.java
@@ -32,12 +32,14 @@ public interface DriverState {
     
     /**
      * Get connection.
-     * 
+     *
+     * @param schemaName schema name
      * @param dataSourceMap data source map
      * @param metaDataContexts meta data contexts
      * @param transactionContexts transaction contexts
      * @param transactionType transaction type
      * @return connection
      */
-    Connection getConnection(Map<String, DataSource> dataSourceMap, MetaDataContexts metaDataContexts, TransactionContexts transactionContexts, TransactionType transactionType);
+    Connection getConnection(String schemaName, Map<String, DataSource> dataSourceMap, MetaDataContexts metaDataContexts, TransactionContexts transactionContexts,
+                             TransactionType transactionType);
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/DriverStateContext.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/DriverStateContext.java
@@ -49,14 +49,16 @@ public final class DriverStateContext {
     /**
      * Get connection.
      *
+     * @param schemaName schema name
      * @param dataSourceMap data source map
      * @param metaDataContexts meta data contexts
      * @param transactionContexts transaction contexts
      * @param transactionType transaction type
      * @return connection
      */
-    public static Connection getConnection(final Map<String, DataSource> dataSourceMap,
-                                           final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final TransactionType transactionType) {
-        return STATES.get(metaDataContexts.getStateContext().getCurrentState()).getConnection(dataSourceMap, metaDataContexts, transactionContexts, transactionType);
+    public static Connection getConnection(final String schemaName, final Map<String, DataSource> dataSourceMap, final MetaDataContexts metaDataContexts,
+                                           final TransactionContexts transactionContexts, final TransactionType transactionType) {
+        return STATES.get(metaDataContexts.getStateContext().getCurrentState()).getConnection(schemaName, dataSourceMap, metaDataContexts,
+                transactionContexts, transactionType);
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/CircuitBreakDriverState.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/CircuitBreakDriverState.java
@@ -33,8 +33,8 @@ import java.util.Map;
 public final class CircuitBreakDriverState implements DriverState {
     
     @Override
-    public Connection getConnection(final Map<String, DataSource> dataSourceMap,
-                                    final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final TransactionType transactionType) {
+    public Connection getConnection(final String schemaName, final Map<String, DataSource> dataSourceMap, final MetaDataContexts metaDataContexts,
+                                    final TransactionContexts transactionContexts, final TransactionType transactionType) {
         return new CircuitBreakerDataSource().getConnection();
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/LockDriverState.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/LockDriverState.java
@@ -32,8 +32,8 @@ import java.util.Map;
 public final class LockDriverState implements DriverState {
     
     @Override
-    public Connection getConnection(final Map<String, DataSource> dataSourceMap,
-                                    final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final TransactionType transactionType) {
+    public Connection getConnection(final String schemaName, final Map<String, DataSource> dataSourceMap, final MetaDataContexts metaDataContexts,
+                                    final TransactionContexts transactionContexts, final TransactionType transactionType) {
         // TODO
         throw new UnsupportedOperationException("LockDriverState");
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/OKDriverState.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/main/java/org/apache/shardingsphere/driver/governance/internal/state/impl/OKDriverState.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.driver.governance.internal.state.impl;
 import org.apache.shardingsphere.driver.governance.internal.state.DriverState;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.transaction.context.TransactionContexts;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
@@ -35,9 +34,8 @@ import java.util.Map;
 public final class OKDriverState implements DriverState {
     
     @Override
-    public Connection getConnection(final Map<String, DataSource> dataSourceMap,
-                                    final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final TransactionType transactionType) {
-        //TODO get real schemaName
-        return new ShardingSphereConnection(DefaultSchema.LOGIC_NAME, dataSourceMap, metaDataContexts, transactionContexts, TransactionTypeHolder.get());
+    public Connection getConnection(final String schemaName, final Map<String, DataSource> dataSourceMap, final MetaDataContexts metaDataContexts,
+                                    final TransactionContexts transactionContexts, final TransactionType transactionType) {
+        return new ShardingSphereConnection(schemaName, dataSourceMap, metaDataContexts, transactionContexts, TransactionTypeHolder.get());
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/datasource/GovernanceShardingSphereDataSourceTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/datasource/GovernanceShardingSphereDataSourceTest.java
@@ -90,7 +90,7 @@ public final class GovernanceShardingSphereDataSourceTest {
     @Test
     public void assertRenewRules() throws SQLException {
         metaDataContexts.renew(new RuleConfigurationsChangedEvent(DefaultSchema.LOGIC_NAME, Arrays.asList(getShardingRuleConfiguration(), getReadwriteSplittingRuleConfiguration())));
-        Optional<ShardingRule> rule = metaDataContexts.getDefaultMetaData().getRuleMetaData().getRules().stream()
+        Optional<ShardingRule> rule = metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getRuleMetaData().getRules().stream()
                 .filter(each -> each instanceof ShardingRule).map(each -> (ShardingRule) each).findFirst();
         assertTrue(rule.isPresent());
         assertThat(rule.get().getTableRules().size(), is(1));
@@ -112,7 +112,7 @@ public final class GovernanceShardingSphereDataSourceTest {
     @Test
     public void assertRenewDataSource() throws SQLException {
         metaDataContexts.renew(new DataSourceChangedEvent(DefaultSchema.LOGIC_NAME, getDataSourceConfigurations()));
-        assertThat(metaDataContexts.getDefaultMetaData().getResource().getDataSources().size(), is(3));
+        assertThat(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getResource().getDataSources().size(), is(3));
     }
     
     private Map<String, DataSourceConfiguration> getDataSourceConfigurations() {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/DriverStateContextTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/DriverStateContextTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.driver.governance.internal.state;
 
 import org.apache.shardingsphere.driver.governance.internal.circuit.connection.CircuitBreakerConnection;
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.persist.DistMetaDataPersistService;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.context.metadata.impl.StandardMetaDataContexts;
@@ -43,16 +44,16 @@ public final class DriverStateContextTest {
     
     @Test
     public void assertGetConnectionWithOkState() {
-        Connection actual = DriverStateContext.getConnection(
-                Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)), metaDataContexts, mock(TransactionContexts.class, RETURNS_DEEP_STUBS), TransactionType.LOCAL);
+        Connection actual = DriverStateContext.getConnection(DefaultSchema.LOGIC_NAME, Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)),
+                metaDataContexts, mock(TransactionContexts.class, RETURNS_DEEP_STUBS), TransactionType.LOCAL);
         assertThat(actual, instanceOf(ShardingSphereConnection.class));
     }
     
     @Test
     public void assertGetConnectionWithCircuitBreakState() {
         metaDataContexts.getStateContext().switchState(new StateEvent(StateType.CIRCUIT_BREAK, true));
-        Connection actual = DriverStateContext.getConnection(
-                Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)), metaDataContexts, mock(TransactionContexts.class, RETURNS_DEEP_STUBS), TransactionType.LOCAL);
+        Connection actual = DriverStateContext.getConnection(DefaultSchema.LOGIC_NAME, Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)),
+                metaDataContexts, mock(TransactionContexts.class, RETURNS_DEEP_STUBS), TransactionType.LOCAL);
         assertThat(actual, instanceOf(CircuitBreakerConnection.class));
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/impl/CircuitBreakDriverStateTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/impl/CircuitBreakDriverStateTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.driver.governance.internal.state.impl;
 
 import org.apache.shardingsphere.driver.governance.internal.circuit.connection.CircuitBreakerConnection;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.transaction.context.TransactionContexts;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.junit.Test;
@@ -34,7 +35,8 @@ public final class CircuitBreakDriverStateTest {
     
     @Test
     public void assertGetConnection() {
-        Connection actual = new CircuitBreakDriverState().getConnection(Collections.emptyMap(), mock(MetaDataContexts.class), mock(TransactionContexts.class), TransactionType.LOCAL);
+        Connection actual = new CircuitBreakDriverState().getConnection(DefaultSchema.LOGIC_NAME, Collections.emptyMap(),
+                mock(MetaDataContexts.class), mock(TransactionContexts.class), TransactionType.LOCAL);
         assertThat(actual, instanceOf(CircuitBreakerConnection.class));
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/impl/OKDriverStateTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-governance/src/test/java/org/apache/shardingsphere/driver/governance/internal/state/impl/OKDriverStateTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.driver.governance.internal.state.impl;
 
 import org.apache.shardingsphere.driver.jdbc.core.connection.ShardingSphereConnection;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.transaction.context.TransactionContexts;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.junit.Test;
@@ -36,7 +37,7 @@ public final class OKDriverStateTest {
     
     @Test
     public void assertGetConnection() {
-        Connection actual = new OKDriverState().getConnection(Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)), 
+        Connection actual = new OKDriverState().getConnection(DefaultSchema.LOGIC_NAME, Collections.singletonMap("ds", mock(DataSource.class, RETURNS_DEEP_STUBS)),
                 mock(MetaDataContexts.class), mock(TransactionContexts.class, RETURNS_DEEP_STUBS), TransactionType.LOCAL);
         assertThat(actual, instanceOf(ShardingSphereConnection.class));
     }


### PR DESCRIPTION
For #11621 

jdbc-governance module remove getDefaultMetaData()
