### PR TITLE
Modify the judgment conditions of `BroadcastDatabaseBackendHandler.java` and `UnicastDatabaseBackendHandler.java`

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
@@ -46,4 +46,13 @@ public final class ShardingSphereMetaData {
     public boolean isComplete() {
         return !ruleMetaData.getRules().isEmpty() && !resource.getDataSources().isEmpty();
     }
+    
+    /**
+     * Determine whether there is a data source.
+     *
+     * @return has datasource or not
+     */
+    public boolean hasDataSource() {
+        return !resource.getDataSources().isEmpty();
+    }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandler.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.proxy.backend.communication.DatabaseCommunicationEngineFactory;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.BackendConnection;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
-import org.apache.shardingsphere.proxy.backend.exception.RuleNotExistedException;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.text.data.DatabaseBackendHandler;
@@ -52,9 +51,6 @@ public final class BroadcastDatabaseBackendHandler implements DatabaseBackendHan
                     continue;
                 }
                 backendConnection.setCurrentSchema(each);
-                if (!ProxyContext.getInstance().getMetaData(each).isComplete()) {
-                    throw new RuleNotExistedException();
-                }
                 databaseCommunicationEngineFactory.newTextProtocolInstance(sqlStatementContext, sql, backendConnection).execute();
             }
         } finally {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandler.java
@@ -48,6 +48,9 @@ public final class BroadcastDatabaseBackendHandler implements DatabaseBackendHan
         String originalSchema = backendConnection.getSchemaName();
         try {
             for (String each : ProxyContext.getInstance().getAllSchemaNames()) {
+                if (!ProxyContext.getInstance().getMetaData(each).hasDataSource()) {
+                    continue;
+                }
                 backendConnection.setCurrentSchema(each);
                 if (!ProxyContext.getInstance().getMetaData(each).isComplete()) {
                     throw new RuleNotExistedException();

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/UnicastDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/UnicastDatabaseBackendHandler.java
@@ -52,7 +52,7 @@ public final class UnicastDatabaseBackendHandler implements DatabaseBackendHandl
     public ResponseHeader execute() throws SQLException {
         String originSchema = backendConnection.getSchemaName();
         String schemaName = null == originSchema ? getFirstSchemaName() : originSchema;
-        if (!ProxyContext.getInstance().getMetaData(schemaName).isComplete()) {
+        if (!ProxyContext.getInstance().getMetaData(schemaName).hasDataSource()) {
             throw new RuleNotExistedException();
         }
         try {
@@ -69,7 +69,7 @@ public final class UnicastDatabaseBackendHandler implements DatabaseBackendHandl
         if (schemaNames.isEmpty()) {
             throw new NoDatabaseSelectedException();
         }
-        Optional<String> result = schemaNames.stream().filter(each -> ProxyContext.getInstance().getMetaData(each).isComplete()).findFirst();
+        Optional<String> result = schemaNames.stream().filter(each -> ProxyContext.getInstance().getMetaData(each).hasDataSource()).findFirst();
         if (!result.isPresent()) {
             throw new RuleNotExistedException();
         }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandlerTest.java
@@ -102,9 +102,8 @@ public final class BroadcastDatabaseBackendHandlerTest {
         Map<String, ShardingSphereMetaData> result = new HashMap<>(10, 1);
         for (int i = 0; i < 10; i++) {
             ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
-            when(metaData.isComplete()).thenReturn(true);
-            when(metaData.getResource().getDatabaseType()).thenReturn(new H2DatabaseType());
             when(metaData.hasDataSource()).thenReturn(true);
+            when(metaData.getResource().getDatabaseType()).thenReturn(new H2DatabaseType());
             result.put(String.format(SCHEMA_PATTERN, i), metaData);
         }
         return result;

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/BroadcastDatabaseBackendHandlerTest.java
@@ -104,6 +104,7 @@ public final class BroadcastDatabaseBackendHandlerTest {
             ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
             when(metaData.isComplete()).thenReturn(true);
             when(metaData.getResource().getDatabaseType()).thenReturn(new H2DatabaseType());
+            when(metaData.hasDataSource()).thenReturn(true);
             result.put(String.format(SCHEMA_PATTERN, i), metaData);
         }
         return result;

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/UnicastDatabaseBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/data/impl/UnicastDatabaseBackendHandlerTest.java
@@ -94,7 +94,7 @@ public final class UnicastDatabaseBackendHandlerTest {
         Map<String, ShardingSphereMetaData> result = new HashMap<>(10, 1);
         for (int i = 0; i < 10; i++) {
             ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
-            when(metaData.isComplete()).thenReturn(true);
+            when(metaData.hasDataSource()).thenReturn(true);
             when(metaData.getResource().getDatabaseType()).thenReturn(new H2DatabaseType());
             result.put(String.format(SCHEMA_PATTERN, i), metaData);
         }


### PR DESCRIPTION
Same reason as #12017.

Changes proposed in this pull request:
- Add hasDatasource() method
- Modify the schema judgment condition in BroadcastDatabaseBackendHandler.class
- Modify unit test

![image](https://user-images.githubusercontent.com/52209337/131299952-811480c0-ec7c-4bc5-a9c1-27216467a157.png)

In the current situation, `BroadcastDatabaseBackendHandler.java` and `UnicastDatabaseBackendHandler.java` can be executed without `Rules`