### PR TITLE
Rename RuleSQLStatement to FeaturedDistSQLStatement.

### DIFF
--- a/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/api/DistSQLStatementParserEngine.java
+++ b/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/api/DistSQLStatementParserEngine.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.distsql.parser.api;
 
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.apache.shardingsphere.distsql.parser.core.common.CommonDistSQLStatementParserEngine;
-import org.apache.shardingsphere.distsql.parser.core.rule.RuleSQLStatementParserEngine;
+import org.apache.shardingsphere.distsql.parser.core.rule.FeaturedDistSQLStatementParserEngine;
 import org.apache.shardingsphere.sql.parser.exception.SQLParsingException;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
@@ -38,7 +38,7 @@ public final class DistSQLStatementParserEngine {
         try {
             return new CommonDistSQLStatementParserEngine().parse(sql);
         } catch (final ParseCancellationException | SQLParsingException ignored) {
-            return new RuleSQLStatementParserEngine().parse(sql);
+            return new FeaturedDistSQLStatementParserEngine().parse(sql);
         }
     }
 }

--- a/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/rule/FeaturedDistSQLStatementParserEngine.java
+++ b/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/rule/FeaturedDistSQLStatementParserEngine.java
@@ -21,7 +21,7 @@ import lombok.SneakyThrows;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 import org.apache.shardingsphere.sql.parser.core.SQLParserFactory;
@@ -33,14 +33,14 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 /**
- * Rule SQL statement parser engine.
+ * Featured dist SQL statement parser engine.
  */
-public final class RuleSQLStatementParserEngine {
+public final class FeaturedDistSQLStatementParserEngine {
     
-    private static final Map<String, RuleSQLStatementParserFacade> FACADES = new HashMap<>();
+    private static final Map<String, FeaturedDistSQLStatementParserFacade> FACADES = new HashMap<>();
     
     static {
-        for (RuleSQLStatementParserFacade each : ServiceLoader.load(RuleSQLStatementParserFacade.class)) {
+        for (FeaturedDistSQLStatementParserFacade each : ServiceLoader.load(FeaturedDistSQLStatementParserFacade.class)) {
             FACADES.put(each.getRuleType(), each);
         }
     }
@@ -57,7 +57,7 @@ public final class RuleSQLStatementParserEngine {
     }
     
     private RuleParseASTNode parseToASTNode(final String sql) {
-        for (RuleSQLStatementParserFacade each : FACADES.values()) {
+        for (FeaturedDistSQLStatementParserFacade each : FACADES.values()) {
             try {
                 ParseASTNode parseASTNode = (ParseASTNode) SQLParserFactory.newInstance(sql, each.getLexerClass(), each.getParserClass()).parse();
                 return new RuleParseASTNode(each.getRuleType(), parseASTNode);

--- a/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/spi/FeaturedDistSQLStatementParserFacade.java
+++ b/shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/java/org/apache/shardingsphere/distsql/parser/spi/FeaturedDistSQLStatementParserFacade.java
@@ -15,14 +15,27 @@
  * limitations under the License.
  */
 
-grammar DatabaseDiscoveryRuleStatement;
+package org.apache.shardingsphere.distsql.parser.spi;
 
-import Symbol, RDLStatement, RQLStatement;
+import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
+import org.apache.shardingsphere.sql.parser.spi.SQLParserFacade;
 
-execute
-    : (createDatabaseDiscoveryRule
-    | alterDatabaseDiscoveryRule
-    | dropDatabaseDiscoveryRule
-    | showDatabaseDiscoveryRules
-    ) SEMI?
-    ;
+/**
+ * Featured dist SQL statement parser facade.
+ */
+public interface FeaturedDistSQLStatementParserFacade extends SQLParserFacade {
+    
+    /**
+     * Get visitor class.
+     *
+     * @return visitor class
+     */
+    Class<? extends SQLVisitor> getVisitorClass();
+    
+    /**
+     * Get rule type.
+     *
+     * @return rule type
+     */
+    String getRuleType();
+}

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/DatabaseDiscoveryDistSQLStatement.g4
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/DatabaseDiscoveryDistSQLStatement.g4
@@ -15,18 +15,14 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.readwritesplitting.distsql.parser.core;
+grammar DatabaseDiscoveryDistSQLStatement;
 
-import org.antlr.v4.runtime.CharStream;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementLexer;
-import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
+import Symbol, RDLStatement, RQLStatement;
 
-/**
- * SQL lexer for readwrite-splitting rule.
- */
-public final class ReadwriteSplittingRuleLexer extends ReadwriteSplittingRuleStatementLexer implements SQLLexer {
-    
-    public ReadwriteSplittingRuleLexer(final CharStream input) {
-        super(input);
-    }
-}
+execute
+    : (createDatabaseDiscoveryRule
+    | alterDatabaseDiscoveryRule
+    | dropDatabaseDiscoveryRule
+    | showDatabaseDiscoveryRules
+    ) SEMI?
+    ;

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLLexer.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLLexer.java
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.distsql.parser.core;
+package org.apache.shardingsphere.dbdiscovery.distsql.parser.core;
 
 import org.antlr.v4.runtime.CharStream;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementLexer;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 
 /**
- * SQL lexer for sharding rule.
+ * SQL lexer for database discovery dist SQL.
  */
-public final class ShardingRuleLexer extends ShardingRuleStatementLexer implements SQLLexer {
+public final class DatabaseDiscoveryDistSQLLexer extends DatabaseDiscoveryDistSQLStatementLexer implements SQLLexer {
     
-    public ShardingRuleLexer(final CharStream input) {
+    public DatabaseDiscoveryDistSQLLexer(final CharStream input) {
         super(input);
     }
 }

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLParser.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLParser.java
@@ -15,14 +15,25 @@
  * limitations under the License.
  */
 
-grammar EncryptRuleStatement;
+package org.apache.shardingsphere.dbdiscovery.distsql.parser.core;
 
-import Symbol, RDLStatement, RQLStatement;
+import org.antlr.v4.runtime.TokenStream;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser;
+import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
+import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
+import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 
-execute
-    : (createEncryptRule
-    | alterEncryptRule
-    | dropEncryptRule
-    | showEncryptRules
-    ) SEMI?
-    ;
+/**
+ * SQL parser for database discovery dist SQL.
+ */
+public final class DatabaseDiscoveryDistSQLParser extends DatabaseDiscoveryDistSQLStatementParser implements SQLParser {
+    
+    public DatabaseDiscoveryDistSQLParser(final TokenStream input) {
+        super(input);
+    }
+    
+    @Override
+    public ASTNode parse() {
+        return new ParseASTNode(execute());
+    }
+}

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
@@ -22,17 +22,17 @@ import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.AlterDatab
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.CreateDatabaseDiscoveryRuleStatement;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.DropDatabaseDiscoveryRuleStatement;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryRulesStatement;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementBaseVisitor;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.AlgorithmDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.AlgorithmPropertiesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.AlgorithmPropertyContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.AlterDatabaseDiscoveryRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.CreateDatabaseDiscoveryRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.DatabaseDiscoveryRuleDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.DropDatabaseDiscoveryRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.RuleNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.SchemaNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser.ShowDatabaseDiscoveryRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementBaseVisitor;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.AlgorithmDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.AlgorithmPropertiesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.AlgorithmPropertyContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.AlterDatabaseDiscoveryRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.CreateDatabaseDiscoveryRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.DatabaseDiscoveryRuleDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.DropDatabaseDiscoveryRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.RuleNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.SchemaNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryDistSQLStatementParser.ShowDatabaseDiscoveryRulesContext;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
@@ -44,9 +44,9 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
- * SQL statement visitor for database discovery rule.
+ * SQL statement visitor for database discovery dist SQL.
  */
-public final class DatabaseDiscoveryRuleSQLStatementVisitor extends DatabaseDiscoveryRuleStatementBaseVisitor<ASTNode> implements SQLVisitor {
+public final class DatabaseDiscoveryDistSQLStatementVisitor extends DatabaseDiscoveryDistSQLStatementBaseVisitor<ASTNode> implements SQLVisitor {
     
     @Override
     public ASTNode visitCreateDatabaseDiscoveryRule(final CreateDatabaseDiscoveryRuleContext ctx) {

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/facade/DatabaseDiscoveryDistSQLStatementParserFacade.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/facade/DatabaseDiscoveryDistSQLStatementParserFacade.java
@@ -15,38 +15,38 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.distsql.parser.facade;
+package org.apache.shardingsphere.dbdiscovery.distsql.parser.facade;
 
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
-import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingRuleSQLStatementVisitor;
-import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingRuleLexer;
-import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingRuleParser;
+import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryDistSQLLexer;
+import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryDistSQLParser;
+import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryDistSQLStatementVisitor;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 
 /**
- * SQL parser facade for sharding rule SQL statement.
+ * SQL parser facade for database discovery dist SQL statement.
  */
-public final class ShardingRuleSQLStatementParserFacade implements RuleSQLStatementParserFacade {
+public final class DatabaseDiscoveryDistSQLStatementParserFacade implements FeaturedDistSQLStatementParserFacade {
     
     @Override
     public Class<? extends SQLLexer> getLexerClass() {
-        return ShardingRuleLexer.class;
+        return DatabaseDiscoveryDistSQLLexer.class;
     }
     
     @Override
     public Class<? extends SQLParser> getParserClass() {
-        return ShardingRuleParser.class;
+        return DatabaseDiscoveryDistSQLParser.class;
     }
     
     @Override
     public Class<? extends SQLVisitor> getVisitorClass() {
-        return ShardingRuleSQLStatementVisitor.class;
+        return DatabaseDiscoveryDistSQLStatementVisitor.class;
     }
     
     @Override
     public String getRuleType() {
-        return "sharding";
+        return "database-discovery";
     }
 }

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.encrypt.distsql.parser.facade.EncryptRuleSQLStatementParserFacade
+org.apache.shardingsphere.dbdiscovery.distsql.parser.facade.DatabaseDiscoveryDistSQLStatementParserFacade

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/EncryptDistSQLStatement.g4
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/EncryptDistSQLStatement.g4
@@ -15,17 +15,14 @@
  * limitations under the License.
  */
 
-grammar ReadwriteSplittingRuleStatement;
+grammar EncryptDistSQLStatement;
 
-import Symbol, RALStatement, RDLStatement, RQLStatement;
+import Symbol, RDLStatement, RQLStatement;
 
 execute
-    : (createReadwriteSplittingRule
-    | alterReadwriteSplittingRule
-    | dropReadwriteSplittingRule
-    | showReadwriteSplittingRules
-    | setReadwriteSplittingHintSource
-    | showReadwriteSplittingHintStatus
-    | clearReadwriteSplittingHint
+    : (createEncryptRule
+    | alterEncryptRule
+    | dropEncryptRule
+    | showEncryptRules
     ) SEMI?
     ;

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLLexer.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLLexer.java
@@ -15,25 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.dbdiscovery.distsql.parser.core;
+package org.apache.shardingsphere.encrypt.distsql.parser.core;
 
-import org.antlr.v4.runtime.TokenStream;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementParser;
-import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
-import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
-import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
+import org.antlr.v4.runtime.CharStream;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementLexer;
+import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 
 /**
- * SQL parser for database discovery rule.
+ * SQL lexer for encrypt dist SQL.
  */
-public final class DatabaseDiscoveryRuleParser extends DatabaseDiscoveryRuleStatementParser implements SQLParser {
+public final class EncryptDistSQLLexer extends EncryptDistSQLStatementLexer implements SQLLexer {
     
-    public DatabaseDiscoveryRuleParser(final TokenStream input) {
+    public EncryptDistSQLLexer(final CharStream input) {
         super(input);
-    }
-    
-    @Override
-    public ASTNode parse() {
-        return new ParseASTNode(execute());
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLParser.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLParser.java
@@ -17,16 +17,23 @@
 
 package org.apache.shardingsphere.encrypt.distsql.parser.core;
 
-import org.antlr.v4.runtime.CharStream;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementLexer;
-import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
+import org.antlr.v4.runtime.TokenStream;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser;
+import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
+import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
+import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 
 /**
- * SQL lexer for encrypt rule.
+ * SQL parser for encrypt dist SQL.
  */
-public final class EncryptRuleLexer extends EncryptRuleStatementLexer implements SQLLexer {
+public final class EncryptDistSQLParser extends EncryptDistSQLStatementParser implements SQLParser {
     
-    public EncryptRuleLexer(final CharStream input) {
+    public EncryptDistSQLParser(final TokenStream input) {
         super(input);
+    }
+    
+    @Override
+    public ASTNode parse() {
+        return new ParseASTNode(execute());
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
@@ -17,17 +17,17 @@
 
 package org.apache.shardingsphere.encrypt.distsql.parser.core;
 
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementBaseVisitor;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.AlgorithmDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.AlgorithmPropertyContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.AlterEncryptRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.ColumnDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.CreateEncryptRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.DropEncryptRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.EncryptRuleDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.SchemaNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.ShowEncryptRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser.TableNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementBaseVisitor;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.AlgorithmDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.AlgorithmPropertyContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.AlterEncryptRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.ColumnDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.CreateEncryptRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.DropEncryptRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.EncryptRuleDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.SchemaNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.ShowEncryptRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.EncryptDistSQLStatementParser.TableNameContext;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.distsql.parser.statement.AlterEncryptRuleStatement;
 import org.apache.shardingsphere.encrypt.distsql.parser.statement.CreateEncryptRuleStatement;
@@ -45,9 +45,9 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
- * SQL statement visitor for encrypt rule.
+ * SQL statement visitor for encrypt dist SQL.
  */
-public final class EncryptRuleSQLStatementVisitor extends EncryptRuleStatementBaseVisitor<ASTNode> implements SQLVisitor {
+public final class EncryptDistSQLStatementVisitor extends EncryptDistSQLStatementBaseVisitor<ASTNode> implements SQLVisitor {
     
     @Override
     public ASTNode visitCreateEncryptRule(final CreateEncryptRuleContext ctx) {

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/facade/EncryptDistSQLStatementParserFacade.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/facade/EncryptDistSQLStatementParserFacade.java
@@ -17,32 +17,32 @@
 
 package org.apache.shardingsphere.encrypt.distsql.parser.facade;
 
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
-import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptRuleLexer;
-import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptRuleParser;
-import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptRuleSQLStatementVisitor;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
+import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptDistSQLLexer;
+import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptDistSQLParser;
+import org.apache.shardingsphere.encrypt.distsql.parser.core.EncryptDistSQLStatementVisitor;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 
 /**
- * SQL parser facade for encrypt rule SQL statement.
+ * SQL parser facade for encrypt dist SQL statement.
  */
-public final class EncryptRuleSQLStatementParserFacade implements RuleSQLStatementParserFacade {
+public final class EncryptDistSQLStatementParserFacade implements FeaturedDistSQLStatementParserFacade {
     
     @Override
     public Class<? extends SQLLexer> getLexerClass() {
-        return EncryptRuleLexer.class;
+        return EncryptDistSQLLexer.class;
     }
     
     @Override
     public Class<? extends SQLParser> getParserClass() {
-        return EncryptRuleParser.class;
+        return EncryptDistSQLParser.class;
     }
     
     @Override
     public Class<? extends SQLVisitor> getVisitorClass() {
-        return EncryptRuleSQLStatementVisitor.class;
+        return EncryptDistSQLStatementVisitor.class;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-distsql/shardingsphere-encrypt-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.scaling.distsql.parser.facade.ScalingSQLStatementParserFacade
+org.apache.shardingsphere.encrypt.distsql.parser.facade.EncryptDistSQLStatementParserFacade

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ReadwriteSplittingDistSQLStatement.g4
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ReadwriteSplittingDistSQLStatement.g4
@@ -15,27 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.distsql.parser.spi;
+grammar ReadwriteSplittingDistSQLStatement;
 
-import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
-import org.apache.shardingsphere.sql.parser.spi.SQLParserFacade;
+import Symbol, RALStatement, RDLStatement, RQLStatement;
 
-/**
- * Rule SQL statement parser facade.
- */
-public interface RuleSQLStatementParserFacade extends SQLParserFacade {
-    
-    /**
-     * Get visitor class.
-     *
-     * @return visitor class
-     */
-    Class<? extends SQLVisitor> getVisitorClass();
-    
-    /**
-     * Get rule type.
-     *
-     * @return rule type
-     */
-    String getRuleType();
-}
+execute
+    : (createReadwriteSplittingRule
+    | alterReadwriteSplittingRule
+    | dropReadwriteSplittingRule
+    | showReadwriteSplittingRules
+    | setReadwriteSplittingHintSource
+    | showReadwriteSplittingHintStatus
+    | clearReadwriteSplittingHint
+    ) SEMI?
+    ;

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLLexer.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLLexer.java
@@ -17,23 +17,16 @@
 
 package org.apache.shardingsphere.readwritesplitting.distsql.parser.core;
 
-import org.antlr.v4.runtime.TokenStream;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser;
-import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
-import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
-import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
+import org.antlr.v4.runtime.CharStream;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementLexer;
+import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 
 /**
- * SQL parser for readwrite-splitting rule.
+ * SQL lexer for readwrite-splitting dist SQL.
  */
-public final class ReadwriteSplittingRuleParser extends ReadwriteSplittingRuleStatementParser implements SQLParser {
+public final class ReadwriteSplittingDistSQLLexer extends ReadwriteSplittingDistSQLStatementLexer implements SQLLexer {
     
-    public ReadwriteSplittingRuleParser(final TokenStream input) {
+    public ReadwriteSplittingDistSQLLexer(final CharStream input) {
         super(input);
-    }
-    
-    @Override
-    public ASTNode parse() {
-        return new ParseASTNode(execute());
     }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLParser.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLParser.java
@@ -15,29 +15,25 @@
  * limitations under the License.
  */
 
-grammar ShardingRuleStatement;
+package org.apache.shardingsphere.readwritesplitting.distsql.parser.core;
 
-import Symbol, RALStatement, RDLStatement, RQLStatement;
+import org.antlr.v4.runtime.TokenStream;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser;
+import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
+import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
+import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 
-execute
-    : (createShardingTableRule
-    | createShardingBindingTableRules
-    | createShardingBroadcastTableRules
-    | alterShardingTableRule
-    | alterShardingBindingTableRules
-    | alterShardingBroadcastTableRules
-    | dropShardingTableRule
-    | dropShardingBindingTableRules
-    | dropShardingBroadcastTableRules
-    | dropShardingAlgorithm
-    | showShardingTableRules
-    | showShardingBindingTableRules
-    | showShardingBroadcastTableRules
-    | showShardingAlgorithms
-    | setShardingHintDatabaseValue
-    | addShardingHintDatabaseValue
-    | addShardingHintTableValue
-    | showShardingHintStatus
-    | clearShardingHint
-    ) SEMI?
-    ;
+/**
+ * SQL parser for readwrite-splitting dist SQL.
+ */
+public final class ReadwriteSplittingDistSQLParser extends ReadwriteSplittingDistSQLStatementParser implements SQLParser {
+    
+    public ReadwriteSplittingDistSQLParser(final TokenStream input) {
+        super(input);
+    }
+    
+    @Override
+    public ASTNode parse() {
+        return new ParseASTNode(execute());
+    }
+}

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
@@ -18,18 +18,18 @@
 package org.apache.shardingsphere.readwritesplitting.distsql.parser.core;
 
 import org.antlr.v4.runtime.RuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementBaseVisitor;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.AlgorithmDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.AlgorithmPropertyContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.AlterReadwriteSplittingRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.CreateReadwriteSplittingRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.DropReadwriteSplittingRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.ReadwriteSplittingRuleDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.RuleNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.SchemaNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.SetReadwriteSplittingHintSourceContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.ShowReadwriteSplittingRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingRuleStatementParser.StaticReadwriteSplittingRuleDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementBaseVisitor;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.AlgorithmDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.AlgorithmPropertyContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.AlterReadwriteSplittingRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.CreateReadwriteSplittingRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.DropReadwriteSplittingRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.ReadwriteSplittingRuleDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.RuleNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.SchemaNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.SetReadwriteSplittingHintSourceContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.ShowReadwriteSplittingRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ReadwriteSplittingDistSQLStatementParser.StaticReadwriteSplittingRuleDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.segment.ReadwriteSplittingRuleSegment;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.AlterReadwriteSplittingRuleStatement;
@@ -47,9 +47,9 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
- * SQL statement visitor for readwrite-splitting rule.
+ * SQL statement visitor for readwrite-splitting dist SQL.
  */
-public final class ReadwriteSplittingRuleSQLStatementVisitor extends ReadwriteSplittingRuleStatementBaseVisitor<ASTNode> implements SQLVisitor {
+public final class ReadwriteSplittingDistSQLStatementVisitor extends ReadwriteSplittingDistSQLStatementBaseVisitor<ASTNode> implements SQLVisitor {
     
     @Override
     public ASTNode visitCreateReadwriteSplittingRule(final CreateReadwriteSplittingRuleContext ctx) {

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/facade/ReadwriteSplittingDistSQLStatementParserFacade.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/facade/ReadwriteSplittingDistSQLStatementParserFacade.java
@@ -17,32 +17,32 @@
 
 package org.apache.shardingsphere.readwritesplitting.distsql.parser.facade;
 
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
-import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingRuleSQLStatementVisitor;
-import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingRuleLexer;
-import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingRuleParser;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
+import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingDistSQLStatementVisitor;
+import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingDistSQLLexer;
+import org.apache.shardingsphere.readwritesplitting.distsql.parser.core.ReadwriteSplittingDistSQLParser;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 
 /**
- * SQL parser facade for readwrite-splitting rule SQL statement.
+ * SQL parser facade for readwrite-splitting dist SQL statement.
  */
-public final class ReadwriteSplittingRuleSQLStatementParserFacade implements RuleSQLStatementParserFacade {
+public final class ReadwriteSplittingDistSQLStatementParserFacade implements FeaturedDistSQLStatementParserFacade {
     
     @Override
     public Class<? extends SQLLexer> getLexerClass() {
-        return ReadwriteSplittingRuleLexer.class;
+        return ReadwriteSplittingDistSQLLexer.class;
     }
     
     @Override
     public Class<? extends SQLParser> getParserClass() {
-        return ReadwriteSplittingRuleParser.class;
+        return ReadwriteSplittingDistSQLParser.class;
     }
     
     @Override
     public Class<? extends SQLVisitor> getVisitorClass() {
-        return ReadwriteSplittingRuleSQLStatementVisitor.class;
+        return ReadwriteSplittingDistSQLStatementVisitor.class;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.readwritesplitting.distsql.parser.facade.ReadwriteSplittingRuleSQLStatementParserFacade
+org.apache.shardingsphere.readwritesplitting.distsql.parser.facade.ReadwriteSplittingDistSQLStatementParserFacade

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ShardingDistSQLStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ShardingDistSQLStatement.g4
@@ -15,25 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.distsql.parser.core;
+grammar ShardingDistSQLStatement;
 
-import org.antlr.v4.runtime.TokenStream;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser;
-import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
-import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
-import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
+import Symbol, RALStatement, RDLStatement, RQLStatement;
 
-/**
- * SQL parser for sharding rule.
- */
-public final class ShardingRuleParser extends ShardingRuleStatementParser implements SQLParser {
-    
-    public ShardingRuleParser(final TokenStream input) {
-        super(input);
-    }
-    
-    @Override
-    public ASTNode parse() {
-        return new ParseASTNode(execute());
-    }
-}
+execute
+    : (createShardingTableRule
+    | createShardingBindingTableRules
+    | createShardingBroadcastTableRules
+    | alterShardingTableRule
+    | alterShardingBindingTableRules
+    | alterShardingBroadcastTableRules
+    | dropShardingTableRule
+    | dropShardingBindingTableRules
+    | dropShardingBroadcastTableRules
+    | dropShardingAlgorithm
+    | showShardingTableRules
+    | showShardingBindingTableRules
+    | showShardingBroadcastTableRules
+    | showShardingAlgorithms
+    | setShardingHintDatabaseValue
+    | addShardingHintDatabaseValue
+    | addShardingHintTableValue
+    | showShardingHintStatus
+    | clearShardingHint
+    ) SEMI?
+    ;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLLexer.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLLexer.java
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.dbdiscovery.distsql.parser.core;
+package org.apache.shardingsphere.sharding.distsql.parser.core;
 
 import org.antlr.v4.runtime.CharStream;
-import org.apache.shardingsphere.distsql.parser.autogen.DatabaseDiscoveryRuleStatementLexer;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 
 /**
- * SQL lexer for database discovery rule.
+ * SQL lexer for sharding dist SQL.
  */
-public final class DatabaseDiscoveryRuleLexer extends DatabaseDiscoveryRuleStatementLexer implements SQLLexer {
+public final class ShardingDistSQLLexer extends ShardingDistSQLStatementLexer implements SQLLexer {
     
-    public DatabaseDiscoveryRuleLexer(final CharStream input) {
+    public ShardingDistSQLLexer(final CharStream input) {
         super(input);
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLParser.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLParser.java
@@ -15,20 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.encrypt.distsql.parser.core;
+package org.apache.shardingsphere.sharding.distsql.parser.core;
 
 import org.antlr.v4.runtime.TokenStream;
-import org.apache.shardingsphere.distsql.parser.autogen.EncryptRuleStatementParser;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
 import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
 
 /**
- * SQL parser for encrypt rule.
+ * SQL parser for sharding dist SQL.
  */
-public final class EncryptRuleParser extends EncryptRuleStatementParser implements SQLParser {
+public final class ShardingDistSQLParser extends ShardingDistSQLStatementParser implements SQLParser {
     
-    public EncryptRuleParser(final TokenStream input) {
+    public ShardingDistSQLParser(final TokenStream input) {
         super(input);
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -20,27 +20,27 @@ package org.apache.shardingsphere.sharding.distsql.parser.core;
 import com.google.common.base.Joiner;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementBaseVisitor;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.ShowShardingAlgorithmsContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.AlgorithmDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.AlgorithmPropertyContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.AlterShardingBindingTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.AlterShardingBroadcastTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.AlterShardingTableRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.BindTableRulesDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.CreateShardingBindingTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.CreateShardingBroadcastTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.CreateShardingTableRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.DropShardingBindingTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.DropShardingBroadcastTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.DropShardingTableRuleContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.DropShardingAlgorithmContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.SchemaNameContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.ShardingTableRuleDefinitionContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.ShowShardingBindingTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.ShowShardingBroadcastTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.ShowShardingTableRulesContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ShardingRuleStatementParser.TableNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementBaseVisitor;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.ShowShardingAlgorithmsContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.AlgorithmDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.AlgorithmPropertyContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.AlterShardingBindingTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.AlterShardingBroadcastTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.AlterShardingTableRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.BindTableRulesDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.CreateShardingBindingTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.CreateShardingBroadcastTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.CreateShardingTableRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.DropShardingBindingTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.DropShardingBroadcastTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.DropShardingTableRuleContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.DropShardingAlgorithmContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.SchemaNameContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.ShardingTableRuleDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.ShowShardingBindingTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.ShowShardingBroadcastTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.ShowShardingTableRulesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ShardingDistSQLStatementParser.TableNameContext;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.BindingTableRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.TableRuleSegment;
@@ -71,9 +71,9 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
- * SQL statement visitor for sharding rule.
+ * SQL statement visitor for sharding dist SQL.
  */
-public final class ShardingRuleSQLStatementVisitor extends ShardingRuleStatementBaseVisitor<ASTNode> implements SQLVisitor {
+public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatementBaseVisitor<ASTNode> implements SQLVisitor {
     
     @Override
     public ASTNode visitCreateShardingTableRule(final CreateShardingTableRuleContext ctx) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/facade/ShardingDistSQLStatementParserFacade.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/facade/ShardingDistSQLStatementParserFacade.java
@@ -15,38 +15,38 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.dbdiscovery.distsql.parser.facade;
+package org.apache.shardingsphere.sharding.distsql.parser.facade;
 
-import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryRuleLexer;
-import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryRuleParser;
-import org.apache.shardingsphere.dbdiscovery.distsql.parser.core.DatabaseDiscoveryRuleSQLStatementVisitor;
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
+import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLStatementVisitor;
+import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLLexer;
+import org.apache.shardingsphere.sharding.distsql.parser.core.ShardingDistSQLParser;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLLexer;
 import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 
 /**
- * SQL parser facade for database discovery rule SQL statement.
+ * SQL parser facade for sharding dist SQL statement.
  */
-public final class DatabaseDiscoveryRuleSQLStatementParserFacade implements RuleSQLStatementParserFacade {
+public final class ShardingDistSQLStatementParserFacade implements FeaturedDistSQLStatementParserFacade {
     
     @Override
     public Class<? extends SQLLexer> getLexerClass() {
-        return DatabaseDiscoveryRuleLexer.class;
+        return ShardingDistSQLLexer.class;
     }
     
     @Override
     public Class<? extends SQLParser> getParserClass() {
-        return DatabaseDiscoveryRuleParser.class;
+        return ShardingDistSQLParser.class;
     }
     
     @Override
     public Class<? extends SQLVisitor> getVisitorClass() {
-        return DatabaseDiscoveryRuleSQLStatementVisitor.class;
+        return ShardingDistSQLStatementVisitor.class;
     }
     
     @Override
     public String getRuleType() {
-        return "database-discovery";
+        return "sharding";
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.sharding.distsql.parser.facade.ShardingRuleSQLStatementParserFacade
+org.apache.shardingsphere.sharding.distsql.parser.facade.ShardingDistSQLStatementParserFacade

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/facade/ScalingDistSQLStatementParserFacade.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/facade/ScalingDistSQLStatementParserFacade.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.scaling.distsql.parser.facade;
 
-import org.apache.shardingsphere.distsql.parser.spi.RuleSQLStatementParserFacade;
+import org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade;
 import org.apache.shardingsphere.scaling.distsql.parser.core.ScalingLexer;
 import org.apache.shardingsphere.scaling.distsql.parser.core.ScalingParser;
 import org.apache.shardingsphere.scaling.distsql.parser.core.ScalingSQLStatementVisitor;
@@ -26,9 +26,9 @@ import org.apache.shardingsphere.sql.parser.api.parser.SQLParser;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 
 /**
- * SQL parser facade for scaling SQL statement.
+ * SQL parser facade for scaling dist SQL statement.
  */
-public final class ScalingSQLStatementParserFacade implements RuleSQLStatementParserFacade {
+public final class ScalingDistSQLStatementParserFacade implements FeaturedDistSQLStatementParserFacade {
     
     @Override
     public Class<? extends SQLLexer> getLexerClass() {

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.parser.spi.FeaturedDistSQLStatementParserFacade
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.dbdiscovery.distsql.parser.facade.DatabaseDiscoveryRuleSQLStatementParserFacade
+org.apache.shardingsphere.scaling.distsql.parser.facade.ScalingDistSQLStatementParserFacade


### PR DESCRIPTION
Fixes #11677.

Since the feature modules add the definition of RAL, Statements have more than just rules. Therefore, corresponding to `CommonDistSQLStatement`, modify `RuleSQLStatement` to `FeaturedDistSQLStatement`.
Examples:
- RuleSQLStatementParserEngine -> FeaturedDistSQLStatementParserEngine
- ReadwriteSplittingRuleStatement -> ReadwriteSplittingDistSQLStatement
- ShardingRuleStatement -> ShardingDistSQLStatement

