### PR TITLE
Remove useless parameters from PostgreSQL JDBC URL

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/ConnectionUrlParserTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/ConnectionUrlParserTest.java
@@ -35,7 +35,7 @@ public final class ConnectionUrlParserTest {
     
     private static final String MYSQL_CONNECTION_WITH_REPLICATION = "jdbc:mysql:replication://master_ip:3306,slave_1_ip:3306,slave_2_ip:3306/demo_ds?useUnicode=true";
     
-    private static final String POSTGRESQL_CONNECTION_WITH_PROPS = "jdbc:postgresql://127.0.0.1:5432/demo_ds?serverTimezone=UTC&useSSL=false";
+    private static final String POSTGRESQL_CONNECTION_WITH_PROPS = "jdbc:postgresql://127.0.0.1:5432/demo_ds?prepareThreshold=1&preferQueryMode=extendedForPrepared";
     
     private static final String MICROSOFT_SQLSERVER_CONNECTION_WITHOUT_PROPS = "jdbc:microsoft:sqlserver://127.0.0.1:3306/demo_ds";
     
@@ -82,10 +82,10 @@ public final class ConnectionUrlParserTest {
         assertThat(connectionUrlParser.getScheme(), is("jdbc:postgresql:"));
         assertThat(connectionUrlParser.getAuthority(), is("127.0.0.1:5432"));
         assertThat(connectionUrlParser.getPath(), is("demo_ds"));
-        assertThat(connectionUrlParser.getQuery(), is("serverTimezone=UTC&useSSL=false"));
+        assertThat(connectionUrlParser.getQuery(), is("prepareThreshold=1&preferQueryMode=extendedForPrepared"));
         assertThat(connectionUrlParser.getQueryMap().size(), is(2));
-        assertThat(connectionUrlParser.getQueryMap().get("serverTimezone"), is("UTC"));
-        assertThat(connectionUrlParser.getQueryMap().get("useSSL"), is("false"));
+        assertThat(connectionUrlParser.getQueryMap().get("prepareThreshold"), is("1"));
+        assertThat(connectionUrlParser.getQueryMap().get("preferQueryMode"), is("extendedForPrepared"));
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-database-discovery.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-database-discovery.yaml
@@ -26,7 +26,7 @@
 #
 #dataSources:
 #  primary_ds:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_primary_ds?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_primary_ds
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 3000
@@ -35,7 +35,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  replica_ds_0:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 3000
@@ -44,7 +44,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  replica_ds_1:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 3000

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-encrypt.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-encrypt.yaml
@@ -26,7 +26,7 @@
 #
 #dataSources:
 #  ds_0:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000
@@ -35,7 +35,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  ds_1:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-readwrite-splitting.yaml
@@ -26,7 +26,7 @@
 #
 #dataSources:
 #  primary_ds:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_primary_ds?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_primary_ds
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000
@@ -35,7 +35,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  replica_ds_0:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_0
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000
@@ -44,7 +44,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  replica_ds_1:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_replica_ds_1
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-shadow.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-shadow.yaml
@@ -26,7 +26,7 @@
 #
 #dataSources:
 #  ds:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000
@@ -35,7 +35,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  shadow_ds:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -26,7 +26,7 @@
 #
 #dataSources:
 #  ds_0:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_0
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000
@@ -35,7 +35,7 @@
 #    maxPoolSize: 50
 #    minPoolSize: 1
 #  ds_1:
-#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1?serverTimezone=UTC&useSSL=false
+#    url: jdbc:postgresql://127.0.0.1:5432/demo_ds_1
 #    username: postgres
 #    password: postgres
 #    connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/postgresql/proxy/conf/config-db.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/db/postgresql/proxy/conf/config-db.yaml
@@ -19,7 +19,7 @@ schemaName: db
 
 dataSources:
   ds_0:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -28,7 +28,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_1:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -37,7 +37,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_2:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_2?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -46,7 +46,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_3:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_3?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -55,7 +55,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_4:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_4?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -64,7 +64,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_5:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_5?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -73,7 +73,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_6:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_6?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -82,7 +82,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_7:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_7?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -91,7 +91,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_8:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_8?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -100,7 +100,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   ds_9:
-    url: jdbc:postgresql://postgresql.db.host:5432/db_9?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.db.host:5432/db_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting.yaml
@@ -19,7 +19,7 @@ schemaName: dbtbl_with_readwrite_splitting
 
 dataSources:
   write_ds_0:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -28,7 +28,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_1:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -37,7 +37,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_2:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_2?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -46,7 +46,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_3:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_3?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -55,7 +55,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_4:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_4?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -64,7 +64,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_5:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_5?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -73,7 +73,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_6:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_6?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -82,7 +82,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_7:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_7?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -91,7 +91,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_8:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_8?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -100,7 +100,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   write_ds_9:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_9?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/write_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -109,7 +109,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_0:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -118,7 +118,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_1:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -127,7 +127,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_2:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_2?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -136,7 +136,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_3:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_3?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -145,7 +145,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_4:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_4?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -154,7 +154,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_5:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_5?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -163,7 +163,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_6:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_6?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -172,7 +172,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_7:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_7?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -181,7 +181,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_8:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_8?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -190,7 +190,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_ds_9:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_9?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting.host:5432/read_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/dbtbl_with_readwrite_splitting_and_encrypt/postgresql/proxy/conf/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -19,7 +19,7 @@ schemaName: dbtbl_with_readwrite_splitting_and_encrypt
 
 dataSources:
   encrypt_write_ds_0:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -28,7 +28,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_1:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -37,7 +37,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_2:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_2?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -46,7 +46,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_3:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_3?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -55,7 +55,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_4:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_4?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -64,7 +64,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_5:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_5?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -73,7 +73,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_6:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_6?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -82,7 +82,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_7:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_7?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -91,7 +91,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_8:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_8?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -100,7 +100,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_9:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_9?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_write_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -109,7 +109,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_0:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -118,7 +118,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_1:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -127,7 +127,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_2:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_2?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -136,7 +136,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_3:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_3?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -145,7 +145,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_4:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_4?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -154,7 +154,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_5:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_5?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -163,7 +163,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_6:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_6?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -172,7 +172,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_7:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_7?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -181,7 +181,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_8:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_8?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -190,7 +190,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_9:
-    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_9?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.dbtbl_with_readwrite_splitting_and_encrypt.host:5432/encrypt_read_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/empty_rules/postgresql/proxy/conf/config-empty-rules.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/empty_rules/postgresql/proxy/conf/config-empty-rules.yaml
@@ -19,7 +19,7 @@ schemaName: empty_rules
 
 dataSources:
   encrypt_write_ds_0:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -28,7 +28,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_1:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -37,7 +37,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_2:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -46,7 +46,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_3:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -55,7 +55,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_4:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -64,7 +64,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_5:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -73,7 +73,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_6:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -82,7 +82,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_7:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -91,7 +91,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_8:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -100,7 +100,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_write_ds_9:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_write_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -109,7 +109,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_0:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -118,7 +118,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_1:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -127,7 +127,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_2:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_2?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_2
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -136,7 +136,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_3:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_3?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_3
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -145,7 +145,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_4:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_4?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_4
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -154,7 +154,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_5:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_5?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_5
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -163,7 +163,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_6:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_6?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_6
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -172,7 +172,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_7:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_7?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_7
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -181,7 +181,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_8:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_8?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_8
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -190,7 +190,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   encrypt_read_ds_9:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_9?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/encrypt_read_ds_9
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -199,7 +199,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   rdl_test_0:
-    url: jdbc:postgresql://postgresql.empty_rules.host:5432/rdl_test_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    url: jdbc:postgresql://postgresql.empty_rules.host:5432/rdl_test_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/postgresql/proxy/conf/config-encrypt.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/encrypt/postgresql/proxy/conf/config-encrypt.yaml
@@ -19,7 +19,7 @@ schemaName: encrypt
 
 dataSources:
   encrypt:
-    url: jdbc:postgresql://postgresql.encrypt.host:5432/encrypt?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.encrypt.host:5432/encrypt
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/postgresql/proxy/conf/config-readwrite-splitting.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/readwrite_splitting/postgresql/proxy/conf/config-readwrite-splitting.yaml
@@ -19,7 +19,7 @@ schemaName: readwrite_splitting
 
 dataSources:
   write_ds:
-    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/write_ds?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/write_ds
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -28,7 +28,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_0:
-    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_0?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_0
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000
@@ -37,7 +37,7 @@ dataSources:
     maxPoolSize: 2
     minPoolSize: 2
   read_1:
-    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_1?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.readwrite_splitting.host:5432/read_1
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/postgresql/proxy/conf/config-sharding-governance.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/sharding_governance/postgresql/proxy/conf/config-sharding-governance.yaml
@@ -19,7 +19,7 @@ schemaName: sharding_governance
 
 dataSources:
   governance_db:
-    url: jdbc:postgresql://postgresql.sharding_governance.host:5432/governance_db?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.sharding_governance.host:5432/governance_db
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/postgresql/proxy/conf/config-tbl.yaml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/docker/tbl/postgresql/proxy/conf/config-tbl.yaml
@@ -19,7 +19,7 @@ schemaName: tbl
 
 dataSources:
   tbl:
-    url: jdbc:postgresql://postgresql.tbl.host:5432/tbl?serverTimezone=UTC&useSSL=false
+    url: jdbc:postgresql://postgresql.tbl.host:5432/tbl
     username: root
     password: root
     connectionTimeoutMilliseconds: 30000


### PR DESCRIPTION
The following properties only work in MySQL JDBC Driver:
* `serverTimezone`
* `useSSL`
* `characterEncoding`
