### PR TITLE
Add SQLServer CREATE REMOTE TABLE AS SELECT statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
@@ -20,7 +20,7 @@ grammar DDLStatement;
 import Symbol, Keyword, SQLServerKeyword, Literals, BaseRule, DMLStatement, DCLStatement;
 
 createTable
-    : CREATE TABLE tableName fileTableClause createDefinitionClause
+    : CREATE createTableSpecification TABLE tableName fileTableClause createDefinitionClause
     ;
 
 createIndex
@@ -148,7 +148,7 @@ fileTableClause
     ;
 
 createDefinitionClause
-    : createTableAsSelect? createTableDefinitions partitionScheme fileGroup
+    : createTableAsSelect? createRemoteTableAsSelect? createTableDefinitions partitionScheme fileGroup
     ;
 
 createTableDefinitions
@@ -1077,4 +1077,12 @@ withDistributionOption
 
 optionQueryHintClause
     : (OPTION LP_ queryHint (COMMA_ queryHint)* RP_)?
+    ;
+
+createTableSpecification
+    : REMOTE?
+    ;
+
+createRemoteTableAsSelect
+    : AT LP_ stringLiterals RP_ (WITH LP_ BATCH_SIZE EQ_ INT_NUM_ RP_)? AS select
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/Keyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/Keyword.g4
@@ -679,3 +679,7 @@ RETURN
 READONLY
     : R E A D O N L Y
     ;
+
+AT
+    : A T
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
@@ -1750,3 +1750,7 @@ EXPLAIN
 WITH_RECOMMENDATIONS
     : W I T H UL_ R E C O M M E N D A T I O N S
     ;
+
+BATCH_SIZE
+    : B A T C H UL_ S I Z E
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDDLStatementSQLVisitor.java
@@ -144,6 +144,8 @@ public final class SQLServerDDLStatementSQLVisitor extends SQLServerStatementSQL
                 }
             }
             result.setSelectStatement((SQLServerSelectStatement) visit(ctx.createDefinitionClause().createTableAsSelect().select()));
+        } else if (null != ctx.createDefinitionClause().createRemoteTableAsSelect()) {
+            result.setSelectStatement((SQLServerSelectStatement) visit(ctx.createDefinitionClause().createRemoteTableAsSelect().select()));
         } else {
             CollectionValue<CreateDefinitionSegment> createDefinitions = 
                     (CollectionValue<CreateDefinitionSegment>) generateCreateDefinitionSegment(ctx.createDefinitionClause().createTableDefinitions());

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/create-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/create-table.xml
@@ -1664,4 +1664,40 @@
             </projections>
         </select>
     </create-table>
+
+    <create-table sql-case-id="create_remote_table_as_select">
+        <table name="t_order_new" start-index="20" stop-index="30" />
+        <select>
+            <from>
+                <join-table>
+                    <left>
+                        <simple-table name="t_order_item" alias="i" start-index="119" stop-index="132" />
+                    </left>
+                    <right>
+                        <simple-table name="t_order" alias="o" start-index="139" stop-index="147" />
+                    </right>
+                    <on-condition>
+                        <binary-operation-expression start-index="152" stop-index="174">
+                            <left>
+                                <column name="order_id" start-index="152" stop-index="161">
+                                    <owner name="i" start-index="152" stop-index="152" />
+                                </column>
+                            </left>
+                            <operator>=</operator>
+                            <right>
+                                <column name="order_id" start-index="165" stop-index="174">
+                                    <owner name="o" start-index="165" stop-index="165" />
+                                </column>
+                            </right>
+                        </binary-operation-expression>
+                    </on-condition>
+                </join-table>
+            </from>
+            <projections start-index="110" stop-index="112">
+                <shorthand-projection start-index="110" stop-index="112">
+                    <owner name="i" start-index="110" stop-index="110" />
+                </shorthand-projection>
+            </projections>
+        </select>
+    </create-table>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/create-table.xml
@@ -117,4 +117,5 @@
     <sql-case id="create_table_as_select" value="CREATE TABLE t_order_new WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT * FROM t_order" db-types="SQLServer" />
     <sql-case id="create_table_as_select_with_explicit_column_names" value="CREATE TABLE t_order_new (order_id_new, user_id_new) WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT order_id, user_id FROM t_order" db-types="SQLServer" />
     <sql-case id="create_table_as_select_with_query_hint" value="CREATE TABLE dbo.t_order_new WITH (DISTRIBUTION = ROUND_ROBIN, CLUSTERED COLUMNSTORE INDEX) AS SELECT i.* FROM t_order o JOIN t_order_item i ON o.order_id = i.order_id OPTION ( HASH JOIN )" db-types="SQLServer" />
+    <sql-case id="create_remote_table_as_select" value="CREATE REMOTE TABLE t_order_new AT ('Data Source = ds_0, 3306; User ID = ROOT; Password = 123456;') AS SELECT i.* FROM t_order_item i JOIN t_order o ON i.order_id = o.order_id" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
For #6478

Hi @jingshanglu, @strongduanmu, @tuichenchuxin  I've added  [CREATE REMOTE TABLE AS SELECT](https://docs.microsoft.com/en-us/sql/t-sql/statements/create-remote-table-as-select-parallel-data-warehouse?view=aps-pdw-2016-au7) statement. Please check it.

Changes proposed in this pull request:
- Added  `CREATE REMOTE TABLE AS SELECT` statement.
- Added corresponding test case.
