### PR TITLE
Fixes #12806, fix `ConcurrentModificationException`.

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementContext.java
@@ -88,6 +88,9 @@ public final class InsertStatementContext extends CommonSQLStatementContext<Inse
     
     private ShardingSphereSchema getSchema(final Map<String, ShardingSphereMetaData> metaDataMap, final String defaultSchemaName) {
         String schemaName = tablesContext.getSchemaName().orElse(defaultSchemaName);
+        if (null == schemaName) {
+            throw new SchemaNotExistedException(null);
+        }
         ShardingSphereMetaData metaData = metaDataMap.get(schemaName);
         if (null == metaData) {
             throw new SchemaNotExistedException(schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -95,6 +95,9 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
     
     private ShardingSphereSchema getSchema(final Map<String, ShardingSphereMetaData> metaDataMap, final String defaultSchemaName) {
         String schemaName = tablesContext.getSchemaName().orElse(defaultSchemaName);
+        if (null == schemaName) {
+            throw new SchemaNotExistedException(null);
+        }
         ShardingSphereMetaData metaData = metaDataMap.get(schemaName);
         if (null == metaData) {
             throw new SchemaNotExistedException(schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/InsertStatementContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/InsertStatementContextTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.binder.statement.impl;
 import com.google.common.collect.Sets;
 import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.database.DefaultSchema;
+import org.apache.shardingsphere.infra.exception.SchemaNotExistedException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.AssignmentSegment;
@@ -361,5 +362,12 @@ public final class InsertStatementContextTest {
         List<String> columnNames = insertStatementContext.getInsertColumnNames();
         assertThat(columnNames.size(), is(1));
         assertThat(columnNames.iterator().next(), is("col"));
+    }
+    
+    @Test(expected = SchemaNotExistedException.class)
+    public void assertCreateByNullSchemaName() {
+        MySQLInsertStatement insertStatement = new MySQLInsertStatement();
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        new InsertStatementContext(Collections.singletonMap(DefaultSchema.LOGIC_NAME, metaData), Collections.emptyList(), insertStatement, null);
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/SelectStatementContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/impl/SelectStatementContextTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.binder.statement.impl;
 import com.google.common.collect.Lists;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.database.DefaultSchema;
+import org.apache.shardingsphere.infra.exception.SchemaNotExistedException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.OrderDirection;
@@ -462,6 +463,13 @@ public final class SelectStatementContextTest {
     @Test
     public void assertContainsSubqueryWhereEmptyForSQLServer() {
         assertContainsSubqueryWhereEmpty(new SQLServerSelectStatement(), new SQLServerSelectStatement());
+    }
+    
+    @Test(expected = SchemaNotExistedException.class)
+    public void assertCreateByNullSchemaName() {
+        MySQLSelectStatement selectStatement = new MySQLSelectStatement();
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class);
+        new SelectStatementContext(Collections.singletonMap(DefaultSchema.LOGIC_NAME, metaData), Collections.emptyList(), selectStatement, null);
     }
     
     private void assertContainsSubqueryWhereEmpty(final SelectStatement selectStatement, final SelectStatement subSelectStatement) {

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContexts.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContexts.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mode.metadata;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
+import org.apache.shardingsphere.infra.exception.SchemaNotExistedException;
 import org.apache.shardingsphere.infra.executor.kernel.ExecutorEngine;
 import org.apache.shardingsphere.infra.lock.ShardingSphereLock;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
@@ -34,6 +35,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Meta data contexts.
@@ -61,7 +63,7 @@ public final class MetaDataContexts implements AutoCloseable {
     public MetaDataContexts(final MetaDataPersistService metaDataPersistService, final Map<String, ShardingSphereMetaData> metaDataMap, final ShardingSphereRuleMetaData globalRuleMetaData,
                             final ExecutorEngine executorEngine, final ConfigurationProperties props, final OptimizerContext optimizerContext) {
         this.metaDataPersistService = metaDataPersistService;
-        this.metaDataMap = new LinkedHashMap<>(metaDataMap);
+        this.metaDataMap = new ConcurrentHashMap<>(metaDataMap);
         this.globalRuleMetaData = globalRuleMetaData;
         this.executorEngine = executorEngine;
         this.optimizerContext = optimizerContext;
@@ -93,6 +95,9 @@ public final class MetaDataContexts implements AutoCloseable {
      * @return mata data
      */
     public ShardingSphereMetaData getMetaData(final String schemaName) {
+        if (null == schemaName) {
+            throw new SchemaNotExistedException(null);
+        }
         return metaDataMap.get(schemaName);
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.mode.metadata;
 
 import org.apache.shardingsphere.infra.config.properties.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.DefaultSchema;
+import org.apache.shardingsphere.infra.exception.SchemaNotExistedException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.infra.optimize.context.OptimizerContext;
@@ -50,5 +51,12 @@ public final class MetaDataContextsTest {
         MetaDataContexts metaDataContexts = new MetaDataContexts(mock(MetaDataPersistService.class), Collections.singletonMap(DefaultSchema.LOGIC_NAME, metaData), 
                 mock(ShardingSphereRuleMetaData.class), null, new ConfigurationProperties(new Properties()), optimizerContext);
         assertThat(metaDataContexts.getMetaData(DefaultSchema.LOGIC_NAME), is(metaData));
+    }
+    
+    @Test(expected = SchemaNotExistedException.class)
+    public void assertGetMetaDataByNull() {
+        MetaDataContexts metaDataContexts = new MetaDataContexts(mock(MetaDataPersistService.class), Collections.singletonMap(DefaultSchema.LOGIC_NAME, metaData),
+                mock(ShardingSphereRuleMetaData.class), null, new ConfigurationProperties(new Properties()), optimizerContext);
+        metaDataContexts.getMetaData(null);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowDatabasesExecutorTest.java
@@ -38,6 +38,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Field;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -45,6 +47,7 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,6 +56,8 @@ import static org.mockito.Mockito.when;
 public final class ShowDatabasesExecutorTest {
     
     private static final String SCHEMA_PATTERN = "schema_%s";
+    
+    private static final Collection<String> SCHEMAS = Arrays.asList("schema_0", "schema_1", "schema_2", "schema_3", "schema_4", "schema_5", "schema_6", "schema_7", "schema_8", "schema_9");
     
     private ShowDatabasesExecutor showDatabasesExecutor;
     
@@ -85,9 +90,10 @@ public final class ShowDatabasesExecutorTest {
         assertThat(showDatabasesExecutor.getQueryResultMetaData().getColumnCount(), is(1));
         int count = 0;
         while (showDatabasesExecutor.getMergedResult().next()) {
-            assertThat(showDatabasesExecutor.getMergedResult().getValue(1, Object.class), is(String.format(SCHEMA_PATTERN, count)));
+            assertTrue(SCHEMAS.contains(showDatabasesExecutor.getMergedResult().getValue(1, Object.class)));
             count++;
         }
+        assertThat(count, is(10));
     }
     
     @Test
@@ -100,7 +106,7 @@ public final class ShowDatabasesExecutorTest {
         assertThat(showDatabasesExecutor.getQueryResultMetaData().getColumnCount(), is(1));
         int count = 0;
         while (showDatabasesExecutor.getMergedResult().next()) {
-            assertThat(showDatabasesExecutor.getMergedResult().getValue(1, Object.class), is(String.format(SCHEMA_PATTERN, count)));
+            assertTrue(SCHEMAS.contains(showDatabasesExecutor.getMergedResult().getValue(1, Object.class)));
             count++;
         }
         assertThat(count, is(10));


### PR DESCRIPTION
Fixes #12806.

Changes proposed in this pull request:
- change metaDataMap from LinkedHashMap to ConcurrentHashMap.
- add null check before get from metaDataMap.
- update test cases.

Description：
- ConcurrentHashMap does not support null keys, so judge before get, otherwise NPE will occur.
- The linkedhashMap can maintain the order of the elements, but ConcurrentHashMap cannot guarantee this, so the elements become disordered.