### PR TITLE
fix SingleTableDataNode concurrent exception

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
@@ -244,7 +244,7 @@ public abstract class AbstractRoutingEngineTest {
     protected SingleTableRule createAllSingleTableRule(final Collection<ShardingSphereRule> rules) {
         Map<String, DataSource> dataSourceMap = createDataSourceMapWithMain();
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap, rules, new ConfigurationProperties(new Properties()));
-        singleTableRule.addDataNode("t_category", dataSourceMap.keySet().iterator().next());
+        singleTableRule.put("t_category", dataSourceMap.keySet().iterator().next());
         return singleTableRule;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/AlterTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/AlterTableStatementSchemaRefresher.java
@@ -51,13 +51,13 @@ public final class AlterTableStatementSchemaRefresher implements SchemaRefresher
     
     private void removeTableMetaData(final ShardingSphereMetaData schemaMetaData, final String tableName) {
         schemaMetaData.getSchema().remove(tableName);
-        schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.dropDataNode(tableName));
+        schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(tableName));
     }
     
     private void putTableMetaData(final ShardingSphereMetaData schemaMetaData, 
                                   final Collection<String> logicDataSourceNames, final String tableName, final ConfigurationProperties props) throws SQLException {
         if (!containsInDataNodeContainedRule(tableName, schemaMetaData)) {
-            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.addDataNode(tableName, logicDataSourceNames.iterator().next()));
+            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(tableName, logicDataSourceNames.iterator().next()));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 schemaMetaData.getResource().getDatabaseType(), schemaMetaData.getResource().getDataSources(), schemaMetaData.getRuleMetaData().getRules(), props);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -42,7 +42,7 @@ public final class CreateTableStatementSchemaRefresher implements SchemaRefreshe
                         final CreateTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
         if (!containsInDataNodeContainedRule(tableName, schemaMetaData)) {
-            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.addDataNode(tableName, logicDataSourceNames.iterator().next()));
+            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(tableName, logicDataSourceNames.iterator().next()));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 schemaMetaData.getResource().getDatabaseType(), schemaMetaData.getResource().getDataSources(), schemaMetaData.getRuleMetaData().getRules(), props);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -38,7 +38,7 @@ public final class CreateViewStatementSchemaRefresher implements SchemaRefresher
         TableMetaData tableMetaData = new TableMetaData();
         schemaMetaData.getSchema().put(viewName, tableMetaData);
         if (!containsInDataNodeContainedRule(viewName, schemaMetaData)) {
-            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.addDataNode(viewName, logicDataSourceNames.iterator().next()));
+            schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(viewName, logicDataSourceNames.iterator().next()));
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropTableStatementSchemaRefresher.java
@@ -36,7 +36,7 @@ public final class DropTableStatementSchemaRefresher implements SchemaRefresher<
         sqlStatement.getTables().forEach(each -> schemaMetaData.getSchema().remove(each.getTableName().getIdentifier().getValue()));
         Collection<MutableDataNodeRule> rules = schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getTables()) {
-            rules.forEach(rule -> rule.dropDataNode(each.getTableName().getIdentifier().getValue()));
+            rules.forEach(rule -> rule.remove(each.getTableName().getIdentifier().getValue()));
         }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/refresher/type/DropViewStatementSchemaRefresher.java
@@ -36,7 +36,7 @@ public final class DropViewStatementSchemaRefresher implements SchemaRefresher<D
         sqlStatement.getViews().forEach(each -> schemaMetaData.getSchema().remove(each.getTableName().getIdentifier().getValue()));
         Collection<MutableDataNodeRule> rules = schemaMetaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getViews()) {
-            rules.forEach(rule -> rule.dropDataNode(each.getTableName().getIdentifier().getValue()));
+            rules.forEach(rule -> rule.remove(each.getTableName().getIdentifier().getValue()));
         }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
@@ -30,12 +30,12 @@ public interface MutableDataNodeRule extends ShardingSphereRule {
      * @param tableName table name
      * @param dataSourceName data source name
      */
-    void addDataNode(String tableName, String dataSourceName);
+    void put(String tableName, String dataSourceName);
     
     /**
-     * Drop data node.
+     * Remove data node.
      *
      * @param tableName table name
      */
-    void dropDataNode(String tableName);
+    void remove(String tableName);
 }

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/FederationSchemaMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/FederationSchemaMetaData.java
@@ -20,9 +20,9 @@ package org.apache.shardingsphere.infra.optimize.metadata;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Federation schema meta data.
@@ -32,30 +32,31 @@ public final class FederationSchemaMetaData {
     
     private final String name;
     
-    private final Map<String, FederationTableMetaData> tables = new LinkedHashMap<>();
+    private final Map<String, FederationTableMetaData> tables;
     
     public FederationSchemaMetaData(final String name, final Map<String, TableMetaData> metaData) {
         this.name = name;
+        this.tables = new ConcurrentHashMap<>(metaData.size(), 1);
         for (Entry<String, TableMetaData> entry : metaData.entrySet()) {
-            tables.put(entry.getKey(), new FederationTableMetaData(entry.getValue().getName(), entry.getValue()));
+            tables.put(entry.getKey().toLowerCase(), new FederationTableMetaData(entry.getValue().getName(), entry.getValue()));
         }
     }
     
     /**
-     * Update table meta data.
+     * Add table meta data.
      * 
      * @param metaData table meta data to be updated
      */
-    public synchronized void update(final TableMetaData metaData) {
+    public void put(final TableMetaData metaData) {
         tables.put(metaData.getName().toLowerCase(), new FederationTableMetaData(metaData.getName(), metaData));
     }
     
     /**
-     * Remove table.
+     * Remove table meta data.
      * 
      * @param tableName table name to be removed
      */
-    public synchronized void remove(final String tableName) {
+    public void remove(final String tableName) {
         tables.remove(tableName.toLowerCase());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/refresher/type/AlterTableFederationMetaDataRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/refresher/type/AlterTableFederationMetaDataRefresher.java
@@ -40,10 +40,10 @@ public final class AlterTableFederationMetaDataRefresher implements FederationMe
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
         if (sqlStatement.getRenameTable().isPresent()) {
             String renameTableName = sqlStatement.getRenameTable().get().getTableName().getIdentifier().getValue();
-            buildTableMetaData(materials, renameTableName).ifPresent(schema::update);
+            buildTableMetaData(materials, renameTableName).ifPresent(schema::put);
             schema.remove(tableName);
         } else {
-            buildTableMetaData(materials, tableName).ifPresent(schema::update);
+            buildTableMetaData(materials, tableName).ifPresent(schema::put);
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/refresher/type/CreateTableFederationMetaDataRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-optimize/src/main/java/org/apache/shardingsphere/infra/optimize/metadata/refresher/type/CreateTableFederationMetaDataRefresher.java
@@ -38,6 +38,6 @@ public final class CreateTableFederationMetaDataRefresher implements FederationM
                         final CreateTableStatement sqlStatement, final SchemaBuilderMaterials materials) throws SQLException {
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
         Optional.ofNullable(TableMetaDataBuilder.load(Collections.singletonList(tableName), materials).get(tableName))
-                .map(each -> TableMetaDataBuilder.decorateFederationTableMetaData(each, materials.getRules())).ifPresent(schema::update);
+                .map(each -> TableMetaDataBuilder.decorateFederationTableMetaData(each, materials.getRules())).ifPresent(schema::put);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableDataNodeLoader.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableDataNodeLoader.java
@@ -32,7 +32,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Single table data node loader.
@@ -51,12 +51,12 @@ public final class SingleTableDataNodeLoader {
      */
     public static Map<String, SingleTableDataNode> load(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, 
                                                         final Collection<String> excludedTables, final ConfigurationProperties props) {
-        Map<String, SingleTableDataNode> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        Map<String, SingleTableDataNode> result = new ConcurrentHashMap<>();
         boolean checkDuplicateTable = props.getValue(ConfigurationPropertyKey.CHECK_DUPLICATE_TABLE_ENABLED);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             Map<String, SingleTableDataNode> dataNodeMap = load(databaseType, entry.getKey(), entry.getValue(), excludedTables);
             for (String each : dataNodeMap.keySet()) {
-                SingleTableDataNode existDataNode = result.putIfAbsent(each, dataNodeMap.get(each));
+                SingleTableDataNode existDataNode = result.putIfAbsent(each.toLowerCase(), dataNodeMap.get(each));
                 if (checkDuplicateTable) {
                     Preconditions.checkState(null == existDataNode, "Single table conflict, there are multiple tables `%s` existed.", each);
                 }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableDataNodeLoaderTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableDataNodeLoaderTest.java
@@ -109,11 +109,8 @@ public final class SingleTableDataNodeLoaderTest {
         assertFalse(dataNodeMap.containsKey("salary"));
         assertFalse(dataNodeMap.containsKey("student"));
         assertTrue(dataNodeMap.containsKey("dept"));
-        assertTrue(dataNodeMap.containsKey("DEPT"));
         assertTrue(dataNodeMap.containsKey("teacher"));
-        assertTrue(dataNodeMap.containsKey("TEACHER"));
         assertTrue(dataNodeMap.containsKey("class"));
-        assertTrue(dataNodeMap.containsKey("CLASS"));
         assertThat(dataNodeMap.get("dept").getDataSourceName(), is("ds0"));
         assertThat(dataNodeMap.get("teacher").getDataSourceName(), is("ds1"));
         assertThat(dataNodeMap.get("class").getDataSourceName(), is("ds1"));
@@ -138,11 +135,8 @@ public final class SingleTableDataNodeLoaderTest {
         assertFalse(dataNodeMap.containsKey("salary"));
         assertFalse(dataNodeMap.containsKey("student"));
         assertTrue(dataNodeMap.containsKey("dept"));
-        assertTrue(dataNodeMap.containsKey("DEPT"));
         assertTrue(dataNodeMap.containsKey("teacher"));
-        assertTrue(dataNodeMap.containsKey("TEACHER"));
         assertTrue(dataNodeMap.containsKey("class"));
-        assertTrue(dataNodeMap.containsKey("CLASS"));
         assertThat(dataNodeMap.get("dept").getDataSourceName(), is("ds0"));
         assertThat(dataNodeMap.get("teacher").getDataSourceName(), is("ds1"));
         assertThat(dataNodeMap.get("class").getDataSourceName(), is("ds1"));

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
@@ -30,7 +30,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +38,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -94,9 +94,8 @@ public final class SingleTableRuleTest {
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Map<String, SingleTableDataNode> actual = singleTableRule.getSingleTableDataNodes();
         assertThat(actual.size(), is(2));
-        Iterator<SingleTableDataNode> iterator = actual.values().iterator();
-        assertThat(iterator.next().getTableName(), is("employee"));
-        assertThat(iterator.next().getTableName(), is("student"));
+        assertTrue(actual.containsKey("employee"));
+        assertTrue(actual.containsKey("student"));
     }
     
     @Test
@@ -107,8 +106,7 @@ public final class SingleTableRuleTest {
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Map<String, SingleTableDataNode> actual = singleTableRule.getSingleTableDataNodes();
         assertThat(actual.size(), is(2));
-        Iterator<SingleTableDataNode> iterator = actual.values().iterator();
-        assertThat(iterator.next().getTableName(), is("employee"));
-        assertThat(iterator.next().getTableName(), is("student"));
+        assertTrue(actual.containsKey("employee"));
+        assertTrue(actual.containsKey("student"));
     }
 }

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
@@ -71,8 +71,8 @@ public final class EncryptSQLRewriterParameterizedTest extends AbstractSQLRewrit
     protected void mockRules(final Collection<ShardingSphereRule> rules) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().addDataNode("t_account", "encrypt_ds");
-            singleTableRule.get().addDataNode("t_account_bak", "encrypt_ds");
+            singleTableRule.get().put("t_account", "encrypt_ds");
+            singleTableRule.get().put("t_account_bak", "encrypt_ds");
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
@@ -72,8 +72,8 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
     protected void mockRules(final Collection<ShardingSphereRule> rules) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().addDataNode("t_single", "db");
-            singleTableRule.get().addDataNode("t_single_extend", "db");
+            singleTableRule.get().put("t_single", "db");
+            singleTableRule.get().put("t_single_extend", "db");
         }
     }
     


### PR DESCRIPTION
Fixes #13678.

Changes proposed in this pull request:
- modify SingleTableDataNode type to ConcurrentHashMap
- modify tables' type in FederationSchemaMetaData to ConcurrentHashMap, and remove synchronized lock
- use unified put and remove methods to declare metadata interfaces
