### PR TITLE
Add new dataConsistencyCheck and switchClusterConfiguration methods of ScalingAPI for DistSQL

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/DataConsistencyCheckAlgorithmInfo.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/DataConsistencyCheckAlgorithmInfo.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.api;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.Collection;
+
+/**
+ * Data consistency check algorithm info.
+ */
+@Getter
+@Setter
+@ToString
+public final class DataConsistencyCheckAlgorithmInfo {
+    
+    private String type;
+    
+    private String description;
+    
+    private Collection<String> supportedDatabaseTypes;
+    
+    private String provider;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
@@ -77,6 +77,13 @@ public interface ScalingAPI {
     Map<Integer, JobProgress> getProgress(long jobId);
     
     /**
+     * Stop cluster write to job source schema's underlying DB.
+     *
+     * @param jobId job id
+     */
+    void stopClusterWriteDB(long jobId);
+    
+    /**
      * List all data consistency check algorithms from SPI.
      *
      * @return data consistency check algorithms
@@ -99,6 +106,13 @@ public interface ScalingAPI {
      * @return each logic table check result
      */
     Map<String, DataConsistencyCheckResult> dataConsistencyCheck(long jobId, String algorithmType);
+    
+    /**
+     * Switch job source schema's configuration to job target configuration.
+     *
+     * @param jobId job id
+     */
+    void switchClusterConfiguration(long jobId);
     
     /**
      * Reset scaling job.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.scaling.core.job.check.consistency.DataConsiste
 import org.apache.shardingsphere.scaling.core.job.progress.JobProgress;
 
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -74,6 +75,13 @@ public interface ScalingAPI {
      * @return each sharding item progress
      */
     Map<Integer, JobProgress> getProgress(long jobId);
+    
+    /**
+     * List all data consistency check algorithms from SPI.
+     *
+     * @return data consistency check algorithms
+     */
+    Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms();
     
     /**
      * Do data consistency check.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
@@ -84,6 +84,15 @@ public interface ScalingAPI {
     Map<String, DataConsistencyCheckResult> dataConsistencyCheck(long jobId);
     
     /**
+     * Do data consistency check.
+     *
+     * @param jobId job id
+     * @param algorithmType algorithm type
+     * @return each logic table check result
+     */
+    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(long jobId, String algorithmType);
+    
+    /**
      * Reset scaling job.
      *
      * @param jobId job id

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingDataConsistencyCheckAlgorithm.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingDataConsistencyCheckAlgorithm.java
@@ -19,10 +19,33 @@ package org.apache.shardingsphere.scaling.core.api;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
+
+import java.util.Collection;
 
 /**
  * Scaling data consistency check algorithm for SPI.
  */
 public interface ScalingDataConsistencyCheckAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
     
+    /**
+     * Get algorithm description.
+     *
+     * @return algorithm description
+     */
+    String getDescription();
+    
+    /**
+     * Get supported database types.
+     *
+     * @return supported database types
+     */
+    Collection<Class<? extends DatabaseType>> getSupportedDatabaseTypes();
+    
+    /**
+     * Get algorithm provider.
+     *
+     * @return algorithm provider
+     */
+    String getProvider();
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingDataConsistencyCheckAlgorithm.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingDataConsistencyCheckAlgorithm.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.scaling.core.api;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
-import org.apache.shardingsphere.infra.database.type.DatabaseType;
 
 import java.util.Collection;
 
@@ -40,7 +39,7 @@ public interface ScalingDataConsistencyCheckAlgorithm extends ShardingSphereAlgo
      *
      * @return supported database types
      */
-    Collection<Class<? extends DatabaseType>> getSupportedDatabaseTypes();
+    Collection<String> getSupportedDatabaseTypes();
     
     /**
      * Get algorithm provider.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -19,10 +19,14 @@ package org.apache.shardingsphere.scaling.core.api.impl;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
+import org.apache.shardingsphere.infra.config.TypedSPIConfiguration;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.scaling.core.api.JobInfo;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
+import org.apache.shardingsphere.scaling.core.api.ScalingDataConsistencyCheckAlgorithm;
 import org.apache.shardingsphere.scaling.core.common.constant.ScalingConstant;
 import org.apache.shardingsphere.scaling.core.common.exception.ScalingJobNotFoundException;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
@@ -42,6 +46,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -134,6 +139,14 @@ public final class ScalingAPIImpl implements ScalingAPI {
         }
         log.info("Scaling job {} data consistency checker result {}", jobId, result);
         return result;
+    }
+    
+    @Override
+    public Map<String, DataConsistencyCheckResult> dataConsistencyCheck(final long jobId, final String algorithmType) {
+        TypedSPIConfiguration typedSPIConfig = new ShardingSphereAlgorithmConfiguration(algorithmType, new Properties());
+        ScalingDataConsistencyCheckAlgorithm dataConsistencyCheckAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(typedSPIConfig, ScalingDataConsistencyCheckAlgorithm.class);
+        //TODO
+        return dataConsistencyCheck(jobId);
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -135,6 +135,11 @@ public final class ScalingAPIImpl implements ScalingAPI {
     }
     
     @Override
+    public void stopClusterWriteDB(final long jobId) {
+        //TODO
+    }
+    
+    @Override
     public Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms() {
         return ShardingSphereServiceLoader.getSingletonServiceInstances(ScalingDataConsistencyCheckAlgorithm.class)
                 .stream().map(each -> {
@@ -179,6 +184,11 @@ public final class ScalingAPIImpl implements ScalingAPI {
         if (!supportedDatabaseTypes.contains(targetDatabaseType)) {
             throw new DataCheckFailException("target database type " + targetDatabaseType + " is not supported in " + supportedDatabaseTypes);
         }
+    }
+    
+    @Override
+    public void switchClusterConfiguration(final long jobId) {
+        //TODO
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/exception/DataCheckFailException.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/exception/DataCheckFailException.java
@@ -24,6 +24,10 @@ public final class DataCheckFailException extends RuntimeException {
     
     private static final long serialVersionUID = -4100671584682823997L;
     
+    public DataCheckFailException(final String message) {
+        super(message);
+    }
+    
     public DataCheckFailException(final String message, final Throwable cause) {
         super(message, cause);
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
@@ -123,6 +123,19 @@ public final class ScalingAPIImplTest {
     }
     
     @Test
+    public void assertDataConsistencyCheckWithAlgorithm() {
+        Optional<Long> jobId = scalingAPI.start(ResourceUtil.mockJobConfig());
+        assertTrue(jobId.isPresent());
+        JobConfiguration jobConfig = scalingAPI.getJobConfig(jobId.get());
+        initTableData(jobConfig.getRuleConfig());
+        Map<String, DataConsistencyCheckResult> checkResultMap = scalingAPI.dataConsistencyCheck(jobId.get(), ScalingFixtureDataConsistencyCheckAlgorithm.TYPE);
+        assertThat(checkResultMap.size(), is(1));
+        assertTrue(checkResultMap.get("t_order").isCountValid());
+        assertFalse(checkResultMap.get("t_order").isDataValid());
+        assertThat(checkResultMap.get("t_order").getTargetCount(), is(2L));
+    }
+    
+    @Test
     @SneakyThrows(SQLException.class)
     public void assertResetTargetTable() {
         Optional<Long> jobId = scalingAPI.start(ResourceUtil.mockJobConfig());

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.scaling.core.api.impl;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepositoryConfiguration;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
+import org.apache.shardingsphere.scaling.core.api.DataConsistencyCheckAlgorithmInfo;
 import org.apache.shardingsphere.scaling.core.api.JobInfo;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
@@ -40,6 +41,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -107,6 +109,18 @@ public final class ScalingAPIImplTest {
         assertTrue(jobId.isPresent());
         Map<Integer, JobProgress> jobProgressMap = scalingAPI.getProgress(jobId.get());
         assertThat(jobProgressMap.size(), is(1));
+    }
+    
+    @Test
+    public void assertListDataConsistencyCheckAlgorithms() {
+        Collection<DataConsistencyCheckAlgorithmInfo> algorithmInfos = scalingAPI.listDataConsistencyCheckAlgorithms();
+        assertThat(algorithmInfos.size(), is(1));
+        DataConsistencyCheckAlgorithmInfo algorithmInfo = algorithmInfos.iterator().next();
+        assertThat(algorithmInfo.getType(), is(ScalingFixtureDataConsistencyCheckAlgorithm.TYPE));
+        ScalingFixtureDataConsistencyCheckAlgorithm fixtureAlgorithm = new ScalingFixtureDataConsistencyCheckAlgorithm();
+        assertThat(algorithmInfo.getDescription(), is(fixtureAlgorithm.getDescription()));
+        assertThat(algorithmInfo.getSupportedDatabaseTypes(), is(fixtureAlgorithm.getSupportedDatabaseTypes()));
+        assertThat(algorithmInfo.getProvider(), is(fixtureAlgorithm.getProvider()));
     }
     
     @Test

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingFixtureDataConsistencyCheckAlgorithm.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingFixtureDataConsistencyCheckAlgorithm.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.api.impl;
+
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.scaling.core.api.ScalingDataConsistencyCheckAlgorithm;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public final class ScalingFixtureDataConsistencyCheckAlgorithm implements ScalingDataConsistencyCheckAlgorithm {
+    
+    public static final String TYPE = "FIXTURE";
+    
+    private static final Collection<String> SUPPORTED_DATABASE_TYPES = Arrays.asList(new MySQLDatabaseType().getName(), new PostgreSQLDatabaseType().getName());
+    
+    @Override
+    public void init() {
+    }
+    
+    @Override
+    public String getDescription() {
+        return "Fixture empty implementation";
+    }
+    
+    @Override
+    public Collection<String> getSupportedDatabaseTypes() {
+        return SUPPORTED_DATABASE_TYPES;
+    }
+    
+    @Override
+    public String getProvider() {
+        return "ShardingSphere";
+    }
+    
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingFixtureDataConsistencyCheckAlgorithm.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingFixtureDataConsistencyCheckAlgorithm.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.scaling.core.api.impl;
 
+import lombok.Setter;
+import org.apache.shardingsphere.infra.database.type.dialect.H2DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.scaling.core.api.ScalingDataConsistencyCheckAlgorithm;
@@ -28,7 +30,11 @@ public final class ScalingFixtureDataConsistencyCheckAlgorithm implements Scalin
     
     public static final String TYPE = "FIXTURE";
     
-    private static final Collection<String> SUPPORTED_DATABASE_TYPES = Arrays.asList(new MySQLDatabaseType().getName(), new PostgreSQLDatabaseType().getName());
+    private static final Collection<String> SUPPORTED_DATABASE_TYPES = Arrays.asList(new MySQLDatabaseType().getName(),
+            new PostgreSQLDatabaseType().getName(), new H2DatabaseType().getName());
+    
+    @Setter
+    private Collection<String> supportedDatabaseTypes;
     
     @Override
     public void init() {
@@ -41,7 +47,7 @@ public final class ScalingFixtureDataConsistencyCheckAlgorithm implements Scalin
     
     @Override
     public Collection<String> getSupportedDatabaseTypes() {
-        return SUPPORTED_DATABASE_TYPES;
+        return null != supportedDatabaseTypes ? supportedDatabaseTypes : SUPPORTED_DATABASE_TYPES;
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/META-INF/services/org.apache.shardingsphere.scaling.core.api.ScalingDataConsistencyCheckAlgorithm
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/META-INF/services/org.apache.shardingsphere.scaling.core.api.ScalingDataConsistencyCheckAlgorithm
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.scaling.core.api.impl.ScalingFixtureDataConsistencyCheckAlgorithm


### PR DESCRIPTION
Fixes #12547.

Changes proposed in this pull request:
- Extend `ScalingDataConsistencyCheckAlgorithm` interface, supply `description`, `supported_database_types`, `provider`
- Add new `dataConsistencyCheck(long jobId, String algorithmType)` method for `ScalingAPI`
- Add new `listDataConsistencyCheckAlgorithms()` method for `ScalingAPI`
- Add `stopClusterWriteDB` and `switchClusterConfiguration` method for `ScalingAPI`
- Unit test
