### PR TITLE
Fro 13558, fix H2DataSourceMetaData.isInSameDatabaseInstance method, …

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaData.java
@@ -41,6 +41,8 @@ public final class H2DataSourceMetaData implements DataSourceMetaData {
     
     private static final String MODEL_PWD = "~";
     
+    private static final String MODEL_FILE = "file:";
+    
     private static final Pattern PATTERN = Pattern.compile("jdbc:h2:((?<modelMem>mem|~)[:/](?<catalog>[\\w\\-]+)|"
             + "(?<modelSslOrTcp>ssl:|tcp:)(//)?(?<hostName>[\\w\\-.]+)(:(?<port>[0-9]{1,4})/)?[/~\\w\\-.]+/(?<name>[\\-\\w]*)|"
             + "(?<modelFile>file:)[/~\\w\\-]+/(?<fileName>[\\-\\w]*));?\\S*", Pattern.CASE_INSENSITIVE);
@@ -95,9 +97,11 @@ public final class H2DataSourceMetaData implements DataSourceMetaData {
     
     private boolean isSameModel(final String model1, final String model2) {
         if (MODEL_MEM.equalsIgnoreCase(model1)) {
-            return model1.equalsIgnoreCase(model2) || MODEL_PWD.equalsIgnoreCase(model2);
+            return model1.equalsIgnoreCase(model2) || MODEL_PWD.equalsIgnoreCase(model2) || MODEL_FILE.equalsIgnoreCase(model2);
         } else if (MODEL_PWD.equalsIgnoreCase(model1)) {
-            return model1.equalsIgnoreCase(model2) || MODEL_MEM.equalsIgnoreCase(model2);
+            return model1.equalsIgnoreCase(model2) || MODEL_MEM.equalsIgnoreCase(model2) || MODEL_FILE.equalsIgnoreCase(model2);
+        } else if (MODEL_FILE.equalsIgnoreCase(model1)) {
+            return model1.equalsIgnoreCase(model2) || MODEL_MEM.equalsIgnoreCase(model2) || MODEL_PWD.equalsIgnoreCase(model2);
         } else {
             return model1.equalsIgnoreCase(model2);
         }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
@@ -9,10 +9,16 @@ import org.apache.shardingsphere.infra.database.metadata.dialect.SQL92DataSource
 import org.apache.shardingsphere.infra.database.metadata.dialect.SQLServerDataSourceMetaData;
 import org.junit.Test;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class DataSourceMetaDataTest {
+    
+    @Test
+    public void assertIsInSameDatabaseInstanceWithH2() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:tcp://localhost:8082/~/test1/test2;DB_CLOSE_DELAY=-1");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:tcp://localhost:8082/~/test1/test2;DB_CLOSE_DELAY=-1");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
 
     @Test
     public void assertIsInSameDatabaseInstanceWithMysql() {
@@ -54,131 +60,5 @@ public final class DataSourceMetaDataTest {
         SQLServerDataSourceMetaData actual1 = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_0");
         SQLServerDataSourceMetaData actual2 = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
         assertTrue(actual1.isInSameDatabaseInstance(actual2));
-    }
-
-    @Test
-    public void assertFalseIsInSameDatabaseInstanceWithMysqlAndH2() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualH2));
-    }
-
-    @Test
-    public void assertFalseIsInSameDatabaseInstanceWithMysqlAndOracle() {
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithMysqlAndMariaDB() {
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
-        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualMariaDB));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithMysqlAndPostgreSQL() {
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
-        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualPostgreSQL));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithMysqlAndSQL92() {
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
-        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualSQL92));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithMysqlAndSQLServer() {
-        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
-        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
-        assertFalse(actualMysql.isInSameDatabaseInstance(actualSQLServer));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithH2AndMariaDB() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
-        assertFalse(actualH2.isInSameDatabaseInstance(actualMariaDB));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithH2AndOracle() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        assertFalse(actualH2.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithH2AndPostgreSQL() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
-        assertFalse(actualH2.isInSameDatabaseInstance(actualPostgreSQL));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithH2AndSQL92() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
-        assertFalse(actualH2.isInSameDatabaseInstance(actualSQL92));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithH2AndSQLServer() {
-        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
-        assertFalse(actualH2.isInSameDatabaseInstance(actualSQLServer));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithOracleAndMariaDB() {
-        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        assertFalse(actualMariaDB.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithOracleAndPostgreSQL() {
-        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithOracleAndSQL92() {
-        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        assertFalse(actualSQL92.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithOracleAndSQLServer() {
-        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
-        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
-        assertFalse(actualSQLServer.isInSameDatabaseInstance(actualOracle));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithPostgreSQLAndSQL92() {
-        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
-        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
-        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualSQL92));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithPostgreSQLAndSQLServer() {
-        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
-        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
-        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualSQLServer));
-    }
-
-    @Test
-    public void assertFalseInSameDatabaseInstanceWithSQL92AndSQLServer() {
-        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
-        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
-        assertFalse(actualSQL92.isInSameDatabaseInstance(actualSQLServer));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.infra.database.metadata;
 
 import org.apache.shardingsphere.infra.database.metadata.dialect.H2DataSourceMetaData;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
@@ -1,17 +1,17 @@
 package org.apache.shardingsphere.infra.database.metadata;
 
-import org.apache.shardingsphere.infra.database.metadata.dialect.*;
+import org.apache.shardingsphere.infra.database.metadata.dialect.H2DataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.MariaDBDataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.MySQLDataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.OracleDataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.PostgreSQLDataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.SQL92DataSourceMetaData;
+import org.apache.shardingsphere.infra.database.metadata.dialect.SQLServerDataSourceMetaData;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
 import static org.junit.Assert.assertFalse;
-/**
- * DataSourceMetaDataTest
- *
- * @author YangDy
- * @version 1.0
- * @date 2021/11/15 09:11
- * @since 1.0
- */
+import static org.junit.Assert.assertTrue;
+
 public final class DataSourceMetaDataTest {
 
     @Test

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/DataSourceMetaDataTest.java
@@ -1,0 +1,184 @@
+package org.apache.shardingsphere.infra.database.metadata;
+
+import org.apache.shardingsphere.infra.database.metadata.dialect.*;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+/**
+ * DataSourceMetaDataTest
+ *
+ * @author YangDy
+ * @version 1.0
+ * @date 2021/11/15 09:11
+ * @since 1.0
+ */
+public final class DataSourceMetaDataTest {
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithMysql() {
+        MySQLDataSourceMetaData actual1 = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_1?serverTimezone=UTC&useSSL=false");
+        MySQLDataSourceMetaData actual2 = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithOracle() {
+        OracleDataSourceMetaData actual1 = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9999/ds_0", "test");
+        OracleDataSourceMetaData actual2 = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9999/ds_1", "test");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithMariaDB() {
+        MariaDBDataSourceMetaData actual1 = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        MariaDBDataSourceMetaData actual2 = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_1?serverTimezone=UTC&useSSL=false");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithPostgreSQL() {
+        PostgreSQLDataSourceMetaData actual1 = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        PostgreSQLDataSourceMetaData actual2 = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_1");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithSQL92() {
+        SQL92DataSourceMetaData actual1 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        SQL92DataSourceMetaData actual2 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_1");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithSQLServer() {
+        SQLServerDataSourceMetaData actual1 = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_0");
+        SQLServerDataSourceMetaData actual2 = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertFalseIsInSameDatabaseInstanceWithMysqlAndH2() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualH2));
+    }
+
+    @Test
+    public void assertFalseIsInSameDatabaseInstanceWithMysqlAndOracle() {
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithMysqlAndMariaDB() {
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
+        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualMariaDB));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithMysqlAndPostgreSQL() {
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
+        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualPostgreSQL));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithMysqlAndSQL92() {
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
+        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualSQL92));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithMysqlAndSQLServer() {
+        MySQLDataSourceMetaData actualMysql = new MySQLDataSourceMetaData("jdbc:mysql://127.0.0.1:9988/ds_0?serverTimezone=UTC&useSSL=false");
+        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        assertFalse(actualMysql.isInSameDatabaseInstance(actualSQLServer));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithH2AndMariaDB() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        assertFalse(actualH2.isInSameDatabaseInstance(actualMariaDB));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithH2AndOracle() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        assertFalse(actualH2.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithH2AndPostgreSQL() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        assertFalse(actualH2.isInSameDatabaseInstance(actualPostgreSQL));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithH2AndSQL92() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        assertFalse(actualH2.isInSameDatabaseInstance(actualSQL92));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithH2AndSQLServer() {
+        H2DataSourceMetaData actualH2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        assertFalse(actualH2.isInSameDatabaseInstance(actualSQLServer));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithOracleAndMariaDB() {
+        MariaDBDataSourceMetaData actualMariaDB = new MariaDBDataSourceMetaData("jdbc:mariadb://127.0.0.1:9999/ds_0?serverTimezone=UTC&useSSL=false");
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        assertFalse(actualMariaDB.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithOracleAndPostgreSQL() {
+        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithOracleAndSQL92() {
+        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        assertFalse(actualSQL92.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithOracleAndSQLServer() {
+        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        OracleDataSourceMetaData actualOracle = new OracleDataSourceMetaData("jdbc:oracle:thin:@//127.0.0.1:9988/ds_0", "test");
+        assertFalse(actualSQLServer.isInSameDatabaseInstance(actualOracle));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithPostgreSQLAndSQL92() {
+        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualSQL92));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithPostgreSQLAndSQLServer() {
+        PostgreSQLDataSourceMetaData actualPostgreSQL = new PostgreSQLDataSourceMetaData("jdbc:postgresql://127.0.0.1/ds_0");
+        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        assertFalse(actualPostgreSQL.isInSameDatabaseInstance(actualSQLServer));
+    }
+
+    @Test
+    public void assertFalseInSameDatabaseInstanceWithSQL92AndSQLServer() {
+        SQL92DataSourceMetaData actualSQL92 = new SQL92DataSourceMetaData("jdbc:sql92_db:ds_0");
+        SQLServerDataSourceMetaData actualSQLServer = new SQLServerDataSourceMetaData("jdbc:microsoft:sqlserver://127.0.0.1:9999;DatabaseName=ds_1");
+        assertFalse(actualSQL92.isInSameDatabaseInstance(actualSQLServer));
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
@@ -20,7 +20,9 @@ package org.apache.shardingsphere.infra.database.metadata.dialect;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class H2DataSourceMetaDataTest {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
@@ -84,10 +84,10 @@ public final class H2DataSourceMetaDataTest {
     }
 
     @Test
-    public void assertFalseIsInSameDatabaseInstance() {
+    public void assertIsInSameDatabaseInstance() {
         H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
         H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:~:ds-1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
-        assertFalse(actual1.isInSameDatabaseInstance(actual2));
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
     }
 
     @Test
@@ -104,7 +104,6 @@ public final class H2DataSourceMetaDataTest {
         assertFalse(actual1.isInSameDatabaseInstance(actual2));
     }
 
-
     @Test
     public void assertIsInSameDatabaseInstanceWithSsl() {
         H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:ssl:180.76.76.76/home/test-one");
@@ -118,7 +117,6 @@ public final class H2DataSourceMetaDataTest {
         H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:ssl:181.76.76.76/home/test-two");
         assertFalse(actual1.isInSameDatabaseInstance(actual2));
     }
-
 
     @Test
     public void assertIsInSameDatabaseInstanceWithFile() {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/metadata/dialect/H2DataSourceMetaDataTest.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.infra.database.metadata.dialect;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 public final class H2DataSourceMetaDataTest {
     
@@ -67,5 +67,63 @@ public final class H2DataSourceMetaDataTest {
         assertThat(actual.getPort(), is(-1));
         assertThat(actual.getCatalog(), is("sample"));
         assertNull(actual.getSchema());
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithMem() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:mem:ds_1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithSymbol() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:~:ds-0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:~:ds-1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertFalseIsInSameDatabaseInstance() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:mem:ds_0;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:~:ds-1;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        assertFalse(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithTcp() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:tcp://localhost:8082/~/test1/test2;DB_CLOSE_DELAY=-1");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:tcp://localhost:8082/~/test3/test4;DB_CLOSE_DELAY=-1");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertFalseIsInSameDatabaseInstanceWithTcp() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:tcp://localhost:8082/~/test1/test2;DB_CLOSE_DELAY=-1");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:tcp://192.168.64.76:8082/~/test3/test4;DB_CLOSE_DELAY=-1");
+        assertFalse(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithSsl() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:ssl:180.76.76.76/home/test-one");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:ssl:180.76.76.76/home/test-two");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+    @Test
+    public void assertFalseIsInSameDatabaseInstanceWithSsl() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:ssl:180.76.76.76/home/test-one");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:ssl:181.76.76.76/home/test-two");
+        assertFalse(actual1.isInSameDatabaseInstance(actual2));
+    }
+
+
+    @Test
+    public void assertIsInSameDatabaseInstanceWithFile() {
+        H2DataSourceMetaData actual1 = new H2DataSourceMetaData("jdbc:h2:file:/data/sample-one;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false");
+        H2DataSourceMetaData actual2 = new H2DataSourceMetaData("jdbc:h2:file:/data/sample-two;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false");
+        assertTrue(actual1.isInSameDatabaseInstance(actual2));
     }
 }


### PR DESCRIPTION
Add unit test for H2DataSourceMetaData.isInSameDatabaseInstance and DataSourceMetaData.isInSameDatabaseInstance

Fixes #13558 .

Changes proposed in this pull request:
- fix H2DataSourceMetaData.isInSameDatabaseInstance method
- Add unit test for H2DataSourceMetaData.isInSameDatabaseInstance
