### PR TITLE
Make findColumn case insensitive

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
@@ -30,15 +30,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Database meta data result set.
@@ -358,10 +350,27 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
     @Override
     public int findColumn(final String columnLabel) throws SQLException {
         checkClosed();
-        if (!columnLabelIndexMap.containsKey(columnLabel)) {
-            throw new SQLException(String.format("Can not find columnLabel %s", columnLabel));
+
+        Integer columnIndex = columnLabelIndexMap.get(columnLabel);
+        if (columnIndex != null) {
+            return columnIndex;
         }
-        return columnLabelIndexMap.get(columnLabel);
+
+        columnIndex = columnLabelIndexMap.get(columnLabel.toLowerCase(Locale.US));
+
+        if (columnIndex != null) {
+            columnLabelIndexMap.put(columnLabel, columnIndex);
+            return columnIndex;
+        }
+
+        columnIndex = columnLabelIndexMap.get(columnLabel.toUpperCase(Locale.US));
+
+        if (columnIndex != null) {
+            columnLabelIndexMap.put(columnLabel, columnIndex);
+            return columnIndex;
+        }
+
+        throw new SQLException(String.format("Can not find columnLabel %s", columnLabel));
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
@@ -30,7 +30,15 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
 
 /**
  * Database meta data result set.
@@ -70,7 +78,7 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
     }
     
     private Map<String, Integer> initIndexMap() throws SQLException {
-        Map<String, Integer> result = new HashMap<>(resultSetMetaData.getColumnCount());
+        Map<String, Integer> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
             result.put(resultSetMetaData.getColumnLabel(i), i);
         }
@@ -350,27 +358,10 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
     @Override
     public int findColumn(final String columnLabel) throws SQLException {
         checkClosed();
-
-        Integer columnIndex = columnLabelIndexMap.get(columnLabel);
-        if (columnIndex != null) {
-            return columnIndex;
+        if (!columnLabelIndexMap.containsKey(columnLabel)) {
+            throw new SQLException(String.format("Can not find columnLabel %s", columnLabel));
         }
-
-        columnIndex = columnLabelIndexMap.get(columnLabel.toLowerCase(Locale.US));
-
-        if (columnIndex != null) {
-            columnLabelIndexMap.put(columnLabel, columnIndex);
-            return columnIndex;
-        }
-
-        columnIndex = columnLabelIndexMap.get(columnLabel.toUpperCase(Locale.US));
-
-        if (columnIndex != null) {
-            columnLabelIndexMap.put(columnLabel, columnIndex);
-            return columnIndex;
-        }
-
-        throw new SQLException(String.format("Can not find columnLabel %s", columnLabel));
+        return columnLabelIndexMap.get(columnLabel);
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSetTest.java
@@ -171,6 +171,15 @@ public final class DatabaseMetaDataResultSetTest {
     }
 
     @Test
+    public void assertGetStringWithLabelCaseInsensitive() throws SQLException {
+        databaseMetaDataResultSet.next();
+        assertThat(databaseMetaDataResultSet.getString(TABLE_NAME_COLUMN_LABEL.toLowerCase()), is(LOGIC_TABLE_NAME));
+        assertThat(databaseMetaDataResultSet.getString(NON_TABLE_NAME_COLUMN_LABEL.toLowerCase()), is("true"));
+        assertThat(databaseMetaDataResultSet.getString(NUMBER_COLUMN_LABEL.toLowerCase()), is("100"));
+        assertThat(databaseMetaDataResultSet.getString(INDEX_NAME_COLUMN_LABEL.toLowerCase()), is(LOGIC_INDEX_NAME));
+    }
+
+    @Test
     public void assertGetNStringWithIndex() throws SQLException {
         databaseMetaDataResultSet.next();
         assertThat(databaseMetaDataResultSet.getNString(1), is(LOGIC_TABLE_NAME));


### PR DESCRIPTION
Fixes #5432 

Changes proposed in this pull request:
- Convert HashMap to TreeMap (case insensitive) to handle cases where column name diverges only in upper/lower case;
- This implementation can, and should, be improved as necessity arises;
- Implemented minor test, can improve further upon recommendation
