### PR TITLE
Improve error message for SQLException.

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/err/MySQLErrPacketFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/err/MySQLErrPacketFactory.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.frontend.mysql.err;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.db.protocol.error.CommonErrorCode;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLServerErrorCode;
 import org.apache.shardingsphere.db.protocol.mysql.packet.generic.MySQLErrPacket;
@@ -61,7 +62,7 @@ public final class MySQLErrPacketFactory {
     public static MySQLErrPacket newInstance(final Exception cause) {
         if (cause instanceof SQLException) {
             SQLException sqlException = (SQLException) cause;
-            return null == sqlException.getSQLState() ? new MySQLErrPacket(1, MySQLServerErrorCode.ER_INTERNAL_ERROR, cause.getMessage())
+            return null == sqlException.getSQLState() ? new MySQLErrPacket(1, MySQLServerErrorCode.ER_INTERNAL_ERROR, getErrorMessage(sqlException))
                     : new MySQLErrPacket(1, sqlException.getErrorCode(), sqlException.getSQLState(), sqlException.getMessage());
         }
         if (cause instanceof CommonDistSQLException) {
@@ -124,5 +125,12 @@ public final class MySQLErrPacketFactory {
             return new MySQLErrPacket(1, CommonErrorCode.RUNTIME_EXCEPTION, cause.getMessage());
         }
         return new MySQLErrPacket(1, CommonErrorCode.UNKNOWN_EXCEPTION, cause.getMessage());
+    }
+    
+    private static String getErrorMessage(final SQLException cause) {
+        if (null != cause.getNextException() && StringUtils.isBlank(cause.getMessage())) {
+            return cause.getNextException().getMessage();
+        }
+        return cause.getMessage();
     }
 }


### PR DESCRIPTION
Fixes #13462

Changes proposed in this pull request:
- If the next exception is not null and `getMessage()` returns blank String, get the detail message from next exception.

## Before:
```sql
mysql> INSERT INTO t_order values(1,1,'ok');
Query OK, 1 row affected (0.19 sec)
 
mysql> INSERT INTO t_order values(2,2,'disabled');
Query OK, 1 row affected (0.01 sec)
 
mysql> commit;
1815 - Internal error: 
```

## After:
```sql
mysql> INSERT INTO t_order values(1,1,'ok');
Query OK, 1 row affected (0.18 sec)
 
mysql> INSERT INTO t_order values(2,2,'disabled');
Query OK, 1 row affected (0.01 sec)
 
mysql> commit;
1815 - Internal error: Communications link failure during commit(). Transaction resolution unknown.
```

![image](https://user-images.githubusercontent.com/5668787/140291088-364942f9-3406-4197-b6e1-f4c41ead8c71.png)

