### PR TITLE
modify decoding plugin to mppdb_decoding and repair actual table name

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
@@ -112,6 +112,10 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
         log.info("execute target table sql: {}", sql);
         try (Statement statement = targetConnection.createStatement()) {
             statement.execute(sql);
+        } catch (final SQLException ex) {
+            if (!ex.getMessage().contains("multiple primary keys for table")) {
+                throw ex;
+            }
         }
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussWalDumper.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussWalDumper.java
@@ -116,6 +116,9 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
                 pushRecord(record);
             }
         } catch (final SQLException ex) {
+            if (ex.getMessage().contains("is already active")) {
+                return;
+            }
             throw new ScalingTaskExecuteException(ex);
         }
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/OpenGaussLogicalReplication.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/OpenGaussLogicalReplication.java
@@ -40,7 +40,7 @@ public final class OpenGaussLogicalReplication {
 
     public static final String SLOT_NAME = "sharding_scaling";
 
-    public static final String DECODE_PLUGIN = "test_decoding";
+    public static final String DECODE_PLUGIN = "mppdb_decoding";
 
     public static final String DUPLICATE_OBJECT_ERROR_CODE = "42710";
 
@@ -92,7 +92,7 @@ public final class OpenGaussLogicalReplication {
      */
     public static void createIfNotExists(final Connection conn) throws SQLException {
         if (isSlotNameExist(conn)) {
-            dropSlot(conn);
+            return;
         }
         createSlotBySql(conn);
     }


### PR DESCRIPTION
… issue

Fixes #12620.

Changes proposed in this pull request:
- change decoding plugin from test_decoding to mppdb_decoding.
- skip drop replication slot if already exists.
- ignore exception in dump thread if slot already in use.
- skip recreate primary key exception.
- repair logical and actual table name incorrent get issue.
- remove with sql in create table.