### PR TITLE
issue actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ on:
     branches: [ master, dev ]
   pull_request:
     branches: [ master ]
+  repository_dispatch:
+    types: [rerun-ci]
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=30

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -1,0 +1,92 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: ISSUE Standardized Process
+
+on:
+  schedule:
+    - cron: '0 0 */1 * *'  # once a day
+
+  issue_comment:
+    types: [created,edited]
+
+  issues:
+    types: [labeled,edited,reopened]
+  
+
+jobs:
+  comment-action:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'issue_comment' }}
+    steps:
+      - name: Print Issue Comment
+        run: |
+          echo ${{ github.event.comment.body }}
+
+      - name: Trigger The CI Workflow
+        if: ${{ contains( github.event.comment.body , '/run ci') }} 
+        uses: mvasigh/dispatch-action@main
+        with:
+          token: ${{ secrets.PERSONAL_TOKEN }}
+          repo: shardingsphere
+          owner: ${{ github.actor }}
+          event_type: rerun-ci
+
+  remove-inactive:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'issue_comment' || ( github.event_name == 'issues' && ( github.event.action == 'edited' || github.event.action == 'reopened' ) ) }}
+    steps:
+    - name: Remove "status:inactive" label
+      if: ${{ contains( github.event.issue.labels.*.name , format('status{0} inactive', ':') ) }}
+      uses: actions-cool/issues-helper@v2.2.1
+      with:
+        actions: 'remove-labels'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.issue.number }}
+        labels: "status: inactive"
+
+  
+  check-inactive-issue:
+    runs-on: ubuntu-latest
+    concurrency: check-inactive  # singleton-run-stage
+    if: ${{ github.event_name == 'schedule' }}
+    steps:
+      - name: check-inactive   # add `status: inactive` label
+        uses: actions-cool/issues-helper@v2.2.1 
+        with: 
+          actions: 'check-inactive' 
+          token: ${{ secrets.GITHUB_TOKEN }} 
+          inactive-day: 15
+          inactive-label: "status: inactive"
+          body: |
+            Hello ${{ github.event.issue.user.login }}, this issue has not received a reply for serveral days.
+            This issue is supposed to be closed.
+          contents: "heart"
+  
+  close-issue:
+    runs-on: ubuntu-latest
+    concurrency:    # singleton-run-stage
+      group: close-issue
+      cancel-in-progress: true
+    if: ${{ github.event_name == 'schedule' || ( github.event_name == 'issues' && github.event.action == 'labeled' ) }}
+    steps:
+      - name: Close Issue   # close issues with `labels`
+        uses: actions-cool/issues-helper@v2.2.1
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'status: inactive'

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -25,7 +25,7 @@ on:
     types: [created,edited]
 
   issues:
-    types: [labeled,edited,reopened]
+    types: [labeled,reopened]
   
 
 jobs:
@@ -48,7 +48,7 @@ jobs:
 
   remove-inactive:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'issue_comment' || ( github.event_name == 'issues' && ( github.event.action == 'edited' || github.event.action == 'reopened' ) ) }}
+    if: ${{  github.event_name == 'issues' && github.event.action == 'reopened'  }}
     steps:
     - name: Remove "status:inactive" label
       if: ${{ contains( github.event.issue.labels.*.name , format('status{0} inactive', ':') ) }}


### PR DESCRIPTION
Fixes #9697.

Changes proposed in this pull request:
- `Rerun CI` when comment `/run ci` 
- Remove `status: inactive` tag when the corresponding issue is reopened, edited or commented.
- Close issues without reply for fifteen days
- Close issues with tag `status: inactive`

:eyes: We only need to pay attention to the file: `.github/workflows/issue.yml` 

# :cactus: `Rerun CI` when comment `/run ci` 

```yaml
  comment-action:
    runs-on: ubuntu-latest
    if: ${{ github.event_name == 'issue_comment' }}
    steps:
      - name: Print Issue Comment
        run: |
          echo ${{ github.event.comment.body }}

      - name: Trigger The CI Workflow
        if: ${{ contains( github.event.comment.body , '/run ci') }} 
        uses: mvasigh/dispatch-action@main
        with:
          token: ${{ secrets.PERSONAL_TOKEN }}
          repo: shardingsphere
          owner: ${{ github.actor }}
          event_type: rerun-ci
```

Test result: [here](https://github.com/QiliangFan/shardingsphere/actions/runs/1205832417) | [CI triggered by github actions](https://github.com/QiliangFan/shardingsphere/actions/runs/1205832785)



# 😄  Remove `status: inactive` tag when the corresponding issue is reopened.

```yaml
  remove-inactive:
    runs-on: ubuntu-latest
    if: ${{  github.event_name == 'issues' && github.event.action == 'reopened'  }}
    steps:
    - name: Remove "status:inactive" label
      if: ${{ contains( github.event.issue.labels.*.name , format('status{0} inactive', ':') ) }}
      uses: actions-cool/issues-helper@v2.2.1
      with:
        actions: 'remove-labels'
        token: ${{ secrets.GITHUB_TOKEN }}
        issue-number: ${{ github.event.issue.number }}
        labels: "status: inactive"
```

Test result: [here](https://github.com/QiliangFan/shardingsphere/actions/runs/1205862858)



# :closed_lock_with_key:  Close issues without reply for fifteen days

```yaml
  check-inactive-issue:
    runs-on: ubuntu-latest
    concurrency: check-inactive  # singleton-run-stage
    if: ${{ github.event_name == 'schedule' }}
    steps:
      - name: check-inactive   # add `status: inactive` label
        uses: actions-cool/issues-helper@v2.2.1 
        with: 
          actions: 'check-inactive' 
          token: ${{ secrets.GITHUB_TOKEN }} 
          inactive-day: 15
          inactive-label: "status: inactive"
          body: |
            Hello ${{ github.event.issue.user.login }}, this issue has not received a reply for serveral days.
            This issue is supposed to be closed.
          contents: "heart"
```



# :mask: Close issues with tag `status: inactive`

```yaml
  close-issue:
    runs-on: ubuntu-latest
    concurrency:    # singleton-run-stage
      group: close-issue
      cancel-in-progress: true
    if: ${{ github.event_name == 'schedule' || ( github.event_name == 'issues' && github.event.action == 'labeled' ) }}
    steps:
      - name: Close Issue   # close issues with `labels`
        uses: actions-cool/issues-helper@v2.2.1
        with:
          actions: 'close-issues'
          token: ${{ secrets.GITHUB_TOKEN }}
          labels: 'status: inactive'
```

Test result: [here](https://github.com/QiliangFan/shardingsphere/actions/runs/1205828460)

