### PR TITLE
Switch dataSources and rules configuration after scaling task triggered by http api finished

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/governance/registry/config/event/rule/ClusterSwitchConfigurationEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/governance/registry/config/event/rule/ClusterSwitchConfigurationEvent.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.governance.registry.config.event.rule;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.config.RuleConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Cluster switch configuration event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class ClusterSwitchConfigurationEvent {
+    
+    private final String targetSchemaName;
+    
+    private final Map<String, DataSourceConfiguration> targetDataSourceConfigs;
+    
+    private final Collection<RuleConfiguration> targetRuleConfigs;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/governance/registry/config/event/rule/ScalingTaskFinishedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/governance/registry/config/event/rule/ScalingTaskFinishedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.governance.registry.config.event.rule;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Scaling task finished event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class ScalingTaskFinishedEvent {
+    
+    private final String targetSchemaName;
+    
+    private final String targetParameter;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/datasource/ScalingDataSourceConfigurationWrap.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/datasource/ScalingDataSourceConfigurationWrap.java
@@ -29,6 +29,8 @@ import java.util.Map;
 @Setter
 public class ScalingDataSourceConfigurationWrap {
     
+    private String schemaName;
+    
     private String type;
     
     private String parameter;


### PR DESCRIPTION
Fixes #12204.

Changes proposed in this pull request:
- Add schemaName for /scaling/job/start, indicate which schema to switch
- Switch configuration in governance when scaling task finished, update `dataSources` and `rules`
