### PR TITLE
Add SQLServer CREATE TABLE AS SELECT statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
@@ -148,11 +148,11 @@ fileTableClause
     ;
 
 createDefinitionClause
-    : createTableDefinitions partitionScheme fileGroup
+    : createTableAsSelect? createTableDefinitions partitionScheme fileGroup
     ;
 
 createTableDefinitions
-    : LP_ createTableDefinition (COMMA_ createTableDefinition)* (COMMA_ periodClause)? RP_
+    : (LP_ createTableDefinition (COMMA_ createTableDefinition)* (COMMA_ periodClause)? RP_)?
     ;
 
 createTableDefinition
@@ -357,6 +357,7 @@ tableOption
     | distributionOption
     | dataWareHouseTableOption
     | dataDelectionOption
+    | dataWareHousePartitionOption
     ;
 
 dataDelectionOption
@@ -384,7 +385,7 @@ distributionOption
     ;
 
 dataWareHouseTableOption
-    : CLUSTERED COLUMNSTORE INDEX | HEAP | dataWareHousePartitionOption
+    : CLUSTERED COLUMNSTORE INDEX | CLUSTERED COLUMNSTORE INDEX ORDER columnNames | HEAP | CLUSTERED INDEX LP_ (columnName (ASC | DESC)?) (COMMA_ (columnName (ASC | DESC)?))* RP_
     ;
 
 dataWareHousePartitionOption
@@ -1064,4 +1065,16 @@ schemaNameClause
 
 schemaElement
     : createTable | createView | grant | revoke | deny
+    ;
+
+createTableAsSelect
+    : columnNames? withDistributionOption AS select optionQueryHintClause
+    ;
+
+withDistributionOption
+    : WITH LP_ distributionOption (COMMA_ tableOption (COMMA_ tableOption)*)? RP_
+    ;
+
+optionQueryHintClause
+    : (OPTION LP_ queryHint (COMMA_ queryHint)* RP_)?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandler.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandler.java
@@ -19,7 +19,9 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.ddl.MySQLCreateTableStatement;
@@ -27,6 +29,12 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.Open
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLCreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateTableStatement;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Create table statement handler for different dialect SQL statements.
@@ -51,5 +59,31 @@ public final class CreateTableStatementHandler implements SQLStatementHandler {
             return ((OpenGaussCreateTableStatement) createTableStatement).isContainsNotExistClause();
         }
         return false;
+    }
+    
+    /**
+     * Get select statement.
+     *
+     * @param createTableStatement create table statement
+     * @return select statement
+     */
+    public static Optional<SelectStatement> getSelectStatement(final CreateTableStatement createTableStatement) {
+        if (createTableStatement instanceof SQLServerStatement) {
+            return ((SQLServerCreateTableStatement) createTableStatement).getSelectStatement();
+        }
+        return Optional.empty();
+    }
+    
+    /**
+     * Get list of columns.
+     *
+     * @param createTableStatement create table statement
+     * @return list of columns
+     */
+    public static List<ColumnSegment> getColumns(final CreateTableStatement createTableStatement) {
+        if (createTableStatement instanceof SQLServerStatement) {
+            return ((SQLServerCreateTableStatement) createTableStatement).getColumns();
+        }
+        return Collections.emptyList();
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerCreateTableStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/ddl/SQLServerCreateTableStatement.java
@@ -17,13 +17,36 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * SQLServer create table statement.
  */
+@Getter
+@Setter
 @ToString
 public final class SQLServerCreateTableStatement extends CreateTableStatement implements SQLServerStatement {
+    
+    private final List<ColumnSegment> columns = new LinkedList<>();
+    
+    private SelectStatement selectStatement;
+    
+    /**
+     * Get select statement.
+     *
+     * @return select statement
+     */
+    public Optional<SelectStatement> getSelectStatement() {
+        return Optional.ofNullable(selectStatement);
+    }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/CreateTableStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/ddl/impl/CreateTableStatementAssert.java
@@ -21,15 +21,25 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateTableStatementHandler;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.column.ColumnAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.definition.ColumnDefinitionAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.definition.ConstraintDefinitionAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.dml.impl.SelectStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTableStatementTestCase;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Create table statement assert.
@@ -48,6 +58,8 @@ public final class CreateTableStatementAssert {
         assertTable(assertContext, actual, expected);
         assertColumnDefinitions(assertContext, actual, expected);
         assertConstraintDefinitions(assertContext, actual, expected);
+        assertCreateTableAsSelectStatement(assertContext, actual, expected);
+        assertCreateTableAsSelectStatementColumns(assertContext, actual, expected);
     }
     
     private static void assertTable(final SQLCaseAssertContext assertContext, final CreateTableStatement actual, final CreateTableStatementTestCase expected) {
@@ -68,6 +80,26 @@ public final class CreateTableStatementAssert {
         int count = 0;
         for (ConstraintDefinitionSegment each : actual.getConstraintDefinitions()) {
             ConstraintDefinitionAssert.assertIs(assertContext, each, expected.getConstraintDefinitions().get(count));
+            count++;
+        }
+    }
+    
+    private static void assertCreateTableAsSelectStatement(final SQLCaseAssertContext assertContext, final CreateTableStatement actual, final CreateTableStatementTestCase expected) {
+        Optional<SelectStatement> selectStatement = CreateTableStatementHandler.getSelectStatement(actual);
+        if (null != expected.getCreateTableAsSelectStatement()) {
+            assertTrue("actual select statement should exist", selectStatement.isPresent());
+            SelectStatementAssert.assertIs(assertContext, selectStatement.get(), expected.getCreateTableAsSelectStatement());
+        } else {
+            assertFalse("actual select statement should not exist", selectStatement.isPresent());
+        }
+    }
+    
+    private static void assertCreateTableAsSelectStatementColumns(final SQLCaseAssertContext assertContext, final CreateTableStatement actual, final CreateTableStatementTestCase expected) {
+        List<ColumnSegment> columns = CreateTableStatementHandler.getColumns(actual);
+        assertThat(assertContext.getText("Columns size assertion error: "), columns.size(), is(expected.getColumns().size()));
+        int count = 0;
+        for (ColumnSegment each : columns) {
+            ColumnAssert.assertIs(assertContext, each, expected.getColumns().get(count));
             count++;
         }
     }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/CreateTableStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/CreateTableStatementTestCase.java
@@ -19,10 +19,12 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.definition.ExpectedColumnDefinition;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.definition.ExpectedConstraintDefinition;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.SelectStatementTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
 import java.util.LinkedList;
@@ -43,4 +45,10 @@ public final class CreateTableStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "constraint-definition")
     private final List<ExpectedConstraintDefinition> constraintDefinitions = new LinkedList<>();
+    
+    @XmlElement(name = "column")
+    private final List<ExpectedColumn> columns = new LinkedList<>(); 
+    
+    @XmlElement(name = "select")
+    private SelectStatementTestCase createTableAsSelectStatement;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/create-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/create-table.xml
@@ -1599,4 +1599,69 @@
             <column name="column3" />
         </column-definition>
     </create-table>
+
+    <create-table sql-case-id="create_table_as_select">
+        <table name="t_order_new" start-index="13" stop-index="23" />
+        <select>
+            <from>
+                <simple-table name="t_order" start-index="178" stop-index="184"/>
+            </from>
+            <projections start-index="171" stop-index="171">
+                <shorthand-projection start-index="171" stop-index="171"/>
+            </projections>
+        </select>
+    </create-table>
+
+    <create-table sql-case-id="create_table_as_select_with_explicit_column_names">
+        <table name="t_order_new" start-index="13" stop-index="23" />
+        <column name="order_id_new" start-index="26" stop-index="37" />
+        <column name="user_id_new" start-index="40" stop-index="50" />
+        <select>
+            <from>
+                <simple-table name="t_order" start-index="222" stop-index="228"/>
+            </from>
+            <projections start-index="199" stop-index="215">
+                <column-projection name="order_id" start-index="199" stop-index="206"/>
+                <column-projection name="user_id" start-index="209" stop-index="215"/>
+            </projections>
+        </select>
+    </create-table>
+
+    <create-table sql-case-id="create_table_as_select_with_query_hint">
+        <table name="t_order_new" start-index="13" stop-index="27" >
+            <owner name="dbo" start-index="13" stop-index="15"/>
+        </table>
+        <select>
+            <from>
+                <join-table>
+                    <left>
+                        <simple-table name="t_order" alias="o" start-index="111" stop-index="119" />
+                    </left>
+                    <right>
+                        <simple-table name="t_order_item" alias="i" start-index="126" stop-index="139" />
+                    </right>
+                    <on-condition>
+                        <binary-operation-expression start-index="144" stop-index="166">
+                            <left>
+                                <column name="order_id" start-index="144" stop-index="153">
+                                    <owner name="o" start-index="144" stop-index="144" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="157" stop-index="166">
+                                    <owner name="i" start-index="157" stop-index="157" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </on-condition>
+                </join-table>
+            </from>
+            <projections start-index="102" stop-index="104">
+                <shorthand-projection start-index="102" stop-index="104">
+                    <owner name="i" start-index="102" stop-index="102" />
+                </shorthand-projection>
+            </projections>
+        </select>
+    </create-table>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-table.xml
@@ -114,4 +114,7 @@
     <sql-case id="create_table_with_on_other_vendor_data_type" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, num MIDDLEINT(10))" db-types="MySQL" />
     <sql-case id="create_table_with_enum_and_character_set" value="CREATE TABLE t_order (order_id INT PRIMARY KEY, status ENUM('0', '1') CHARACTER SET UTF8)" db-types="MySQL" />
     <sql-case id="create_table_with_storage_parameter" value="CREATE TABLE t_order (order_id INT DEFAULT 0, user_id INT, status VARCHAR(10), column1 VARCHAR(10), column2 VARCHAR(10), column3 VARCHAR(10)) WITH (FILLFACTOR = 80, ORIENTATION=ROW)" db-types="openGauss" />
+    <sql-case id="create_table_as_select" value="CREATE TABLE t_order_new WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT * FROM t_order" db-types="SQLServer" />
+    <sql-case id="create_table_as_select_with_explicit_column_names" value="CREATE TABLE t_order_new (order_id_new, user_id_new) WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT order_id, user_id FROM t_order" db-types="SQLServer" />
+    <sql-case id="create_table_as_select_with_query_hint" value="CREATE TABLE dbo.t_order_new WITH (DISTRIBUTION = ROUND_ROBIN, CLUSTERED COLUMNSTORE INDEX) AS SELECT i.* FROM t_order o JOIN t_order_item i ON o.order_id = i.order_id OPTION ( HASH JOIN )" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
For #6478

Hi @jingshanglu, I've added SQLServer [CREATE TABLE AS SELECT](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-as-select-azure-sql-data-warehouse?view=aps-pdw-2016-au7#syntax) statement. Please check it. After successfully completing this PR, I'll add this statement into SQLServer `EXPLAIN` statement's `SQL_statement` (#13546).

Changes proposed in this pull request:
- Added  `CREATE TABLE AS SELECT` statement.
- Added corresponding test cases.
- In the  `CREATE TABLE AS SELECT` statement, seems like `OPTION <query_hint>` is not correct as it can't parse [`OPTION ( HASH JOIN )` ](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-as-select-azure-sql-data-warehouse?view=aps-pdw-2016-au7#examples-for-query-hints). I've found the option clause for query hint [here](https://docs.microsoft.com/en-us/sql/t-sql/queries/option-clause-transact-sql?view=aps-pdw-2016-au7#syntax-for--and-) and utilized it.