### PR TITLE
Fixed #12674 show resources does not show custom connection pool parameters

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSet.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSet.java
@@ -25,6 +25,8 @@ import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
+import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.config.util.DataSourceParameterConverter;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
@@ -33,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Result set for show data source.
@@ -48,7 +51,9 @@ public final class DataSourceQueryResultSet implements DistSQLResultSet {
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
         resource = metaData.getResource();
-        dataSourceParameterMap = DataSourceParameterConverter.getDataSourceParameterMap(DataSourceConverter.getDataSourceConfigurationMap(metaData.getResource().getDataSources()));
+        Optional<MetaDataPersistService> persistService = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaDataPersistService();
+        dataSourceParameterMap = persistService.isPresent() ? DataSourceParameterConverter.getDataSourceParameterMap(persistService.get().getDataSourceService().load(metaData.getName()))
+                : DataSourceParameterConverter.getDataSourceParameterMap(DataSourceConverter.getDataSourceConfigurationMap(metaData.getResource().getDataSources()));
         dataSourceNames = dataSourceParameterMap.keySet().iterator();
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSetTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/DataSourceQueryResultSetTest.java
@@ -19,12 +19,17 @@ package org.apache.shardingsphere.proxy.backend.text.distsql.rql;
 
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowResourcesStatement;
 import org.apache.shardingsphere.infra.config.DatabaseAccessConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.resource.DataSourcesMetaData;
 import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
+import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.test.mock.MockedDataSource;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,9 +42,12 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +74,10 @@ public final class DataSourceQueryResultSetTest {
     
     @Test
     public void assertGetRowData() {
+        ContextManager manager = mock(ContextManager.class);
+        when(manager.getMetaDataContexts()).thenReturn(mock(MetaDataContexts.class));
+        when(manager.getMetaDataContexts().getMetaDataPersistService()).thenReturn(Optional.empty());
+        ProxyContext.getInstance().init(manager);
         DistSQLResultSet resultSet = new DataSourceQueryResultSet();
         resultSet.init(shardingSphereMetaData, mock(ShowResourcesStatement.class));
         Collection<Object> actual = resultSet.getRowData();
@@ -78,5 +90,28 @@ public final class DataSourceQueryResultSetTest {
         assertThat(rowData.next(), is("demo_ds"));
         assertThat(rowData.next(), is("{\"maxLifetimeMilliseconds\":1800000,\"readOnly\":false,"
                 + "\"minPoolSize\":1,\"idleTimeoutMilliseconds\":60000,\"maxPoolSize\":50,\"connectionTimeoutMilliseconds\":30000}"));
+        MetaDataPersistService persistService = mock(MetaDataPersistService.class, RETURNS_DEEP_STUBS);
+        when(persistService.getDataSourceService().load(any())).thenReturn(mockDataSourceConfigurationMap());
+        when(manager.getMetaDataContexts().getMetaDataPersistService()).thenReturn(Optional.ofNullable(persistService));
+        resultSet.init(shardingSphereMetaData, mock(ShowResourcesStatement.class));
+        actual = resultSet.getRowData();
+        assertThat(actual.size(), is(6));
+        rowData = actual.iterator();
+        assertThat(rowData.next(), is("ds_0"));
+        assertThat(rowData.next(), is("MySQL"));
+        assertThat(rowData.next(), is("localhost"));
+        assertThat(rowData.next(), is(3306));
+        assertThat(rowData.next(), is("demo_ds"));
+        assertThat(rowData.next(), is("{\"maxLifetimeMilliseconds\":1800000,\"readOnly\":true,\"customPoolProps\":{\"test\":\"test\"},"
+                + "\"minPoolSize\":1,\"idleTimeoutMilliseconds\":60000,\"maxPoolSize\":50,\"connectionTimeoutMilliseconds\":30000}"));
+    }
+    
+    private Map<String, DataSourceConfiguration> mockDataSourceConfigurationMap() {
+        Map<String, DataSourceConfiguration> result = new HashMap<>();
+        DataSourceConfiguration ds0 = new DataSourceConfiguration("ds_0");
+        ds0.getCustomPoolProps().put("test", "test");
+        ds0.getProps().put("readOnly", true);
+        result.put("ds_0", ds0);
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #12674
Changes proposed in this pull request:
- Use `MetaDataPersistService` to get database information