### PR TITLE
Remove the check method of sharding rule

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/AbstractShardingRuleConfigurationChecker.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/AbstractShardingRuleConfigurationChecker.java
@@ -17,10 +17,9 @@
 
 package org.apache.shardingsphere.sharding.rule.checker;
 
-import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
+import org.apache.shardingsphere.infra.rule.checker.RuleConfigurationChecker;
 import org.apache.shardingsphere.sharding.algorithm.config.AlgorithmProvidedShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 
 /**
  * Abstract sharding rule configuration checker.
@@ -33,7 +32,4 @@ public abstract class AbstractShardingRuleConfigurationChecker<T extends RuleCon
         return !config.getTables().isEmpty() || null != config.getDefaultTableShardingStrategy() || !config.getAutoTables().isEmpty();
     }
     
-    protected final boolean hasAvailableTableConfigurations(final ShardingRuleConfiguration config) {
-        return !config.getTables().isEmpty() || null != config.getDefaultTableShardingStrategy() || !config.getAutoTables().isEmpty();
-    }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleConfigurationChecker.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleConfigurationChecker.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sharding.rule.checker;
 
-import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.constant.ShardingOrder;
 
@@ -28,7 +27,6 @@ public final class ShardingRuleConfigurationChecker extends AbstractShardingRule
     
     @Override
     public void check(final String schemaName, final ShardingRuleConfiguration config) {
-        Preconditions.checkState(hasAvailableTableConfigurations(config), "No available rule configs in `%s` for governance.", schemaName);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/checker/ShardingRuleConfigurationCheckerTest.java
@@ -56,15 +56,4 @@ public final class ShardingRuleConfigurationCheckerTest {
         checker.check("test", ruleConfig);
     }
     
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Test(expected = IllegalStateException.class)
-    public void assertCheckNoPass() {
-        ShardingRuleConfiguration ruleConfig = mock(ShardingRuleConfiguration.class);
-        when(ruleConfig.getTables()).thenReturn(Collections.emptyList());
-        when(ruleConfig.getAutoTables()).thenReturn(Collections.emptyList());
-        RuleConfigurationChecker checker = OrderedSPIRegistry.getRegisteredServices(RuleConfigurationChecker.class, Collections.singleton(ruleConfig)).get(ruleConfig);
-        assertNotNull(checker);
-        assertThat(checker, instanceOf(ShardingRuleConfigurationChecker.class));
-        checker.check("test", ruleConfig);
-    }
 }


### PR DESCRIPTION
Fixes #12195

Changes proposed in this pull request:
- Remove the check method of sharding rule

When I use `drop sharding table rule` to delete the last rule, the `tables` and `autoTables` in the local `ShardingSphereMetaData` will be empty, which will cause persistence failure.

When starting and modifying `sharding table rule`, local data should be persisted to ZK