### PR TITLE
support for @ShardingSphereTransactionType(value = TransactionType.BASE)

### DIFF
--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/ConnectionTransaction.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/ConnectionTransaction.java
@@ -44,7 +44,7 @@ public final class ConnectionTransaction {
         this(schemaName, rule.getDefaultType(), transactionContexts);
     }
     
-    private ConnectionTransaction(final String schemaName, final TransactionType transactionType, final TransactionContexts transactionContexts) {
+    public ConnectionTransaction(final String schemaName, final TransactionType transactionType, final TransactionContexts transactionContexts) {
         this.transactionType = transactionType;
         transactionManager = transactionContexts.getEngines().get(schemaName).getTransactionManager(transactionType);
         TransactionTypeHolder.set(transactionType);


### PR DESCRIPTION


Fixes #13550 .

Changes proposed in this pull request:
- Get the `connectionTransaction` according to the `TransActiontype` in the annotation, throw an exception if you can't get it, and get `connectionTransaction` by config file.
- change `privite ConnectionTransaction(final String schemaName, final TransactionType transactionType, final TransactionContexts transactionContexts) ` to `public ConnectionTransaction(final String schemaName, final TransactionType transactionType, final TransactionContexts transactionContexts) {`


Test

- [x] MANUAL
- [ ] UT
- [ ] IT 
