### PR TITLE
Enhance of TypedSPI and RequiredSPI

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.dbdiscovery.rule;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import lombok.Getter;
 import org.apache.shardingsphere.dbdiscovery.algorithm.config.AlgorithmProvidedDatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
@@ -37,7 +36,6 @@ import org.apache.shardingsphere.infra.rule.identifier.scope.SchemaRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.StatusContainedRule;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -64,15 +62,15 @@ public final class DatabaseDiscoveryRule implements FeatureRule, SchemaRule, Dat
     private final Map<String, DatabaseDiscoveryDataSourceRule> dataSourceRules;
     
     public DatabaseDiscoveryRule(final DatabaseDiscoveryRuleConfiguration config, final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final String schemaName) {
-        Preconditions.checkArgument(!config.getDataSources().isEmpty(), "HA data source rules can not be empty.");
-        Preconditions.checkArgument(null != dataSourceMap && !dataSourceMap.isEmpty(), "Data sources cannot be empty.");
-        Preconditions.checkArgument(null != databaseType, "Database type cannot be null.");
+        Preconditions.checkArgument(!config.getDataSources().isEmpty(), "database discovery rules can not be empty.");
+        Preconditions.checkArgument(null != dataSourceMap && !dataSourceMap.isEmpty(), "Data sources of cannot be empty.");
+        Preconditions.checkNotNull(databaseType, "Database type cannot be null.");
         config.getDiscoveryTypes().forEach((key, value) -> discoveryTypes.put(key, ShardingSphereAlgorithmFactory.createAlgorithm(value, DatabaseDiscoveryType.class)));
         dataSourceRules = new HashMap<>(config.getDataSources().size(), 1);
         for (DatabaseDiscoveryDataSourceRuleConfiguration each : config.getDataSources()) {
-            DatabaseDiscoveryType databaseDiscoveryType = Strings.isNullOrEmpty(each.getDiscoveryTypeName()) || !discoveryTypes.containsKey(each.getDiscoveryTypeName())
-                    ? TypedSPIRegistry.getRegisteredService(DatabaseDiscoveryType.class) : discoveryTypes.get(each.getDiscoveryTypeName());
-            dataSourceRules.put(each.getName(), new DatabaseDiscoveryDataSourceRule(each, databaseDiscoveryType));
+            Preconditions.checkNotNull(each.getDiscoveryTypeName(), "Discovery type cannot be null of rule name `%s`.", each.getName());
+            Preconditions.checkArgument(discoveryTypes.containsKey(each.getDiscoveryTypeName()), "Can not find discovery type of rule name `%s`.", each.getName());
+            dataSourceRules.put(each.getName(), new DatabaseDiscoveryDataSourceRule(each, discoveryTypes.get(each.getDiscoveryTypeName())));
         }
         for (Entry<String, DatabaseDiscoveryDataSourceRule> entry : dataSourceRules.entrySet()) {
             String groupName = entry.getKey();
@@ -101,9 +99,9 @@ public final class DatabaseDiscoveryRule implements FeatureRule, SchemaRule, Dat
         Preconditions.checkArgument(null != databaseType, "Database type cannot be null.");
         dataSourceRules = new HashMap<>(config.getDataSources().size(), 1);
         for (DatabaseDiscoveryDataSourceRuleConfiguration each : config.getDataSources()) {
-            DatabaseDiscoveryType databaseDiscoveryType = Strings.isNullOrEmpty(each.getDiscoveryTypeName()) || !discoveryTypes.containsKey(each.getDiscoveryTypeName())
-                    ? TypedSPIRegistry.getRegisteredService(DatabaseDiscoveryType.class) : discoveryTypes.get(each.getDiscoveryTypeName());
-            dataSourceRules.put(each.getName(), new DatabaseDiscoveryDataSourceRule(each, databaseDiscoveryType));
+            Preconditions.checkNotNull(each.getDiscoveryTypeName(), "Discovery type cannot be null of rule name `%s`.", each.getName());
+            Preconditions.checkArgument(discoveryTypes.containsKey(each.getDiscoveryTypeName()), "Can not find discovery type of rule name `%s`.", each.getName());
+            dataSourceRules.put(each.getName(), new DatabaseDiscoveryDataSourceRule(each, discoveryTypes.get(each.getDiscoveryTypeName())));
         }
         for (Entry<String, DatabaseDiscoveryDataSourceRule> entry : dataSourceRules.entrySet()) {
             String groupName = entry.getKey();

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/route/DatabaseDiscoverySQLRouterTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/route/DatabaseDiscoverySQLRouterTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDa
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
@@ -54,11 +55,11 @@ import static org.mockito.Mockito.mock;
 @RunWith(MockitoJUnitRunner.class)
 public final class DatabaseDiscoverySQLRouterTest {
     
-    private static final String DATASOURCE_NAME = "ds";
+    private static final String DATA_SOURCE_NAME = "ds";
     
-    private static final String NONE_DB_DISCOVERY_DATASOURCE_NAME = "noneDatabaseDiscoveryDatasource";
+    private static final String NONE_DB_DISCOVERY_DATA_SOURCE_NAME = "noneDatabaseDiscoveryDatasource";
     
-    private static final String PRIMARY_DATASOURCE = "primary";
+    private static final String PRIMARY_DATA_SOURCE = "primary";
     
     private DatabaseDiscoveryRule rule;
     
@@ -73,11 +74,11 @@ public final class DatabaseDiscoverySQLRouterTest {
     
     @Before
     public void setUp() {
-        DatabaseDiscoveryDataSourceRuleConfiguration databaseDiscoveryDataSourceRuleConfiguration 
-                = new DatabaseDiscoveryDataSourceRuleConfiguration(DATASOURCE_NAME, Collections.singletonList(PRIMARY_DATASOURCE), "discoveryTypeName");
-        DatabaseDiscoveryRuleConfiguration databaseDiscoveryRuleConfiguration 
-                = new DatabaseDiscoveryRuleConfiguration(Collections.singleton(databaseDiscoveryDataSourceRuleConfiguration), Collections.emptyMap());
-        rule = new DatabaseDiscoveryRule(databaseDiscoveryRuleConfiguration, mock(DatabaseType.class), Collections.singletonMap("ds", mock(DataSource.class)), "ha_db");
+        DatabaseDiscoveryDataSourceRuleConfiguration dataSourceConfig 
+                = new DatabaseDiscoveryDataSourceRuleConfiguration(DATA_SOURCE_NAME, Collections.singletonList(PRIMARY_DATA_SOURCE), "TEST");
+        ShardingSphereAlgorithmConfiguration algorithmConfig = new ShardingSphereAlgorithmConfiguration("TEST", new Properties());
+        DatabaseDiscoveryRuleConfiguration config = new DatabaseDiscoveryRuleConfiguration(Collections.singleton(dataSourceConfig), Collections.singletonMap("TEST", algorithmConfig));
+        rule = new DatabaseDiscoveryRule(config, mock(DatabaseType.class), Collections.singletonMap("ds", mock(DataSource.class)), "TEST");
         sqlRouter = (DatabaseDiscoverySQLRouter) OrderedSPIRegistry.getRegisteredServices(SQLRouter.class, Collections.singleton(rule)).get(rule);
     }
     
@@ -88,7 +89,7 @@ public final class DatabaseDiscoverySQLRouterTest {
                 mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule)), mock(ShardingSphereSchema.class));
         RouteContext actual = sqlRouter.createRouteContext(logicSQL, metaData, rule, new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATASOURCE));
+        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATA_SOURCE));
     }
     
     @Test
@@ -99,8 +100,8 @@ public final class DatabaseDiscoverySQLRouterTest {
                 mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule)), mock(ShardingSphereSchema.class));
         sqlRouter.decorateRouteContext(actual, logicSQL, metaData, rule, new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(NONE_DB_DISCOVERY_DATASOURCE_NAME));
-        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATASOURCE));
+        assertThat(routedDataSourceNames.next(), is(NONE_DB_DISCOVERY_DATA_SOURCE_NAME));
+        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATA_SOURCE));
     }
     
     @Test
@@ -110,7 +111,7 @@ public final class DatabaseDiscoverySQLRouterTest {
                 mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule)), mock(ShardingSphereSchema.class));
         RouteContext actual = sqlRouter.createRouteContext(logicSQL, metaData, rule, new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATASOURCE));
+        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATA_SOURCE));
     }
     
     @Test
@@ -121,8 +122,8 @@ public final class DatabaseDiscoverySQLRouterTest {
                 mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule)), mock(ShardingSphereSchema.class));
         sqlRouter.decorateRouteContext(actual, logicSQL, metaData, rule, new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(NONE_DB_DISCOVERY_DATASOURCE_NAME));
-        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATASOURCE));
+        assertThat(routedDataSourceNames.next(), is(NONE_DB_DISCOVERY_DATA_SOURCE_NAME));
+        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATA_SOURCE));
     }
     
     @Test
@@ -132,14 +133,14 @@ public final class DatabaseDiscoverySQLRouterTest {
                 mock(ShardingSphereResource.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule)), mock(ShardingSphereSchema.class));
         RouteContext actual = sqlRouter.createRouteContext(logicSQL, metaData, rule, new ConfigurationProperties(new Properties()));
         Iterator<String> routedDataSourceNames = actual.getActualDataSourceNames().iterator();
-        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATASOURCE));
+        assertThat(routedDataSourceNames.next(), is(PRIMARY_DATA_SOURCE));
     }
     
     private RouteContext mockRouteContext() {
         RouteContext result = new RouteContext();
-        RouteUnit routeUnit = new RouteUnit(new RouteMapper(DATASOURCE_NAME, DATASOURCE_NAME), Collections.singletonList(new RouteMapper("table", "table_0")));
+        RouteUnit routeUnit = new RouteUnit(new RouteMapper(DATA_SOURCE_NAME, DATA_SOURCE_NAME), Collections.singletonList(new RouteMapper("table", "table_0")));
         result.getRouteUnits().add(routeUnit);
-        result.getRouteUnits().add(new RouteUnit(new RouteMapper(NONE_DB_DISCOVERY_DATASOURCE_NAME, NONE_DB_DISCOVERY_DATASOURCE_NAME), Collections.emptyList()));
+        result.getRouteUnits().add(new RouteUnit(new RouteMapper(NONE_DB_DISCOVERY_DATA_SOURCE_NAME, NONE_DB_DISCOVERY_DATA_SOURCE_NAME), Collections.emptyList()));
         return result;
     }
 }

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
@@ -49,22 +49,14 @@ public final class DatabaseDiscoveryRuleTest {
     
     @Test
     public void assertFindDataSourceRule() {
-        Optional<DatabaseDiscoveryDataSourceRule> actual = createHARule().findDataSourceRule("test_pr");
+        Optional<DatabaseDiscoveryDataSourceRule> actual = createRule().findDataSourceRule("test_pr");
         assertTrue(actual.isPresent());
         assertDataSourceRule(actual.get());
     }
     
     @Test
     public void assertGetSingleDataSourceRule() {
-        assertDataSourceRule(createHARule().getSingleDataSourceRule());
-    }
-    
-    private DatabaseDiscoveryRule createHARule() {
-        DatabaseDiscoveryDataSourceRuleConfiguration config =
-                new DatabaseDiscoveryDataSourceRuleConfiguration("test_pr", Arrays.asList("ds_0", "ds_1"), "discoveryTypeName");
-        return new DatabaseDiscoveryRule(new DatabaseDiscoveryRuleConfiguration(
-                Collections.singleton(config), ImmutableMap.of("mgr", new ShardingSphereAlgorithmConfiguration("MGR", new Properties()))),
-                mock(DatabaseType.class), dataSourceMap, "ha_db");
+        assertDataSourceRule(createRule().getSingleDataSourceRule());
     }
     
     private void assertDataSourceRule(final DatabaseDiscoveryDataSourceRule actual) {
@@ -74,21 +66,21 @@ public final class DatabaseDiscoveryRuleTest {
     
     @Test
     public void assertUpdateRuleStatusWithNotExistDataSource() {
-        DatabaseDiscoveryRule databaseDiscoveryRule = createHARule();
+        DatabaseDiscoveryRule databaseDiscoveryRule = createRule();
         databaseDiscoveryRule.updateRuleStatus(new DataSourceNameDisabledEvent("db", true));
         assertThat(databaseDiscoveryRule.getSingleDataSourceRule().getDataSourceNames(), is(Arrays.asList("ds_0", "ds_1")));
     }
     
     @Test
     public void assertUpdateRuleStatus() {
-        DatabaseDiscoveryRule databaseDiscoveryRule = createHARule();
+        DatabaseDiscoveryRule databaseDiscoveryRule = createRule();
         databaseDiscoveryRule.updateRuleStatus(new DataSourceNameDisabledEvent("ds_0", true));
         assertThat(databaseDiscoveryRule.getSingleDataSourceRule().getDataSourceNames(), is(Collections.singletonList("ds_1")));
     }
     
     @Test
     public void assertUpdateRuleStatusWithEnable() {
-        DatabaseDiscoveryRule databaseDiscoveryRule = createHARule();
+        DatabaseDiscoveryRule databaseDiscoveryRule = createRule();
         databaseDiscoveryRule.updateRuleStatus(new DataSourceNameDisabledEvent("ds_0", true));
         assertThat(databaseDiscoveryRule.getSingleDataSourceRule().getDataSourceNames(), is(Collections.singletonList("ds_1")));
         databaseDiscoveryRule.updateRuleStatus(new DataSourceNameDisabledEvent("ds_0", false));
@@ -97,9 +89,16 @@ public final class DatabaseDiscoveryRuleTest {
     
     @Test
     public void assertGetDataSourceMapper() {
-        DatabaseDiscoveryRule databaseDiscoveryRule = createHARule();
+        DatabaseDiscoveryRule databaseDiscoveryRule = createRule();
         Map<String, Collection<String>> actual = databaseDiscoveryRule.getDataSourceMapper();
         Map<String, Collection<String>> expected = ImmutableMap.of("test_pr", Arrays.asList("ds_0", "ds_1"));
         assertThat(actual, is(expected));
+    }
+    
+    private DatabaseDiscoveryRule createRule() {
+        DatabaseDiscoveryDataSourceRuleConfiguration config = new DatabaseDiscoveryDataSourceRuleConfiguration("test_pr", Arrays.asList("ds_0", "ds_1"), "TEST");
+        return new DatabaseDiscoveryRule(new DatabaseDiscoveryRuleConfiguration(
+                Collections.singleton(config), ImmutableMap.of("TEST", new ShardingSphereAlgorithmConfiguration("TEST", new Properties()))),
+                mock(DatabaseType.class), dataSourceMap, "ha_db");
     }
 }

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/builder/DatabaseDiscoveryRuleBuilderTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/builder/DatabaseDiscoveryRuleBuilderTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.dbdiscovery.rule.builder;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.rule.builder.ShardingSphereRulesBuilderMaterials;
@@ -37,7 +38,6 @@ import java.util.Properties;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public final class DatabaseDiscoveryRuleBuilderTest {
     
@@ -48,13 +48,13 @@ public final class DatabaseDiscoveryRuleBuilderTest {
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Test
     public void assertBuild() {
-        DatabaseDiscoveryRuleConfiguration ruleConfig = mock(DatabaseDiscoveryRuleConfiguration.class);
-        DatabaseDiscoveryDataSourceRuleConfiguration dataSourceRuleConfig = new DatabaseDiscoveryDataSourceRuleConfiguration("name", Collections.singletonList("name"), "discoveryTypeName");
-        when(ruleConfig.getDataSources()).thenReturn(Collections.singletonList(dataSourceRuleConfig));
-        SchemaRuleBuilder builder = OrderedSPIRegistry.getRegisteredServices(SchemaRuleBuilder.class, Collections.singletonList(ruleConfig)).get(ruleConfig);
+        DatabaseDiscoveryDataSourceRuleConfiguration dataSourceConfig = new DatabaseDiscoveryDataSourceRuleConfiguration("name", Collections.singletonList("name"), "TEST");
+        DatabaseDiscoveryRuleConfiguration config = new DatabaseDiscoveryRuleConfiguration(
+                Collections.singleton(dataSourceConfig), Collections.singletonMap("TEST", new ShardingSphereAlgorithmConfiguration("TEST", new Properties())));
+        SchemaRuleBuilder builder = OrderedSPIRegistry.getRegisteredServices(SchemaRuleBuilder.class, Collections.singletonList(config)).get(config);
         Map<String, DataSource> dataSourceMap = new HashMap<>(1, 1);
         dataSourceMap.put("primaryDataSourceName", mock(DataSource.class));
         assertThat(builder.build(new ShardingSphereRulesBuilderMaterials("test_schema", Collections.emptyList(), mock(DatabaseType.class),
-                dataSourceMap, new ConfigurationProperties(new Properties())), ruleConfig, Collections.emptyList()), instanceOf(DatabaseDiscoveryRule.class));
+                dataSourceMap, new ConfigurationProperties(new Properties())), config, Collections.emptyList()), instanceOf(DatabaseDiscoveryRule.class));
     }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-api/src/main/java/org/apache/shardingsphere/readwritesplitting/spi/ReplicaLoadBalanceAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-api/src/main/java/org/apache/shardingsphere/readwritesplitting/spi/ReplicaLoadBalanceAlgorithm.java
@@ -18,13 +18,14 @@
 package org.apache.shardingsphere.readwritesplitting.spi;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.spi.required.RequiredSPI;
 
 import java.util.List;
 
 /**
  * Replica load-balance algorithm.
  */
-public interface ReplicaLoadBalanceAlgorithm extends ShardingSphereAlgorithm {
+public interface ReplicaLoadBalanceAlgorithm extends ShardingSphereAlgorithm, RequiredSPI {
     
     /**
      * Get data source.

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/RoundRobinReplicaLoadBalanceAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/RoundRobinReplicaLoadBalanceAlgorithm.java
@@ -49,4 +49,9 @@ public final class RoundRobinReplicaLoadBalanceAlgorithm implements ReplicaLoadB
     public String getType() {
         return "ROUND_ROBIN";
     }
+    
+    @Override
+    public boolean isDefault() {
+        return true;
+    }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
@@ -31,7 +31,7 @@ import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleCo
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.spi.ReplicaLoadBalanceAlgorithm;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
+import org.apache.shardingsphere.spi.required.RequiredSPIRegistry;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -60,7 +60,7 @@ public final class ReadwriteSplittingRule implements FeatureRule, SchemaRule, Da
         for (ReadwriteSplittingDataSourceRuleConfiguration each : ruleConfig.getDataSources()) {
             // TODO check if can not find load balancer should throw exception.
             ReplicaLoadBalanceAlgorithm loadBalanceAlgorithm = Strings.isNullOrEmpty(each.getLoadBalancerName()) || !loadBalancers.containsKey(each.getLoadBalancerName())
-                    ? TypedSPIRegistry.getRegisteredService(ReplicaLoadBalanceAlgorithm.class) : loadBalancers.get(each.getLoadBalancerName());
+                    ? RequiredSPIRegistry.getRegisteredService(ReplicaLoadBalanceAlgorithm.class) : loadBalancers.get(each.getLoadBalancerName());
             dataSourceRules.put(each.getName(), new ReadwriteSplittingDataSourceRule(each, loadBalanceAlgorithm));
         }
     }
@@ -72,7 +72,7 @@ public final class ReadwriteSplittingRule implements FeatureRule, SchemaRule, Da
         for (ReadwriteSplittingDataSourceRuleConfiguration each : ruleConfig.getDataSources()) {
             // TODO check if can not find load balancer should throw exception.
             ReplicaLoadBalanceAlgorithm loadBalanceAlgorithm = Strings.isNullOrEmpty(each.getLoadBalancerName()) || !loadBalancers.containsKey(each.getLoadBalancerName())
-                    ? TypedSPIRegistry.getRegisteredService(ReplicaLoadBalanceAlgorithm.class) : loadBalancers.get(each.getLoadBalancerName());
+                    ? RequiredSPIRegistry.getRegisteredService(ReplicaLoadBalanceAlgorithm.class) : loadBalancers.get(each.getLoadBalancerName());
             dataSourceRules.put(each.getName(), new ReadwriteSplittingDataSourceRule(each, loadBalanceAlgorithm));
         }
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/spi/KeyGenerateAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/spi/KeyGenerateAlgorithm.java
@@ -19,11 +19,12 @@ package org.apache.shardingsphere.sharding.spi;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
+import org.apache.shardingsphere.spi.required.RequiredSPI;
 
 /**
  * Key generate algorithm.
  */
-public interface KeyGenerateAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
+public interface KeyGenerateAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor, RequiredSPI {
     
     /**
      * Generate key.

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithm.java
@@ -163,4 +163,9 @@ public final class SnowflakeKeyGenerateAlgorithm implements KeyGenerateAlgorithm
     public String getType() {
         return "SNOWFLAKE";
     }
+    
+    @Override
+    public boolean isDefault() {
+        return true;
+    }
 }

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPI.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPI.java
@@ -27,5 +27,7 @@ public interface RequiredSPI {
      *
      * @return is default service provider or not
      */
-    boolean isDefault();
+    default boolean isDefault() {
+        return false;
+    }
 }

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistry.java
@@ -45,6 +45,6 @@ public final class RequiredSPIRegistry {
         if (1 == services.size()) {
             return services.iterator().next();
         }
-        return services.stream().filter(each -> !each.isDefault()).findFirst().orElseGet(() -> services.iterator().next());
+        return services.stream().filter(RequiredSPI::isDefault).findFirst().orElseGet(() -> services.iterator().next());
     }
 }

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/typed/TypedSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/typed/TypedSPIRegistry.java
@@ -75,19 +75,4 @@ public final class TypedSPIRegistry {
         }
         throw new ServiceProviderNotFoundException(typedSPIClass, type);
     }
-    
-    /**
-     * Get registered service.
-     *
-     * @param typedSPIClass typed SPI class
-     * @param <T> type
-     * @return registered service
-     */
-    public static <T extends TypedSPI> T getRegisteredService(final Class<T> typedSPIClass) {
-        Optional<T> serviceInstance = ShardingSphereServiceLoader.newServiceInstances(typedSPIClass).stream().findFirst();
-        if (serviceInstance.isPresent()) {
-            return serviceInstance.get();
-        }
-        throw new ServiceProviderNotFoundException(typedSPIClass);
-    }
 }

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistryTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistryTest.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
 import org.apache.shardingsphere.spi.fixture.required.NoImplRequiredSPIFixture;
 import org.apache.shardingsphere.spi.fixture.required.RequiredSPIFixture;
-import org.apache.shardingsphere.spi.fixture.required.RequiredSPIFixtureDefaultFalseImpl;
+import org.apache.shardingsphere.spi.fixture.required.RequiredSPIFixtureDefaultTrueImpl;
 import org.apache.shardingsphere.spi.fixture.required.RequiredSPIImpl;
 import org.junit.Test;
 
@@ -48,6 +48,6 @@ public final class RequiredSPIRegistryTest {
     @Test
     public void assertRegisteredServiceMoreThanOne() {
         RequiredSPIFixture actualRegisteredService = RequiredSPIRegistry.getRegisteredService(RequiredSPIFixture.class);
-        assertTrue(actualRegisteredService instanceof RequiredSPIFixtureDefaultFalseImpl);
+        assertTrue(actualRegisteredService instanceof RequiredSPIFixtureDefaultTrueImpl);
     }
 }

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/typed/TypedSPIRegistryTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/typed/TypedSPIRegistryTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.spi.typed;
 
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
-import org.apache.shardingsphere.spi.fixture.typed.NoImplTypedSPIFixture;
 import org.apache.shardingsphere.spi.fixture.typed.TypedSPIFixture;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,37 +38,23 @@ public final class TypedSPIRegistryTest {
     
     @Test
     public void assertGetRegisteredService() {
-        String type = "FIXTURE";
-        TypedSPIFixture actual = TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, type, new Properties());
+        TypedSPIFixture actual = TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, "FIXTURE", new Properties());
         assertNotNull(actual);
     }
     
     @Test
-    public void assertPropertiesGetRegisteredService() {
+    public void assertGetRegisteredServiceWithProperties() {
         Properties properties = new Properties();
         properties.put("key1", 1);
         properties.put("key2", 2L);
-        String type = "FIXTURE";
-        TypedSPIFixture actual = TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, type, properties);
+        TypedSPIFixture actual = TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, "FIXTURE", properties);
         assertNotNull(actual);
         assertThat(actual.getProps().getProperty("key1"), is("1"));
         assertThat(actual.getProps().getProperty("key2"), is("2"));
     }
     
-    @Test
-    public void assertGetRegisteredServiceBySPIClass() {
-        TypedSPIFixture actual = TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class);
-        assertNotNull(actual);
-    }
-    
     @Test(expected = ServiceProviderNotFoundException.class)
     public void assertGetRegisteredServiceWhenTypeIsNotExist() {
-        String type = "TEST_FIXTURE";
-        TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, type, new Properties());
-    }
-    
-    @Test(expected = ServiceProviderNotFoundException.class)
-    public void assertGetRegisteredServiceWhenSPIClassIsNotExist() {
-        TypedSPIRegistry.getRegisteredService(NoImplTypedSPIFixture.class);
+        TypedSPIRegistry.getRegisteredService(TypedSPIFixture.class, "NOT_EXISTED", new Properties());
     }
 }


### PR DESCRIPTION
- Add RequiredSPI for KeyGenerateAlgorithm and ReplicaLoadBalanceAlgorithm
- Remove TypedSPIRegistry.getRegisteredService without type
- Use RequiredSPIRegistry get default impl for KeyGenerateAlgorithm and ReplicaLoadBalanceAlgorithm
- Fix RequiredSPIRegistry error with get default SPI
- Check arg of DatabaseDiscovery, do not permit empty of DatabaseDiscoveryType