### PR TITLE
fixbug: columnMatchTableAndCheckAmbiguous on same simpleTableSegment but alias

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/impl/EncryptProjectionTokenGenerator.java
@@ -115,7 +115,7 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
         if (!columnProjectionSegment.getColumn().getOwner().isPresent()) {
             return false;
         }
-        return selectStatementContext.getTablesContext().getAllUniqueTables().stream().anyMatch(table -> tableName.equals(table.getTableName().getIdentifier().getValue()) 
+        return selectStatementContext.getTablesContext().getOriginalTables().stream().anyMatch(table -> tableName.equals(table.getTableName().getIdentifier().getValue())
                 && table.getAlias().isPresent() && columnProjectionSegment.getColumn().getOwner().get().getIdentifier().getValue().equals(table.getAlias().get()));
     }
     
@@ -123,7 +123,7 @@ public final class EncryptProjectionTokenGenerator extends BaseEncryptSQLTokenGe
         if (!columnProjectionSegment.getColumn().getOwner().isPresent()) {
             return false;
         }
-        return selectStatementContext.getTablesContext().getAllUniqueTables().stream().anyMatch(table -> tableName.equals(table.getTableName().getIdentifier().getValue()) 
+        return selectStatementContext.getTablesContext().getOriginalTables().stream().anyMatch(table -> tableName.equals(table.getTableName().getIdentifier().getValue())
                 && !table.getAlias().isPresent() && columnProjectionSegment.getColumn().getOwner().get().getIdentifier().getValue().equals(tableName));
     }
     

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
@@ -68,10 +68,8 @@ public final class EncryptProjectionTokenGeneratorTest {
         SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
         doctor.setAlias(new AliasSegment(8, 9, new IdentifierValue("a")));
         SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor1")));
-
         when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor", "doctor1"));
-
         IdentifierValue identifierValue = new IdentifierValue("mobile");
         ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
         OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("a"));
@@ -90,10 +88,8 @@ public final class EncryptProjectionTokenGeneratorTest {
         SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
         doctor.setAlias(new AliasSegment(8, 9, new IdentifierValue("a")));
         SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor")));
-
         when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor"));
-
         IdentifierValue identifierValue = new IdentifierValue("mobile");
         ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
         OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("a"));
@@ -109,13 +105,10 @@ public final class EncryptProjectionTokenGeneratorTest {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projectionsSegment);
-
         SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
         SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor1")));
-
         when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor", "doctor1"));
-
         IdentifierValue identifierValue = new IdentifierValue("mobile");
         ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
         OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("doctor"));
@@ -158,7 +151,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         }
         return Arrays.asList(table1, table2);
     }
-
+    
     private EncryptRule buildEncryptRule() {
         EncryptRule encryptRule = mock(EncryptRule.class);
         EncryptTable encryptTable1 = mock(EncryptTable.class);

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
@@ -51,15 +51,15 @@ public final class EncryptProjectionTokenGeneratorTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-
+    
     private EncryptProjectionTokenGenerator encryptProjectionTokenGenerator;
-
+    
     @Before
     public void setup() {
         encryptProjectionTokenGenerator = new EncryptProjectionTokenGenerator();
         encryptProjectionTokenGenerator.setEncryptRule(buildEncryptRule());
     }
-
+    
     @Test
     public void assertOwnerExistsMatchTableAliasGenerateSQLTokens() {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
@@ -79,7 +79,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(tokens.size(), is(1));
     }
-
+    
     @Test
     public void assertOwnerExistsMatchTableAliasGenerateSQLTokens2() {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
@@ -99,7 +99,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(tokens.size(), is(1));
     }
-
+    
     @Test
     public void assertOwnerExistsMatchTableNameGenerateSQLTokens() {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
@@ -118,7 +118,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(tokens.size(), is(1));
     }
-
+    
     @Test
     public void assertColumnUnAmbiguousGenerateSQLTokens() {
         expectedException.expect(IllegalStateException.class);
@@ -135,11 +135,11 @@ public final class EncryptProjectionTokenGeneratorTest {
         when(projectionsSegment.getProjections()).thenReturn(Collections.singletonList(columnProjectionSegment));
         encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
     }
-
+    
     private List<SimpleTableSegment> buildAllUniqueTables() {
         return buildAllUniqueTables(true);
     }
-
+    
     private List<SimpleTableSegment> buildAllUniqueTables(final boolean hasAlias) {
         SimpleTableSegment table1 = mock(SimpleTableSegment.class, RETURNS_DEEP_STUBS);
         when(table1.getTableName().getIdentifier().getValue()).thenReturn("doctor");

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class EncryptProjectionTokenGeneratorTest {
-
+    
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
     

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
@@ -25,8 +25,10 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.Substituta
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionsSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,26 +48,30 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class EncryptProjectionTokenGeneratorTest {
-    
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
-    
+
     private EncryptProjectionTokenGenerator encryptProjectionTokenGenerator;
-    
+
     @Before
     public void setup() {
         encryptProjectionTokenGenerator = new EncryptProjectionTokenGenerator();
         encryptProjectionTokenGenerator.setEncryptRule(buildEncryptRule());
     }
-    
+
     @Test
     public void assertOwnerExistsMatchTableAliasGenerateSQLTokens() {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projectionsSegment);
+        SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
+        doctor.setAlias(new AliasSegment(8, 9, new IdentifierValue("a")));
+        SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor1")));
+
+        when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor", "doctor1"));
-        List<SimpleTableSegment> allUniqueTables = buildAllUniqueTables();
-        when(sqlStatementContext.getTablesContext().getAllUniqueTables()).thenReturn(allUniqueTables);
+
         IdentifierValue identifierValue = new IdentifierValue("mobile");
         ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
         OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("a"));
@@ -75,15 +81,41 @@ public final class EncryptProjectionTokenGeneratorTest {
         Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(tokens.size(), is(1));
     }
-    
+
+    @Test
+    public void assertOwnerExistsMatchTableAliasGenerateSQLTokens2() {
+        ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
+        SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
+        when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projectionsSegment);
+        SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
+        doctor.setAlias(new AliasSegment(8, 9, new IdentifierValue("a")));
+        SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor")));
+
+        when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
+        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor"));
+
+        IdentifierValue identifierValue = new IdentifierValue("mobile");
+        ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
+        OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("a"));
+        columnSegment.setOwner(ownerSegment);
+        ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment(columnSegment);
+        when(projectionsSegment.getProjections()).thenReturn(Collections.singletonList(columnProjectionSegment));
+        Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
+        assertThat(tokens.size(), is(1));
+    }
+
     @Test
     public void assertOwnerExistsMatchTableNameGenerateSQLTokens() {
         ProjectionsSegment projectionsSegment = mock(ProjectionsSegment.class);
         SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSqlStatement().getProjections()).thenReturn(projectionsSegment);
+
+        SimpleTableSegment doctor = new SimpleTableSegment(new TableNameSegment(1, 7, new IdentifierValue("doctor")));
+        SimpleTableSegment doctor1 = new SimpleTableSegment(new TableNameSegment(10, 17, new IdentifierValue("doctor1")));
+
+        when(sqlStatementContext.getTablesContext().getOriginalTables()).thenReturn(Arrays.asList(doctor, doctor1));
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Arrays.asList("doctor", "doctor1"));
-        List<SimpleTableSegment> allUniqueTables = buildAllUniqueTables(false);
-        when(sqlStatementContext.getTablesContext().getAllUniqueTables()).thenReturn(allUniqueTables);
+
         IdentifierValue identifierValue = new IdentifierValue("mobile");
         ColumnSegment columnSegment = new ColumnSegment(0, 0, identifierValue);
         OwnerSegment ownerSegment = new OwnerSegment(0, 0, new IdentifierValue("doctor"));
@@ -93,7 +125,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         Collection<SubstitutableColumnNameToken> tokens = encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
         assertThat(tokens.size(), is(1));
     }
-    
+
     @Test
     public void assertColumnUnAmbiguousGenerateSQLTokens() {
         expectedException.expect(IllegalStateException.class);
@@ -110,11 +142,11 @@ public final class EncryptProjectionTokenGeneratorTest {
         when(projectionsSegment.getProjections()).thenReturn(Collections.singletonList(columnProjectionSegment));
         encryptProjectionTokenGenerator.generateSQLTokens(sqlStatementContext);
     }
-    
+
     private List<SimpleTableSegment> buildAllUniqueTables() {
         return buildAllUniqueTables(true);
     }
-    
+
     private List<SimpleTableSegment> buildAllUniqueTables(final boolean hasAlias) {
         SimpleTableSegment table1 = mock(SimpleTableSegment.class, RETURNS_DEEP_STUBS);
         when(table1.getTableName().getIdentifier().getValue()).thenReturn("doctor");
@@ -126,7 +158,7 @@ public final class EncryptProjectionTokenGeneratorTest {
         }
         return Arrays.asList(table1, table2);
     }
-    
+
     private EncryptRule buildEncryptRule() {
         EncryptRule encryptRule = mock(EncryptRule.class);
         EncryptTable encryptTable1 = mock(EncryptTable.class);


### PR DESCRIPTION
Fixes #12825

Changes proposed in this pull request:
- fixbug: columnMatchTableAndCheckAmbiguous on same simpleTableSegment but alias