### PR TITLE
Mock DataSource with AutoCloseable in scaling unit test

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/datasource/DataSourceWrapper.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/common/datasource/DataSourceWrapper.java
@@ -97,7 +97,7 @@ public final class DataSourceWrapper implements DataSource, AutoCloseable {
                 throw new SQLException("data source close failed.", ex);
             }
         } else {
-            log.error("dataSource is not closed, it might cause connection leak, dataSource={}", dataSource, new RuntimeException());
+            log.warn("dataSource is not closed, it might cause connection leak, dataSource={}", dataSource);
         }
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/common/datasource/MetaDataManagerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/common/datasource/MetaDataManagerTest.java
@@ -58,7 +58,7 @@ public final class MetaDataManagerTest {
     
     private static final String TEST_TABLE = "test";
     
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource dataSource;
     
     @Mock

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
@@ -75,7 +75,7 @@ public final class AbstractImporterTest {
     @Mock
     private Channel channel;
     
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource dataSource;
     
     @Mock

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/check/AbstractDataSourceCheckerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/check/AbstractDataSourceCheckerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public final class AbstractDataSourceCheckerTest {
     
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource dataSource;
     
     @Mock

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
@@ -58,10 +58,10 @@ public final class MySQLDataSourcePreparerTest {
     @Mock
     private ShardingSphereJDBCDataSourceConfiguration targetScalingDataSourceConfiguration;
 
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource sourceDataSource;
 
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource targetDataSource;
 
     @Mock

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLPositionInitializerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLPositionInitializerTest.java
@@ -44,7 +44,7 @@ public final class MySQLPositionInitializerTest {
     
     private static final long SERVER_ID = 555555;
     
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource dataSource;
     
     @Mock

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/component/PostgreSQLPositionInitializerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-postgresql/src/test/java/org/apache/shardingsphere/scaling/postgresql/component/PostgreSQLPositionInitializerTest.java
@@ -46,7 +46,7 @@ public final class PostgreSQLPositionInitializerTest {
     
     private static final String POSTGRESQL_10_LSN = "0/1634520";
     
-    @Mock
+    @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource dataSource;
     
     @Mock


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
- Mock DataSource with AutoCloseable in scaling unit test. Eliminate data source not closed check error log.
