### PR TITLE
[DistSQL] Update `show db_discovery rules` to show `primary_data_source_name`.

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-api/src/main/java/org/apache/shardingsphere/dbdiscovery/constant/DatabaseDiscoveryRuleConstants.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-api/src/main/java/org/apache/shardingsphere/dbdiscovery/constant/DatabaseDiscoveryRuleConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.dbdiscovery.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Database discovery rule constants.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DatabaseDiscoveryRuleConstants {
+    
+    public static final String PRIMARY_DATA_SOURCE_KEY = "primary_data_source_key";
+}

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import org.apache.shardingsphere.dbdiscovery.algorithm.config.AlgorithmProvidedDatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
+import org.apache.shardingsphere.dbdiscovery.constant.DatabaseDiscoveryRuleConstants;
 import org.apache.shardingsphere.dbdiscovery.spi.DatabaseDiscoveryType;
 import org.apache.shardingsphere.infra.aware.DataSourceNameAware;
 import org.apache.shardingsphere.infra.aware.DataSourceNameAwareFactory;
@@ -33,6 +34,7 @@ import org.apache.shardingsphere.infra.rule.event.impl.DataSourceNameDisabledEve
 import org.apache.shardingsphere.infra.rule.event.impl.PrimaryDataSourceChangedEvent;
 import org.apache.shardingsphere.infra.rule.identifier.scope.SchemaRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.StatusContainedRule;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
@@ -48,7 +50,7 @@ import java.util.Optional;
 /**
  * Database discovery rule.
  */
-public final class DatabaseDiscoveryRule implements SchemaRule, DataSourceContainedRule, StatusContainedRule {
+public final class DatabaseDiscoveryRule implements SchemaRule, DataSourceContainedRule, StatusContainedRule, ExportableRule {
     
     static {
         ShardingSphereServiceLoader.register(DatabaseDiscoveryType.class);
@@ -173,6 +175,19 @@ public final class DatabaseDiscoveryRule implements SchemaRule, DataSourceContai
                 }
             }
         }
+    }
+    
+    @Override
+    public Map<String, Object> export() {
+        Map<String, Object> result = new HashMap<>(1, 1);
+        result.put(DatabaseDiscoveryRuleConstants.PRIMARY_DATA_SOURCE_KEY, exportPrimaryDataSourceMap());
+        return result;
+    }
+    
+    private Map<String, String> exportPrimaryDataSourceMap() {
+        Map<String, String> result = new HashMap<>(dataSourceRules.size(), 1);
+        dataSourceRules.forEach((name, dataSourceRule) -> result.put(dataSourceRule.getName(), dataSourceRule.getPrimaryDataSourceName()));
+        return result;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSet.java
@@ -19,11 +19,13 @@ package org.apache.shardingsphere.dbdiscovery.distsql.handler.query;
 
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
+import org.apache.shardingsphere.dbdiscovery.constant.DatabaseDiscoveryRuleConstants;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryRulesStatement;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.properties.PropertiesConverter;
-import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
@@ -42,17 +44,22 @@ public final class DatabaseDiscoveryRuleQueryResultSet implements DistSQLResultS
     
     private Map<String, ShardingSphereAlgorithmConfiguration> discoveryTypes;
     
+    private Map<String, String> primaryDataSources;
+    
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
         Optional<DatabaseDiscoveryRuleConfiguration> ruleConfig = metaData.getRuleMetaData().getConfigurations()
                 .stream().filter(each -> each instanceof DatabaseDiscoveryRuleConfiguration).map(each -> (DatabaseDiscoveryRuleConfiguration) each).findAny();
         data = ruleConfig.map(optional -> optional.getDataSources().iterator()).orElse(Collections.emptyIterator());
         discoveryTypes = ruleConfig.map(DatabaseDiscoveryRuleConfiguration::getDiscoveryTypes).orElse(Collections.emptyMap());
+        Optional<ExportableRule> exportableRule = metaData.getRuleMetaData().getRules()
+                .stream().filter(each -> each instanceof ExportableRule).map(each -> (ExportableRule) each).findAny();
+        primaryDataSources = (Map<String, String>) exportableRule.map(optional -> optional.export().get(DatabaseDiscoveryRuleConstants.PRIMARY_DATA_SOURCE_KEY)).orElse(Collections.emptyMap());
     }
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("name", "data_source_names", "discover_type", "discover_props");
+        return Arrays.asList("name", "data_source_names", "primary_data_source_name", "discover_type", "discover_props");
     }
     
     @Override
@@ -63,7 +70,9 @@ public final class DatabaseDiscoveryRuleQueryResultSet implements DistSQLResultS
     @Override
     public Collection<Object> getRowData() {
         DatabaseDiscoveryDataSourceRuleConfiguration dataSourceRuleConfig = data.next();
-        return Arrays.asList(dataSourceRuleConfig.getName(), String.join(",", dataSourceRuleConfig.getDataSourceNames()), 
+        String name = dataSourceRuleConfig.getName();
+        String primaryDataSourceName = null == primaryDataSources.get(name) ? "" : primaryDataSources.get(name);
+        return Arrays.asList(name, primaryDataSourceName, String.join(",", dataSourceRuleConfig.getDataSourceNames()),
                 discoveryTypes.get(dataSourceRuleConfig.getDiscoveryTypeName()).getType(), PropertiesConverter.convert(discoveryTypes.get(dataSourceRuleConfig.getDiscoveryTypeName()).getProps()));
     }
     

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSet.java
@@ -72,7 +72,7 @@ public final class DatabaseDiscoveryRuleQueryResultSet implements DistSQLResultS
         DatabaseDiscoveryDataSourceRuleConfiguration dataSourceRuleConfig = data.next();
         String name = dataSourceRuleConfig.getName();
         String primaryDataSourceName = null == primaryDataSources.get(name) ? "" : primaryDataSources.get(name);
-        return Arrays.asList(name, primaryDataSourceName, String.join(",", dataSourceRuleConfig.getDataSourceNames()),
+        return Arrays.asList(name, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, 
                 discoveryTypes.get(dataSourceRuleConfig.getDiscoveryTypeName()).getType(), PropertiesConverter.convert(discoveryTypes.get(dataSourceRuleConfig.getDiscoveryTypeName()).getProps()));
     }
     

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-distsql/shardingsphere-db-discovery-distsql-handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryRuleQueryResultSetTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,10 +47,16 @@ public final class DatabaseDiscoveryRuleQueryResultSetTest {
     public void assertGetRowData() {
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
         when(metaData.getRuleMetaData().getConfigurations()).thenReturn(Collections.singleton(createRuleConfiguration()));
+        ExportableRule exportableRule = mock(ExportableRule.class);
+        when(exportableRule.export()).thenReturn(Collections.emptyMap());
+        when(metaData.getRuleMetaData().getRules()).thenReturn(Collections.singleton(exportableRule));
         DistSQLResultSet resultSet = new DatabaseDiscoveryRuleQueryResultSet();
         resultSet.init(metaData, mock(ShowDatabaseDiscoveryRulesStatement.class));
+        Collection<String> columnNames = resultSet.getColumnNames();
         Collection<Object> actual = resultSet.getRowData();
-        assertThat(actual.size(), is(4));
+        assertThat(columnNames.size(), is(5));
+        columnNames.containsAll(Arrays.asList("name", "data_source_names", "primary_data_source_name", "discover_type", "discover_props"));
+        assertThat(actual.size(), is(5));
         assertTrue(actual.contains("ms_group"));
         assertTrue(actual.contains("ds_0,ds_1"));
         assertTrue(actual.contains("MGR"));

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
@@ -27,7 +27,7 @@ import java.util.Map;
 public interface ExportableRule extends ShardingSphereRule {
     
     /**
-     * Get data map.
+     * Export data map.
      *
      * @return data map
      */

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.rule.identifier.type;
+
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+
+import java.util.Map;
+
+/**
+ * ShardingSphere rule which support exporting data.
+ */
+public interface ExportableRule extends ShardingSphereRule {
+    
+    /**
+     * Get data map.
+     *
+     * @return data map
+     */
+    Map<String, Object> export();
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/ExportableRule.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import java.util.Map;
 
 /**
- * ShardingSphere rule which support exporting data.
+ * ShardingSphere rule which supports exporting data.
  */
 public interface ExportableRule extends ShardingSphereRule {
     


### PR DESCRIPTION
Related issue: https://github.com/apache/shardingsphere/issues/13287

Update `show db_discovery rules` DistSQL:
- add `primary_data_source_name` to result set.

## Valid MGR data sources:
![image](https://user-images.githubusercontent.com/5668787/139418625-b8fcaaf7-d9f1-4b0f-b2ae-31e65d97c7ae.png)


## Invalid MGR data sources:
![image](https://user-images.githubusercontent.com/5668787/139418729-651ff794-8d8d-4896-bbb0-01bfbe261d98.png)

