### PR TITLE
Scaling prepare tables part 2 : Add AbstractDataSourcePreparer and add IF NOT EXISTS for create table SQL

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.job.preparer;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.scaling.core.common.datasource.DataSourceFactory;
+import org.apache.shardingsphere.scaling.core.common.datasource.DataSourceWrapper;
+import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.config.datasource.ScalingDataSourceConfiguration;
+import org.apache.shardingsphere.scaling.core.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.scaling.core.config.yaml.ShardingRuleConfigurationSwapper;
+import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract data source preparer.
+ */
+@Slf4j
+public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
+    
+    private final DataSourceFactory dataSourceFactory = new DataSourceFactory();
+    
+    protected DataSourceWrapper getSourceDataSource(final JobConfiguration jobConfig) {
+        return dataSourceFactory.newInstance(jobConfig.getRuleConfig().getSource().unwrap());
+    }
+    
+    protected DataSourceWrapper getTargetDataSource(final JobConfiguration jobConfig) {
+        return dataSourceFactory.newInstance(jobConfig.getRuleConfig().getTarget().unwrap());
+    }
+    
+    protected List<String> getLogicTableNames(final ScalingDataSourceConfiguration sourceConfig) {
+        List<String> result = new ArrayList<>();
+        ShardingSphereJDBCDataSourceConfiguration source = (ShardingSphereJDBCDataSourceConfiguration) sourceConfig;
+        ShardingRuleConfiguration ruleConfig = ShardingRuleConfigurationSwapper.findAndConvertShardingRuleConfiguration(source.getRootConfig().getRules());
+        List<String> tableNames = ruleConfig.getTables().stream().map(ShardingTableRuleConfiguration::getLogicTable).collect(Collectors.toList());
+        List<String> autoTableNames = ruleConfig.getAutoTables().stream().map(ShardingAutoTableRuleConfiguration::getLogicTable).collect(Collectors.toList());
+        result.addAll(tableNames);
+        result.addAll(autoTableNames);
+        return result;
+    }
+    
+    protected void createTargetTable(final Connection targetConnection, final String createTableSQL) throws SQLException {
+        String sql = createTableSQL.replaceFirst("CREATE TABLE", "CREATE TABLE IF NOT EXISTS");
+        log.info("create target table, sql: {}", sql);
+        try (Statement statement = targetConnection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/preparer/AbstractDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/preparer/AbstractDataSourcePreparerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.preparer;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.job.preparer.AbstractDataSourcePreparer;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+
+public final class AbstractDataSourcePreparerTest {
+    
+    private static final Pattern PATTERN_CREATE_TABLE_IF_NOT_EXISTS = Pattern.compile("CREATE\\s+TABLE\\s+IF\\s+NOT\\s+EXISTS\\s+", Pattern.CASE_INSENSITIVE);
+    
+    @Test
+    @SneakyThrows(ReflectiveOperationException.class)
+    public void assertAddIfNotExistsForCreateTableSQL() {
+        Method method = AbstractDataSourcePreparer.class.getDeclaredMethod("addIfNotExistsForCreateTableSQL", String.class);
+        method.setAccessible(true);
+        AbstractDataSourcePreparer preparer = new AbstractDataSourcePreparer() {
+            @Override
+            public void prepareTargetTables(final JobConfiguration jobConfig) {
+            }
+        };
+        List<String> createTableSQLs = Arrays.asList("CREATE TABLE IF NOT EXISTS t (id int)", "CREATE TABLE t (id int)",
+                "CREATE  TABLE IF \nNOT \tEXISTS t (id int)", "CREATE \tTABLE t (id int)");
+        for (String createTableSQL : createTableSQLs) {
+            String sql = (String) method.invoke(preparer, createTableSQL);
+            assertTrue(PATTERN_CREATE_TABLE_IF_NOT_EXISTS.matcher(sql).find());
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12336 part 2.

Changes proposed in this pull request:
- Extract AbstractDataSourcePreparer for extension
- Add if not exists for create table sql, `prepareTargetTables` may be invoked several time in sharding jobs
