### PR TITLE
support parsing RESET statement for mysql

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
@@ -21,6 +21,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.operation.SQLStatementVisitor;
 import org.apache.shardingsphere.sql.parser.api.visitor.type.DALSQLVisitor;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AnalyzeTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.BinlogContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CacheIndexContext;
@@ -45,6 +46,8 @@ import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.OptionV
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.OptionValueListContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.OptionValueNoOptionTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.RepairTableContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ResetOptionContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ResetPersistContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.ResetStatementContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.RestartContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.SetCharacterContext;
@@ -116,6 +119,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLLoadIndexInfoStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLOptimizeTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLRepairTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetPersistStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLRestartStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLSetResourceGroupStatement;
@@ -148,6 +152,9 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLUseStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.CloneActionSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.CloneInstanceSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetMasterOptionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetSlaveOptionSegment;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -240,7 +247,60 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
     
     @Override
     public ASTNode visitResetStatement(final ResetStatementContext ctx) {
-        return new MySQLResetStatement();
+        ResetPersistContext persistContext = ctx.resetPersist();
+        if (null != persistContext) {
+            return visit(persistContext);
+        }
+        MySQLResetStatement result = new MySQLResetStatement();
+        for (ResetOptionContext each : ctx.resetOption()) {
+            result.getOptions().add((ResetOptionSegment) (visit(each)));
+        }
+        return result;
+    }
+
+    @Override
+    public ASTNode visitResetPersist(final ResetPersistContext ctx) {
+        MySQLResetPersistStatement result = new MySQLResetPersistStatement();
+        if (null != ctx.existClause()) {
+            result.setContainsExistClause(true);
+        }
+        if (null != ctx.identifier()) {
+            result.setIdentifier(new IdentifierValue(ctx.identifier().getText()));
+        }
+        return result;
+    }
+
+    @Override
+    public ASTNode visitResetOption(final ResetOptionContext ctx) {
+        if (null != ctx.MASTER()) {
+            ResetMasterOptionSegment result = new ResetMasterOptionSegment();
+            if (null != ctx.binaryLogFileIndexNumber()) {
+                result.setBinaryLogFileIndexNumber((NumberLiteralValue) visit(ctx.binaryLogFileIndexNumber()));
+            }
+            result.setStartIndex(ctx.start.getStartIndex());
+            result.setStopIndex(ctx.stop.getStopIndex());
+            return result;
+        }
+        ResetSlaveOptionSegment result = new ResetSlaveOptionSegment();
+        if (null != ctx.ALL()) {
+            result.setAll(true);
+        }
+        if (null != ctx.channelOption()) {
+            result.setChannelOption((StringLiteralValue) visit(ctx.channelOption()));
+        }
+        result.setStartIndex(ctx.start.getStartIndex());
+        result.setStopIndex(ctx.stop.getStopIndex());
+        return result;
+    }
+
+    @Override
+    public ASTNode visitChannelOption(final MySQLStatementParser.ChannelOptionContext ctx) {
+        return visit(ctx.string_());
+    }
+
+    @Override
+    public ASTNode visitBinaryLogFileIndexNumber(final MySQLStatementParser.BinaryLogFileIndexNumberContext ctx) {
+        return new NumberLiteralValue(ctx.getText());
     }
 
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -286,6 +286,10 @@ public enum SQLVisitorRule {
     
     KILL("Kill", SQLStatementType.DAL),
     
+    RESET("ResetStatement", SQLStatementType.DAL),
+
+    RESET_PERSIST("ResetPersistStatement", SQLStatementType.DAL),
+
     CALL("Call", SQLStatementType.DML),
     
     CHANGE_MASTER("ChangeMaster", SQLStatementType.RL), 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLResetPersistStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLResetPersistStatement.java
@@ -18,21 +18,22 @@
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
-
-import java.util.LinkedList;
-import java.util.List;
 
 /**
- * MySQL reset statement.
+ * MySQL reset persist statement.
  */
 @ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
+@Setter
+public final class MySQLResetPersistStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
     
-    private List<ResetOptionSegment> options = new LinkedList<>();
+    private boolean containsExistClause;
+
+    private IdentifierValue identifier;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetMasterOptionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetMasterOptionSegment.java
@@ -15,24 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
-
-import java.util.LinkedList;
-import java.util.List;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 
 /**
- * MySQL reset statement.
+ * MySQL reset master option segment.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
-    
-    private List<ResetOptionSegment> options = new LinkedList<>();
+@Setter
+public final class ResetMasterOptionSegment extends ResetOptionSegment {
+
+    private int startIndex;
+
+    private int stopIndex;
+
+    private NumberLiteralValue binaryLogFileIndexNumber;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetOptionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetOptionSegment.java
@@ -15,24 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
-
-import java.util.LinkedList;
-import java.util.List;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
 
 /**
- * MySQL reset statement.
+ * MySQL reset option segment.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
-    
-    private List<ResetOptionSegment> options = new LinkedList<>();
+@Setter
+public abstract class ResetOptionSegment implements SQLSegment {
+
+    private int startIndex;
+
+    private int stopIndex;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetSlaveOptionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/segment/ResetSlaveOptionSegment.java
@@ -15,24 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
-
-import java.util.LinkedList;
-import java.util.List;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
 
 /**
- * MySQL reset statement.
+ * MySQL reset master option segment.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
+@Setter
+public final class ResetSlaveOptionSegment extends ResetOptionSegment {
     
-    private List<ResetOptionSegment> options = new LinkedList<>();
+    private boolean all;
+
+    private StringLiteralValue channelOption;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/DALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/DALStatementAssert.java
@@ -28,6 +28,8 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLFlushStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLInstallComponentStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLInstallPluginStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetPersistStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLOptimizeTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLRepairTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLRestartStatement;
@@ -55,6 +57,8 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.InstallPluginStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLBinlogStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLCreateResourceGroupStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLResetPersistStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLResetStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLOptimizeTableStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLRepairTableStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl.MySQLSetResourceGroupStatementAssert;
@@ -86,6 +90,8 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.OptimizeTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.RepairTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.RestartStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetPersistStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.SetParameterStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.SetResourceGroupStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ShowColumnsStatementTestCase;
@@ -172,6 +178,10 @@ public final class DALStatementAssert {
             ShowProcedureStatusStatementAssert.assertIs(assertContext, (MySQLShowProcedureStatusStatement) actual, (ShowProcedureStatusStatementTestCase) expected);
         } else if (actual instanceof MySQLShowReplicasStatement) {
             ShowReplicasStatementAssert.assertIs(assertContext, (MySQLShowReplicasStatement) actual, (ShowReplicasStatementTestCase) expected);
+        } else if (actual instanceof MySQLResetStatement) {
+            MySQLResetStatementAssert.assertIs(assertContext, (MySQLResetStatement) actual, (ResetStatementTestCase) expected);
+        } else if (actual instanceof MySQLResetPersistStatement) {
+            MySQLResetPersistStatementAssert.assertIs(assertContext, (MySQLResetPersistStatement) actual, (ResetPersistStatementTestCase) expected);
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/MySQLResetPersistStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/MySQLResetPersistStatementAssert.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetPersistStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetPersistStatementTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * MySQL reset persist statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MySQLResetPersistStatementAssert {
+
+    /**
+     * Assert reset persist statement is correct with expected reset persist statement test case.
+     *
+     * @param assertContext assert context
+     * @param actual        actual reset persist statement
+     * @param expected      expected reset persist statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLResetPersistStatement actual, final ResetPersistStatementTestCase expected) {
+        assertThat(assertContext.getText("Actual reset persist exist clause does not match: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
+        if (null != expected.getIdentifier()) {
+            assertThat(assertContext.getText("Actual reset persist identifier does not match: "), actual.getIdentifier().getValue(), is(expected.getIdentifier()));
+        }
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/MySQLResetStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/MySQLResetStatementAssert.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dal.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLResetStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetMasterOptionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetSlaveOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.reset.ExpectedResetOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetStatementTestCase;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * MySQL reset statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MySQLResetStatementAssert {
+
+    /**
+     * Assert reset statement is correct with expected reset statement test case.
+     *
+     * @param assertContext assert context
+     * @param actual        actual reset statement
+     * @param expected      expected reset statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final MySQLResetStatement actual, final ResetStatementTestCase expected) {
+        assertThat(assertContext.getText("Actual options size assertion error: "), actual.getOptions().size(), is(expected.getOptions().size()));
+        assertOptions(assertContext, actual.getOptions(), expected.getOptions());
+    }
+
+    private static void assertOptions(final SQLCaseAssertContext assertContext, final List<ResetOptionSegment> actual, final List<ExpectedResetOptionSegment> expected) {
+        int i = 0;
+        for (ExpectedResetOptionSegment each : expected) {
+            SQLSegmentAssert.assertIs(assertContext, actual.get(i), each);
+            if (each.isMaster()) {
+                assertMasterOption(assertContext, (ResetMasterOptionSegment) actual.get(i), each);
+            } else {
+                assertSlaveOption(assertContext, (ResetSlaveOptionSegment) actual.get(i), each);
+            }
+            i++;
+        }
+    }
+
+    private static void assertMasterOption(final SQLCaseAssertContext assertContext, final ResetMasterOptionSegment actual, final ExpectedResetOptionSegment expected) {
+        if (null != expected.getBinaryLogFileIndexNumber()) {
+            assertThat(assertContext.getText("Actual reset master binlog index does not match: "), actual.getBinaryLogFileIndexNumber().getValue(), is(expected.getBinaryLogFileIndexNumber()));
+        }
+    }
+
+    private static void assertSlaveOption(final SQLCaseAssertContext assertContext, final ResetSlaveOptionSegment actual, final ExpectedResetOptionSegment expected) {
+        assertThat(assertContext.getText("Actual reset slave all does not match: "), actual.isAll(), is(expected.isAll()));
+        if (null != expected.getChannel()) {
+            assertThat(assertContext.getText("Actual reset slave channel does not match: "), actual.getChannelOption().getValue(), is(expected.getChannel()));
+        }
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -28,6 +28,8 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.FlushStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.InstallComponentStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.InstallPluginStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetPersistStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ResetStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.OptimizeTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.RepairTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.SetParameterStatementTestCase;
@@ -696,6 +698,12 @@ public final class SQLParserTestCases {
     @XmlElement(name = "alter-sharding-algorithm")
     private final List<AlterShardingAlgorithmStatementTestCase> alterShardingAlgorithmStatementTestCases = new LinkedList<>();
     
+    @XmlElement(name = "reset")
+    private final List<ResetStatementTestCase> resetStatementTestCases = new LinkedList<>();
+
+    @XmlElement(name = "reset-persist")
+    private final List<ResetPersistStatementTestCase> resetPersistStatementTestCases = new LinkedList<>();
+
     /**
      * Get all SQL parser test cases.
      *
@@ -867,6 +875,8 @@ public final class SQLParserTestCases {
         putAll(createDefaultShardingStrategyStatementTestCases, result);
         putAll(createShardingTableRuleTestCases, result);
         putAll(alterShardingTableRuleTestCases, result);
+        putAll(resetStatementTestCases, result);
+        putAll(resetPersistStatementTestCases, result);
         putAll(showReplicasStatementTestCases, result);
         putAll(alterShardingAlgorithmStatementTestCases, result);
         return result;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/reset/ExpectedResetOptionSegment.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/reset/ExpectedResetOptionSegment.java
@@ -15,24 +15,28 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.reset;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.AbstractExpectedSQLSegment;
 
-import java.util.LinkedList;
-import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * MySQL reset statement.
+ * Expected reset option segment.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
+public final class ExpectedResetOptionSegment extends AbstractExpectedSQLSegment {
     
-    private List<ResetOptionSegment> options = new LinkedList<>();
+    @XmlAttribute(name = "master")
+    private boolean master;
+
+    @XmlAttribute(name = "binary-log-file-index-number")
+    private Integer binaryLogFileIndexNumber;
+
+    @XmlAttribute(name = "all")
+    private boolean all;
+
+    @XmlAttribute(name = "channel")
+    private String channel;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ResetPersistStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ResetPersistStatementTestCase.java
@@ -15,24 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
-import java.util.LinkedList;
-import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * MySQL reset statement.
+ * MySQL reset persist statement test case.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
-    
-    private List<ResetOptionSegment> options = new LinkedList<>();
+public final class ResetPersistStatementTestCase extends SQLParserTestCase {
+
+    @XmlAttribute(name = "exist-clause")
+    private boolean containsExistClause;
+
+    @XmlAttribute(name = "exist-clause")
+    private String identifier;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ResetStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ResetStatementTestCase.java
@@ -15,24 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal;
 
 import lombok.Getter;
-import lombok.ToString;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.DALStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.segment.ResetOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.reset.ExpectedResetOptionSegment;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
-import java.util.LinkedList;
+import javax.xml.bind.annotation.XmlElement;
 import java.util.List;
 
 /**
- * MySQL reset statement.
+ * MySQL reset statement test case.
  */
-@ToString
 @Getter
-public final class MySQLResetStatement extends AbstractSQLStatement implements DALStatement, MySQLStatement {
-    
-    private List<ResetOptionSegment> options = new LinkedList<>();
+public final class ResetStatementTestCase extends SQLParserTestCase {
+
+    @XmlElement(name = "option")
+    private List<ExpectedResetOptionSegment> options;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/reset.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/reset.xml
@@ -17,6 +17,31 @@
   -->
 
 <sql-parser-test-cases>
-    <common sql-case-id="reset_all" />
-    <common sql-case-id="reset_timezone" />
+    <common sql-case-id="reset_all"/>
+    <common sql-case-id="reset_timezone"/>
+    <reset sql-case-id="reset_master">
+        <option master="true" start-index="6" stop-index="11"/>
+    </reset>
+    <reset sql-case-id="reset_slave">
+        <option master="false" start-index="6" stop-index="10"/>
+    </reset>
+    <reset sql-case-id="reset_master_slave">
+        <option master="true" start-index="6" stop-index="11"/>
+        <option master="false" start-index="14" stop-index="18"/>
+    </reset>
+    <reset sql-case-id="reset_master_with_binlog">
+        <option master="true" binary-log-file-index-number="10" start-index="6" stop-index="17"/>
+    </reset>
+    <reset sql-case-id="reset_slave_with_all">
+        <option master="false" all="true" start-index="6" stop-index="14"/>
+    </reset>
+    <reset sql-case-id="reset_slave_with_channel">
+        <option master="false" channel="TEST_CHANNEL" start-index="6" stop-index="37"/>
+    </reset>
+    <reset sql-case-id="reset_slave_with_all_channel">
+        <option master="false" all="true" channel="TEST_CHANNEL" start-index="6" stop-index="41"/>
+    </reset>
+    <reset-persist sql-case-id="reset_persist"/>
+    <reset-persist sql-case-id="reset_persist_identifier" identifier="TEST_ID"/>
+    <reset-persist sql-case-id="reset_persist_exist_identifier" exist-clause="true" identifier="TEST_ID"/>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/reset.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/reset.xml
@@ -19,4 +19,14 @@
 <sql-cases>
     <sql-case id="reset_all" value="RESET ALL"  db-types="PostgreSQL,openGauss" />
     <sql-case id="reset_timezone" value="RESET timezone"  db-types="PostgreSQL,openGauss" />
+    <sql-case id="reset_master" value="RESET MASTER" db-types="MySQL"/>
+    <sql-case id="reset_slave" value="RESET SLAVE" db-types="MySQL"/>
+    <sql-case id="reset_master_slave" value="RESET MASTER, SLAVE" db-types="MySQL"/>
+    <sql-case id="reset_master_with_binlog" value="RESET MASTER TO 10" db-types="MySQL"/>
+    <sql-case id="reset_slave_with_all" value="RESET SLAVE ALL" db-types="MySQL"/>
+    <sql-case id="reset_slave_with_channel" value="RESET SLAVE FOR CHANNEL 'TEST_CHANNEL'" db-types="MySQL"/>
+    <sql-case id="reset_slave_with_all_channel" value="RESET SLAVE ALL FOR CHANNEL 'TEST_CHANNEL'" db-types="MySQL"/>
+    <sql-case id="reset_persist" value="RESET PERSIST" db-types="MySQL"/>
+    <sql-case id="reset_persist_identifier" value="RESET PERSIST TEST_ID" db-types="MySQL"/>
+    <sql-case id="reset_persist_exist_identifier" value="RESET PERSIST IF EXISTS TEST_ID" db-types="MySQL"/>
 </sql-cases>


### PR DESCRIPTION
Fixes #13148.

Changes proposed in this pull request:
- MySQLResetStatement
- MySQLResetPersistStatement
-  Override methods `visitResetOption`, `visitBinaryLogFileIndexNumber` and visitChannelOption`

Notice to reviewer:
- I found that the syntax is different from MySQL preference, and I choose to follow the definition in .g4 files
- I think it's better to use `MySQLResetStatement` and `MySQLResetPersistStatement`, because it makes code clear
