### PR TITLE
Fix Issue#12449 : Scaling job does not stop properly if exception thrown before inventory task start

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingWorker.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.scaling.core.api;
 
 import com.google.common.eventbus.Subscribe;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cache.event.StartScalingEvent;
@@ -42,13 +43,25 @@ public final class ScalingWorker {
     
     private final ScalingAPI scalingAPI = ScalingAPIFactory.getScalingAPI();
     
+    @Getter
+    private final ScalingJobExecutor scalingJobExecutor = new ScalingJobExecutor();
+    
     /**
      * Init scaling worker.
      */
     public static void init() {
         ShardingSphereEventBus.getInstance().register(INSTANCE);
         new FinishedCheckJobExecutor().start();
-        new ScalingJobExecutor().start();
+        INSTANCE.scalingJobExecutor.start();
+    }
+    
+    /**
+     * Get instance.
+     *
+     * @return scaling worker
+     */
+    public static ScalingWorker getInstance() {
+        return INSTANCE;
     }
     
     /**

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/executor/job/ScalingJobExecutor.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/executor/job/ScalingJobExecutor.java
@@ -58,8 +58,7 @@ public final class ScalingJobExecutor extends AbstractScalingExecutor {
             }
             JobConfigurationPOJO jobConfigPOJO = jobConfigPOJOOptional.get();
             if (DataChangedEvent.Type.DELETED == event.getType() || jobConfigPOJO.isDisabled()) {
-                EXECUTING_JOBS.remove(jobConfigPOJO.getJobName());
-                JobSchedulerCenter.stop(Long.parseLong(jobConfigPOJO.getJobName()));
+                stopJob(jobConfigPOJO.getJobName());
                 return;
             }
             switch (event.getType()) {
@@ -91,5 +90,15 @@ public final class ScalingJobExecutor extends AbstractScalingExecutor {
         if (EXECUTING_JOBS.add(jobConfigPOJO.getJobName())) {
             new OneOffJobBootstrap(ScalingAPIFactory.getRegistryCenter(), new ScalingJob(), jobConfigPOJO.toJobConfiguration()).execute();
         }
+    }
+    
+    /**
+     * Stop job.
+     *
+     * @param jobName job name
+     */
+    public void stopJob(final String jobName) {
+        EXECUTING_JOBS.remove(jobName);
+        JobSchedulerCenter.stop(Long.parseLong(jobName));
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/incremental/IncrementalTask.java
@@ -59,7 +59,7 @@ public final class IncrementalTask extends AbstractScalingExecutor implements Sc
     
     private final DataSourceManager dataSourceManager;
     
-    private Dumper dumper;
+    private volatile Dumper dumper;
     
     @Getter
     private final IncrementalTaskProgress progress;
@@ -120,7 +120,9 @@ public final class IncrementalTask extends AbstractScalingExecutor implements Sc
             @Override
             public void onFailure(final Throwable throwable) {
                 log.error("get an error when migrating the increment data", throwable);
-                dumper.stop();
+                if (null != dumper) {
+                    dumper.stop();
+                }
             }
         };
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/inventory/InventoryTask.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/task/inventory/InventoryTask.java
@@ -55,7 +55,7 @@ public final class InventoryTask extends AbstractScalingExecutor implements Scal
     
     private final DataSourceManager dataSourceManager;
     
-    private Dumper dumper;
+    private volatile Dumper dumper;
     
     private ScalingPosition<?> position;
     
@@ -90,7 +90,9 @@ public final class InventoryTask extends AbstractScalingExecutor implements Scal
             @Override
             public void onFailure(final Throwable throwable) {
                 log.error("get an error when migrating the inventory data", throwable);
-                dumper.stop();
+                if (null != dumper) {
+                    dumper.stop();
+                }
             }
         });
         dumper.start();


### PR DESCRIPTION
Fixes #12449.

Changes proposed in this pull request:
- Stop job if exception thrown before inventory task start
- `dumper` might be null in inventory and incremental task `onFailure`
