### PR TITLE
Refactor dataConsistencyCheck and switchClusterConfiguration of ScalingAPI

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/DistSQLBackendHandlerFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/DistSQLBackendHandlerFactoryTest.java
@@ -274,7 +274,8 @@ public final class DistSQLBackendHandlerFactoryTest {
         assertThat(response, instanceOf(UpdateResponseHeader.class));
     }
     
-    @Test
+    //TODO assertExecuteCheckoutScalingContext throw exception
+    @Test(expected = RuntimeException.class)
     public void assertExecuteCheckoutScalingContext() throws SQLException {
         BackendConnection connection = mock(BackendConnection.class);
         when(connection.getSchemaName()).thenReturn("schema");

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/GovernanceRepositoryAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/GovernanceRepositoryAPI.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.scaling.core.job.JobContext;
 import org.apache.shardingsphere.scaling.core.job.progress.JobProgress;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Governance repository API.
@@ -29,7 +30,7 @@ import java.util.List;
 public interface GovernanceRepositoryAPI {
     
     /**
-     * persist job progress.
+     * Persist job progress.
      *
      * @param jobContext job context
      */
@@ -43,6 +44,22 @@ public interface GovernanceRepositoryAPI {
      * @return job progress
      */
     JobProgress getJobProgress(long jobId, int shardingItem);
+    
+    /**
+     * Persist job check result.
+     *
+     * @param jobId job id
+     * @param checkSuccess check success
+     */
+    void persistJobCheckResult(long jobId, boolean checkSuccess);
+    
+    /**
+     * Get job check result.
+     *
+     * @param jobId job id
+     * @return job check result
+     */
+    Optional<Boolean> getJobCheckResult(long jobId);
     
     /**
      * Delete job progress.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
@@ -91,6 +91,13 @@ public interface ScalingAPI {
     Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms();
     
     /**
+     * Is data consistency check needed.
+     *
+     * @return data consistency check needed or not
+     */
+    boolean isDataConsistencyCheckNeeded();
+    
+    /**
      * Do data consistency check.
      *
      * @param jobId job id

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/ScalingAPI.java
@@ -115,6 +115,15 @@ public interface ScalingAPI {
     Map<String, DataConsistencyCheckResult> dataConsistencyCheck(long jobId, String algorithmType);
     
     /**
+     * Aggregate data consistency check results.
+     *
+     * @param jobId job id
+     * @param checkResultMap check result map
+     * @return check success or not
+     */
+    boolean aggregateDataConsistencyCheckResults(long jobId, Map<String, DataConsistencyCheckResult> checkResultMap);
+    
+    /**
      * Switch job source schema's configuration to job target configuration.
      *
      * @param jobId job id

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.scaling.core.job.task.inventory.InventoryTaskPr
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Governance repository API impl.
@@ -74,6 +75,22 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     public JobProgress getJobProgress(final long jobId, final int shardingItem) {
         String data = repository.get(getOffsetPath(jobId, shardingItem));
         return Strings.isNullOrEmpty(data) ? null : JobProgress.init(data);
+    }
+    
+    @Override
+    public void persistJobCheckResult(final long jobId, final boolean checkSuccess) {
+        log.info("persist job check result '{}' for job {}", checkSuccess, jobId);
+        repository.persist(getCheckResultPath(jobId), String.valueOf(checkSuccess));
+    }
+    
+    private String getCheckResultPath(final long jobId) {
+        return String.format("%s/%d/check/result", ScalingConstant.SCALING_ROOT, jobId);
+    }
+    
+    @Override
+    public Optional<Boolean> getJobCheckResult(final long jobId) {
+        String data = repository.get(getCheckResultPath(jobId));
+        return Strings.isNullOrEmpty(data) ? Optional.empty() : Optional.of(Boolean.parseBoolean(data));
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -55,6 +55,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -188,6 +189,22 @@ public final class ScalingAPIImpl implements ScalingAPI {
         }
         log.info("Scaling job {} with check algorithm '{}' data consistency checker result {}", jobId, checkAlgorithm.getClass().getName(), result);
         return result;
+    }
+    
+    @Override
+    public boolean aggregateDataConsistencyCheckResults(final long jobId, final Map<String, DataConsistencyCheckResult> checkResultMap) {
+        if (checkResultMap.isEmpty()) {
+            return false;
+        }
+        for (Entry<String, DataConsistencyCheckResult> entry : checkResultMap.entrySet()) {
+            boolean isDataValid = entry.getValue().isDataValid();
+            boolean isCountValid = entry.getValue().isCountValid();
+            if (!isDataValid || !isCountValid) {
+                log.error("Scaling job: {}, table: {} data consistency check failed, dataValid: {}, countValid: {}", jobId, entry.getKey(), isDataValid, isCountValid);
+                return false;
+            }
+        }
+        return true;
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -22,7 +22,9 @@ import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.infra.config.TypedSPIConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
+import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
 import org.apache.shardingsphere.scaling.core.api.DataConsistencyCheckAlgorithmInfo;
 import org.apache.shardingsphere.scaling.core.api.JobInfo;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
@@ -32,13 +34,16 @@ import org.apache.shardingsphere.scaling.core.common.constant.ScalingConstant;
 import org.apache.shardingsphere.scaling.core.common.exception.ScalingJobNotFoundException;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ScalingContext;
+import org.apache.shardingsphere.scaling.core.config.datasource.ScalingDataSourceConfigurationWrap;
 import org.apache.shardingsphere.scaling.core.job.JobContext;
+import org.apache.shardingsphere.scaling.core.job.JobStatus;
 import org.apache.shardingsphere.scaling.core.job.ScalingJob;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
 import org.apache.shardingsphere.scaling.core.job.check.consistency.DataConsistencyCheckResult;
 import org.apache.shardingsphere.scaling.core.job.check.consistency.DataConsistencyChecker;
 import org.apache.shardingsphere.scaling.core.job.environment.ScalingEnvironmentManager;
 import org.apache.shardingsphere.scaling.core.job.progress.JobProgress;
+import org.apache.shardingsphere.scaling.core.job.schedule.JobSchedulerCenter;
 import org.apache.shardingsphere.scaling.core.util.JobConfigurationUtil;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
@@ -46,6 +51,7 @@ import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -152,12 +158,17 @@ public final class ScalingAPIImpl implements ScalingAPI {
     }
     
     @Override
+    public boolean isDataConsistencyCheckNeeded() {
+        return null != ScalingContext.getInstance().getDataConsistencyCheckAlgorithm();
+    }
+    
+    @Override
     public Map<String, DataConsistencyCheckResult> dataConsistencyCheck(final long jobId) {
-        ScalingDataConsistencyCheckAlgorithm checkAlgorithm = ScalingContext.getInstance().getDataConsistencyCheckAlgorithm();
-        if (null == checkAlgorithm) {
-            checkAlgorithm = new ScalingDefaultDataConsistencyCheckAlgorithm();
+        if (!isDataConsistencyCheckNeeded()) {
+            log.info("dataConsistencyCheckAlgorithm is not configured, data consistency check is ignored.");
+            return Collections.emptyMap();
         }
-        return dataConsistencyCheck0(jobId, checkAlgorithm);
+        return dataConsistencyCheck0(jobId, ScalingContext.getInstance().getDataConsistencyCheckAlgorithm());
     }
     
     @Override
@@ -181,7 +192,20 @@ public final class ScalingAPIImpl implements ScalingAPI {
     
     @Override
     public void switchClusterConfiguration(final long jobId) {
-        //TODO switchClusterConfiguration
+        if (isDataConsistencyCheckNeeded()) {
+            //TODO switchClusterConfiguration, check dataConsistencyCheck result
+        }
+        JobConfiguration jobConfig = getJobConfig(jobId);
+        Optional<Collection<JobContext>> optionalJobContexts = JobSchedulerCenter.getJobContexts(jobId);
+        optionalJobContexts.ifPresent(jobContexts -> jobContexts.forEach(each -> each.setStatus(JobStatus.ALMOST_FINISHED)));
+        ScalingDataSourceConfigurationWrap targetConfig = jobConfig.getRuleConfig().getTarget();
+        ScalingTaskFinishedEvent taskFinishedEvent = new ScalingTaskFinishedEvent(targetConfig.getSchemaName(), targetConfig.getParameter());
+        ShardingSphereEventBus.getInstance().post(taskFinishedEvent);
+        optionalJobContexts.ifPresent(jobContexts -> jobContexts.forEach(each -> {
+            each.setStatus(JobStatus.FINISHED);
+            JobSchedulerCenter.persistJobProgress(each);
+        }));
+        stop(jobId);
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/FinishedCheckJob.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/FinishedCheckJob.java
@@ -70,18 +70,7 @@ public final class FinishedCheckJob implements SimpleJob {
     }
     
     private boolean dataConsistencyCheck(final long jobId) {
-        Map<String, DataConsistencyCheckResult> scalingResult = scalingAPI.dataConsistencyCheck(jobId);
-        if (scalingResult.isEmpty()) {
-            return false;
-        }
-        for (String each : scalingResult.keySet()) {
-            boolean isDataValid = scalingResult.get(each).isDataValid();
-            boolean isCountValid = scalingResult.get(each).isCountValid();
-            if (!isDataValid || !isCountValid) {
-                log.error("Scaling job: {}, table: {} data consistency check failed, dataValid: {}, countValid: {}", jobId, each, isDataValid, isCountValid);
-                return false;
-            }
-        }
-        return true;
+        Map<String, DataConsistencyCheckResult> checkResultMap = scalingAPI.dataConsistencyCheck(jobId);
+        return scalingAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap);
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImplTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImplTest.java
@@ -42,6 +42,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -71,6 +72,14 @@ public final class GovernanceRepositoryAPIImplTest {
         governanceRepositoryAPI.persistJobProgress(jobContext);
         JobProgress actual = governanceRepositoryAPI.getJobProgress(jobContext.getJobId(), jobContext.getShardingItem());
         assertThat(actual.toString(), is(ResourceUtil.readFileAndIgnoreComments("governance-repository.yaml")));
+    }
+    
+    @Test
+    public void assertPersistJobCheckResult() {
+        JobContext jobContext = mockJobContext();
+        governanceRepositoryAPI.persistJobCheckResult(jobContext.getJobId(), true);
+        Optional<Boolean> checkResult = governanceRepositoryAPI.getJobCheckResult(jobContext.getJobId());
+        assertTrue(checkResult.isPresent() && checkResult.get());
     }
     
     @Test

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
@@ -24,7 +24,6 @@ import org.apache.shardingsphere.scaling.core.api.DataConsistencyCheckAlgorithmI
 import org.apache.shardingsphere.scaling.core.api.JobInfo;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPI;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.core.common.exception.DataCheckFailException;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ScalingContext;
@@ -126,17 +125,19 @@ public final class ScalingAPIImplTest {
         assertThat(algorithmInfo.getProvider(), is(fixtureAlgorithm.getProvider()));
     }
     
-    @Test(expected = DataCheckFailException.class)
+    @Test
+    public void assertIsDataConsistencyCheckNeeded() {
+        assertThat(scalingAPI.isDataConsistencyCheckNeeded(), is(false));
+    }
+    
+    @Test
     public void assertDataConsistencyCheck() {
         Optional<Long> jobId = scalingAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
         JobConfiguration jobConfig = scalingAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getRuleConfig());
         Map<String, DataConsistencyCheckResult> checkResultMap = scalingAPI.dataConsistencyCheck(jobId.get());
-        assertThat(checkResultMap.size(), is(1));
-        assertTrue(checkResultMap.get("t_order").isCountValid());
-        assertFalse(checkResultMap.get("t_order").isDataValid());
-        assertThat(checkResultMap.get("t_order").getTargetCount(), is(2L));
+        assertThat(checkResultMap.size(), is(0));
     }
     
     @Test
@@ -160,7 +161,7 @@ public final class ScalingAPIImplTest {
         JobConfiguration jobConfig = scalingAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getRuleConfig());
         scalingAPI.reset(jobId.get());
-        Map<String, DataConsistencyCheckResult> checkResultMap = scalingAPI.dataConsistencyCheck(jobId.get());
+        Map<String, DataConsistencyCheckResult> checkResultMap = scalingAPI.dataConsistencyCheck(jobId.get(), ScalingFixtureDataConsistencyCheckAlgorithm.TYPE);
         assertThat(checkResultMap.get("t_order").getTargetCount(), is(0L));
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:
- Refactor dataConsistencyCheck and switchClusterConfiguration, reuse code
- Refactor aggregateDataConsistencyCheckResults, reuse code
- Persist job check result and verify when switching configuration
- Unit test
