### PR TITLE
Upgrade Atomikos version to eliminate XAConnection createation on registerResource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <commons-io.version>2.8.0</commons-io.version>
         
         <javax.transaction.version>1.1</javax.transaction.version>
-        <atomikos.version>4.0.6</atomikos.version>
+        <atomikos.version>5.0.8</atomikos.version>
         <seata.version>1.4.2</seata.version>
         <narayana.version>5.9.1.Final</narayana.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -298,11 +298,11 @@ The following components are provided under the Apache License. See project link
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
     groovy 2.4.19-indy: https://github.com/apache/groovy, Apache 2.0
-    atomikos-util 4.0.6: https://www.atomikos.com, Apache 2.0
-    transactions 4.0.6: https://www.atomikos.com, Apache 2.0
-    transactions-api 4.0.6: https://www.atomikos.com, Apache 2.0
-    transactions-jdbc 4.0.6: https://www.atomikos.com, Apache 2.0
-    transactions-jta 4.0.6: https://www.atomikos.com, Apache 2.0
+    atomikos-util 5.0.8: https://www.atomikos.com, Apache 2.0
+    transactions 5.0.8: https://www.atomikos.com, Apache 2.0
+    transactions-api 5.0.8: https://www.atomikos.com, Apache 2.0
+    transactions-jdbc 5.0.8: https://www.atomikos.com, Apache 2.0
+    transactions-jta 5.0.8: https://www.atomikos.com, Apache 2.0
     
 ========================================================================
 BSD licenses

--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-core/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-core/pom.xml
@@ -37,18 +37,6 @@
             <artifactId>shardingsphere-transaction-xa-atomikos</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.atomikos</groupId>
-            <artifactId>transactions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.atomikos</groupId>
-            <artifactId>transactions-jta</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.atomikos</groupId>
-            <artifactId>transactions-jdbc</artifactId>
-        </dependency>
         
         <dependency>
             <groupId>com.zaxxer</groupId>

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/logback.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/logback.xml
@@ -26,17 +26,11 @@
         <appender-ref ref="console" />
     </logger>
     
-    <logger name="com.zaxxer.hikari" level="error">
-        <appender-ref ref="console" />
-    </logger>
+    <logger name="com.zaxxer.hikari" level="error" />
     
-    <logger name="com.atomikos" level="error">
-        <appender-ref ref="console" />
-    </logger>
+    <logger name="com.atomikos" level="error" />
     
-    <logger name="io.netty" level="error">
-        <appender-ref ref="console" />
-    </logger>
+    <logger name="io.netty" level="error" />
     
     <root>
         <level value="info" />

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/datasource/DataSourceWrapper.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/datasource/DataSourceWrapper.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.scaling.core.common.datasource;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 import javax.sql.DataSource;
 import java.io.PrintWriter;
@@ -30,6 +31,7 @@ import java.util.logging.Logger;
  * Data source wrapper is for abstract standard jdbc and sharding jdbc.
  */
 @RequiredArgsConstructor
+@Slf4j
 public final class DataSourceWrapper implements DataSource, AutoCloseable {
     
     private final DataSource dataSource;
@@ -94,6 +96,8 @@ public final class DataSourceWrapper implements DataSource, AutoCloseable {
                 // CHECKSTYLE:ON
                 throw new SQLException("data source close failed.", ex);
             }
+        } else {
+            log.error("dataSource is not closed, it might cause connection leak, dataSource={}", dataSource, new RuntimeException());
         }
     }
 }


### PR DESCRIPTION
Fixes #13434.

Changes proposed in this pull request:
- Upgrade atomikos version to 5.0.8 to eliminate new XAConnection created on registerResource
- Update atomikos version in LICENSE
- Remove duplicated atomikos dependencies
