### PR TITLE
Ignore files auto generated by IDEA Antlr plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ logs/
 Thumbs.db
 
 # antlr ignore
-src/main/antlr4/imports/**/gen/
+gen/
+*.tokens
 
 # agent build ignore
 /agent/


### PR DESCRIPTION
The exists rule is not sufficient to ignore files auto generated by IDEA Antlr plugin.

Before change
```
➜  apache-shardingsphere git:(antlr) ✗ git status
On branch antlr
Your branch is behind 'origin/antlr' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/gen/
        shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/antlr4/imports/Keyword.tokens
        shardingsphere-distsql-parser/shardingsphere-distsql-parser-engine/src/main/antlr4/imports/gen/
        shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/gen/
        shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.tokens
        shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/gen/

nothing added to commit but untracked files present (use "git add" to track)
```