### PR TITLE
Fix allIncrementalTasksAlmostFinished check return true earlier than configured threshold when scaling incremental task has no any data

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
@@ -72,7 +72,6 @@ public final class IncrementalTask extends AbstractScalingExecutor implements Sc
         taskId = dumperConfig.getDataSourceName();
         progress = new IncrementalTaskProgress();
         progress.setPosition(dumperConfig.getPosition());
-        progress.getIncrementalTaskDelay().setLatestActiveTimeMillis(System.currentTimeMillis());
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
@@ -72,10 +72,12 @@ public final class IncrementalTask extends AbstractScalingExecutor implements Sc
         taskId = dumperConfig.getDataSourceName();
         progress = new IncrementalTaskProgress();
         progress.setPosition(dumperConfig.getPosition());
+        progress.getIncrementalTaskDelay().setLatestActiveTimeMillis(System.currentTimeMillis());
     }
     
     @Override
     public void start() {
+        progress.getIncrementalTaskDelay().setLatestActiveTimeMillis(System.currentTimeMillis());
         dumper = DumperFactory.newInstanceLogDumper(dumperConfig, progress.getPosition());
         Collection<Importer> importers = instanceImporters();
         instanceChannel(importers);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/ScalingTaskUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/ScalingTaskUtil.java
@@ -60,7 +60,10 @@ public final class ScalingTaskUtil {
     private static boolean allIncrementalTasksAlmostFinished(final Map<Integer, JobProgress> jobProgressMap) {
         long currentTimeMillis = System.currentTimeMillis();
         Collection<Long> incrementalTaskIdleMinutes = jobProgressMap.values().stream().flatMap(each -> each.getIncrementalTaskProgressMap().values().stream())
-                .map(each -> TimeUnit.MILLISECONDS.toMinutes(currentTimeMillis - each.getIncrementalTaskDelay().getLatestActiveTimeMillis()))
+                .map(each -> {
+                    long latestActiveTimeMillis = each.getIncrementalTaskDelay().getLatestActiveTimeMillis();
+                    return latestActiveTimeMillis > 0 ? TimeUnit.MILLISECONDS.toMinutes(currentTimeMillis - latestActiveTimeMillis) : 0;
+                })
                 .collect(Collectors.toList());
         ScalingClusterAutoSwitchAlgorithm clusterAutoSwitchAlgorithm = ScalingContext.getInstance().getClusterAutoSwitchAlgorithm();
         return clusterAutoSwitchAlgorithm.allIncrementalTasksAlmostFinished(incrementalTaskIdleMinutes);

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
@@ -39,6 +39,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
     
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
+        long currentTimeMillis = System.currentTimeMillis();
         data = ScalingAPIFactory.getScalingAPI().getProgress(((ShowScalingJobStatusStatement) sqlStatement).getJobId()).entrySet().stream()
                 .map(entry -> {
                     Collection<Object> list = new LinkedList<>();
@@ -48,7 +49,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
                         list.add(entry.getValue().getStatus());
                         list.add(entry.getValue().getInventoryFinishedPercentage());
                         long latestActiveTimeMillis = entry.getValue().getIncrementalLatestActiveTimeMillis();
-                        list.add(latestActiveTimeMillis > 0 ? TimeUnit.MILLISECONDS.toMinutes(System.currentTimeMillis() - latestActiveTimeMillis) : 0);
+                        list.add(latestActiveTimeMillis > 0 ? TimeUnit.MILLISECONDS.toMinutes(currentTimeMillis - latestActiveTimeMillis) : 0);
                     }
                     return list;
                 }).collect(Collectors.toList()).iterator();


### PR DESCRIPTION
Changes proposed in this pull request:
- Update latestActiveTimeMillis on incremental task start

Configuration:
incremental-task-idle-minute-threshold: 30
