### PR TITLE
add SQLServer simple alter and drop grammar

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
@@ -36,11 +36,11 @@ createFunction
     ;
 
 createProcedure
-    : CREATE (OR ALTER)? (PROC | PROCEDURE) procedureName procParameters createProcClause
+    : CREATE (OR ALTER)? (PROC | PROCEDURE) procedureName procParameters createOrAlterProcClause
     ;
 
 createView
-    : CREATE (OR ALTER)? VIEW viewName createViewClause
+    : CREATE (OR ALTER)? VIEW viewName createOrAlterViewClause
     ;
 
 createTrigger
@@ -59,6 +59,18 @@ alterIndex
     : ALTER INDEX (indexName | ALL) ON tableName alterIndexClause
     ;
 
+alterProcedure
+    : ALTER (PROC | PROCEDURE) procedureName procParameters createOrAlterProcClause
+    ;
+
+alterFunction
+    : ALTER FUNCTION functionName funcParameters funcReturns
+    ;
+
+alterView
+    : ALTER VIEW viewName createOrAlterViewClause
+    ;
+
 alterTrigger
     : ALTER TRIGGER triggerName ON triggerTarget createTriggerClause
     ;
@@ -73,6 +85,30 @@ dropTable
 
 dropIndex
     : DROP INDEX ifExist? indexName ON tableName
+    ;
+
+dropDatabase
+    : DROP DATABASE ifExist? databaseName (COMMA_ databaseName)*
+    ;
+
+dropFunction
+    : DROP FUNCTION ifExist? functionName (COMMA_ functionName)*
+    ;
+
+dropProcedure
+    : DROP (PROC | PROCEDURE) ifExist? procedureName (COMMA_ procedureName)*
+    ;
+
+dropView
+    : DROP VIEW ifExist? viewName (COMMA_ viewName)*
+    ;
+
+dropTrigger
+    : DROP TRIGGER ifExist? triggerName (COMMA_ triggerName)* (ON (DATABASE | ALL SERVER))?
+    ;
+
+dropSequence
+    : DROP SEQUENCE ifExist? sequenceName (COMMA_ sequenceName)*
     ;
 
 truncateTable
@@ -647,7 +683,7 @@ procParameter
     : variable VARYING? (EQ_ literals)? (OUT | OUTPUT | READONLY)?
     ;
 
-createProcClause
+createOrAlterProcClause
     : withCreateProcOption? (FOR REPLICATION)? AS procAsClause
     ;
 
@@ -677,7 +713,7 @@ procSetOption
     | DELAYED_DURABILITY = ( OFF | ON )
     ;
 
-createViewClause
+createOrAlterViewClause
     : (WITH viewAttribute (COMMA_ viewAttribute)*)? AS withCommonTableExpr? select (WITH CHECK OPTION)?
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
@@ -37,6 +37,12 @@ execute
     | alterTrigger
     | alterSequence
     | dropTable
+    | dropDatabase
+    | dropFunction
+    | dropProcedure
+    | dropView
+    | dropTrigger
+    | dropSequence
     | truncateTable
     | createFunction
     | setTransaction

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDDLStatementSQLVisitor.java
@@ -25,11 +25,14 @@ import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.Add
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterCheckConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterColumnAddOptionContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterDefinitionClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterIndexContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterProcedureContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterSequenceContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterTableDropConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterTriggerContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.AlterViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ColumnConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ColumnDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ColumnDefinitionOptionContext;
@@ -46,8 +49,14 @@ import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.Cre
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.CreateViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropConstraintNameContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropDatabaseContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropIndexContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropProcedureContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropSequenceContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropTableContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropTriggerContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DropViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ModifyColumnSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.TableConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.TruncateTableContext;
@@ -67,10 +76,13 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.Column
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DataTypeSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.collection.CollectionValue;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterFunctionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterProcedureStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterSequenceStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerAlterViewStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateDatabaseStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateIndexStatement;
@@ -79,8 +91,14 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateTriggerStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateViewStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropDatabaseStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropFunctionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropProcedureStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropSequenceStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerDropViewStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerTruncateStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerSelectStatement;
 
@@ -94,11 +112,11 @@ import java.util.Properties;
  */
 @NoArgsConstructor
 public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQLVisitor implements DDLSQLVisitor, SQLStatementVisitor {
-    
+
     public SQLServerDDLStatementSQLVisitor(final Properties props) {
         super(props);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitCreateTable(final CreateTableContext ctx) {
@@ -116,7 +134,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @Override
     public ASTNode visitCreateDefinitionClause(final CreateDefinitionClauseContext ctx) {
         CollectionValue<CreateDefinitionSegment> result = new CollectionValue<>();
@@ -130,7 +148,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
@@ -152,7 +170,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     private boolean isPrimaryKey(final ColumnDefinitionContext ctx) {
         for (ColumnDefinitionOptionContext each : ctx.columnDefinitionOption()) {
             for (ColumnConstraintContext columnConstraint : each.columnConstraint()) {
@@ -168,7 +186,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return false;
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitTableConstraint(final TableConstraintContext ctx) {
@@ -189,7 +207,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitAlterTable(final AlterTableContext ctx) {
@@ -214,7 +232,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitAlterDefinitionClause(final AlterDefinitionClauseContext ctx) {
@@ -236,7 +254,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @Override
     public ASTNode visitAddColumnSpecification(final AddColumnSpecificationContext ctx) {
         CollectionValue<AddColumnDefinitionSegment> result = new CollectionValue<>();
@@ -244,7 +262,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
             for (AlterColumnAddOptionContext each : ctx.alterColumnAddOptions().alterColumnAddOption()) {
                 if (null != each.columnDefinition()) {
                     AddColumnDefinitionSegment addColumnDefinition = new AddColumnDefinitionSegment(
-                            each.columnDefinition().getStart().getStartIndex(), each.columnDefinition().getStop().getStopIndex(), 
+                            each.columnDefinition().getStart().getStartIndex(), each.columnDefinition().getStop().getStopIndex(),
                             Collections.singletonList((ColumnDefinitionSegment) visit(each.columnDefinition())));
                     result.getValue().add(addColumnDefinition);
                 }
@@ -252,7 +270,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         }
         return result;
     }
-    
+
     @Override
     public ASTNode visitModifyColumnSpecification(final ModifyColumnSpecificationContext ctx) {
         // TODO visit pk and table ref
@@ -261,7 +279,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         ColumnDefinitionSegment columnDefinition = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false);
         return new ModifyColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), columnDefinition);
     }
-    
+
     @Override
     public ASTNode visitDropColumnSpecification(final DropColumnSpecificationContext ctx) {
         Collection<ColumnSegment> columns = new LinkedList<>();
@@ -279,14 +297,14 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         result.setContainsExistClause(null != ctx.ifExist());
         return result;
     }
-    
+
     @Override
     public ASTNode visitTruncateTable(final TruncateTableContext ctx) {
         SQLServerTruncateStatement result = new SQLServerTruncateStatement();
         result.getTables().add((SimpleTableSegment) visit(ctx.tableName()));
         return result;
     }
-    
+
     @Override
     public ASTNode visitCreateIndex(final CreateIndexContext ctx) {
         SQLServerCreateIndexStatement result = new SQLServerCreateIndexStatement();
@@ -294,7 +312,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         result.setIndex((IndexSegment) visit(ctx.indexName()));
         return result;
     }
-    
+
     @Override
     public ASTNode visitAlterIndex(final AlterIndexContext ctx) {
         SQLServerAlterIndexStatement result = new SQLServerAlterIndexStatement();
@@ -304,7 +322,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         result.setTable((SimpleTableSegment) visit(ctx.tableName()));
         return result;
     }
-    
+
     @Override
     public ASTNode visitDropIndex(final DropIndexContext ctx) {
         SQLServerDropIndexStatement result = new SQLServerDropIndexStatement();
@@ -313,12 +331,12 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
         result.setContainsExistClause(null != ctx.ifExist());
         return result;
     }
-    
+
     @Override
     public ASTNode visitAlterCheckConstraint(final AlterCheckConstraintContext ctx) {
         return new ModifyConstraintDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), (ConstraintSegment) visit(ctx.constraintName()));
     }
-    
+
     @Override
     public ASTNode visitAlterTableDropConstraint(final AlterTableDropConstraintContext ctx) {
         CollectionValue<DropConstraintDefinitionSegment> result = new CollectionValue<>();
@@ -349,7 +367,7 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
     public ASTNode visitCreateView(final CreateViewContext ctx) {
         SQLServerCreateViewStatement result = new SQLServerCreateViewStatement();
         result.setView((SimpleTableSegment) visit(ctx.viewName()));
-        result.setSelect((SQLServerSelectStatement) visit(ctx.createViewClause().select()));
+        result.setSelect((SQLServerSelectStatement) visit(ctx.createOrAlterViewClause().select()));
         return result;
     }
 
@@ -371,5 +389,50 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
     @Override
     public ASTNode visitAlterSequence(final AlterSequenceContext ctx) {
         return new SQLServerAlterSequenceStatement();
+    }
+
+    @Override
+    public ASTNode visitAlterProcedure(final AlterProcedureContext ctx) {
+        return new SQLServerAlterProcedureStatement();
+    }
+
+    @Override
+    public ASTNode visitAlterFunction(final AlterFunctionContext ctx) {
+        return new SQLServerAlterFunctionStatement();
+    }
+
+    @Override
+    public ASTNode visitAlterView(final AlterViewContext ctx) {
+        return new SQLServerAlterViewStatement();
+    }
+
+    @Override
+    public ASTNode visitDropDatabase(final DropDatabaseContext ctx) {
+        return new SQLServerDropDatabaseStatement();
+    }
+
+    @Override
+    public ASTNode visitDropFunction(final DropFunctionContext ctx) {
+        return new SQLServerDropFunctionStatement();
+    }
+
+    @Override
+    public ASTNode visitDropProcedure(final DropProcedureContext ctx) {
+        return new SQLServerDropProcedureStatement();
+    }
+
+    @Override
+    public ASTNode visitDropView(final DropViewContext ctx) {
+        return new SQLServerDropViewStatement();
+    }
+
+    @Override
+    public ASTNode visitDropTrigger(final DropTriggerContext ctx) {
+        return new SQLServerDropTriggerStatement();
+    }
+
+    @Override
+    public ASTNode visitDropSequence(final DropSequenceContext ctx) {
+        return new SQLServerDropSequenceStatement();
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterFunctionStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterFunctionStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterFunctionStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer alter function statement.
+ */
+@ToString
+public class SQLServerAlterFunctionStatement extends AlterFunctionStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterProcedureStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterProcedureStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterProcedureStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer alter procedure statement.
+ */
+@ToString
+public class SQLServerAlterProcedureStatement extends AlterProcedureStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterViewStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerAlterViewStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterViewStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer alter view statement.
+ */
+@ToString
+public class SQLServerAlterViewStatement extends AlterViewStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropDatabaseStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropDatabaseStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropDatabaseStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop database statement.
+ */
+@ToString
+public class SQLServerDropDatabaseStatement extends DropDatabaseStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropFunctionStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropFunctionStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropFunctionStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop function statement.
+ */
+@ToString
+public class SQLServerDropFunctionStatement extends DropFunctionStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropProcedureStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropProcedureStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropProcedureStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop procedure statement.
+ */
+@ToString
+public class SQLServerDropProcedureStatement extends DropProcedureStatement implements SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropSequenceStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropSequenceStatement.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop sequence statement.
+ */
+@ToString
+public class SQLServerDropSequenceStatement extends AbstractSQLStatement implements DDLStatement, SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropTriggerStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropTriggerStatement.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop trigger statement.
+ */
+@ToString
+public class SQLServerDropTriggerStatement extends AbstractSQLStatement implements DDLStatement, SQLServerStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropViewStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerDropViewStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropViewStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+/**
+ * SQLServer drop view statement.
+ */
+@ToString
+public class SQLServerDropViewStatement extends DropViewStatement implements SQLServerStatement {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-procedure.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-procedure.xml
@@ -18,4 +18,5 @@
 
 <sql-parser-test-cases>
     <drop-procedure sql-case-id="drop_procedure" />
+    <drop-procedure sql-case-id="drop_multiple_procedure" />
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-trigger.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-trigger.xml
@@ -17,5 +17,5 @@
   -->
 
 <sql-parser-test-cases>
-<!--    <drop-trigger sql-case-id="drop_trigger" />-->
+    <drop-trigger sql-case-id="drop_trigger" />
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-procedure.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-procedure.xml
@@ -29,6 +29,5 @@
         AS
             SELECT FirstName, LastName, JobTitle, Department
             FROM HumanResources.vEmployeeDepartment
-            WHERE FirstName = @FirstName AND LastName = @LastName;
-        GO" db-types="SQLServer"/>
+            WHERE FirstName = @FirstName AND LastName = @LastName;" db-types="SQLServer"/>
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-database.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-database.xml
@@ -17,6 +17,6 @@
   -->
 
 <sql-cases>
-    <sql-case id="drop_database_if_exist" value="DROP DATABASE IF EXISTS database1" db-types="PostgreSQL" />
-    <sql-case id="drop_database" value="DROP DATABASE database1" db-types="PostgreSQL" />
+    <sql-case id="drop_database_if_exist" value="DROP DATABASE IF EXISTS database1" db-types="PostgreSQL, SQLServer" />
+    <sql-case id="drop_database" value="DROP DATABASE database1" db-types="PostgreSQL, SQLServer" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-procedure.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-procedure.xml
@@ -18,4 +18,5 @@
 
 <sql-cases>
     <sql-case id="drop_procedure" value="DROP PROCEDURE do_db_maintenance()" db-types="PostgreSQL" />
+    <sql-case id="drop_multiple_procedure" value="DROP PROCEDURE dbo.uspGetSalesbyMonth, dbo.uspUpdateSalesQuotes, dbo.uspGetSalesByYear;" db-types="SQLServer" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-sequence.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-sequence.xml
@@ -17,5 +17,5 @@
   -->
 
 <sql-cases>
-    <sql-case id="drop_sequence" value="DROP SEQUENCE seq_id" db-types="PostgreSQL" />
+    <sql-case id="drop_sequence" value="DROP SEQUENCE seq_id" db-types="PostgreSQL, SQLServer" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-trigger.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-trigger.xml
@@ -17,7 +17,5 @@
   -->
 
 <sql-cases>
-    <sql-case id="drop_function" value="DROP FUNCTION sqrt(integer)" db-types="PostgreSQL" />
-    <sql-case id="drop_functions" value="DROP FUNCTION sqrt(integer), sqrt(bigint)" db-types="PostgreSQL" />
-    <sql-case id="drop_function_without_argument_list" value="DROP FUNCTION update_employee_salaries" db-types="PostgreSQL, SQLServer" />
+    <sql-case id="drop_trigger" value="DROP TRIGGER safety ON DATABASE" db-types="SQLServer" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-view.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-view.xml
@@ -17,5 +17,5 @@
   -->
 
 <sql-cases>
-    <sql-case id="drop_view" value="DROP VIEW kinds" db-types="PostgreSQL" />
+    <sql-case id="drop_view" value="DROP VIEW kinds" db-types="PostgreSQL, SQLServer" />
 </sql-cases>


### PR DESCRIPTION
For #6478.

Changes proposed in this pull request:
- add alter procedure, alter function, alter view grammar
- add drop database, drop function, drop procedure, drop view, drop trigger, drop sequence
- add tests for drop statement

Hi, @jingshanglu , I've added these changes, please check it. And alter statements have the same sytnax with corresponding create statements, do I need to add tests for the alter statements? 
