### PR TITLE
Fix 12283 : Fix ignored NPE in FinishedCheckJobTest.assertExecuteActiveJob

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/FinishedCheckJobTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/FinishedCheckJobTest.java
@@ -76,7 +76,11 @@ public final class FinishedCheckJobTest {
     public void assertExecuteActiveJob() {
         JobInfo jobInfo = new JobInfo(1L);
         jobInfo.setActive(true);
-        jobInfo.setJobParameter("handleConfig:\nruleConfig:\n");
+        jobInfo.setJobParameter("handleConfig:\n"
+                + "  concurrency: 2\n"
+                + "  shardingTables:\n"
+                + "  - ds_0.t_order_$->{0..1}\n"
+                + "ruleConfig:\n");
         List<JobInfo> jobInfos = Collections.singletonList(jobInfo);
         when(scalingAPI.list()).thenReturn(jobInfos);
         when(scalingAPI.getProgress(1L)).thenReturn(Collections.emptyMap());


### PR DESCRIPTION
Fixes #12283.

Changes proposed in this pull request:
- Exception in `FinishedCheckJob.execute` is printed and ignored, make exception not happen
