### PR TITLE
Call ScalingAPIFactory.getScalingAPI() on demand to prevent RALUpdater init exception when scaling not enabled

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingJobUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingJobUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.scaling.distsql.handler;
 
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
 import org.apache.shardingsphere.scaling.distsql.statement.DropScalingJobStatement;
 
@@ -27,11 +26,9 @@ import org.apache.shardingsphere.scaling.distsql.statement.DropScalingJobStateme
  */
 public final class DropScalingJobUpdater implements RALUpdater<DropScalingJobStatement> {
     
-    private final ScalingAPI scalingAPI = ScalingAPIFactory.getScalingAPI();
-    
     @Override
     public void executeUpdate(final DropScalingJobStatement sqlStatement) {
-        scalingAPI.remove(sqlStatement.getJobId());
+        ScalingAPIFactory.getScalingAPI().remove(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingJobUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingJobUpdater.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.scaling.distsql.handler;
 
 import org.apache.shardingsphere.scaling.distsql.exception.ScalingJobOperateException;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
 import org.apache.shardingsphere.scaling.distsql.statement.ResetScalingJobStatement;
 
@@ -30,12 +29,10 @@ import java.sql.SQLException;
  */
 public final class ResetScalingJobUpdater implements RALUpdater<ResetScalingJobStatement> {
     
-    private final ScalingAPI scalingAPI = ScalingAPIFactory.getScalingAPI();
-    
     @Override
     public void executeUpdate(final ResetScalingJobStatement sqlStatement) {
         try {
-            scalingAPI.reset(sqlStatement.getJobId());
+            ScalingAPIFactory.getScalingAPI().reset(sqlStatement.getJobId());
         } catch (final SQLException ex) {
             throw new ScalingJobOperateException(ex.getMessage());
         }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingJobUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingJobUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.scaling.distsql.handler;
 
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
 import org.apache.shardingsphere.scaling.distsql.statement.StartScalingJobStatement;
 
@@ -27,11 +26,9 @@ import org.apache.shardingsphere.scaling.distsql.statement.StartScalingJobStatem
  */
 public final class StartScalingJobUpdater implements RALUpdater<StartScalingJobStatement> {
     
-    private final ScalingAPI scalingAPI = ScalingAPIFactory.getScalingAPI();
-    
     @Override
     public void executeUpdate(final StartScalingJobStatement sqlStatement) {
-        scalingAPI.start(sqlStatement.getJobId());
+        ScalingAPIFactory.getScalingAPI().start(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingJobUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingJobUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.scaling.distsql.handler;
 
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
 import org.apache.shardingsphere.scaling.distsql.statement.StopScalingJobStatement;
 
@@ -27,11 +26,9 @@ import org.apache.shardingsphere.scaling.distsql.statement.StopScalingJobStateme
  */
 public final class StopScalingJobUpdater implements RALUpdater<StopScalingJobStatement> {
     
-    private final ScalingAPI scalingAPI = ScalingAPIFactory.getScalingAPI();
-    
     @Override
     public void executeUpdate(final StopScalingJobStatement sqlStatement) {
-        scalingAPI.stop(sqlStatement.getJobId());
+        ScalingAPIFactory.getScalingAPI().stop(sqlStatement.getJobId());
     }
     
     @Override


### PR DESCRIPTION
Fixes #12485.

Changes proposed in this pull request:
- Call `ScalingAPIFactory.getScalingAPI()` on demand to prevent `RALUpdater` init exception when scaling not enabled
