### PR TITLE
utilize static import in MySQL statement assertion

### DIFF
--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ShowCreateTriggerStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ShowCreateTriggerStatementAssert.java
@@ -22,9 +22,10 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLShowCreateTriggerStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ShowCreateTriggerStatementTestCase;
-import org.junit.Assert;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * Show create trigger statement assert.
@@ -40,7 +41,7 @@ public final class ShowCreateTriggerStatementAssert {
      * @param expected expected show create trigger statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLShowCreateTriggerStatement actual, final ShowCreateTriggerStatementTestCase expected) {
-        Assert.assertNotNull("expected show create trigger should be not null", expected.getTrigger());
-        Assert.assertThat(actual.getName(), is(expected.getTrigger().getName()));
+        assertNotNull("expected show create trigger should be not null", expected.getTrigger());
+        assertThat(actual.getName(), is(expected.getTrigger().getName()));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- small change: make use of static import in `ShowCreateTriggerStatementAssert` class.
