### PR TITLE
fix PostgreSQL unicodeEscape ambiguous parse

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -112,11 +112,7 @@ literalsType
     ;
 
 identifier
-    : unicodeEscapes? IDENTIFIER_ uescape? |  unreservedWord 
-    ;
-
-unicodeEscapes
-    : ('U' | 'u') AMPERSAND_
+    : UNICODE_ESCAPE? IDENTIFIER_ uescape? |  unreservedWord 
     ;
 
 uescape

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
@@ -74,7 +74,7 @@ setClause
     ;
 
 setTarget
-    : colId optIndirection
+    : colId
     ;
 
 setTargetList

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/Symbol.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/Symbol.g4
@@ -63,6 +63,7 @@ NOT_TILDE_TILDE_:    '!~~';
 TYPE_CAST_:          '::';
 ILIKE_:              '~~*';
 NOT_ILIKE_:          '!~~*';
+UNICODE_ESCAPE:      'U&' | 'u&';
 JSON_EXTRACT_:       '->';
 JSON_EXTRACT_TEXT_:  '->>';
 JSON_PATH_EXTRACT_:  '#>';

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -658,23 +658,13 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementB
         List<ColumnSegment> columnSegments = new LinkedList<>();
         columnSegments.add(columnSegment);
         ExpressionSegment expressionSegment = (ExpressionSegment) visit(ctx.aExpr());
-        AssignmentSegment result = new ColumnAssignmentSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), columnSegments, expressionSegment);
-        return result;
+        return new ColumnAssignmentSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), columnSegments, expressionSegment);
     }
     
     @Override
     public ASTNode visitSetTarget(final SetTargetContext ctx) {
-        OwnerSegment owner = null;
-        IdentifierValue identifierValue;
-        if (null != ctx.optIndirection().indirectionEl()) {
-            owner = new OwnerSegment(ctx.colId().start.getStartIndex(), ctx.colId().stop.getStopIndex(), new IdentifierValue(ctx.colId().getText()));
-            identifierValue = new IdentifierValue(ctx.optIndirection().getText());
-        } else {
-            identifierValue = new IdentifierValue(ctx.colId().getText());
-        }
-        ColumnSegment result = new ColumnSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), identifierValue);
-        result.setOwner(owner);
-        return result;
+        IdentifierValue identifierValue = new IdentifierValue(ctx.colId().getText());
+        return new ColumnSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), identifierValue);
     }
     
     @Override

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/update.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/update.xml
@@ -115,6 +115,56 @@
         </where>
     </update>
 
+    <update sql-case-id="update_with_unicode_escape_alias" parameters="'update', 1, 1">
+        <table start-index="7" stop-index="18" >
+            <simple-table name="t_order" alias="u" start-index="7" stop-index="18" />
+        </table>
+        <set start-index="20" stop-index="33" literal-stop-index="40">
+            <assignment start-index="24" stop-index="33" literal-stop-index="40">
+                <column name="status" start-index="24" stop-index="29" />
+                <assignment-value>
+                    <parameter-marker-expression value="0" start-index="33" stop-index="33" />
+                    <literal-expression value="update" start-index="33" stop-index="40" />
+                </assignment-value>
+            </assignment>
+        </set>
+        <where start-index="35" stop-index="72" literal-start-index="42" literal-stop-index="79">
+            <expr>
+                <binary-operation-expression start-index="41" stop-index="72" literal-start-index="48" literal-stop-index="79">
+                    <left>
+                        <binary-operation-expression start-index="41" stop-index="54" literal-start-index="48" literal-stop-index="61">
+                            <left>
+                                <column name="order_id" start-index="41" stop-index="50" literal-start-index="48" literal-stop-index="57">
+                                    <owner name="u" start-index="41" stop-index="41" literal-start-index="48" literal-stop-index="48" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="61" stop-index="61" />
+                                <parameter-marker-expression value="1" start-index="54" stop-index="54" />
+                            </right>
+                        </binary-operation-expression>
+                    </left>
+                    <operator>AND</operator>
+                    <right>
+                        <binary-operation-expression start-index="60" stop-index="72" literal-start-index="67" literal-stop-index="79">
+                            <left>
+                                <column name="user_id" start-index="60" stop-index="68" literal-start-index="67" literal-stop-index="75">
+                                    <owner name="u" start-index="60" stop-index="60" literal-start-index="67" literal-stop-index="67" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <literal-expression value="1" start-index="79" stop-index="79" />
+                                <parameter-marker-expression value="2" start-index="72" stop-index="72" />
+                            </right>
+                        </binary-operation-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </update>
+
     <update sql-case-id="update_equal_with_geography" parameters="'2017-06-07', 100, 200, '{&quot;rule2&quot;:&quot;null2&quot;}', 3, 5, 7, 200">
         <table start-index="7" stop-index="13">
             <simple-table name="t_order" start-index="7" stop-index="13"/>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/update.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/update.xml
@@ -19,6 +19,7 @@
 <sql-cases>
     <sql-case id="update_without_alias" value="UPDATE t_order SET status = ? WHERE order_id = ? AND user_id = ?" />
     <sql-case id="update_with_alias" value="UPDATE t_order AS o SET o.status = ? WHERE o.order_id = ? AND o.user_id = ?" db-types="MySQL,H2" />
+    <sql-case id="update_with_unicode_escape_alias" value="UPDATE t_order AS u SET status = ? WHERE u.order_id = ? AND u.user_id = ?" db-types="PostgreSQL" />
     <sql-case id="update_equal_with_geography" value="UPDATE t_order SET start_time = ?, status = 0, start_point = ST_GeographyFromText('SRID=4326;POINT('||?||' '||?||')'), rule = ?::jsonb, discount_type = ?, order_type = ? WHERE user_id = ? AND order_id = ?" db-types="PostgreSQL" />
     <sql-case id="update_without_condition" value="UPDATE t_order o SET o.status = 'finished'" db-types="MySQL,H2" />
     <sql-case id="update_with_extra_keywords" value="UPDATE LOW_PRIORITY IGNORE t_order SET status = ? WHERE order_id = ? AND user_id = ?" db-types="MySQL" />


### PR DESCRIPTION
Fixes #11465.

Changes proposed in this pull request:
- fix PostgreSQL unicodeEscape ambiguous parse
- correct `update .. set ...` statement wrong parse result
