### PR TITLE
Avoid to define optional as method's param in class MetaDataInfoCollector

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/main/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/MetaDataInfoCollector.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/main/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/MetaDataInfoCollector.java
@@ -55,33 +55,30 @@ public final class MetaDataInfoCollector extends Collector {
     public List<MetricFamilySamples> collect() {
         List<MetricFamilySamples> result = new LinkedList<>();
         Optional<GaugeMetricFamily> metaDataInfo = FACTORY.createGaugeMetricFamily(MetricIds.METADATA_INFO);
-        if (MetricsUtil.classNotExist(PROXY_CONTEXT_CLASS_STR)) {
+        if (MetricsUtil.classNotExist(PROXY_CONTEXT_CLASS_STR) || !metaDataInfo.isPresent()) {
             return result;
         }
-        collectProxy(metaDataInfo);
-        metaDataInfo.ifPresent(m -> result.add(m));
+        collectProxy(metaDataInfo.get());
+        result.add(metaDataInfo.get());
         return result;
     }
     
-    private void collectProxy(final Optional<GaugeMetricFamily> metricFamily) {
+    private void collectProxy(final GaugeMetricFamily metricFamily) {
         StandardMetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
-        metricFamily.ifPresent(m -> m.addMetric(Collections.singletonList(LOGIC_DB_COUNT), metaDataContexts.getMetaDataMap().size()));
-        metricFamily.ifPresent(m -> {
-            Map databaseMap = new HashMap<>();
-            metaDataContexts.getMetaDataMap().values().forEach(d ->
-                d.getResource().getDataSources().values().forEach(ds -> 
-                        countDatabase(databaseMap, ds)));
-            m.addMetric(Collections.singletonList(ACTUAL_DB_COUNT), databaseMap.size());
-        });
+        metricFamily.addMetric(Collections.singletonList(LOGIC_DB_COUNT), metaDataContexts.getMetaDataMap().size());
+        Map<String, String> databaseMap = new HashMap<>();
+        metaDataContexts.getMetaDataMap().values().forEach(each -> each.getResource().getDataSources().values()
+                .forEach(dataSource -> MetaDataInfoCollector.this.countDatabase(databaseMap, dataSource)));
+        metricFamily.addMetric(Collections.singletonList(ACTUAL_DB_COUNT), databaseMap.size());
     }
     
-    private void countDatabase(final Map map, final DataSource dataSource) {
+    private void countDatabase(final Map<String, String> databaseMap, final DataSource dataSource) {
         if (dataSource instanceof HikariDataSource) {
             String jdbcUrl = ((HikariDataSource) dataSource).getJdbcUrl();
             try {
                 URI uri = new URI(jdbcUrl.substring(5));
                 if (null != uri.getPath()) {
-                    map.put(uri.getPath(), "");
+                    databaseMap.put(uri.getPath(), "");
                 }
             } catch (URISyntaxException | NullPointerException e) {
                 log.info("Unsupported jdbc url by URI: {}", jdbcUrl);

--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/main/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/MetaDataInfoCollector.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/main/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/MetaDataInfoCollector.java
@@ -38,7 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Meta data collector.
+ * Meta data information collector.
  */
 @Slf4j
 public final class MetaDataInfoCollector extends Collector {


### PR DESCRIPTION
- Avoid to define optional as method's param in class
- Use generic type with map