### PR TITLE
Add scaling distSQL:`CHECKOUT SCALING jobId`.

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-api/src/test/java/org/apache/shardingsphere/agent/metrics/api/advice/SQLParserEngineAdviceTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-api/src/test/java/org/apache/shardingsphere/agent/metrics/api/advice/SQLParserEngineAdviceTest.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.agent.metrics.api.constant.MetricIds;
 import org.apache.shardingsphere.agent.metrics.api.fixture.FixtureWrapper;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.create.AddResourceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowResourcesStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobListStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingListStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLShowDatabasesStatement;
@@ -98,7 +98,7 @@ public final class SQLParserEngineAdviceTest extends MetricsAdviceBaseTest {
     
     @Test
     public void assertParseRAL() {
-        assertParse(MetricIds.PARSE_DIST_SQL_RAL, new ShowScalingJobListStatement());
+        assertParse(MetricIds.PARSE_DIST_SQL_RAL, new ShowScalingListStatement());
     }
     
     private void assertParse(final String metricIds, final SQLStatement sqlStatement) {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/DistSQLBackendHandlerFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/DistSQLBackendHandlerFactoryTest.java
@@ -46,6 +46,7 @@ import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.Cre
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.DropReadwriteSplittingRuleStatement;
 import org.apache.shardingsphere.scaling.core.config.ScalingContext;
 import org.apache.shardingsphere.scaling.core.config.ServerConfiguration;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckoutScalingStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingCheckAlgorithmsStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.StopScalingSourceWritingStatement;
 import org.apache.shardingsphere.shadow.api.config.ShadowRuleConfiguration;
@@ -270,6 +271,15 @@ public final class DistSQLBackendHandlerFactoryTest {
         when(connection.getSchemaName()).thenReturn("schema");
         mockScalingContext();
         ResponseHeader response = RALBackendHandlerFactory.newInstance(mock(StopScalingSourceWritingStatement.class), connection).execute();
+        assertThat(response, instanceOf(UpdateResponseHeader.class));
+    }
+    
+    @Test
+    public void assertExecuteCheckoutScalingContext() throws SQLException {
+        BackendConnection connection = mock(BackendConnection.class);
+        when(connection.getSchemaName()).thenReturn("schema");
+        mockScalingContext();
+        ResponseHeader response = RALBackendHandlerFactory.newInstance(mock(CheckoutScalingStatement.class), connection).execute();
         assertThat(response, instanceOf(UpdateResponseHeader.class));
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -21,56 +21,56 @@
 # 
 ######################################################################################################
 
-scaling:
-  blockQueueSize: 10000
-  workerThread: 40
-  clusterAutoSwitchAlgorithm:
-    type: IDLE
-    props:
-      incremental-task-idle-minute-threshold: 30
-  dataConsistencyCheckAlgorithm:
-    type: DEFAULT
+#scaling:
+#  blockQueueSize: 10000
+#  workerThread: 40
+#  clusterAutoSwitchAlgorithm:
+#    type: IDLE
+#    props:
+#      incremental-task-idle-minute-threshold: 30
+#  dataConsistencyCheckAlgorithm:
+#    type: DEFAULT
+#
+#mode:
+#  type: Cluster
+#  repository:
+#    type: ZooKeeper
+#    props:
+#      namespace: governance_ds
+#      server-lists: localhost:2181
+#      retryIntervalMilliseconds: 500
+#      timeToLiveSeconds: 60
+#      maxRetries: 3
+#      operationTimeoutMilliseconds: 500
+#  overwrite: false
+#
+#rules:
+#  - !AUTHORITY
+#    users:
+#      - root@%:root
+#      - sharding@:sharding
+#    provider:
+#      type: NATIVE
+#  - !TRANSACTION
+#    defaultType: XA
+#    providerType: Atomikos
 
-mode:
-  type: Cluster
-  repository:
-    type: ZooKeeper
-    props:
-      namespace: governance_ds
-      server-lists: localhost:2181
-      retryIntervalMilliseconds: 500
-      timeToLiveSeconds: 60
-      maxRetries: 3
-      operationTimeoutMilliseconds: 500
-  overwrite: true
-
-rules:
-  - !AUTHORITY
-    users:
-      - root@%:root
-      - sharding@:sharding
-    provider:
-      type: ALL_PRIVILEGES_PERMITTED
-  - !TRANSACTION
-    defaultType: XA
-    providerType: Atomikos
-
-props:
-  max-connections-size-per-query: 1
-  executor-size: 16  # Infinite by default.
-  proxy-frontend-flush-threshold: 128  # The default value is 128.
-  proxy-opentracing-enabled: false
-  proxy-hint-enabled: false
-  sql-show: true
-  check-table-metadata-enabled: false
-  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
-  show-process-list-enabled: false
-    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
-    # The default value is -1, which means set the minimum value for different JDBC drivers.
-  proxy-backend-query-fetch-size: -1
-  check-duplicate-table-enabled: false
-  sql-comment-parse-enabled: false
-  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
-    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
-    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
-  proxy-backend-executor-suitable: OLAP
+#props:
+#  max-connections-size-per-query: 1
+#  executor-size: 16  # Infinite by default.
+#  proxy-frontend-flush-threshold: 128  # The default value is 128.
+#  proxy-opentracing-enabled: false
+#  proxy-hint-enabled: false
+#  sql-show: false
+#  check-table-metadata-enabled: false
+#  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
+#  show-process-list-enabled: false
+#    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
+#    # The default value is -1, which means set the minimum value for different JDBC drivers.
+#  proxy-backend-query-fetch-size: -1
+#  check-duplicate-table-enabled: false
+#  sql-comment-parse-enabled: false
+#  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
+#    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
+#    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
+#  proxy-backend-executor-suitable: OLAP

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -21,56 +21,56 @@
 # 
 ######################################################################################################
 
-#scaling:
-#  blockQueueSize: 10000
-#  workerThread: 40
-#  clusterAutoSwitchAlgorithm:
-#    type: IDLE
-#    props:
-#      incremental-task-idle-minute-threshold: 30
-#  dataConsistencyCheckAlgorithm:
-#    type: DEFAULT
-#
-#mode:
-#  type: Cluster
-#  repository:
-#    type: ZooKeeper
-#    props:
-#      namespace: governance_ds
-#      server-lists: localhost:2181
-#      retryIntervalMilliseconds: 500
-#      timeToLiveSeconds: 60
-#      maxRetries: 3
-#      operationTimeoutMilliseconds: 500
-#  overwrite: false
-#
-#rules:
-#  - !AUTHORITY
-#    users:
-#      - root@%:root
-#      - sharding@:sharding
-#    provider:
-#      type: NATIVE
-#  - !TRANSACTION
-#    defaultType: XA
-#    providerType: Atomikos
+scaling:
+  blockQueueSize: 10000
+  workerThread: 40
+  clusterAutoSwitchAlgorithm:
+    type: IDLE
+    props:
+      incremental-task-idle-minute-threshold: 30
+  dataConsistencyCheckAlgorithm:
+    type: DEFAULT
 
-#props:
-#  max-connections-size-per-query: 1
-#  executor-size: 16  # Infinite by default.
-#  proxy-frontend-flush-threshold: 128  # The default value is 128.
-#  proxy-opentracing-enabled: false
-#  proxy-hint-enabled: false
-#  sql-show: false
-#  check-table-metadata-enabled: false
-#  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
-#  show-process-list-enabled: false
-#    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
-#    # The default value is -1, which means set the minimum value for different JDBC drivers.
-#  proxy-backend-query-fetch-size: -1
-#  check-duplicate-table-enabled: false
-#  sql-comment-parse-enabled: false
-#  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
-#    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
-#    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
-#  proxy-backend-executor-suitable: OLAP
+mode:
+  type: Cluster
+  repository:
+    type: ZooKeeper
+    props:
+      namespace: governance_ds
+      server-lists: localhost:2181
+      retryIntervalMilliseconds: 500
+      timeToLiveSeconds: 60
+      maxRetries: 3
+      operationTimeoutMilliseconds: 500
+  overwrite: true
+
+rules:
+  - !AUTHORITY
+    users:
+      - root@%:root
+      - sharding@:sharding
+    provider:
+      type: ALL_PRIVILEGES_PERMITTED
+  - !TRANSACTION
+    defaultType: XA
+    providerType: Atomikos
+
+props:
+  max-connections-size-per-query: 1
+  executor-size: 16  # Infinite by default.
+  proxy-frontend-flush-threshold: 128  # The default value is 128.
+  proxy-opentracing-enabled: false
+  proxy-hint-enabled: false
+  sql-show: true
+  check-table-metadata-enabled: false
+  lock-wait-timeout-milliseconds: 50000 # The maximum time to wait for a lock
+  show-process-list-enabled: false
+    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
+    # The default value is -1, which means set the minimum value for different JDBC drivers.
+  proxy-backend-query-fetch-size: -1
+  check-duplicate-table-enabled: false
+  sql-comment-parse-enabled: false
+  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
+    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
+    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
+  proxy-backend-executor-suitable: OLAP

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/CheckoutScalingUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/CheckoutScalingUpdater.java
@@ -15,18 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.statement;
+package org.apache.shardingsphere.scaling.distsql.handler;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
+import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
+import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckoutScalingStatement;
 
 /**
- * Start scaling job statement.
+ * Checkout scaling updater.
  */
-@RequiredArgsConstructor
-@Getter
-public final class StartScalingJobStatement extends UpdatableRALStatement {
+public final class CheckoutScalingUpdater implements RALUpdater<CheckoutScalingStatement> {
     
-    private final long jobId;
+    @Override
+    public void executeUpdate(final CheckoutScalingStatement sqlStatement) {
+        ScalingAPIFactory.getScalingAPI().switchClusterConfiguration(sqlStatement.getJobId());
+    }
+    
+    @Override
+    public String getType() {
+        return CheckoutScalingStatement.class.getCanonicalName();
+    }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingUpdater.java
@@ -15,18 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.statement;
+package org.apache.shardingsphere.scaling.distsql.handler;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
+import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
+import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
+import org.apache.shardingsphere.scaling.distsql.statement.DropScalingStatement;
 
 /**
- * Stop scaling job statement.
+ * Drop scaling updater.
  */
-@RequiredArgsConstructor
-@Getter
-public final class StopScalingJobStatement extends UpdatableRALStatement {
+public final class DropScalingUpdater implements RALUpdater<DropScalingStatement> {
     
-    private final long jobId;
+    @Override
+    public void executeUpdate(final DropScalingStatement sqlStatement) {
+        ScalingAPIFactory.getScalingAPI().remove(sqlStatement.getJobId());
+    }
+    
+    @Override
+    public String getType() {
+        return DropScalingStatement.class.getCanonicalName();
+    }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingUpdater.java
@@ -17,22 +17,29 @@
 
 package org.apache.shardingsphere.scaling.distsql.handler;
 
+import org.apache.shardingsphere.scaling.distsql.exception.ScalingJobOperateException;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.StartScalingJobStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ResetScalingStatement;
+
+import java.sql.SQLException;
 
 /**
- * Start scaling job updater.
+ * Reset scaling updater.
  */
-public final class StartScalingJobUpdater implements RALUpdater<StartScalingJobStatement> {
+public final class ResetScalingUpdater implements RALUpdater<ResetScalingStatement> {
     
     @Override
-    public void executeUpdate(final StartScalingJobStatement sqlStatement) {
-        ScalingAPIFactory.getScalingAPI().start(sqlStatement.getJobId());
+    public void executeUpdate(final ResetScalingStatement sqlStatement) {
+        try {
+            ScalingAPIFactory.getScalingAPI().reset(sqlStatement.getJobId());
+        } catch (final SQLException ex) {
+            throw new ScalingJobOperateException(ex.getMessage());
+        }
     }
     
     @Override
     public String getType() {
-        return StartScalingJobStatement.class.getCanonicalName();
+        return ResetScalingStatement.class.getCanonicalName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSet.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.scaling.distsql.handler;
 
-import com.google.gson.Gson;
+import com.google.common.base.Joiner;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
@@ -44,7 +44,7 @@ public final class ShowScalingCheckAlgorithmsQueryResultSet implements DistSQLRe
                     Collection<Object> list = new LinkedList<>();
                     list.add(each.getType());
                     list.add(each.getDescription());
-                    list.add((new Gson()).toJson(each.getSupportedDatabaseTypes()));
+                    list.add(Joiner.on(",").join(each.getSupportedDatabaseTypes()));
                     list.add(each.getProvider());
                     return list;
                 }).collect(Collectors.toList()).iterator();

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.scaling.distsql.handler;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobStatusStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingStatusStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
@@ -40,7 +40,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
         long currentTimeMillis = System.currentTimeMillis();
-        data = ScalingAPIFactory.getScalingAPI().getProgress(((ShowScalingJobStatusStatement) sqlStatement).getJobId()).entrySet().stream()
+        data = ScalingAPIFactory.getScalingAPI().getProgress(((ShowScalingStatusStatement) sqlStatement).getJobId()).entrySet().stream()
                 .map(entry -> {
                     Collection<Object> list = new LinkedList<>();
                     list.add(entry.getKey());
@@ -72,6 +72,6 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
     
     @Override
     public String getType() {
-        return ShowScalingJobStatusStatement.class.getCanonicalName();
+        return ShowScalingStatusStatement.class.getCanonicalName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.scaling.distsql.handler;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.CheckScalingJobStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingListStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
@@ -30,29 +30,30 @@ import java.util.LinkedList;
 import java.util.stream.Collectors;
 
 /**
- * Check scaling job query result set.
+ * Show scaling list query result set.
  */
-public final class CheckScalingJobQueryResultSet implements DistSQLResultSet {
+public final class ShowScalingListQueryResultSet implements DistSQLResultSet {
     
     private Iterator<Collection<Object>> data;
     
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
-        data = ScalingAPIFactory.getScalingAPI().dataConsistencyCheck(((CheckScalingJobStatement) sqlStatement).getJobId()).entrySet().stream()
+        data = ScalingAPIFactory.getScalingAPI().list().stream()
                 .map(each -> {
                     Collection<Object> list = new LinkedList<>();
-                    list.add(each.getKey());
-                    list.add(each.getValue().getTargetCount());
-                    list.add(each.getValue().getSourceCount());
-                    list.add(each.getValue().isCountValid() ? 1 : 0);
-                    list.add(each.getValue().isDataValid() ? 1 : 0);
+                    list.add(each.getJobId());
+                    list.add(each.getTables());
+                    list.add(each.getShardingTotalCount());
+                    list.add(each.isActive() ? 1 : 0);
+                    list.add(each.getCreateTime());
+                    list.add(each.getStopTime());
                     return list;
                 }).collect(Collectors.toList()).iterator();
     }
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("table_name", "source_count", "target_count", "count_valid", "data_valid");
+        return Arrays.asList("id", "tables", "sharding_total_count", "active", "create_time", "stop_time");
     }
     
     @Override
@@ -67,6 +68,6 @@ public final class CheckScalingJobQueryResultSet implements DistSQLResultSet {
     
     @Override
     public String getType() {
-        return CheckScalingJobStatement.class.getCanonicalName();
+        return ShowScalingListStatement.class.getCanonicalName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
@@ -15,12 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral;
+package org.apache.shardingsphere.scaling.distsql.handler;
 
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
+import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
+import org.apache.shardingsphere.scaling.distsql.statement.StartScalingStatement;
 
 /**
- * Show scaling job list statement test case.
+ * Start scaling updater.
  */
-public final class ShowScalingJobListStatementTestCase extends SQLParserTestCase {
+public final class StartScalingUpdater implements RALUpdater<StartScalingStatement> {
+    
+    @Override
+    public void executeUpdate(final StartScalingStatement sqlStatement) {
+        ScalingAPIFactory.getScalingAPI().start(sqlStatement.getJobId());
+    }
+    
+    @Override
+    public String getType() {
+        return StartScalingStatement.class.getCanonicalName();
+    }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingUpdater.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingUpdater.java
@@ -17,29 +17,22 @@
 
 package org.apache.shardingsphere.scaling.distsql.handler;
 
-import org.apache.shardingsphere.scaling.distsql.exception.ScalingJobOperateException;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.ResetScalingJobStatement;
-
-import java.sql.SQLException;
+import org.apache.shardingsphere.scaling.distsql.statement.StopScalingStatement;
 
 /**
- * Reset scaling job updater.
+ * Stop scaling updater.
  */
-public final class ResetScalingJobUpdater implements RALUpdater<ResetScalingJobStatement> {
+public final class StopScalingUpdater implements RALUpdater<StopScalingStatement> {
     
     @Override
-    public void executeUpdate(final ResetScalingJobStatement sqlStatement) {
-        try {
-            ScalingAPIFactory.getScalingAPI().reset(sqlStatement.getJobId());
-        } catch (final SQLException ex) {
-            throw new ScalingJobOperateException(ex.getMessage());
-        }
+    public void executeUpdate(final StopScalingStatement sqlStatement) {
+        ScalingAPIFactory.getScalingAPI().stop(sqlStatement.getJobId());
     }
     
     @Override
     public String getType() {
-        return ResetScalingJobStatement.class.getCanonicalName();
+        return StopScalingStatement.class.getCanonicalName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.scaling.distsql.handler.CheckScalingJobQueryResultSet
-org.apache.shardingsphere.scaling.distsql.handler.ShowScalingJobListQueryResultSet
+org.apache.shardingsphere.scaling.distsql.handler.CheckScalingQueryResultSet
+org.apache.shardingsphere.scaling.distsql.handler.ShowScalingListQueryResultSet
 org.apache.shardingsphere.scaling.distsql.handler.ShowScalingJobStatusQueryResultSet
 org.apache.shardingsphere.scaling.distsql.handler.ShowScalingCheckAlgorithmsQueryResultSet

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
@@ -15,8 +15,9 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.scaling.distsql.handler.StartScalingJobUpdater
-org.apache.shardingsphere.scaling.distsql.handler.StopScalingJobUpdater
-org.apache.shardingsphere.scaling.distsql.handler.ResetScalingJobUpdater
-org.apache.shardingsphere.scaling.distsql.handler.DropScalingJobUpdater
+org.apache.shardingsphere.scaling.distsql.handler.StartScalingUpdater
+org.apache.shardingsphere.scaling.distsql.handler.StopScalingUpdater
+org.apache.shardingsphere.scaling.distsql.handler.ResetScalingUpdater
+org.apache.shardingsphere.scaling.distsql.handler.DropScalingUpdater
 org.apache.shardingsphere.scaling.distsql.handler.StopScalingSourceWritingUpdater
+org.apache.shardingsphere.scaling.distsql.handler.CheckoutScalingUpdater

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/test/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSetTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/test/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSetTest.java
@@ -65,7 +65,7 @@ public final class ShowScalingCheckAlgorithmsQueryResultSetTest {
         Iterator<Object> rowData = actual.iterator();
         assertThat(rowData.next(), is("DEFAULT"));
         assertThat(rowData.next(), is("Default implementation with CRC32 of all records."));
-        assertThat(rowData.next(), is("[\"MySQL\",\"PostgreSQL\"]"));
+        assertThat(rowData.next(), is("MySQL,PostgreSQL"));
         assertThat(rowData.next(), is("ShardingSphere"));
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/antlr4/imports/scaling/RALStatement.g4
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/antlr4/imports/scaling/RALStatement.g4
@@ -19,32 +19,32 @@ grammar RALStatement;
 
 import Keyword, Literals, Symbol;
 
-showScalingJobList
-    : SHOW SCALING JOB LIST
+showScalingList
+    : SHOW SCALING LIST
     ;
 
-showScalingJobStatus
-    : SHOW SCALING JOB STATUS jobId
+showScalingStatus
+    : SHOW SCALING STATUS jobId
     ;
 
-startScalingJob
-    : START SCALING JOB jobId
+startScaling
+    : START SCALING jobId
     ;
 
-stopScalingJob
-    : STOP SCALING JOB jobId
+stopScaling
+    : STOP SCALING jobId
     ;
 
-dropScalingJob
-    : DROP SCALING JOB jobId
+dropScaling
+    : DROP SCALING jobId
     ;
 
-resetScalingJob
-    : RESET SCALING JOB jobId
+resetScaling
+    : RESET SCALING jobId
     ;
 
-checkScalingJob
-    : CHECK SCALING JOB jobId
+checkScaling
+    : CHECK SCALING jobId
     ;
 
 showScalingCheckAlgorithms
@@ -53,6 +53,10 @@ showScalingCheckAlgorithms
 
 stopScalingSourceWriting
     : STOP SCALING SOURCE WRITING jobId
+    ;
+
+checkoutScaling
+    : CHECKOUT SCALING jobId
     ;
 
 jobId

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ScalingStatement.g4
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/ScalingStatement.g4
@@ -20,14 +20,15 @@ grammar ScalingStatement;
 import Symbol, RALStatement;
 
 execute
-    : (showScalingJobList
-    | showScalingJobStatus
-    | startScalingJob
-    | stopScalingJob
-    | dropScalingJob
-    | resetScalingJob
-    | checkScalingJob
+    : (showScalingList
+    | showScalingStatus
+    | startScaling
+    | stopScaling
+    | dropScaling
+    | resetScaling
+    | checkScaling
     | showScalingCheckAlgorithms
     | stopScalingSourceWriting
+    | checkoutScaling
     ) SEMI?
     ;

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/core/ScalingSQLStatementVisitor.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/core/ScalingSQLStatementVisitor.java
@@ -18,23 +18,25 @@
 package org.apache.shardingsphere.scaling.distsql.parser.core;
 
 import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementBaseVisitor;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.CheckScalingJobContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.DropScalingJobContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ResetScalingJobContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.CheckScalingContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.CheckoutScalingContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.DropScalingContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ResetScalingContext;
 import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ShowScalingCheckAlgorithmsContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ShowScalingJobListContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ShowScalingJobStatusContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.StartScalingJobContext;
-import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.StopScalingJobContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ShowScalingListContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.ShowScalingStatusContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.StartScalingContext;
+import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.StopScalingContext;
 import org.apache.shardingsphere.distsql.parser.autogen.ScalingStatementParser.StopScalingSourceWritingContext;
-import org.apache.shardingsphere.scaling.distsql.statement.CheckScalingJobStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.DropScalingJobStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.ResetScalingJobStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckScalingStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckoutScalingStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.DropScalingStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ResetScalingStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingCheckAlgorithmsStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobListStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobStatusStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.StartScalingJobStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.StopScalingJobStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingListStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingStatusStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.StartScalingStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.StopScalingStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.StopScalingSourceWritingStatement;
 import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
@@ -45,38 +47,38 @@ import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 public final class ScalingSQLStatementVisitor extends ScalingStatementBaseVisitor<ASTNode> implements SQLVisitor {
     
     @Override
-    public ASTNode visitShowScalingJobList(final ShowScalingJobListContext ctx) {
-        return new ShowScalingJobListStatement();
+    public ASTNode visitShowScalingList(final ShowScalingListContext ctx) {
+        return new ShowScalingListStatement();
     }
     
     @Override
-    public ASTNode visitShowScalingJobStatus(final ShowScalingJobStatusContext ctx) {
-        return new ShowScalingJobStatusStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitShowScalingStatus(final ShowScalingStatusContext ctx) {
+        return new ShowScalingStatusStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
-    public ASTNode visitStartScalingJob(final StartScalingJobContext ctx) {
-        return new StartScalingJobStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitStartScaling(final StartScalingContext ctx) {
+        return new StartScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
-    public ASTNode visitStopScalingJob(final StopScalingJobContext ctx) {
-        return new StopScalingJobStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitStopScaling(final StopScalingContext ctx) {
+        return new StopScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
-    public ASTNode visitDropScalingJob(final DropScalingJobContext ctx) {
-        return new DropScalingJobStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitDropScaling(final DropScalingContext ctx) {
+        return new DropScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
-    public ASTNode visitResetScalingJob(final ResetScalingJobContext ctx) {
-        return new ResetScalingJobStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitResetScaling(final ResetScalingContext ctx) {
+        return new ResetScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
-    public ASTNode visitCheckScalingJob(final CheckScalingJobContext ctx) {
-        return new CheckScalingJobStatement(Long.parseLong(ctx.jobId().getText()));
+    public ASTNode visitCheckScaling(final CheckScalingContext ctx) {
+        return new CheckScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
     
     @Override
@@ -87,5 +89,10 @@ public final class ScalingSQLStatementVisitor extends ScalingStatementBaseVisito
     @Override
     public ASTNode visitStopScalingSourceWriting(final StopScalingSourceWritingContext ctx) {
         return new StopScalingSourceWritingStatement(Long.parseLong(ctx.jobId().getText()));
+    }
+    
+    @Override
+    public ASTNode visitCheckoutScaling(final CheckoutScalingContext ctx) {
+        return new CheckoutScalingStatement(Long.parseLong(ctx.jobId().getText()));
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/CheckScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/CheckScalingStatement.java
@@ -19,14 +19,14 @@ package org.apache.shardingsphere.scaling.distsql.statement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 
 /**
- * Drop scaling job statement.
+ * Check scaling statement.
  */
 @RequiredArgsConstructor
 @Getter
-public final class DropScalingJobStatement extends UpdatableRALStatement {
+public final class CheckScalingStatement extends QueryableRALStatement {
     
     private final long jobId;
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/CheckoutScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/CheckoutScalingStatement.java
@@ -15,66 +15,18 @@
  * limitations under the License.
  */
 
-lexer grammar Keyword;
+package org.apache.shardingsphere.scaling.distsql.statement;
 
-import Alphabet;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
-WS
-    : [ \t\r\n] + ->skip
-    ;
-
-ALGORITHMS
-    : A L G O R I T H M S
-    ;
-
-DROP
-    : D R O P
-    ;
-
-SHOW
-    : S H O W
-    ;
-
-START
-    : S T A R T
-    ;
-
-STOP
-    : S T O P
-    ;
-
-RESET
-    : R E S E T
-    ;
-
-CHECK
-    : C H E C K
-    ;
-
-CHECKOUT
-    : C H E C K O U T
-    ;
-
-SCALING
-    : S C A L I N G
-    ;
-
-JOB
-    : J O B
-    ;
-
-LIST
-    : L I S T
-    ;
-
-STATUS
-    : S T A T U S
-    ;
-
-SOURCE
-    : S O U R C E
-    ;
-
-WRITING
-    : W R I T I N G
-    ;
+/**
+ * Checkout scaling statement.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class CheckoutScalingStatement extends UpdatableRALStatement {
+    
+    private final long jobId;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/DropScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/DropScalingStatement.java
@@ -19,14 +19,14 @@ package org.apache.shardingsphere.scaling.distsql.statement;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
 /**
- * Show scaling job status statement.
+ * Drop scaling statement.
  */
 @RequiredArgsConstructor
 @Getter
-public final class ShowScalingJobStatusStatement extends QueryableRALStatement {
+public final class DropScalingStatement extends UpdatableRALStatement {
     
     private final long jobId;
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ResetScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ResetScalingStatement.java
@@ -15,66 +15,18 @@
  * limitations under the License.
  */
 
-lexer grammar Keyword;
+package org.apache.shardingsphere.scaling.distsql.statement;
 
-import Alphabet;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
-WS
-    : [ \t\r\n] + ->skip
-    ;
-
-ALGORITHMS
-    : A L G O R I T H M S
-    ;
-
-DROP
-    : D R O P
-    ;
-
-SHOW
-    : S H O W
-    ;
-
-START
-    : S T A R T
-    ;
-
-STOP
-    : S T O P
-    ;
-
-RESET
-    : R E S E T
-    ;
-
-CHECK
-    : C H E C K
-    ;
-
-CHECKOUT
-    : C H E C K O U T
-    ;
-
-SCALING
-    : S C A L I N G
-    ;
-
-JOB
-    : J O B
-    ;
-
-LIST
-    : L I S T
-    ;
-
-STATUS
-    : S T A T U S
-    ;
-
-SOURCE
-    : S O U R C E
-    ;
-
-WRITING
-    : W R I T I N G
-    ;
+/**
+ * Reset scaling statement.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class ResetScalingStatement extends UpdatableRALStatement {
+    
+    private final long jobId;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ShowScalingListStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ShowScalingListStatement.java
@@ -15,24 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.handler;
+package org.apache.shardingsphere.scaling.distsql.statement;
 
-import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.StopScalingJobStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 
 /**
- * Stop scaling job updater.
+ * Show scaling list statement.
  */
-public final class StopScalingJobUpdater implements RALUpdater<StopScalingJobStatement> {
-    
-    @Override
-    public void executeUpdate(final StopScalingJobStatement sqlStatement) {
-        ScalingAPIFactory.getScalingAPI().stop(sqlStatement.getJobId());
-    }
-    
-    @Override
-    public String getType() {
-        return StopScalingJobStatement.class.getCanonicalName();
-    }
+public final class ShowScalingListStatement extends QueryableRALStatement {
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ShowScalingStatusStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/ShowScalingStatusStatement.java
@@ -15,24 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.handler;
+package org.apache.shardingsphere.scaling.distsql.statement;
 
-import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.distsql.statement.DropScalingJobStatement;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 
 /**
- * Drop scaling job updater.
+ * Show scaling status statement.
  */
-public final class DropScalingJobUpdater implements RALUpdater<DropScalingJobStatement> {
+@RequiredArgsConstructor
+@Getter
+public final class ShowScalingStatusStatement extends QueryableRALStatement {
     
-    @Override
-    public void executeUpdate(final DropScalingJobStatement sqlStatement) {
-        ScalingAPIFactory.getScalingAPI().remove(sqlStatement.getJobId());
-    }
-    
-    @Override
-    public String getType() {
-        return DropScalingJobStatement.class.getCanonicalName();
-    }
+    private final long jobId;
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/StartScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/StartScalingStatement.java
@@ -15,66 +15,18 @@
  * limitations under the License.
  */
 
-lexer grammar Keyword;
+package org.apache.shardingsphere.scaling.distsql.statement;
 
-import Alphabet;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
-WS
-    : [ \t\r\n] + ->skip
-    ;
-
-ALGORITHMS
-    : A L G O R I T H M S
-    ;
-
-DROP
-    : D R O P
-    ;
-
-SHOW
-    : S H O W
-    ;
-
-START
-    : S T A R T
-    ;
-
-STOP
-    : S T O P
-    ;
-
-RESET
-    : R E S E T
-    ;
-
-CHECK
-    : C H E C K
-    ;
-
-CHECKOUT
-    : C H E C K O U T
-    ;
-
-SCALING
-    : S C A L I N G
-    ;
-
-JOB
-    : J O B
-    ;
-
-LIST
-    : L I S T
-    ;
-
-STATUS
-    : S T A T U S
-    ;
-
-SOURCE
-    : S O U R C E
-    ;
-
-WRITING
-    : W R I T I N G
-    ;
+/**
+ * Start scaling statement.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class StartScalingStatement extends UpdatableRALStatement {
+    
+    private final long jobId;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/StopScalingStatement.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/StopScalingStatement.java
@@ -17,10 +17,16 @@
 
 package org.apache.shardingsphere.scaling.distsql.statement;
 
-import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
 /**
- * Show scaling job list statement.
+ * Stop scaling statement.
  */
-public final class ShowScalingJobListStatement extends QueryableRALStatement {
+@RequiredArgsConstructor
+@Getter
+public final class StopScalingStatement extends UpdatableRALStatement {
+    
+    private final long jobId;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/QueryableRALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/QueryableRALStatementAssert.java
@@ -21,13 +21,13 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingCheckAlgorithmsStatement;
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobListStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingListStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.query.ShowScalingCheckAlgorithmsStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.query.ShowScalingJobListStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.query.ShowScalingListStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.ShowScalingCheckAlgorithmsStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingJobListStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingListStatementTestCase;
 
 /**
  * Queryable RAL statement assert.
@@ -44,8 +44,8 @@ public final class QueryableRALStatementAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final QueryableRALStatement actual, final SQLParserTestCase expected) {
         // TODO add more test case
-        if (actual instanceof ShowScalingJobListStatement) {
-            ShowScalingJobListStatementAssert.assertIs(assertContext, (ShowScalingJobListStatement) actual, (ShowScalingJobListStatementTestCase) expected);
+        if (actual instanceof ShowScalingListStatement) {
+            ShowScalingListStatementAssert.assertIs(assertContext, (ShowScalingListStatement) actual, (ShowScalingListStatementTestCase) expected);
         } else if (actual instanceof ShowScalingCheckAlgorithmsStatement) {
             ShowScalingCheckAlgorithmsStatementAssert.assertIs(assertContext, (ShowScalingCheckAlgorithmsStatement) actual, (ShowScalingCheckAlgorithmsStatementTestCase) expected);
         }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/UpdatableRALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/UpdatableRALStatementAssert.java
@@ -20,10 +20,13 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckoutScalingStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.StopScalingSourceWritingStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.update.CheckoutScalingStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.update.StopScalingSourceWritingStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.CheckoutScalingStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.StopScalingSourceWritingStatementTestCase;
 
 /**
@@ -43,6 +46,8 @@ public final class UpdatableRALStatementAssert {
         // TODO add more test case
         if (actual instanceof StopScalingSourceWritingStatement) {
             StopScalingSourceWritingStatementAssert.assertIs(assertContext, (StopScalingSourceWritingStatement) actual, (StopScalingSourceWritingStatementTestCase) expected);
+        } else if (actual instanceof CheckoutScalingStatement) {
+            CheckoutScalingStatementAssert.assertIs(assertContext, (CheckoutScalingStatement) actual, (CheckoutScalingStatementTestCase) expected);
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/query/ShowScalingListStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/query/ShowScalingListStatementAssert.java
@@ -17,22 +17,30 @@
 
 package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.query;
 
-import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingJobListStatement;
+import org.apache.shardingsphere.scaling.distsql.statement.ShowScalingListStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingJobListStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingListStatementTestCase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
- * Show scaling job list statement assert.
+ * Show scaling list statement assert.
  */
-public final class ShowScalingJobListStatementAssert {
+public final class ShowScalingListStatementAssert {
     
     /**
-     * Assert show scaling job list statement is correct with expected parser result.
+     * Assert show scaling list statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual show scaling job list statement
-     * @param expected expected show scaling job list statement test case
+     * @param actual actual show scaling list statement
+     * @param expected expected show scaling list statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowScalingJobListStatement actual, final ShowScalingJobListStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowScalingListStatement actual, final ShowScalingListStatementTestCase expected) {
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual statement should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual statement should exist."), actual);
+        }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/update/CheckoutScalingStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/update/CheckoutScalingStatementAssert.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.update;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.shardingsphere.scaling.distsql.statement.CheckoutScalingStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.CheckoutScalingStatementTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Checkout scaling statement assert.
+ */
+public final class CheckoutScalingStatementAssert {
+    
+    /**
+     * Assert checkout scaling statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual checkout scaling statement
+     * @param expected expected checkout scaling statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final CheckoutScalingStatement actual, final CheckoutScalingStatementTestCase expected) {
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual statement should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual statement should exist."), actual);
+            assertJobIds(assertContext, actual.getJobId(), expected.getJobIds());
+        }
+    }
+    
+    private static void assertJobIds(final SQLCaseAssertContext assertContext, final long actual, final List<Long> expected) {
+        if (CollectionUtils.isEmpty(expected)) {
+            assertNull(assertContext.getText("Actual job id should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual job id should exist."), actual);
+            assertThat(assertContext.getText("job id assertion error"), actual, is(expected.iterator().next().longValue()));
+        }
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -96,8 +96,9 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.SetShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.SetVariableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowReadwriteSplittingHintStatusStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.CheckoutScalingStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.ShowScalingCheckAlgorithmsStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingJobListStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowScalingListStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowShardingHintStatusStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowVariableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling.StopScalingSourceWritingStatementTestCase;
@@ -495,14 +496,17 @@ public final class SQLParserTestCases {
     @XmlElement(name = "show-sharding-table-rule")
     private final List<ShowShardingTableRulesStatementTestCase> showShardingTableRuleTestCase = new LinkedList<>();
     
-    @XmlElement(name = "show-scaling-job-list")
-    private final List<ShowScalingJobListStatementTestCase> showScalingJobListStatementTestCase = new LinkedList<>();
+    @XmlElement(name = "show-scaling-list")
+    private final List<ShowScalingListStatementTestCase> showScalingListStatementTestCase = new LinkedList<>();
     
     @XmlElement(name = "show-scaling-check-algorithms")
     private final List<ShowScalingCheckAlgorithmsStatementTestCase> showScalingCheckAlgorithmsStatementTestCase = new LinkedList<>();
     
     @XmlElement(name = "stop-scaling-source-writing")
     private final List<StopScalingSourceWritingStatementTestCase> stopScalingSourceWritingStatementTestCase = new LinkedList<>();
+    
+    @XmlElement(name = "checkout-scaling")
+    private final List<CheckoutScalingStatementTestCase> checkoutScalingStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "preview-sql")
     private final List<PreviewStatementTestCase> previewStatementTestCase = new LinkedList<>();
@@ -680,9 +684,10 @@ public final class SQLParserTestCases {
         putAll(showShardingAlgorithmsTestCase, result);
         putAll(showShardingTableRulesTestCase, result);
         putAll(showShardingTableRuleTestCase, result);
-        putAll(showScalingJobListStatementTestCase, result);
+        putAll(showScalingListStatementTestCase, result);
         putAll(showScalingCheckAlgorithmsStatementTestCase, result);
         putAll(stopScalingSourceWritingStatementTestCase, result);
+        putAll(checkoutScalingStatementTestCases, result);
         putAll(showVariableStatementTestCase, result);
         putAll(setVariableStatementTestCase, result);
         putAll(previewStatementTestCase, result);

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ShowScalingListStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ShowScalingListStatementTestCase.java
@@ -15,18 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.statement;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 /**
- * Reset scaling job statement.
+ * Show scaling list statement test case.
  */
-@RequiredArgsConstructor
-@Getter
-public final class ResetScalingJobStatement extends UpdatableRALStatement {
-    
-    private final long jobId;
+public final class ShowScalingListStatementTestCase extends SQLParserTestCase {
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/scaling/CheckoutScalingStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/scaling/CheckoutScalingStatementTestCase.java
@@ -15,18 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.distsql.statement;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.scaling;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
- * Check scaling job statement.
+ * Checkout scaling statement test case.
  */
-@RequiredArgsConstructor
 @Getter
-public final class CheckScalingJobStatement extends QueryableRALStatement {
+@Setter
+public final class CheckoutScalingStatementTestCase extends SQLParserTestCase {
     
-    private final long jobId;
+    @XmlElement(name = "job-id")
+    private final List<Long> jobIds = new LinkedList<>();
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/query.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/query.xml
@@ -17,6 +17,6 @@
   -->
 
 <sql-parser-test-cases>
-    <show-scaling-job-list sql-case-id="show-scaling-job-list" />
+    <show-scaling-list sql-case-id="show-scaling-list" />
     <show-scaling-check-algorithms sql-case-id="show-scaling-check-algorithms" />
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/update.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/update.xml
@@ -20,4 +20,8 @@
     <stop-scaling-source-writing sql-case-id="stop-scaling-source-writing">
         <job-id>123</job-id>
     </stop-scaling-source-writing>
+
+    <checkout-scaling sql-case-id="checkout-scaling">
+        <job-id>123</job-id>
+    </checkout-scaling>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/query.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/query.xml
@@ -17,6 +17,6 @@
   -->
 
 <sql-cases>
-    <distsql-case id="show-scaling-job-list" value="SHOW SCALING JOB LIST;" />
+    <distsql-case id="show-scaling-list" value="SHOW SCALING LIST;" />
     <distsql-case id="show-scaling-check-algorithms" value="SHOW SCALING CHECK ALGORITHMS;" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/update.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/update.xml
@@ -18,4 +18,5 @@
 
 <sql-cases>
     <distsql-case id="stop-scaling-source-writing" value="STOP SCALING SOURCE WRITING 123;" />
+    <distsql-case id="checkout-scaling" value="CHECKOUT SCALING 123;" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
1. Add scaling distSQL:`CHECKOUT SCALING jobId`.

2. Remove `JOB` keyword from the following SQL syntax
  - SHOW SCALING JOB LIST   ->   SHOW SCALING LIST
  - SHOW SCALING JOB STATUS jobId   ->   SHOW SCALING STATUS jobId
  - START SCALING JOB jobId   ->   START SCALING jobId
  - STOP SCALING JOB jobId   ->   STOP SCALING jobId
  - DROP SCALING JOB jobId   ->   DROP SCALING jobId
  - RESET SCALING JOB jobId   ->   RESET SCALING jobId
  - CHECK SCALING JOB jobId   ->   CHECK SCALING jobId

