### PR TITLE
Supports build with Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
             version: 11,
             maven_args: "-Dmaven.javadoc.skip=true"
           }
+          - {
+            version: 17,
+            maven_args: "-Dmaven.javadoc.skip=true"
+          }
     steps:
       - name: Cache Maven Repos
         uses: actions/cache@v2

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -51,7 +51,7 @@
         <h2.version>1.4.196</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.0</logback.version>
-        <lombok.version>1.18.16</lombok.version>
+        <lombok.version>1.18.20</lombok.version>
         <mybatis.version>3.5.1</mybatis.version>
         <mybatis-spring.version>2.0.1</mybatis-spring.version>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -71,8 +71,8 @@
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
-        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <freemarker.version>2.3.31</freemarker.version>
         
         <javadocExecutable>${java.home}/../bin/javadoc</javadocExecutable>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <opengauss.version>2.0.1-compatibility</opengauss.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
-        <bytebuddy.version>1.10.21</bytebuddy.version>
+        <bytebuddy.version>1.11.18</bytebuddy.version>
         
         <elasticjob.version>3.0.0-beta</elasticjob.version>
         

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <opengauss.version>2.0.1-compatibility</opengauss.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
-        <bytebuddy.version>1.10.16</bytebuddy.version>
+        <bytebuddy.version>1.10.21</bytebuddy.version>
         
         <elasticjob.version>3.0.0-beta</elasticjob.version>
         
@@ -132,7 +132,7 @@
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
         <cobertura-maven-plugin.version>2.7</cobertura-maven-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.7</jacoco-maven-plugin.version>
         <findbugs-maven-plugin.version>3.0.2</findbugs-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
         <maven-pmd-plugin.version>3.5</maven-pmd-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <curator.version>5.1.0</curator.version>
         <jetcd.version>0.5.0</jetcd.version>
         
-        <lombok.version>1.18.16</lombok.version>
+        <lombok.version>1.18.20</lombok.version>
         
         <springframework.version>[4.3.6.RELEASE,5.0.0.M1)</springframework.version>
         <spring-boot.version>[1.5.20.RELEASE,2.0.0.M1)</spring-boot.version>
@@ -118,16 +118,16 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-resources-plugin.version>2.7</maven-resources-plugin.version>
-        <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
+        <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
         <maven-site-plugin.version>3.4</maven-site-plugin.version>
-        <maven-enforcer-plugin.version>1.4</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
         <maven-project-info-reports-plugin.version>2.8</maven-project-info-reports-plugin.version>
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
-        <maven-source-plugin.version>2.4</maven-source-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>

--- a/shardingsphere-infra/shardingsphere-infra-executor/pom.xml
+++ b/shardingsphere-infra/shardingsphere-infra-executor/pom.xml
@@ -74,6 +74,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <!-- TODO Consider refactoring tests which changed Field's modifiers -->
                                 <exclude>org.apache.shardingsphere.infra.executor.sql.log.SQLLoggerTest</exclude>
                             </excludes>
                         </configuration>

--- a/shardingsphere-infra/shardingsphere-infra-executor/pom.xml
+++ b/shardingsphere-infra/shardingsphere-infra-executor/pom.xml
@@ -60,4 +60,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.infra.executor.sql.log.SQLLoggerTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/pom.xml
@@ -40,4 +40,26 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.proxy.frontend.opengauss.OpenGaussFrontendEngineTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/pom.xml
@@ -54,6 +54,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <!-- TODO Consider refactoring tests which changed Field's modifiers -->
                                 <exclude>org.apache.shardingsphere.proxy.frontend.opengauss.OpenGaussFrontendEngineTest</exclude>
                             </excludes>
                         </configuration>

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/pom.xml
@@ -67,6 +67,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <!-- TODO Consider refactoring tests which changed Field's modifiers -->
                                 <exclude>org.apache.shardingsphere.proxy.frontend.postgresql.command.query.text.PostgreSQLComQueryExecutorTest</exclude>
                             </excludes>
                         </configuration>

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/pom.xml
@@ -53,4 +53,26 @@
             <artifactId>netty-all</artifactId>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.proxy.frontend.postgresql.command.query.text.PostgreSQLComQueryExecutorTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shardingsphere-spi/pom.xml
+++ b/shardingsphere-spi/pom.xml
@@ -41,6 +41,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <!-- TODO Consider refactoring tests which changed Field's modifiers -->
                                 <exclude>org.apache.shardingsphere.spi.ordered.cache.OrderedServicesCacheTest</exclude>
                                 <exclude>org.apache.shardingsphere.spi.ordered.OrderedSPIRegistryTest</exclude>
                             </excludes>

--- a/shardingsphere-spi/pom.xml
+++ b/shardingsphere-spi/pom.xml
@@ -27,4 +27,27 @@
     </parent>
     <artifactId>shardingsphere-spi</artifactId>
     <name>${project.artifactId}</name>
+    
+    <profiles>
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.spi.ordered.cache.OrderedServicesCacheTest</exclude>
+                                <exclude>org.apache.shardingsphere.spi.ordered.OrderedSPIRegistryTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/pom.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/pom.xml
@@ -47,4 +47,26 @@
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>jdk12+</id>
+            <activation>
+                <jdk>[12,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.sql.parser.api.SQLParserEngineTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/pom.xml
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/pom.xml
@@ -61,6 +61,7 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludes>
+                                <!-- TODO Consider refactoring tests which changed Field's modifiers -->
                                 <exclude>org.apache.shardingsphere.sql.parser.api.SQLParserEngineTest</exclude>
                             </excludes>
                         </configuration>


### PR DESCRIPTION
Fixes #12442.

Changes:
- Add CI for Java 17
- Upgrade `byte-buddy` from `1.10.16` to `1.11.18`
- Exclude tests which changed Field's modifiers
- Upgrade `lombok` from `1.18.16` to `1.18.20`
- Upgrade `maven-jar-plugin` from `2.6` to `3.2.0`
- Upgrade `maven-enforcer-plugin` from `1.4` to `3.0.0`
- Upgrade `maven-source-plugin` from `2.4` to `3.2.1`
- Upgrade `jacoco-maven-plugin` from `0.8.5` to `0.8.7`