### PR TITLE
Remove uneven trailing and leading spaces in hex dump log

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-core/src/main/java/org/apache/shardingsphere/db/protocol/codec/PacketCodec.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-core/src/main/java/org/apache/shardingsphere/db/protocol/codec/PacketCodec.java
@@ -43,7 +43,7 @@ public final class PacketCodec extends ByteToMessageCodec<DatabasePacket<?>> {
             return;
         }
         if (log.isDebugEnabled()) {
-            log.debug("Read from client {} : \n {}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(in));
+            log.debug("Read from client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(in));
         }
         databasePacketCodecEngine.decode(context, in, out);
     }
@@ -53,7 +53,7 @@ public final class PacketCodec extends ByteToMessageCodec<DatabasePacket<?>> {
     protected void encode(final ChannelHandlerContext context, final DatabasePacket<?> message, final ByteBuf out) {
         databasePacketCodecEngine.encode(context, message, out);
         if (log.isDebugEnabled()) {
-            log.debug("Write to client {} : \n {}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(out));
+            log.debug("Write to client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(out));
         }
     }
 }


### PR DESCRIPTION
Before:
```
Write to client 638a1ebe : 
          +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 05 00 00 09 fe 00 00 02 00                      |.........       |
+--------+-------------------------------------------------+----------------+
```

After:
```
Write to client 638a1ebe :
         +-------------------------------------------------+
         |  0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f |
+--------+-------------------------------------------------+----------------+
|00000000| 05 00 00 09 fe 00 00 02 00                      |.........       |
+--------+-------------------------------------------------+----------------+
```