### PR TITLE
Fixes #13621

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacket.java
@@ -69,9 +69,9 @@ public final class OpenGaussErrorResponsePacket implements PostgreSQLIdentifierP
         fillRequiredFieldsIfNecessary();
     }
     
-    public OpenGaussErrorResponsePacket(final PostgreSQLMessageSeverityLevel severityLevel, final String sqlState, final String message) {
+    public OpenGaussErrorResponsePacket(final String severityLevel, final String sqlState, final String message) {
         fields = new LinkedHashMap<>(4, 1);
-        fields.put(FIELD_TYPE_SEVERITY, severityLevel.name());
+        fields.put(FIELD_TYPE_SEVERITY, severityLevel);
         fields.put(FIELD_TYPE_CODE, sqlState);
         fields.put(FIELD_TYPE_MESSAGE, message);
         fillRequiredFieldsIfNecessary();

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacket.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.opengauss.packet.command.generic;
 
-import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLMessageSeverityLevel;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/test/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-opengauss/src/test/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/generic/OpenGaussErrorResponsePacketTest.java
@@ -83,7 +83,7 @@ public final class OpenGaussErrorResponsePacketTest {
     
     private OpenGaussErrorResponsePacket createErrorResponsePacket() {
         Map<Character, String> serverErrorMessages = new LinkedHashMap<>();
-        serverErrorMessages.put(OpenGaussErrorResponsePacket.FIELD_TYPE_SEVERITY, PostgreSQLMessageSeverityLevel.FATAL.name());
+        serverErrorMessages.put(OpenGaussErrorResponsePacket.FIELD_TYPE_SEVERITY, PostgreSQLMessageSeverityLevel.FATAL);
         serverErrorMessages.put(OpenGaussErrorResponsePacket.FIELD_TYPE_CODE, PostgreSQLErrorCode.INVALID_CATALOG_NAME.getErrorCode());
         serverErrorMessages.put(OpenGaussErrorResponsePacket.FIELD_TYPE_MESSAGE, "database \"test\" does not exist");
         serverErrorMessages.put(OpenGaussErrorResponsePacket.FIELD_TYPE_ERRORCODE, "-1");

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLMessageSeverityLevel.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLMessageSeverityLevel.java
@@ -22,7 +22,7 @@ package org.apache.shardingsphere.db.protocol.postgresql.constant;
  *
  * @see <a href="https://www.postgresql.org/docs/12/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS">Table 19.2. Message Severity Levels</a>
  */
-public class PostgreSQLMessageSeverityLevel {
+public final class PostgreSQLMessageSeverityLevel {
     
     public static final String DEBUG1 = "DEBUG1";
 

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLMessageSeverityLevel.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLMessageSeverityLevel.java
@@ -22,29 +22,29 @@ package org.apache.shardingsphere.db.protocol.postgresql.constant;
  *
  * @see <a href="https://www.postgresql.org/docs/12/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS">Table 19.2. Message Severity Levels</a>
  */
-public enum PostgreSQLMessageSeverityLevel {
+public class PostgreSQLMessageSeverityLevel {
     
-    DEBUG1,
-    
-    DEBUG2,
-    
-    DEBUG3,
-    
-    DEBUG4,
-    
-    DEBUG5,
-    
-    INFO,
-    
-    NOTICE,
-    
-    WARNING,
-    
-    ERROR,
-    
-    LOG,
-    
-    FATAL,
-    
-    PANIC
+    public static final String DEBUG1 = "DEBUG1";
+
+    public static final String DEBUG2 = "DEBUG2";
+
+    public static final String DEBUG3 = "DEBUG3";
+
+    public static final String DEBUG4 = "DEBUG4";
+
+    public static final String DEBUG5 = "DEBUG5";
+
+    public static final String INFO = "INFO";
+
+    public static final String NOTICE = "NOTICE";
+
+    public static final String WARNING = "WARNING";
+
+    public static final String ERROR = "ERROR";
+
+    public static final String LOG = "LOG";
+
+    public static final String FATAL = "FATAL";
+
+    public static final String PANIC = "PANIC";
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLErrorResponsePacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLErrorResponsePacket.java
@@ -112,7 +112,7 @@ public final class PostgreSQLErrorResponsePacket implements PostgreSQLIdentifier
      * @return PostgreSQL error response packet builder
      * @see <a href="https://www.postgresql.org/docs/12/protocol-error-fields.html">52.8. Error and Notice Message Fields</a>
      */
-    public static Builder newBuilder(final PostgreSQLMessageSeverityLevel severity, final PostgreSQLErrorCode postgreSQLErrorCode, final String message) {
+    public static Builder newBuilder(final String severity, final PostgreSQLErrorCode postgreSQLErrorCode, final String message) {
         return newBuilder(severity, postgreSQLErrorCode.getErrorCode(), message);
     }
     
@@ -125,7 +125,7 @@ public final class PostgreSQLErrorResponsePacket implements PostgreSQLIdentifier
      * @return PostgreSQL error response packet builder
      * @see <a href="https://www.postgresql.org/docs/12/protocol-error-fields.html">52.8. Error and Notice Message Fields</a>
      */
-    public static Builder newBuilder(final PostgreSQLMessageSeverityLevel severity, final String code, final String message) {
+    public static Builder newBuilder(final String severity, final String code, final String message) {
         return new Builder(severity, code, message);
     }
     
@@ -133,12 +133,12 @@ public final class PostgreSQLErrorResponsePacket implements PostgreSQLIdentifier
         
         private final Map<Character, String> fields = new LinkedHashMap<>(16, 1);
         
-        private Builder(final PostgreSQLMessageSeverityLevel severity, final String code, final String message) {
+        private Builder(final String severity, final String code, final String message) {
             Preconditions.checkArgument(null != severity, "The severity is always present!");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(code), "The SQLSTATE code is always present!");
             Preconditions.checkArgument(!Strings.isNullOrEmpty(message), "The message is always present!");
-            fields.put(FIELD_TYPE_SEVERITY, severity.name());
-            fields.put(FIELD_TYPE_SEVERITY_NON_LOCALIZED, severity.name());
+            fields.put(FIELD_TYPE_SEVERITY, severity);
+            fields.put(FIELD_TYPE_SEVERITY_NON_LOCALIZED, severity);
             fields.put(FIELD_TYPE_CODE, code);
             fields.put(FIELD_TYPE_MESSAGE, message);
         }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLErrorResponsePacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLErrorResponsePacket.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLErrorCode;
-import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLMessageSeverityLevel;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactory.java
@@ -73,7 +73,7 @@ public final class PostgreSQLErrPacketFactory {
     }
     
     private static PostgreSQLErrorResponsePacket createErrorResponsePacket(final ServerErrorMessage serverErrorMessage) {
-        return PostgreSQLErrorResponsePacket.newBuilder(PostgreSQLMessageSeverityLevel.valueOf(serverErrorMessage.getSeverity()), serverErrorMessage.getSQLState(), serverErrorMessage.getMessage())
+        return PostgreSQLErrorResponsePacket.newBuilder(serverErrorMessage.getSeverity(), serverErrorMessage.getSQLState(), serverErrorMessage.getMessage())
                 .detail(serverErrorMessage.getDetail()).hint(serverErrorMessage.getHint()).position(serverErrorMessage.getPosition())
                 .internalQueryAndInternalPosition(serverErrorMessage.getInternalQuery(), serverErrorMessage.getInternalPosition()).where(serverErrorMessage.getWhere())
                 .schemaName(serverErrorMessage.getSchema()).tableName(serverErrorMessage.getTable()).columnName(serverErrorMessage.getColumn()).dataTypeName(serverErrorMessage.getDatatype())

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactoryTest.java
@@ -37,7 +37,7 @@ public final class PostgreSQLErrPacketFactoryTest {
     @Test
     public void assertPSQLExceptionWithServerErrorMessageNotNull() throws NoSuchFieldException, IllegalAccessException {
         ServerErrorMessage serverErrorMessage = mock(ServerErrorMessage.class);
-        when(serverErrorMessage.getSeverity()).thenReturn(PostgreSQLMessageSeverityLevel.FATAL.name());
+        when(serverErrorMessage.getSeverity()).thenReturn(PostgreSQLMessageSeverityLevel.FATAL);
         when(serverErrorMessage.getSQLState()).thenReturn("sqlState");
         when(serverErrorMessage.getMessage()).thenReturn("message");
         when(serverErrorMessage.getPosition()).thenReturn(1);
@@ -45,7 +45,7 @@ public final class PostgreSQLErrPacketFactoryTest {
         Field packetField = PostgreSQLErrorResponsePacket.class.getDeclaredField("fields");
         packetField.setAccessible(true);
         Map<Character, String> fields = (Map<Character, String>) packetField.get(actual);
-        assertThat(fields.get(PostgreSQLErrorResponsePacket.FIELD_TYPE_SEVERITY), is(PostgreSQLMessageSeverityLevel.FATAL.name()));
+        assertThat(fields.get(PostgreSQLErrorResponsePacket.FIELD_TYPE_SEVERITY), is(PostgreSQLMessageSeverityLevel.FATAL));
         assertThat(fields.get(PostgreSQLErrorResponsePacket.FIELD_TYPE_CODE), is("sqlState"));
         assertThat(fields.get(PostgreSQLErrorResponsePacket.FIELD_TYPE_MESSAGE), is("message"));
         assertThat(fields.get(PostgreSQLErrorResponsePacket.FIELD_TYPE_POSITION), is("1"));


### PR DESCRIPTION
Fixes #13621.

Changes proposed in this pull request:
1、Change the enum PostgreSQLMessageSeverityLevel to a class, refactor each element to String.
2、Change the first parameter's type of org.apache.shardingsphere.db.protocol.postgresql.packet.generic.PostgreSQLErrorResponsePacket#newBuilder to String, so that we can pass the constants or severity directly to the method and no need to valueOf.