### PR TITLE
Complete SQLServer EXPLAIN statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
@@ -17,12 +17,12 @@
 
 grammar DALStatement;
 
-import SQLServerKeyword, DMLStatement;
+import SQLServerKeyword, DMLStatement, DDLStatement;
 
 explain
     : EXPLAIN WITH_RECOMMENDATIONS? explainableStatement
     ;
 
 explainableStatement
-    : select | insert | update | delete
+    : select | insert | update | delete | createTableAsSelectClause
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
@@ -20,7 +20,11 @@ grammar DDLStatement;
 import Symbol, Keyword, SQLServerKeyword, Literals, BaseRule, DMLStatement, DCLStatement;
 
 createTable
-    : CREATE createTableSpecification TABLE tableName fileTableClause createDefinitionClause
+    : createTableClause | createTableAsSelectClause
+    ;
+
+createTableClause
+    : CREATE TABLE tableName fileTableClause createDefinitionClause
     ;
 
 createIndex
@@ -148,11 +152,11 @@ fileTableClause
     ;
 
 createDefinitionClause
-    : createTableAsSelect? createRemoteTableAsSelect? createTableDefinitions partitionScheme fileGroup
+    : createTableDefinitions partitionScheme fileGroup
     ;
 
 createTableDefinitions
-    : (LP_ createTableDefinition (COMMA_ createTableDefinition)* (COMMA_ periodClause)? RP_)?
+    : LP_ createTableDefinition (COMMA_ createTableDefinition)* (COMMA_ periodClause)? RP_
     ;
 
 createTableDefinition
@@ -1067,8 +1071,16 @@ schemaElement
     : createTable | createView | grant | revoke | deny
     ;
 
+createTableAsSelectClause
+    : createTableAsSelect | createRemoteTableAsSelect
+    ;
+
 createTableAsSelect
-    : columnNames? withDistributionOption AS select optionQueryHintClause
+    : CREATE TABLE tableName columnNames? withDistributionOption AS select optionQueryHintClause
+    ;
+
+createRemoteTableAsSelect
+    : CREATE REMOTE TABLE tableName AT LP_ stringLiterals RP_ (WITH LP_ BATCH_SIZE EQ_ INT_NUM_ RP_)? AS select
     ;
 
 withDistributionOption
@@ -1077,12 +1089,4 @@ withDistributionOption
 
 optionQueryHintClause
     : (OPTION LP_ queryHint (COMMA_ queryHint)* RP_)?
-    ;
-
-createTableSpecification
-    : REMOTE?
-    ;
-
-createRemoteTableAsSelect
-    : AT LP_ stringLiterals RP_ (WITH LP_ BATCH_SIZE EQ_ INT_NUM_ RP_)? AS select
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDALStatementSQLVisitor.java
@@ -53,8 +53,10 @@ public final class SQLServerDALStatementSQLVisitor extends SQLServerStatementSQL
             return visit(ctx.insert());
         } else if (null != ctx.update()) {
             return visit(ctx.update());
-        } else {
+        } else if (null != ctx.delete()) {
             return visit(ctx.delete());
+        } else {
+            return visit(ctx.createTableAsSelectClause());
         }
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerStatementSQLVisitor.java
@@ -42,6 +42,7 @@ import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.Col
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ColumnNamesContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ColumnNamesWithSortContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.ConstraintNameContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.CreateTableAsSelectClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.CteClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DataTypeContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.DataTypeLengthContext;
@@ -162,6 +163,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.Number
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.parametermarker.ParameterMarkerValue;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerDeleteStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerInsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerSelectStatement;
@@ -1172,5 +1174,24 @@ public abstract class SQLServerStatementSQLVisitor extends SQLServerStatementBas
     @Override
     public ASTNode visitSubquery(final SubqueryContext ctx) {
         return visit(ctx.aggregationClause());
+    }
+    
+    @Override
+    public ASTNode visitCreateTableAsSelectClause(final CreateTableAsSelectClauseContext ctx) {
+        SQLServerCreateTableStatement result = new SQLServerCreateTableStatement();
+        if (null != ctx.createTableAsSelect()) {
+            result.setTable((SimpleTableSegment) visit(ctx.createTableAsSelect().tableName()));
+            result.setSelectStatement((SQLServerSelectStatement) visit(ctx.createTableAsSelect().select()));
+            if (null != ctx.createTableAsSelect().columnNames()) {
+                CollectionValue<ColumnSegment> columnSegments = (CollectionValue<ColumnSegment>) visit(ctx.createTableAsSelect().columnNames());
+                for (ColumnSegment each : columnSegments.getValue()) {
+                    result.getColumns().add(each);
+                }
+            }
+        } else {
+            result.setTable((SimpleTableSegment) visit(ctx.createRemoteTableAsSelect().tableName()));
+            result.setSelectStatement((SQLServerSelectStatement) visit(ctx.createRemoteTableAsSelect().select()));
+        }
+        return result;
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
@@ -53,6 +53,9 @@ public final class ExplainStatementAssert {
         } else if (null != expected.getDeleteClause()) {
             assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
             SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getDeleteClause());
+        } else if (null != expected.getCreateTableAsSelectClause()) {
+            assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
+            SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getCreateTableAsSelectClause());
         } else {
             assertFalse(assertContext.getText("Actual statement should not exist."), actual.getStatement().isPresent());
         }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.DeleteStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.InsertStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.SelectStatementTestCase;
@@ -45,5 +46,7 @@ public final class ExplainStatementTestCase extends SQLParserTestCase {
 
     @XmlElement(name = "delete")
     private DeleteStatementTestCase deleteClause;
-
+    
+    @XmlElement(name = "create-table")
+    private CreateTableStatementTestCase createTableAsSelectClause;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
@@ -123,4 +123,73 @@
             </where>
         </select>
     </describe>
+
+    <describe sql-case-id="explain_create_table_as_select">
+        <create-table>
+            <table name="t_order_new" start-index="21" stop-index="31" />
+            <select>
+                <from>
+                    <simple-table name="t_order" start-index="186" stop-index="192"/>
+                </from>
+                <projections start-index="179" stop-index="179">
+                    <shorthand-projection start-index="179" stop-index="179"/>
+                </projections>
+            </select>
+        </create-table>
+    </describe>
+
+    <describe sql-case-id="explain_create_table_as_select_with_explicit_column_names">
+        <create-table>
+            <table name="t_order_new" start-index="21" stop-index="31" />
+            <column name="order_id_new" start-index="34" stop-index="45" />
+            <column name="user_id_new" start-index="48" stop-index="58" />
+            <select>
+                <from>
+                    <simple-table name="t_order" start-index="230" stop-index="236"/>
+                </from>
+                <projections start-index="207" stop-index="223">
+                    <column-projection name="order_id" start-index="207" stop-index="214"/>
+                    <column-projection name="user_id" start-index="217" stop-index="223"/>
+                </projections>
+            </select>
+        </create-table>
+    </describe>
+
+    <describe sql-case-id="explain_create_remote_table_as_select">
+        <create-table>
+            <table name="t_order_new" start-index="28" stop-index="38" />
+            <select>
+                <from>
+                    <join-table>
+                        <left>
+                            <simple-table name="t_order_item" alias="i" start-index="127" stop-index="140" />
+                        </left>
+                        <right>
+                            <simple-table name="t_order" alias="o" start-index="147" stop-index="155" />
+                        </right>
+                        <on-condition>
+                            <binary-operation-expression start-index="160" stop-index="182">
+                                <left>
+                                    <column name="order_id" start-index="160" stop-index="169">
+                                        <owner name="i" start-index="160" stop-index="160" />
+                                    </column>
+                                </left>
+                                <operator>=</operator>
+                                <right>
+                                    <column name="order_id" start-index="173" stop-index="182">
+                                        <owner name="o" start-index="173" stop-index="173" />
+                                    </column>
+                                </right>
+                            </binary-operation-expression>
+                        </on-condition>
+                    </join-table>
+                </from>
+                <projections start-index="118" stop-index="120">
+                    <shorthand-projection start-index="118" stop-index="120">
+                        <owner name="i" start-index="118" stop-index="118" />
+                    </shorthand-projection>
+                </projections>
+            </select>
+        </create-table>
+    </describe>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
@@ -22,4 +22,7 @@
     <sql-case id="explain_insert_without_parameters" value="EXPLAIN INSERT INTO t_order (order_id, user_id, status) VALUES (1, 1, 'insert')" db-types="PostgreSQL, openGauss, MySQL, SQLServer" />
     <sql-case id="explain_delete_without_sharding_value" value="EXPLAIN DELETE FROM t_order WHERE status='init'" db-types="PostgreSQL, openGauss, MySQL, SQLServer" />
     <sql-case id="explain_select_with_binding_tables" value="EXPLAIN SELECT i.* FROM t_order o JOIN t_order_item i USING(order_id) WHERE o.order_id = 10" db-types="SQLServer" />
+    <sql-case id="explain_create_table_as_select" value="EXPLAIN CREATE TABLE t_order_new WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT * FROM t_order" db-types="SQLServer" />
+    <sql-case id="explain_create_table_as_select_with_explicit_column_names" value="EXPLAIN CREATE TABLE t_order_new (order_id_new, user_id_new) WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT order_id, user_id FROM t_order" db-types="SQLServer" />
+    <sql-case id="explain_create_remote_table_as_select" value="EXPLAIN CREATE REMOTE TABLE t_order_new AT ('Data Source = ds_0, 3306; User ID = ROOT; Password = 123456;') AS SELECT i.* FROM t_order_item i JOIN t_order o ON i.order_id = o.order_id" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
For #6478

Hi @jingshanglu, @strongduanmu, @tuichenchuxin I've completed SQLServer [EXPLAIN](https://docs.microsoft.com/en-us/sql/t-sql/queries/explain-transact-sql?view=azure-sqldw-latest#syntax) statement. Please check it.

Changes proposed in this pull request:
- Completed SQLServer `EXPLAIN` statement by adding `CREATE TABLE AS SELECT`, and `CREATE REMOTE TABLE AS SELECT` in the `explainableStatement`.
- Added corresponding test cases.
