### PR TITLE
Remove unnecessary rules in Oracle DML statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -147,10 +147,6 @@ parenthesisSelectSubquery
     : LP_ selectSubquery RP_
     ;
 
-unionClause
-    : queryBlock (UNION (ALL | DISTINCT)? queryBlock)*
-    ;
-
 queryBlock
     : withClause? SELECT hint? duplicateSpecification? selectList selectFromClause whereClause? hierarchicalQueryClause? groupByClause? modelClause?
     ;
@@ -405,20 +401,8 @@ duplicateSpecification
     : (DISTINCT | UNIQUE) | ALL
     ;
 
-projections
-    : (unqualifiedShorthand | projection) (COMMA_ projection)*
-    ;
-
-projection
-    : (columnName | expr) (AS? alias)? | qualifiedShorthand
-    ;
-
 unqualifiedShorthand
     : ASTERISK_
-    ;
-
-qualifiedShorthand
-    : identifier DOT_ASTERISK_
     ;
 
 selectList
@@ -433,31 +417,6 @@ selectProjection
 
 selectProjectionExprClause
     : expr (AS? alias)?
-    ;
-
-fromClause
-    : FROM tableReferences
-    ;
-
-tableReferences
-    : tableReference (COMMA_ tableReference)*
-    ;
-
-tableReference
-    : tableFactor joinedTable*
-    ;
-
-tableFactor
-    : tableName (AS? alias)? | subquery AS? alias? columnNames? | LP_ tableReferences RP_
-    ;
-
-joinedTable
-    : NATURAL? ((INNER | CROSS)? JOIN) tableFactor joinSpecification?
-    | NATURAL? (LEFT | RIGHT | FULL) OUTER? JOIN tableFactor joinSpecification?
-    ;
-
-joinSpecification
-    : ON expr | USING columnNames
     ;
 
 selectFromClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
@@ -92,7 +92,6 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.Subque
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.SubqueryFactoringClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.TableCollectionExprContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.TableNameContext;
-import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.UnionClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.UpdateContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.UpdateSetClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.UpdateSetColumnClauseContext;
@@ -169,7 +168,6 @@ public final class OracleDMLStatementSQLVisitor extends OracleStatementSQLVisito
     @Override
     public ASTNode visitInsert(final InsertContext ctx) {
         // TODO :FIXME, since there is no segment for insertValuesClause, InsertStatement is created by sub rule.
-        // TODO :deal with insert select
         if (null != ctx.insertSingleTable()) {
             OracleInsertStatement result = (OracleInsertStatement) visit(ctx.insertSingleTable());
             return result;
@@ -470,19 +468,12 @@ public final class OracleDMLStatementSQLVisitor extends OracleStatementSQLVisito
     
     @Override
     public ASTNode visitSelect(final SelectContext ctx) {
-        // TODO :Unsupported for withClause.
         OracleSelectStatement result = (OracleSelectStatement) visit(ctx.selectSubquery());
         result.setParameterCount(getCurrentParameterIndex());
         if (null != ctx.forUpdateClause()) {
             result.setLock((LockSegment) visit(ctx.forUpdateClause()));
         }
         return result;
-    }
-    
-    @Override
-    public ASTNode visitUnionClause(final UnionClauseContext ctx) {
-        // TODO :Unsupported for union SQL.
-        return visit(ctx.queryBlock(0));
     }
     
     @Override


### PR DESCRIPTION
#10111

Hi @wgy8283335, I've removed rules that are not used in Oracle DML statements and removed todos that are already implemented.

Changes proposed in this pull request:
- Removed unnecessary rules
- Removed todos that are already implemented.
