### PR TITLE
fix mysql delete multiple table with alias rewrite wrong result

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/DeleteStatementContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/DeleteStatementContext.java
@@ -29,7 +29,11 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Sim
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DeleteStatement;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Delete statement context.
@@ -50,7 +54,20 @@ public final class DeleteStatementContext extends CommonSQLStatementContext<Dele
     private Collection<SimpleTableSegment> getAllSimpleTableSegments() {
         TableExtractor tableExtractor = new TableExtractor();
         tableExtractor.extractTablesFromDelete(getSqlStatement());
-        return tableExtractor.getRewriteTables();
+        return filterAliasDeleteTable(tableExtractor.getRewriteTables());
+    }
+    
+    private Collection<SimpleTableSegment> filterAliasDeleteTable(final Collection<SimpleTableSegment> tableSegments) {
+        Map<String, SimpleTableSegment> aliasTableSegmentMap = tableSegments.stream().filter(each 
+            -> each.getAlias().isPresent()).collect(Collectors.toMap(each -> each.getAlias().get(), Function.identity(), (oldValue, currentValue) -> oldValue));
+        Collection<SimpleTableSegment> result = new LinkedList<>();
+        for (SimpleTableSegment each : tableSegments) {
+            SimpleTableSegment aliasDeleteTable = aliasTableSegmentMap.get(each.getTableName().getIdentifier().getValue());
+            if (null == aliasDeleteTable || aliasDeleteTable.equals(each)) {
+                result.add(each);
+            }
+        }
+        return result;
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
@@ -92,19 +92,6 @@ public final class TableExtractor {
         }
     }
     
-    /**
-     * Extract tables with from clause.
-     *
-     * @param selectStatement select statement
-     * @return tables with from clause
-     */
-    public Collection<SimpleTableSegment> extractTablesWithFromClause(final SelectStatement selectStatement) {
-        if (null != selectStatement.getFrom()) {
-            extractTablesFromTableSegment(selectStatement.getFrom());
-        }
-        return rewriteTables;
-    }
-    
     private void extractTablesFromTableSegment(final TableSegment tableSegment) {
         if (tableSegment instanceof SimpleTableSegment) {
             tableContext.add(tableSegment);
@@ -122,9 +109,7 @@ public final class TableExtractor {
         if (tableSegment instanceof DeleteMultiTableSegment) {
             DeleteMultiTableSegment deleteMultiTableSegment = (DeleteMultiTableSegment) tableSegment;
             rewriteTables.addAll(deleteMultiTableSegment.getActualDeleteTables());
-            if (deleteMultiTableSegment.getRelationTable() instanceof JoinTableSegment) {
-                extractTablesFromJoinTableSegment((JoinTableSegment) deleteMultiTableSegment.getRelationTable());
-            }
+            extractTablesFromTableSegment(deleteMultiTableSegment.getRelationTable());
         }
     }
     

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/delete.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/delete.xml
@@ -38,4 +38,24 @@
         <output sql="DELETE FROM t_account_0 WHERE status = 'OK'" />
         <output sql="DELETE FROM t_account_1 WHERE status = 'OK'" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="delete_multiple_table_with_alias_with_sharding_value_for_parameters" db-type="MySQL">
+        <input sql="DELETE t FROM t_account t WHERE t.account_id = ?" parameters="100" />
+        <output sql="DELETE t FROM t_account_0 t WHERE t.account_id = ?" parameters="100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="delete_multiple_table_with_alias_with_sharding_value_for_literals" db-type="MySQL">
+        <input sql="DELETE t FROM t_account t WHERE t.account_id = 100" />
+        <output sql="DELETE t FROM t_account_0 t WHERE t.account_id = 100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="delete_multiple_table_with_same_table_name_alias_with_sharding_value_for_parameters" db-type="MySQL">
+        <input sql="DELETE t_account FROM t_account t_account WHERE t_account.account_id = ?" parameters="100" />
+        <output sql="DELETE t_account FROM t_account_0 t_account WHERE t_account.account_id = ?" parameters="100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="delete_multiple_table_with_same_table_name_alias_with_sharding_value_for_literals" db-type="MySQL">
+        <input sql="DELETE t_account FROM t_account t_account WHERE t_account.account_id = 100" />
+        <output sql="DELETE t_account FROM t_account_0 t_account WHERE t_account.account_id = 100" />
+    </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #13273.

Changes proposed in this pull request:
- fix mysql delete multiple table with alias rewrite wrong result
- add test case
