### PR TITLE
Support Administration Statements sql parse DROP RESOURCE GROUP #12455

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
@@ -160,6 +160,10 @@ dropRole
     : DROP ROLE (IF EXISTS)? roleName (COMMA_ roleName)*
     ;
 
+dropGroup
+    : DROP RESOURCE GROUP (IF EXISTS)? groupName (COMMA_ groupName)*
+    ;
+
 renameUser
     : RENAME USER userName TO userName (COMMA_ userName TO userName)*
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DCLStatement.g4
@@ -161,7 +161,7 @@ dropRole
     ;
 
 dropGroup
-    : DROP RESOURCE GROUP (IF EXISTS)? groupName (COMMA_ groupName)*
+    : DROP RESOURCE GROUP groupName (FORCE)?
     ;
 
 renameUser


### PR DESCRIPTION
Fixes #12455

Changes proposed in this pull request:
- Support Administration Statements sql parse DROP RESOURCE GROUP 
- Updated the DCLStatement file ANTLR to parse the mysql statement 
```DROP RESOURCE GROUP [FORCE]```
