### PR TITLE
Support to build with JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,9 @@
         <calcite.version>1.27.0</calcite.version>
         <embedded-mysql.version>4.6.1</embedded-mysql.version>
         <embedded-postgresql.version>2.10</embedded-postgresql.version>
+
+        <jaxb.version>2.3.0</jaxb.version>
+        <annotation-api.version>1.3.2</annotation-api.version>
         
         <!-- Plugin versions -->
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
@@ -887,6 +890,27 @@
         </plugins>
     </build>
     
+    <profiles>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+	    </activation>
+	    <dependencies>
+		<dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+		    <version>${jaxb.version}</version>
+                </dependency>
+		<dependency>
+                    <groupId>javax.annotation</groupId>
+                    <artifactId>javax.annotation-api</artifactId>
+		    <version>${annotation-api.version}</version>
+                </dependency>
+	    </dependencies>
+	</profile>
+    </profiles>
+
     <reporting>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -889,26 +889,26 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>jdk11+</id>
             <activation>
                 <jdk>[11,)</jdk>
-	    </activation>
-	    <dependencies>
-		<dependency>
+            </activation>
+            <dependencies>
+                <dependency>
                     <groupId>javax.xml.bind</groupId>
                     <artifactId>jaxb-api</artifactId>
-		    <version>${jaxb.version}</version>
+                    <version>${jaxb.version}</version>
                 </dependency>
-		<dependency>
+                <dependency>
                     <groupId>javax.annotation</groupId>
                     <artifactId>javax.annotation-api</artifactId>
-		    <version>${annotation-api.version}</version>
+                    <version>${annotation-api.version}</version>
                 </dependency>
-	    </dependencies>
-	</profile>
+            </dependencies>
+        </profile>
     </profiles>
 
     <reporting>

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/SchemaYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/SchemaYamlSwapper.java
@@ -45,7 +45,8 @@ public final class SchemaYamlSwapper implements YamlConfigurationSwapper<YamlSch
     @Override
     public YamlSchema swapToYamlConfiguration(final ShardingSphereSchema schema) {
         Map<String, YamlTableMetaData> tables = schema.getAllTableNames().stream()
-                .collect(Collectors.<String, String, YamlTableMetaData, Map>toMap(each -> each, each -> swapYamlTable(schema.get(each)), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
+                .collect(Collectors.<String, String, YamlTableMetaData, Map<String, YamlTableMetaData>>toMap(
+                    each -> each, each -> swapYamlTable(schema.get(each)), (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
         YamlSchema result = new YamlSchema();
         result.setTables(tables);
         return result;


### PR DESCRIPTION
Fixes #12578

Changes proposed in this pull request:
- Add dependency of ```javax.xml.bind::jaxb-api``` and ```javax.annotation::javax.annotation-api```
- minor fix the generic type complitation error in ```SchemaYamlSwapper:swapToYamlConfiguration```
