### PR TITLE
support openGauss mppdb_decoding plugin

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/record/Column.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/record/Column.java
@@ -18,12 +18,11 @@
 package org.apache.shardingsphere.scaling.core.common.record;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
 /**
  * Column.
  */
-@RequiredArgsConstructor
 @Getter
 public final class Column {
     
@@ -32,7 +31,8 @@ public final class Column {
     /**
      * Value are available only when the primary key column is updated.
      */
-    private final Object oldValue;
+    @Setter
+    private Object oldValue;
     
     private final Object value;
     
@@ -42,6 +42,14 @@ public final class Column {
     
     public Column(final String name, final Object value, final boolean updated, final boolean primaryKey) {
         this(name, null, value, updated, primaryKey);
+    }
+    
+    public Column(final String name, final Object oldValue, final Object value, final boolean updated, final boolean primaryKey) {
+        this.name = name;
+        this.oldValue = oldValue;
+        this.value = value;
+        this.updated = updated;
+        this.primaryKey = primaryKey;
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/sqlbuilder/AbstractScalingSQLBuilder.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/sqlbuilder/AbstractScalingSQLBuilder.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.scaling.core.common.sqlbuilder;
 
-import com.google.common.collect.Collections2;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -100,7 +99,7 @@ public abstract class AbstractScalingSQLBuilder implements ScalingSQLBuilder {
             sqlCacheMap.put(sqlCacheKey, buildUpdateSQLInternal(dataRecord.getTableName(), conditionColumns));
         }
         StringBuilder updatedColumnString = new StringBuilder();
-        for (Column each : extractUpdatedColumns(dataRecord.getColumns())) {
+        for (Column each : extractUpdatedColumns(dataRecord.getColumns(), dataRecord)) {
             updatedColumnString.append(String.format("%s = ?,", quote(each.getName())));
         }
         updatedColumnString.setLength(updatedColumnString.length() - 1);
@@ -109,10 +108,6 @@ public abstract class AbstractScalingSQLBuilder implements ScalingSQLBuilder {
     
     private String buildUpdateSQLInternal(final String tableName, final Collection<Column> conditionColumns) {
         return String.format("UPDATE %s SET %%s WHERE %s", quote(tableName), buildWhereSQL(conditionColumns));
-    }
-    
-    private Collection<Column> extractUpdatedColumns(final Collection<Column> columns) {
-        return Collections2.filter(columns, Column::isUpdated);
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/sqlbuilder/ScalingSQLBuilder.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/sqlbuilder/ScalingSQLBuilder.java
@@ -19,8 +19,11 @@ package org.apache.shardingsphere.scaling.core.common.sqlbuilder;
 
 import org.apache.shardingsphere.scaling.core.common.record.Column;
 import org.apache.shardingsphere.scaling.core.common.record.DataRecord;
+import org.apache.shardingsphere.scaling.core.common.record.RecordUtil;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Scaling SQL builder.
@@ -43,6 +46,17 @@ public interface ScalingSQLBuilder {
      * @return update SQL
      */
     String buildUpdateSQL(DataRecord dataRecord, Collection<Column> conditionColumns);
+    
+    /**
+     * Extract need updated columns.
+     *
+     * @param columns the input columns
+     * @param record the input datarecord
+     * @return the filtered columns.
+     */
+    default List<Column> extractUpdatedColumns(Collection<Column> columns, DataRecord record) {
+        return new ArrayList<>(RecordUtil.extractUpdatedColumns(record));
+    }
     
     /**
      * Build delete SQL.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporter.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporter.java
@@ -182,7 +182,7 @@ public abstract class AbstractImporter extends AbstractScalingExecutor implement
     
     private void executeUpdate(final Connection connection, final DataRecord record) throws SQLException {
         List<Column> conditionColumns = RecordUtil.extractConditionColumns(record, importerConfig.getShardingColumnsMap().get(record.getTableName()));
-        List<Column> updatedColumns = RecordUtil.extractUpdatedColumns(record);
+        List<Column> updatedColumns = scalingSqlBuilder.extractUpdatedColumns(record.getColumns(), record);
         String updateSql = scalingSqlBuilder.buildUpdateSQL(record, conditionColumns);
         try (PreparedStatement ps = connection.prepareStatement(updateSql)) {
             for (int i = 0; i < updatedColumns.size(); i++) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/AbstractDataSourcePreparer.java
@@ -60,6 +60,8 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
     
     private static final Pattern PATTERN_ALTER_TABLE = Pattern.compile("ALTER\\s+TABLE\\s+", Pattern.CASE_INSENSITIVE);
     
+    private static final String[] IGNORE_EXCEPTION_MESSAGE = {"multiple primary keys for table", "already exists"};
+    
     private final DataSourceFactory dataSourceFactory = new DataSourceFactory();
     
     protected DataSourceWrapper getSourceDataSource(final JobConfiguration jobConfig) {
@@ -113,9 +115,12 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
         try (Statement statement = targetConnection.createStatement()) {
             statement.execute(sql);
         } catch (final SQLException ex) {
-            if (!ex.getMessage().contains("multiple primary keys for table")) {
-                throw ex;
+            for (String ignoreMessage: IGNORE_EXCEPTION_MESSAGE) {
+                if (ex.getMessage().contains(ignoreMessage)) {
+                    return;
+                }
             }
+            throw ex;
         }
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
@@ -130,6 +131,7 @@ public final class AbstractImporterTest {
         when(scalingSqlBuilder.buildUpdateSQL(updateRecord, mockConditionColumns(updateRecord))).thenReturn(UPDATE_SQL);
         when(connection.prepareStatement(UPDATE_SQL)).thenReturn(preparedStatement);
         when(channel.fetchRecords(anyInt(), anyInt())).thenReturn(mockRecords(updateRecord));
+        when(scalingSqlBuilder.extractUpdatedColumns(any(), any())).thenReturn(RecordUtil.extractUpdatedColumns(updateRecord));
         jdbcImporter.run();
         verify(preparedStatement).setObject(1, 10);
         verify(preparedStatement).setObject(2, "UPDATE");
@@ -144,6 +146,7 @@ public final class AbstractImporterTest {
         when(scalingSqlBuilder.buildUpdateSQL(updateRecord, mockConditionColumns(updateRecord))).thenReturn(UPDATE_SQL);
         when(connection.prepareStatement(UPDATE_SQL)).thenReturn(preparedStatement);
         when(channel.fetchRecords(anyInt(), anyInt())).thenReturn(mockRecords(updateRecord));
+        when(scalingSqlBuilder.extractUpdatedColumns(any(), any())).thenReturn(RecordUtil.extractUpdatedColumns(updateRecord));
         jdbcImporter.run();
         InOrder inOrder = inOrder(preparedStatement);
         inOrder.verify(preparedStatement).setObject(1, 2);

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussScalingSQLBuilder.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussScalingSQLBuilder.java
@@ -17,9 +17,14 @@
 
 package org.apache.shardingsphere.scaling.opengauss.component;
 
+import com.google.common.collect.Collections2;
+import org.apache.shardingsphere.scaling.core.common.record.Column;
 import org.apache.shardingsphere.scaling.core.common.record.DataRecord;
 import org.apache.shardingsphere.scaling.core.common.sqlbuilder.AbstractScalingSQLBuilder;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -34,17 +39,29 @@ public final class OpenGaussScalingSQLBuilder extends AbstractScalingSQLBuilder 
     
     @Override
     public String getLeftIdentifierQuoteString() {
-        return "\"";
+        return "";
     }
     
     @Override
     public String getRightIdentifierQuoteString() {
-        return "\"";
+        return "";
     }
     
     @Override
     public String buildInsertSQL(final DataRecord dataRecord) {
         return super.buildInsertSQL(dataRecord) + buildConflictSQL();
+    }
+    
+    @Override
+    public List<Column> extractUpdatedColumns(final Collection<Column> columns, final DataRecord record) {
+        return new ArrayList(Collections2.filter(columns, column -> !(column.isPrimaryKey()
+                || isShardingColumn(getShardingColumnsMap(), record.getTableName(), column.getName()))));
+    }
+    
+    private boolean isShardingColumn(final Map<String, Set<String>> shardingColumnsMap,
+                                     final String tableName, final String columnName) {
+        return shardingColumnsMap.containsKey(tableName)
+                && shardingColumnsMap.get(tableName).contains(columnName);
     }
     
     private String buildConflictSQL() {

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussWalDumper.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/component/OpenGaussWalDumper.java
@@ -20,7 +20,10 @@ package org.apache.shardingsphere.scaling.opengauss.component;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.scaling.core.common.channel.Channel;
+import org.apache.shardingsphere.scaling.core.common.constant.ScalingConstant;
 import org.apache.shardingsphere.scaling.core.common.exception.ScalingTaskExecuteException;
+import org.apache.shardingsphere.scaling.core.common.record.Column;
+import org.apache.shardingsphere.scaling.core.common.record.DataRecord;
 import org.apache.shardingsphere.scaling.core.common.record.Record;
 import org.apache.shardingsphere.scaling.core.config.DumperConfiguration;
 import org.apache.shardingsphere.scaling.core.config.datasource.StandardJDBCDataSourceConfiguration;
@@ -29,11 +32,12 @@ import org.apache.shardingsphere.scaling.core.executor.dumper.IncrementalDumper;
 import org.apache.shardingsphere.scaling.core.job.position.ScalingPosition;
 import org.apache.shardingsphere.scaling.core.util.ThreadUtil;
 import org.apache.shardingsphere.scaling.opengauss.wal.OpenGaussLogicalReplication;
+import org.apache.shardingsphere.scaling.opengauss.wal.decode.MppdbDecodingPlugin;
 import org.apache.shardingsphere.scaling.opengauss.wal.decode.OpenGaussTimestampUtils;
 import org.apache.shardingsphere.scaling.opengauss.wal.decode.OpenGaussLogSequenceNumber;
 import org.apache.shardingsphere.scaling.postgresql.wal.WalEventConverter;
 import org.apache.shardingsphere.scaling.postgresql.wal.WalPosition;
-import org.apache.shardingsphere.scaling.postgresql.wal.decode.TestDecodingPlugin;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.DecodingPlugin;
 import org.apache.shardingsphere.scaling.postgresql.wal.event.AbstractWalEvent;
 import org.apache.shardingsphere.scaling.postgresql.wal.event.PlaceholderEvent;
 import org.opengauss.jdbc.PgConnection;
@@ -57,6 +61,8 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
     private final OpenGaussLogicalReplication logicalReplication = new OpenGaussLogicalReplication();
 
     private final WalEventConverter walEventConverter;
+    
+    private String slotName = OpenGaussLogicalReplication.SLOT_NAME_PREFIX;
 
     @Setter
     private Channel channel;
@@ -82,14 +88,15 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
                 .unwrap(PgConnection.class);
     }
 
-    private TestDecodingPlugin initReplication() {
-        TestDecodingPlugin plugin = null;
+    private MppdbDecodingPlugin initReplication() {
+        MppdbDecodingPlugin plugin = null;
         try {
             DataSource dataSource = dumperConfig.getDataSourceConfig().toDataSource();
             try (Connection conn = dataSource.getConnection()) {
+                slotName = OpenGaussLogicalReplication.getUniqueSlotName(conn);
                 OpenGaussLogicalReplication.createIfNotExists(conn);
                 OpenGaussTimestampUtils utils = new OpenGaussTimestampUtils(conn.unwrap(PgConnection.class).getTimestampUtils());
-                plugin = new TestDecodingPlugin(utils);
+                plugin = new MppdbDecodingPlugin(utils);
             }
         } catch (SQLException sqlExp) {
             log.warn("create replication slot failed!");
@@ -98,9 +105,9 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
     }
 
     private void dump() {
-        TestDecodingPlugin decodingPlugin = initReplication();
+        DecodingPlugin decodingPlugin = initReplication();
         try (PgConnection pgConnection = getReplicationConn()) {
-            PGReplicationStream stream = logicalReplication.createReplicationStream(pgConnection, walPosition.getLogSequenceNumber());
+            PGReplicationStream stream = logicalReplication.createReplicationStream(pgConnection, walPosition.getLogSequenceNumber(), slotName);
             while (isRunning()) {
                 ByteBuffer message = stream.readPending();
                 if (null == message) {
@@ -113,6 +120,7 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
                 if (!(event instanceof PlaceholderEvent) && log.isDebugEnabled()) {
                     log.debug("dump, event={}, record={}", event, record);
                 }
+                updateRecordOldValue(record);
                 pushRecord(record);
             }
         } catch (final SQLException ex) {
@@ -123,6 +131,21 @@ public final class OpenGaussWalDumper extends AbstractScalingExecutor implements
         }
     }
 
+    private void updateRecordOldValue(final Record record) {
+        if (!(record instanceof DataRecord)) {
+            return;
+        }
+        DataRecord dataRecord = (DataRecord) record;
+        if (!ScalingConstant.UPDATE.equals(dataRecord.getType())) {
+            return;
+        }
+        for (Column col: dataRecord.getColumns()) {
+            if (col.isPrimaryKey() && col.isUpdated()) {
+                col.setOldValue(col.getValue());
+            }
+        }
+    }
+    
     private void pushRecord(final Record record) {
         try {
             channel.pushRecord(record);

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppTableData.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppTableData.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.opengauss.wal.decode;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Mppdb decoding Gson related class.
+ */
+@Setter
+@Getter
+public final class MppTableData {
+    
+    @SerializedName("table_name")
+    private String tableName;
+
+    @SerializedName("op_type")
+    private String opType;
+
+    @SerializedName("columns_name")
+    private String[] columnsName;
+
+    @SerializedName("columns_type")
+    private String[] columnsType;
+
+    @SerializedName("columns_val")
+    private String[] columnsVal;
+
+    @SerializedName("old_keys_name")
+    private String[] oldKeysName;
+
+    @SerializedName("old_keys_type")
+    private String[] oldKeysType;
+
+    @SerializedName("old_keys_val")
+    private String[] oldKeysVal;
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPlugin.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPlugin.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.opengauss.wal.decode;
+
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.scaling.core.common.constant.ScalingConstant;
+import org.apache.shardingsphere.scaling.core.common.exception.ScalingTaskExecuteException;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.BaseLogSequenceNumber;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.BaseTimestampUtils;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.DecodingException;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.DecodingPlugin;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.AbstractRowEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.AbstractWalEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.DeleteRowEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.PlaceholderEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.UpdateRowEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.WriteRowEvent;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.sql.Date;
+import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Test decoding plugin.
+ */
+@AllArgsConstructor
+public final class MppdbDecodingPlugin implements DecodingPlugin {
+    
+    private final BaseTimestampUtils timestampUtils;
+    
+    @Override
+    public AbstractWalEvent decode(final ByteBuffer data, final BaseLogSequenceNumber logSequenceNumber) {
+        AbstractWalEvent result;
+        char eventType = readOneChar(data);
+        if ('{' == eventType) {
+            result = readTableEvent(readMppData(data));
+        } else {
+            result = new PlaceholderEvent();
+        }
+        result.setLogSequenceNumber(logSequenceNumber);
+        return result;
+    }
+    
+    private char readOneChar(final ByteBuffer data) {
+        return (char) data.get();
+    }
+    
+    private String readMppData(final ByteBuffer data) {
+        StringBuilder mppData = new StringBuilder();
+        mppData.append('{');
+        int depth = 1;
+        while (depth != 0 && data.hasRemaining()) {
+            char next = (char) data.get();
+            mppData.append(next);
+            int optDepth = '{' == next ? 1 : ('}' == next ? -1 : 0);
+            depth += optDepth;
+        }
+        return mppData.toString();
+    }
+    
+    private AbstractRowEvent readTableEvent(final String mppData) {
+        Gson mppDataGson = new Gson();
+        MppTableData mppTableData = mppDataGson.fromJson(mppData, MppTableData.class);
+        AbstractRowEvent result;
+        String rowEventType = mppTableData.opType;
+        switch (rowEventType) {
+            case ScalingConstant.INSERT:
+                result = readWriteRowEvent(mppTableData);
+                break;
+            case ScalingConstant.UPDATE:
+                result = readUpdateRowEvent(mppTableData);
+                break;
+            case ScalingConstant.DELETE:
+                result = readDeleteRowEvent(mppTableData);
+                break;
+            default:
+                throw new ScalingTaskExecuteException("");
+        }
+        String[] tableMetaData = mppTableData.getTableName().split("\\.");
+        result.setSchemaName(tableMetaData[0]);
+        result.setTableName(tableMetaData[1]);
+        return result;
+    }
+    
+    private AbstractRowEvent readWriteRowEvent(final MppTableData data) {
+        WriteRowEvent result = new WriteRowEvent();
+        result.setAfterRow(getColumnDataFromMppDataEvent(data));
+        return result;
+    }
+    
+    private AbstractRowEvent readUpdateRowEvent(final MppTableData data) {
+        UpdateRowEvent result = new UpdateRowEvent();
+        result.setAfterRow(getColumnDataFromMppDataEvent(data));
+        return result;
+    }
+    
+    private AbstractRowEvent readDeleteRowEvent(final MppTableData data) {
+        DeleteRowEvent result = new DeleteRowEvent();
+        result.setPrimaryKeys(getDeleteColumnDataFromMppDataEvent(data));
+        return result;
+    }
+
+    private List<Object> getColumnDataFromMppDataEvent(final MppTableData data) {
+        List<Object> columns = new LinkedList<>();
+    
+        for (int i = 0; i < data.getColumnsType().length; i++) {
+            columns.add(readColumnData(data.getColumnsVal()[i], data.getColumnsType()[i]));
+        }
+        return columns;
+    }
+    
+    private List<Object> getDeleteColumnDataFromMppDataEvent(final MppTableData data) {
+        List<Object> columns = new LinkedList<>();
+        
+        for (int i = 0; i < data.getOldKeysType().length; i++) {
+            columns.add(readColumnData(data.getOldKeysVal()[i], data.getOldKeysType()[i]));
+        }
+        return columns;
+    }
+    
+    private Object readColumnData(final String data, final String columnType) {
+        if (columnType.startsWith("numeric")) {
+            return new BigDecimal(data);
+        }
+        if (columnType.startsWith("bit") || columnType.startsWith("bit varying")) {
+            return data;
+        }
+        switch (columnType) {
+            case "smallint":
+                return Short.parseShort(data);
+            case "integer":
+                return Integer.parseInt(data);
+            case "bigint":
+                return Long.parseLong(data);
+            case "real":
+                return Float.parseFloat(data);
+            case "double precision":
+                return Double.parseDouble(data);
+            case "boolean":
+                return Boolean.parseBoolean(data);
+            case "time without time zone":
+                try {
+                    return timestampUtils.toTime(null, data);
+                } catch (final SQLException ex) {
+                    throw new DecodingException(ex);
+                }
+            case "date":
+                return Date.valueOf(data);
+            case "timestamp without time zone":
+                try {
+                    return timestampUtils.toTimestamp(null, data);
+                } catch (final SQLException ex) {
+                    throw new DecodingException(ex);
+                }
+            case "bytea":
+                return decodeHex(data.substring(2));
+            case "character varying":
+                return decodeString(data);
+            default:
+                return data;
+        }
+    }
+    
+    private static String decodeString(final String data) {
+        if (data.length() > 1) {
+            int begin = data.charAt(0) == '\'' ? 1 : 0;
+            int end = data.length() + (data.charAt(data.length() - 1) == '\'' ? -1 : 0);
+            return data.substring(begin, end);
+        }
+        return data;
+    }
+    
+    private byte[] decodeHex(final String hexString) {
+        int dataLength = hexString.length();
+        if (0 != (dataLength & 1)) {
+            throw new IllegalArgumentException(String.format("Illegal hex data %s", hexString));
+        }
+        if (0 == dataLength) {
+            return new byte[0];
+        }
+        byte[] result = new byte[dataLength >>> 1];
+        for (int i = 0; i < dataLength; i += 2) {
+            result[i >>> 1] = decodeHexByte(hexString, i);
+        }
+        return result;
+    }
+    
+    private byte decodeHexByte(final String hexString, final int index) {
+        int firstHexChar = Character.digit(hexString.charAt(index), 16);
+        int secondHexChar = Character.digit(hexString.charAt(index + 1), 16);
+        if (-1 == firstHexChar || -1 == secondHexChar) {
+            throw new IllegalArgumentException(String.format("Illegal hex byte '%s' in index %d", hexString, index));
+        }
+        return (byte) ((firstHexChar << 4) + secondHexChar);
+    }
+    
+    @Setter
+    @Getter
+    public static final class MppTableData {
+    
+        @SerializedName("table_name")
+        private String tableName;
+    
+        @SerializedName("op_type")
+        private String opType;
+    
+        @SerializedName("columns_name")
+        private String[] columnsName;
+    
+        @SerializedName("columns_type")
+        private String[] columnsType;
+    
+        @SerializedName("columns_val")
+        private String[] columnsVal;
+    
+        @SerializedName("old_keys_name")
+        private String[] oldKeysName;
+    
+        @SerializedName("old_keys_type")
+        private String[] oldKeysType;
+    
+        @SerializedName("old_keys_val")
+        private String[] oldKeysVal;
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPlugin.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/main/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPlugin.java
@@ -18,10 +18,7 @@
 package org.apache.shardingsphere.scaling.opengauss.wal.decode;
 
 import com.google.gson.Gson;
-import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.shardingsphere.scaling.core.common.constant.ScalingConstant;
 import org.apache.shardingsphere.scaling.core.common.exception.ScalingTaskExecuteException;
 import org.apache.shardingsphere.scaling.postgresql.wal.decode.BaseLogSequenceNumber;
@@ -43,7 +40,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Test decoding plugin.
+ * Mppdb decoding plugin in openGauss.
  */
 @AllArgsConstructor
 public final class MppdbDecodingPlugin implements DecodingPlugin {
@@ -84,7 +81,7 @@ public final class MppdbDecodingPlugin implements DecodingPlugin {
         Gson mppDataGson = new Gson();
         MppTableData mppTableData = mppDataGson.fromJson(mppData, MppTableData.class);
         AbstractRowEvent result;
-        String rowEventType = mppTableData.opType;
+        String rowEventType = mppTableData.getOpType();
         switch (rowEventType) {
             case ScalingConstant.INSERT:
                 result = readWriteRowEvent(mppTableData);
@@ -214,34 +211,5 @@ public final class MppdbDecodingPlugin implements DecodingPlugin {
             throw new IllegalArgumentException(String.format("Illegal hex byte '%s' in index %d", hexString, index));
         }
         return (byte) ((firstHexChar << 4) + secondHexChar);
-    }
-    
-    @Setter
-    @Getter
-    public static final class MppTableData {
-    
-        @SerializedName("table_name")
-        private String tableName;
-    
-        @SerializedName("op_type")
-        private String opType;
-    
-        @SerializedName("columns_name")
-        private String[] columnsName;
-    
-        @SerializedName("columns_type")
-        private String[] columnsType;
-    
-        @SerializedName("columns_val")
-        private String[] columnsVal;
-    
-        @SerializedName("old_keys_name")
-        private String[] oldKeysName;
-    
-        @SerializedName("old_keys_type")
-        private String[] oldKeysType;
-    
-        @SerializedName("old_keys_val")
-        private String[] oldKeysVal;
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/test/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPluginTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/test/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPluginTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.scaling.opengauss.wal.decode;
 import com.google.gson.Gson;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.scaling.core.common.exception.ScalingTaskExecuteException;
-import org.apache.shardingsphere.scaling.opengauss.wal.decode.MppdbDecodingPlugin.MppTableData;
 import org.apache.shardingsphere.scaling.postgresql.wal.decode.DecodingException;
 import org.apache.shardingsphere.scaling.postgresql.wal.event.AbstractWalEvent;
 import org.apache.shardingsphere.scaling.postgresql.wal.event.DeleteRowEvent;
@@ -48,7 +47,7 @@ public final class MppdbDecodingPluginTest {
     
     @Test
     public void assertDecodeWriteRowEvent() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("INSERT");
         tableData.setColumnsName(new String[]{"data"});
@@ -63,7 +62,7 @@ public final class MppdbDecodingPluginTest {
     
     @Test
     public void assertDecodeUpdateRowEvent() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("UPDATE");
         tableData.setColumnsName(new String[]{"data"});
@@ -78,7 +77,7 @@ public final class MppdbDecodingPluginTest {
     
     @Test
     public void assertDecodeDeleteRowEvent() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("DELETE");
         tableData.setOldKeysName(new String[]{"data"});
@@ -93,7 +92,7 @@ public final class MppdbDecodingPluginTest {
     
     @Test
     public void assertDecodeWriteRowEventWithByteA() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("INSERT");
         tableData.setColumnsName(new String[]{"data"});
@@ -115,7 +114,7 @@ public final class MppdbDecodingPluginTest {
     
     @Test(expected = ScalingTaskExecuteException.class)
     public void assertDecodeUnknownRowEventType() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("UNKNOWN");
         tableData.setColumnsName(new String[]{"data"});
@@ -128,7 +127,7 @@ public final class MppdbDecodingPluginTest {
     @Test(expected = DecodingException.class)
     @SneakyThrows(SQLException.class)
     public void assertDecodeTime() {
-        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        MppTableData tableData = new MppTableData();
         tableData.setTableName("public.test");
         tableData.setOpType("INSERT");
         tableData.setColumnsName(new String[]{"data"});

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/test/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPluginTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-opengauss/src/test/java/org/apache/shardingsphere/scaling/opengauss/wal/decode/MppdbDecodingPluginTest.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.opengauss.wal.decode;
+
+import com.google.gson.Gson;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.scaling.core.common.exception.ScalingTaskExecuteException;
+import org.apache.shardingsphere.scaling.opengauss.wal.decode.MppdbDecodingPlugin.MppTableData;
+import org.apache.shardingsphere.scaling.postgresql.wal.decode.DecodingException;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.AbstractWalEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.DeleteRowEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.PlaceholderEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.UpdateRowEvent;
+import org.apache.shardingsphere.scaling.postgresql.wal.event.WriteRowEvent;
+import org.junit.Test;
+import org.opengauss.jdbc.TimestampUtils;
+import org.opengauss.replication.LogSequenceNumber;
+
+import java.nio.ByteBuffer;
+import java.sql.SQLException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class MppdbDecodingPluginTest {
+
+    private final LogSequenceNumber pgSequenceNumber = LogSequenceNumber.valueOf("0/14EFDB8");
+
+    private final OpenGaussLogSequenceNumber logSequenceNumber = new OpenGaussLogSequenceNumber(pgSequenceNumber);
+    
+    @Test
+    public void assertDecodeWriteRowEvent() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("INSERT");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"character varyint"});
+        tableData.setColumnsVal(new String[]{"1 2 3"});
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getTableName(), is("test"));
+        assertThat(actual.getAfterRow().get(0), is("1 2 3"));
+    }
+    
+    @Test
+    public void assertDecodeUpdateRowEvent() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("UPDATE");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"character varyint"});
+        tableData.setColumnsVal(new String[]{"1 2 3"});
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        UpdateRowEvent actual = (UpdateRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getTableName(), is("test"));
+        assertThat(actual.getAfterRow().get(0), is("1 2 3"));
+    }
+    
+    @Test
+    public void assertDecodeDeleteRowEvent() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("DELETE");
+        tableData.setOldKeysName(new String[]{"data"});
+        tableData.setOldKeysType(new String[]{"integer"});
+        tableData.setOldKeysVal(new String[]{"1"});
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        DeleteRowEvent actual = (DeleteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getTableName(), is("test"));
+        assertThat(actual.getPrimaryKeys().get(0), is(1));
+    }
+    
+    @Test
+    public void assertDecodeWriteRowEventWithByteA() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("INSERT");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"bytea"});
+        tableData.setColumnsVal(new String[]{"\\xff00ab"});
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        WriteRowEvent actual = (WriteRowEvent) new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertThat(actual.getLogSequenceNumber(), is(logSequenceNumber));
+        assertThat(actual.getTableName(), is("test"));
+        assertThat(actual.getAfterRow().get(0), is(new byte[]{(byte) 0xff, (byte) 0, (byte) 0xab}));
+    }
+    
+    @Test
+    public void assertDecodeUnknownTableType() {
+        ByteBuffer data = ByteBuffer.wrap("unknown".getBytes());
+        AbstractWalEvent actual = new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+        assertTrue(actual instanceof PlaceholderEvent);
+    }
+    
+    @Test(expected = ScalingTaskExecuteException.class)
+    public void assertDecodeUnknownRowEventType() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("UNKNOWN");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"character varying"});
+        tableData.setColumnsVal(new String[]{"1 2 3"});
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        new MppdbDecodingPlugin(null).decode(data, logSequenceNumber);
+    }
+    
+    @Test(expected = DecodingException.class)
+    @SneakyThrows(SQLException.class)
+    public void assertDecodeTime() {
+        MppdbDecodingPlugin.MppTableData tableData = new MppTableData();
+        tableData.setTableName("public.test");
+        tableData.setOpType("INSERT");
+        tableData.setColumnsName(new String[]{"data"});
+        tableData.setColumnsType(new String[]{"time without time zone"});
+        tableData.setColumnsVal(new String[]{"1 2 3'"});
+        TimestampUtils timestampUtils = mock(TimestampUtils.class);
+        when(timestampUtils.toTime(null, "1 2 3'")).thenThrow(new SQLException(""));
+        ByteBuffer data = ByteBuffer.wrap(new Gson().toJson(tableData).getBytes());
+        new MppdbDecodingPlugin(new OpenGaussTimestampUtils(timestampUtils)).decode(data, logSequenceNumber);
+    }
+}


### PR DESCRIPTION
…caling and add mppdb decoding.

Fixes #12748 
Changes proposed in this pull request:
- add mppdb_decoding plugin instance and testcase.
- ignore duplicate create table and constraint exception.
- modify update sql, because sharding-proxy can't modify sharding-key, so update attribute must skip it.
- use different slotName in openGauss, because same named slot can't reuse in different schema on one database!
