### PR TITLE
[DistSQL]Remove unnecessary assertions.

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/set/executor/SetVariableExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/set/executor/SetVariableExecutorTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.set.exec
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.set.SetVariableStatement;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.BackendConnection;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction.TransactionStatus;
-import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.set.excutor.SetVariableExecutor;
 import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtil;
@@ -57,7 +56,5 @@ public final class SetVariableExecutorTest {
         SetVariableStatement statement = new SetVariableStatement("proxy_frontend_flush_threshold", "1024");
         BackendConnection connection = mock(BackendConnection.class);
         new SetVariableExecutor(statement, connection).execute();
-        String expectedValue = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getProps().getProps().get("proxy-frontend-flush-threshold").toString();
-        Assert.assertThat(expectedValue, is("1024"));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/issues/13460.

Changes proposed in this pull request:
- After modifying the `ConfigurationKey`, the data will be updated to `zk`, and the local data will also be refreshed according to the data of `zk`, so the verification data here is the data before updating `zk`, not the final result
