### PR TITLE
The error message is not detailed enough when adding resources.

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceValidator.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/DataSourceValidator.java
@@ -29,8 +29,9 @@ public final class DataSourceValidator {
      *
      * @param dataSourceConfiguration data source configuration
      * @return is valid or not
+     * @throws Exception exception
      */
-    public boolean validate(final DataSourceConfiguration dataSourceConfiguration) {
+    public boolean validate(final DataSourceConfiguration dataSourceConfiguration) throws Exception {
         DataSource dataSource = null;
         try {
             dataSource = DataSourceConverter.getDataSource(dataSourceConfiguration);
@@ -38,7 +39,7 @@ public final class DataSourceValidator {
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
-            return false;
+            throw ex;
         } finally {
             if (null != dataSource) {
                 close(dataSource);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/DataSourceValidatorTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/DataSourceValidatorTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertThat;
 public final class DataSourceValidatorTest {
     
     @Test
-    public void assertValidate() {
+    public void assertValidate() throws Exception {
         DataSourceValidator dataSourceValidator = new DataSourceValidator();
         assertThat(dataSourceValidator.validate(createDataSourceConfiguration()), is(Boolean.TRUE));
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/resource/AddResourceBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/resource/AddResourceBackendHandlerTest.java
@@ -83,7 +83,7 @@ public final class AddResourceBackendHandlerTest {
     }
     
     @Test
-    public void assertExecute() throws DistSQLException {
+    public void assertExecute() throws Exception {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts()).thenReturn(metaDataContexts);
         ProxyContext.getInstance().init(contextManager);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/resource/AlterResourceBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/resource/AlterResourceBackendHandlerTest.java
@@ -88,7 +88,7 @@ public final class AlterResourceBackendHandlerTest {
     }
     
     @Test
-    public void assertExecute() throws DistSQLException {
+    public void assertExecute() throws Exception {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts()).thenReturn(metaDataContexts);
         ProxyContext.getInstance().init(contextManager);


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed There is no detailed exception information when adding resource is unsuccessful


---

Before:
```
Can not add invalid resources [resource_0, resource_1]
```
After:
```
Can not add invalid resources [`resource_0` Failed to initialize pool: Unknown database 'db0', `resource_1` Failed to initialize pool: Access denied for user 'root'@'172.17.0.1' (using password: YES)]
```