### PR TITLE
Delete getDefaultEngine method for TransactionContexts interface

### DIFF
--- a/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/transaction/GovernanceTransactionContexts.java
+++ b/shardingsphere-governance/shardingsphere-governance-context/src/main/java/org/apache/shardingsphere/governance/context/transaction/GovernanceTransactionContexts.java
@@ -81,11 +81,6 @@ public final class GovernanceTransactionContexts implements TransactionContexts 
     }
     
     @Override
-    public ShardingTransactionManagerEngine getDefaultEngine() {
-        return contexts.getDefaultEngine();
-    }
-    
-    @Override
     public void close() throws Exception {
         contexts.close();
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnection.java
@@ -72,8 +72,7 @@ public final class ShardingSphereConnection extends AbstractConnectionAdapter im
         this.dataSourceMap = dataSourceMap;
         this.metaDataContexts = metaDataContexts;
         this.transactionType = transactionType;
-        //TODO remove getDefaultEngine()
-        shardingTransactionManager = transactionContexts.getDefaultEngine().getTransactionManager(transactionType);
+        shardingTransactionManager = transactionContexts.getEngines().get(schemaName).getTransactionManager(transactionType);
     }
     
     /**

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/datasource/ShardingSphereDataSource.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/datasource/ShardingSphereDataSource.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.context.metadata.MetaDataContextsBuilder;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.persist.config.DistMetaDataPersistRuleConfiguration;
 import org.apache.shardingsphere.infra.persist.rule.DistMetaDataPersistRule;
@@ -81,8 +80,7 @@ public final class ShardingSphereDataSource extends AbstractUnsupportedOperation
     private TransactionContexts createTransactionContexts(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final String xaTransactionMangerType) {
         ShardingTransactionManagerEngine engine = new ShardingTransactionManagerEngine();
         engine.init(databaseType, dataSourceMap, xaTransactionMangerType);
-        // TODO pass real schemaName into TransactionContexts
-        return new StandardTransactionContexts(Collections.singletonMap(DefaultSchema.LOGIC_NAME, engine));
+        return new StandardTransactionContexts(Collections.singletonMap(schemaName, engine));
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/executor/AbstractBaseExecutorTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/executor/AbstractBaseExecutorTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractBaseExecutorTest {
         ShardingRule shardingRule = mockShardingRule();
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getRuleMetaData().getRules()).thenReturn(Collections.singletonList(shardingRule));
         TransactionContexts transactionContexts = mock(TransactionContexts.class);
-        when(transactionContexts.getDefaultEngine()).thenReturn(new ShardingTransactionManagerEngine());
+        when(transactionContexts.getEngines().get(DefaultSchema.LOGIC_NAME)).thenReturn(new ShardingTransactionManagerEngine());
         DataSource dataSource = mock(DataSource.class, RETURNS_DEEP_STUBS);
         Map<String, DataSource> dataSourceSourceMap = new LinkedHashMap<>(2, 1);
         dataSourceSourceMap.put("ds_0", dataSource);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/executor/AbstractBaseExecutorTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/executor/AbstractBaseExecutorTest.java
@@ -72,6 +72,7 @@ public abstract class AbstractBaseExecutorTest {
         ShardingRule shardingRule = mockShardingRule();
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getRuleMetaData().getRules()).thenReturn(Collections.singletonList(shardingRule));
         TransactionContexts transactionContexts = mock(TransactionContexts.class);
+        when(transactionContexts.getEngines()).thenReturn(mock(Map.class));
         when(transactionContexts.getEngines().get(DefaultSchema.LOGIC_NAME)).thenReturn(new ShardingTransactionManagerEngine());
         DataSource dataSource = mock(DataSource.class, RETURNS_DEEP_STUBS);
         Map<String, DataSource> dataSourceSourceMap = new LinkedHashMap<>(2, 1);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
@@ -83,7 +83,7 @@ public final class ShardingSphereConnectionTest {
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getResource().getDatabaseType()).thenReturn(DatabaseTypeRegistry.getActualDatabaseType("H2"));
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME)).thenReturn(metaData);
         transactionContexts = mock(TransactionContexts.class);
-        when(transactionContexts.getDefaultEngine()).thenReturn(new ShardingTransactionManagerEngine());
+        when(transactionContexts.getEngines().get(DefaultSchema.LOGIC_NAME)).thenReturn(new ShardingTransactionManagerEngine());
         ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
         shardingRuleConfig.getTables().add(new ShardingTableRuleConfiguration("test"));
         connection = new ShardingSphereConnection(DefaultSchema.LOGIC_NAME, dataSourceMap, metaDataContexts, transactionContexts, TransactionType.LOCAL);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ShardingSphereConnectionTest.java
@@ -83,6 +83,7 @@ public final class ShardingSphereConnectionTest {
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME).getResource().getDatabaseType()).thenReturn(DatabaseTypeRegistry.getActualDatabaseType("H2"));
         when(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME)).thenReturn(metaData);
         transactionContexts = mock(TransactionContexts.class);
+        when(transactionContexts.getEngines()).thenReturn(mock(Map.class));
         when(transactionContexts.getEngines().get(DefaultSchema.LOGIC_NAME)).thenReturn(new ShardingTransactionManagerEngine());
         ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
         shardingRuleConfig.getTables().add(new ShardingTableRuleConfiguration("test"));

--- a/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/context/TransactionContexts.java
+++ b/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/context/TransactionContexts.java
@@ -32,11 +32,4 @@ public interface TransactionContexts extends AutoCloseable {
      * @return transaction manager engines
      */
     Map<String, ShardingTransactionManagerEngine> getEngines();
-    
-    /**
-     * Get default transaction manager engine.
-     *
-     * @return default transaction manager engine
-     */
-    ShardingTransactionManagerEngine getDefaultEngine();
 }

--- a/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/context/impl/StandardTransactionContexts.java
+++ b/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/context/impl/StandardTransactionContexts.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.transaction.context.impl;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.transaction.ShardingTransactionManagerEngine;
 import org.apache.shardingsphere.transaction.context.TransactionContexts;
 
@@ -37,11 +36,6 @@ public final class StandardTransactionContexts implements TransactionContexts {
     
     public StandardTransactionContexts() {
         this(new HashMap<>());
-    }
-    
-    @Override
-    public ShardingTransactionManagerEngine getDefaultEngine() {
-        return engines.get(DefaultSchema.LOGIC_NAME);
     }
     
     @Override

--- a/shardingsphere-transaction/shardingsphere-transaction-core/src/test/java/org/apache/shardingsphere/transaction/context/impl/StandardTransactionContextsTest.java
+++ b/shardingsphere-transaction/shardingsphere-transaction-core/src/test/java/org/apache/shardingsphere/transaction/context/impl/StandardTransactionContextsTest.java
@@ -49,7 +49,7 @@ public final class StandardTransactionContextsTest {
         Map<String, ShardingTransactionManagerEngine> engines = transactionContexts.getEngines();
         assertThat(engines.size(), is(1));
         assertThat(engines, is(actualEngines));
-        ShardingTransactionManagerEngine defaultEngine = transactionContexts.getDefaultEngine();
+        ShardingTransactionManagerEngine defaultEngine = transactionContexts.getEngines().get(DefaultSchema.LOGIC_NAME);
         assertNotNull(defaultEngine);
     }
     


### PR DESCRIPTION
For #11621 

Delete getDefaultEngine method for TransactionContexts interface
