### PR TITLE
Add spring namespace jpa and jdbc example and template

### DIFF
--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/java/org/apache/sharding/example/engine/SpringNamespaceJDBCGenerator.java
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/java/org/apache/sharding/example/engine/SpringNamespaceJDBCGenerator.java
@@ -35,8 +35,12 @@ public final class SpringNamespaceJDBCGenerator extends ExampleGenerateEngine {
         
         UN_NAME_TEMPLATE_MAP.put("entity/Order", "entity/Order.java");
         UN_NAME_TEMPLATE_MAP.put("entity/OrderItem", "entity/OrderItem.java");
-        
+        UN_NAME_TEMPLATE_MAP.put("entity/User", "entity/User.java");
+        UN_NAME_TEMPLATE_MAP.put("TestQueryAssistedShardingEncryptAlgorithm", "TestQueryAssistedShardingEncryptAlgorithm.java");
+
         RESOURCE_TEMPLATE_MAP.put("xml/application", "application.xml");
+        RESOURCE_TEMPLATE_MAP.put("log/logback", "logback.xml");
+        RESOURCE_TEMPLATE_MAP.put("spi/encryptAlgorithm", "META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm");
     }
     
     public SpringNamespaceJDBCGenerator() {

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/java/org/apache/sharding/example/engine/SpringNamespaceJpaGenerator.java
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/java/org/apache/sharding/example/engine/SpringNamespaceJpaGenerator.java
@@ -36,8 +36,11 @@ public final class SpringNamespaceJpaGenerator extends ExampleGenerateEngine {
         
         UN_NAME_TEMPLATE_MAP.put("entity/Order", "entity/Order.java");
         UN_NAME_TEMPLATE_MAP.put("entity/OrderItem", "entity/OrderItem.java");
-        
+        UN_NAME_TEMPLATE_MAP.put("TestQueryAssistedShardingEncryptAlgorithm", "TestQueryAssistedShardingEncryptAlgorithm.java");
+
         RESOURCE_TEMPLATE_MAP.put("xml/application", "application.xml");
+        RESOURCE_TEMPLATE_MAP.put("log/logback", "logback.xml");
+        RESOURCE_TEMPLATE_MAP.put("spi/encryptAlgorithm", "META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm");
     }
     
     public SpringNamespaceJpaGenerator() {

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/dataModel/spring-namespace-jpa/data-model.yaml
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/dataModel/spring-namespace-jpa/data-model.yaml
@@ -17,6 +17,6 @@
 
 mode: memory
 transaction: local
-feature: readwrite-splitting
+feature: encrypt
 framework: spring-namespace-jpa
 

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/TestQueryAssistedShardingEncryptAlgorithm.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/TestQueryAssistedShardingEncryptAlgorithm.ftl
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.encrypt.spi.QueryAssistedEncryptAlgorithm;
+
+import java.util.Properties;
+
+public final class TestQueryAssistedShardingEncryptAlgorithm implements QueryAssistedEncryptAlgorithm<Object, String> {
+
+    @Getter
+    @Setter
+    private Properties props;
+
+    @Override
+    public void init() {
+    }
+    
+    @Override
+    public String encrypt(final Object plainValue) {
+        return "encryptValue";
+    }
+    
+    @Override
+    public Object decrypt(final String cipherValue) {
+        return "decryptValue";
+    }
+    
+    @Override
+    public String queryAssistedEncrypt(final Object plainValue) {
+        return "assistedEncryptValue";
+    }
+    
+    @Override
+    public String getType() {
+        return "assistedTest";
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/ExampleService.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/ExampleService.ftl
@@ -1,91 +1,21 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
-
-import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.Order;
-import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.OrderItem;
-import org.springframework.stereotype.Service;
-
-import javax.annotation.Resource;
-import java.util.ArrayList;
-import java.util.List;
-
-<#assign frameworkName="">
-<#list framework?split("-") as framework1>
-    <#assign frameworkName=frameworkName + framework1?cap_first>
-</#list>
-<#assign featureName="">
-<#list feature?split("-") as feature1>
-    <#assign featureName=featureName + feature1?cap_first>
-</#list>
-@Service
-public final class ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}ExampleService {
-    
-    @Resource
-    private ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}Repository repository;
-
-    /**
-     * Execute test.
-     */
-    public void run() {
-        System.out.println("-------------- Process Success Begin ---------------");
-        List<Long> orderIds = insertData();
-        printData(); 
-        deleteData(orderIds);
-        printData();
-        System.out.println("-------------- Process Success Finish --------------");
-    }
-
-    private List<Long> insertData() {
-        System.out.println("---------------------------- Insert Data ----------------------------");
-        List<Long> result = new ArrayList<>(10);
-        for (int i = 1; i <= 10; i++) {
-            Order order = new Order();
-            order.setUserId(i);
-            order.setAddressId(i);
-            order.setStatus("INSERT_TEST");
-            repository.insertOrder(order);
-            OrderItem orderItem = new OrderItem();
-            orderItem.setOrderId(order.getOrderId());
-            orderItem.setUserId(i);
-            orderItem.setStatus("INSERT_TEST");
-            repository.insertOrderItem(orderItem);
-            result.add(order.getOrderId());
-        }
-        return result;
-    }
-
-    private void deleteData(final List<Long> orderIds) {
-        System.out.println("---------------------------- Delete Data ----------------------------");
-        for (Long each : orderIds) {
-            repository.deleteOrder(each);
-            repository.deleteOrderItem(each);
-        }
-    }
-    
-    private void printData() {
-        System.out.println("---------------------------- Print Order Data -----------------------");
-        for (Object each : repository.selectAllOrder()) {
-            System.out.println(each);
-        }
-        System.out.println("---------------------------- Print OrderItem Data -------------------");
-        for (Object each : repository.selectAllOrderItem()) {
-            System.out.println(each);
-        }
-    }
-}
+<#--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<#if feature=="encrypt">
+    <#include "encryptExampleService.ftl">
+<#else>
+    <#include "otherExampleService.ftl">
+</#if>

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/encryptExampleService.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/encryptExampleService.ftl
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
+
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.User;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+<#assign frameworkName="">
+<#list framework?split("-") as framework1>
+    <#assign frameworkName=frameworkName + framework1?cap_first>
+</#list>
+<#assign featureName="">
+<#list feature?split("-") as feature1>
+    <#assign featureName=featureName + feature1?cap_first>
+</#list>
+@Service
+public final class ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}ExampleService {
+
+    @Resource
+    private ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}Repository repository;
+
+    /**
+     * Execute test.
+     */
+    public void run() {
+        System.out.println("-------------- Process Success Begin ---------------");
+        List<Integer> usersIds = insertData();
+        printData(); 
+        deleteData(usersIds);
+        printData();
+        System.out.println("-------------- Process Success Finish --------------");
+    }
+
+    private List<Integer> insertData() {
+        System.out.println("---------------------------- Insert Data ----------------------------");
+        List<Integer> result = new ArrayList<>(10);
+        for (int i = 1; i <= 10; i++) {
+            User user = new User();
+            user.setUserName("test_" + i);
+            user.setPwd("pwd" + i);
+            repository.insertUser(user);
+            result.add(user.getUserId());
+        }
+        return result;
+    }
+
+    private void deleteData(final List<Integer> userIds) {
+        System.out.println("---------------------------- Delete Data ----------------------------");
+        for (Integer each : userIds) {
+            repository.deleteUser(each);
+        }
+    }
+    
+    private void printData() {
+        System.out.println("---------------------------- Print User Data -----------------------");
+        for (Object each : repository.selectAllUsers()) {
+            System.out.println(each);
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/encryptRepository.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/encryptRepository.ftl
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
+
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.User;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.transaction.Transactional;
+import java.util.List;
+
+<#assign frameworkName="">
+<#list framework?split("-") as framework1>
+    <#assign frameworkName=frameworkName + framework1?cap_first>
+</#list>
+<#assign featureName="">
+<#list feature?split("-") as feature1>
+    <#assign featureName=featureName + feature1?cap_first>
+</#list>
+@Repository
+@Transactional
+public class ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}Repository {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public int insertUser(final User user) {
+        entityManager.persist(user);
+        return user.getUserId();
+    }
+    
+    public List<User> selectAllUsers() {
+        return (List<User>) entityManager.createQuery("SELECT o FROM User o").getResultList();
+    }
+
+    public void deleteUser(final int userId) {
+        Query query = entityManager.createQuery("DELETE FROM User o WHERE o.userId = ?1");
+        query.setParameter(1, userId);
+        query.executeUpdate();
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/otherExampleService.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/otherExampleService.ftl
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
+
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.Order;
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.OrderItem;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+<#assign frameworkName="">
+<#list framework?split("-") as framework1>
+    <#assign frameworkName=frameworkName + framework1?cap_first>
+</#list>
+<#assign featureName="">
+<#list feature?split("-") as feature1>
+    <#assign featureName=featureName + feature1?cap_first>
+</#list>
+@Service
+public final class ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}ExampleService {
+    
+    @Resource
+    private ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}Repository repository;
+
+    /**
+     * Execute test.
+     */
+    public void run() {
+        System.out.println("-------------- Process Success Begin ---------------");
+        List<Long> orderIds = insertData();
+        printData(); 
+        deleteData(orderIds);
+        printData();
+        System.out.println("-------------- Process Success Finish --------------");
+    }
+
+    private List<Long> insertData() {
+        System.out.println("---------------------------- Insert Data ----------------------------");
+        List<Long> result = new ArrayList<>(10);
+        for (int i = 1; i <= 10; i++) {
+            Order order = new Order();
+            order.setUserId(i);
+            order.setAddressId(i);
+            order.setStatus("INSERT_TEST");
+            repository.insertOrder(order);
+            OrderItem orderItem = new OrderItem();
+            orderItem.setOrderId(order.getOrderId());
+            orderItem.setUserId(i);
+            orderItem.setStatus("INSERT_TEST");
+            repository.insertOrderItem(orderItem);
+            result.add(order.getOrderId());
+        }
+        return result;
+    }
+
+    private void deleteData(final List<Long> orderIds) {
+        System.out.println("---------------------------- Delete Data ----------------------------");
+        for (Long each : orderIds) {
+            repository.deleteOrder(each);
+            repository.deleteOrderItem(each);
+        }
+    }
+    
+    private void printData() {
+        System.out.println("---------------------------- Print Order Data -----------------------");
+        for (Object each : repository.selectAllOrder()) {
+            System.out.println(each);
+        }
+        System.out.println("---------------------------- Print OrderItem Data -------------------");
+        for (Object each : repository.selectAllOrderItem()) {
+            System.out.println(each);
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/otherRepository.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/jpa/otherRepository.ftl
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')};
+
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.Order;
+import org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity.OrderItem;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.transaction.Transactional;
+import java.util.List;
+
+<#assign frameworkName="">
+<#list framework?split("-") as framework1>
+    <#assign frameworkName=frameworkName + framework1?cap_first>
+</#list>
+<#assign featureName="">
+<#list feature?split("-") as feature1>
+    <#assign featureName=featureName + feature1?cap_first>
+</#list>
+@Repository
+@Transactional
+public class ${mode?cap_first}${transaction?cap_first}${featureName}${frameworkName}Repository {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public Long insertOrder(final Order order) {
+        entityManager.persist(order);
+        return order.getOrderId();
+    }
+
+    public Long insertOrderItem(final OrderItem orderItem) {
+        entityManager.persist(orderItem);
+        return orderItem.getOrderItemId();
+    }
+    
+    public List<Order> selectAllOrder() {
+        return (List<Order>) entityManager.createQuery("SELECT o FROM Order o").getResultList();
+    }
+    
+    public List<OrderItem> selectAllOrderItem() {
+        return (List<OrderItem>) entityManager.createQuery("SELECT o from OrderItem o").getResultList();
+    }
+
+    public void deleteOrder(final Long orderId) {
+        Query query = entityManager.createQuery("DELETE FROM Order o WHERE o.orderId = ?1");
+        query.setParameter(1, orderId);
+        query.executeUpdate();
+    }
+
+    public void deleteOrderItem(final Long orderId) {
+        Query query = entityManager.createQuery("DELETE FROM OrderItem i WHERE i.orderId = ?1");
+        query.setParameter(1, orderId);
+        query.executeUpdate();
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/spi/encryptAlgorithm.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/spi/encryptAlgorithm.ftl
@@ -15,8 +15,4 @@
 # limitations under the License.
 #
 
-mode: memory
-transaction: local
-feature: encrypt
-framework: spring-namespace-jdbc
-
+org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.TestQueryAssistedShardingEncryptAlgorithm

--- a/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/xml/encryptApplication.ftl
+++ b/examples/shardingsphere-sample/shardingsphere-example-engine/src/main/resources/template/xml/encryptApplication.ftl
@@ -14,8 +14,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<#if feature=="encrypt">
-    <#include "encryptRepository.ftl">
-<#else>
-    <#include "otherRepository.ftl">
-</#if>
+    
+    <encrypt:encrypt-algorithm id="name_encryptor" type="AES">
+        <props>
+            <prop key="aes-key-value">123456</prop>
+        </props>
+    </encrypt:encrypt-algorithm>
+    <encrypt:encrypt-algorithm id="pwd_encryptor" type="assistedTest" />
+    
+    <encrypt:rule id="encryptRule">
+        <encrypt:table name="t_user">
+            <encrypt:column logic-column="user_name" cipher-column="user_name" plain-column="user_name_plain" encrypt-algorithm-ref="name_encryptor" />
+            <encrypt:column logic-column="pwd" cipher-column="pwd" assisted-query-column="assisted_query_pwd" encrypt-algorithm-ref="pwd_encryptor" />
+        </encrypt:table>
+    </encrypt:rule>
+    
+    <shardingsphere:data-source id="dataSource" data-source-names="demo_ds_0" rule-refs="encryptRule" />
+

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/pom.xml
@@ -33,9 +33,5 @@
         <module>shardingsphere-jdbc-memory-local-encrypt-jdbc-example</module>
         <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example</module>
         <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-mybatis-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-mybatis-example</module>
     </modules>
 </project>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/pom.xml
@@ -20,22 +20,24 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>shardingsphere-jdbc-memory-local-example</artifactId>
+        <artifactId>shardingsphere-jdbc-memory-local-encrypt-example</artifactId>
         <groupId>org.apache.shardingsphere.example</groupId>
         <version>5.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
-    <artifactId>shardingsphere-jdbc-memory-local-encrypt-example</artifactId>
+    <artifactId>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example</artifactId>
     <name>${project.artifactId}</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core-spring-namespace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.1.5.RELEASE</version>
+        </dependency>
+    </dependencies>
     
-    <modules>
-        <module>shardingsphere-jdbc-memory-local-encrypt-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-mybatis-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-mybatis-example</module>
-    </modules>
 </project>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/MemoryLocalEncryptSpringNamespaceJdbcExample.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/MemoryLocalEncryptSpringNamespaceJdbcExample.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import java.sql.SQLException;
+
+public class MemoryLocalEncryptSpringNamespaceJdbcExample {
+    
+    public static void main(final String[] args) throws SQLException {
+        try (ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext("application.xml")) {
+            MemoryLocalEncryptSpringNamespaceJdbcExampleService exampleService = applicationContext.getBean(MemoryLocalEncryptSpringNamespaceJdbcExampleService.class);
+            exampleService.run();
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/MemoryLocalEncryptSpringNamespaceJdbcExampleService.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/MemoryLocalEncryptSpringNamespaceJdbcExampleService.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc;
+
+import lombok.AllArgsConstructor;
+import org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc.entity.User;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+public final class MemoryLocalEncryptSpringNamespaceJdbcExampleService {
+    
+    private final DataSource dataSource;
+
+    /**
+     * Execute test.
+     *
+     * @throws SQLException
+     */
+    public void run() throws SQLException {
+        try {
+            this.initEnvironment();
+            this.processSuccess();
+        } finally {
+            this.cleanEnvironment();
+        }
+    }
+
+
+    /**
+     * Initialize the database test environment.
+     * @throws SQLException
+     */
+    private void initEnvironment() throws SQLException {
+        String createUserTableSql = "CREATE TABLE IF NOT EXISTS t_user" 
+                + "(user_id INT NOT NULL AUTO_INCREMENT, user_name VARCHAR(200), pwd VARCHAR(200), PRIMARY KEY (user_id))";
+        String truncateUserTable = "TRUNCATE TABLE t_user";
+        
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(createUserTableSql);
+            statement.executeUpdate(truncateUserTable);
+        }
+    }
+    
+    private void processSuccess() throws SQLException {
+        System.out.println("-------------- Process Success Begin ---------------");
+        List<Long> ids = insertData();
+        printData(); 
+        deleteData(ids);
+        printData();
+        System.out.println("-------------- Process Success Finish --------------");
+    }
+
+    private List<Long> insertData() throws SQLException {
+        System.out.println("---------------------------- Insert Data ----------------------------");
+        List<Long> result = new ArrayList<>(10);
+        for (int i = 1; i <= 10; i++) {
+            User user = new User();
+            user.setUserId(i);
+            user.setUserName("test_" + i);
+            user.setPwd("pwd" + i);
+            insert(user);
+            result.add((long) user.getUserId());
+        }
+        return result;
+    }
+    
+    private long insert(final User user) throws SQLException {
+        String sql = "INSERT INTO t_user (user_id, user_name, pwd) VALUES (?, ?, ?)";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            preparedStatement.setInt(1, user.getUserId());
+            preparedStatement.setString(2, user.getUserName());
+            preparedStatement.setString(3, user.getPwd());
+            preparedStatement.executeUpdate();
+        }
+        return user.getUserId();
+    }
+
+    private void deleteData(final List<Long> orderIds) throws SQLException {
+        System.out.println("---------------------------- Delete Data ----------------------------");
+        String sql = "DELETE FROM t_user WHERE user_id=?";
+        for (Long each : orderIds) {
+            try (Connection connection = dataSource.getConnection();
+                 PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+                preparedStatement.setLong(1, each);
+                preparedStatement.executeUpdate();
+            }
+        }
+    }
+    
+    private void printData() throws SQLException {
+        System.out.println("---------------------------- Print User Data -----------------------");
+        for (Object each : this.getUsers()) {
+            System.out.println(each);
+        }
+    }
+
+    protected List<User> getUsers() throws SQLException {
+        List<User> result = new LinkedList<>();
+        String sql = "SELECT * FROM t_user";
+        try (Connection connection = dataSource.getConnection();
+             PreparedStatement preparedStatement = connection.prepareStatement(sql);
+             ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                User user = new User();
+                user.setUserId(resultSet.getInt("user_id"));
+                user.setUserName(resultSet.getString("user_name"));
+                user.setPwd(resultSet.getString("pwd"));
+                result.add(user);
+            }
+        }
+        return result;
+    }
+    
+    /**
+     * Restore the environment.
+     * @throws SQLException
+     */
+    private void cleanEnvironment() throws SQLException {
+        String dropUserSql = "DROP TABLE t_user";
+        try (Connection connection = dataSource.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.executeUpdate(dropUserSql);
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/TestQueryAssistedShardingEncryptAlgorithm.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/TestQueryAssistedShardingEncryptAlgorithm.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.encrypt.spi.QueryAssistedEncryptAlgorithm;
+
+import java.util.Properties;
+
+public final class TestQueryAssistedShardingEncryptAlgorithm implements QueryAssistedEncryptAlgorithm<Object, String> {
+
+    @Getter
+    @Setter
+    private Properties props;
+
+    @Override
+    public void init() {
+    }
+    
+    @Override
+    public String encrypt(final Object plainValue) {
+        return "encryptValue";
+    }
+    
+    @Override
+    public Object decrypt(final String cipherValue) {
+        return "decryptValue";
+    }
+    
+    @Override
+    public String queryAssistedEncrypt(final Object plainValue) {
+        return "assistedEncryptValue";
+    }
+    
+    @Override
+    public String getType() {
+        return "assistedTest";
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/entity/User.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jdbc/entity/User.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc.entity;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+    
+    private static final long serialVersionUID = 263434701950670170L;
+    
+    private int userId;
+    
+    private String userName;
+    
+    private String pwd;
+    
+    public int getUserId() {
+        return userId;
+    }
+    
+    public void setUserId(final int userId) {
+        this.userId = userId;
+    }
+    
+    public String getUserName() {
+        return userName;
+    }
+    
+    public void setUserName(final String userName) {
+        this.userName = userName;
+    }
+    
+    public String getPwd() {
+        return pwd;
+    }
+    
+    public void setPwd(final String pwd) {
+        this.pwd = pwd;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("user_id: %d, user_name: %s, pwd: %s", userId, userName, pwd);
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm
@@ -15,8 +15,4 @@
 # limitations under the License.
 #
 
-mode: memory
-transaction: local
-feature: encrypt
-framework: spring-namespace-jdbc
-
+org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc.TestQueryAssistedShardingEncryptAlgorithm

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/application.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/application.xml
@@ -41,25 +41,7 @@
                            http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd
                            ">
     <context:annotation-config />
-    <context:component-scan base-package="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}"/>
-<#if framework=="spring-namespace-jpa">
-    <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
-        <property name="dataSource" ref="dataSource" />
-        <property name="jpaVendorAdapter">
-            <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter" p:database="MYSQL" />
-        </property>
-        <property name="packagesToScan" value="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity" />
-        <property name="jpaProperties">
-            <props>
-                <prop key="hibernate.dialect">org.hibernate.dialect.MySQL5Dialect</prop>
-                <prop key="hibernate.hbm2ddl.auto">create-drop</prop>
-                <prop key="hibernate.show_sql">false</prop>
-            </props>
-        </property>
-    </bean>
-    <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager" p:entityManagerFactory-ref="entityManagerFactory" />
-    <tx:annotation-driven />
-</#if>
+    <context:component-scan base-package="org.apache.shardingsphere.example.encrypt.spring.namespace.jdbc"/>
     
     <bean id="demo_ds_0" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="com.mysql.jdbc.Driver"/>
@@ -74,28 +56,22 @@
         <property name="username" value="root"/>
         <property name="password" value="123456"/>
     </bean>
-<#if feature=="sharding">
-    <#include "shardingApplication.ftl">
-<#elseif feature=="readwrite-splitting">
-    <#include "readwriteSplittingApplication.ftl">
-<#elseif feature=="encrypt">
-    <#include "encryptApplication.ftl">
-</#if>
     
-<#if framework=="spring-namespace-mybatis">
-    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="dataSource" />
-    </bean>
-    <tx:annotation-driven />
+    <encrypt:encrypt-algorithm id="name_encryptor" type="AES">
+        <props>
+            <prop key="aes-key-value">123456</prop>
+        </props>
+    </encrypt:encrypt-algorithm>
+    <encrypt:encrypt-algorithm id="pwd_encryptor" type="assistedTest" />
+    
+    <encrypt:rule id="encryptRule">
+        <encrypt:table name="t_user">
+            <encrypt:column logic-column="user_name" cipher-column="user_name" plain-column="user_name_plain" encrypt-algorithm-ref="name_encryptor" />
+            <encrypt:column logic-column="pwd" cipher-column="pwd" assisted-query-column="assisted_query_pwd" encrypt-algorithm-ref="pwd_encryptor" />
+        </encrypt:table>
+    </encrypt:rule>
+    
+    <shardingsphere:data-source id="dataSource" data-source-names="demo_ds_0" rule-refs="encryptRule" />
 
-    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="mapperLocations" value="classpath*:mappers/*.xml"/>
-    </bean>
-
-    <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-        <property name="basePackage" value="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.repository"/>
-        <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-    </bean>
-</#if>
+    
 </beans>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/logback.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with
   ~ this work for additional information regarding copyright ownership.
@@ -14,8 +15,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<#if feature=="encrypt">
-    <#include "encryptRepository.ftl">
-<#else>
-    <#include "otherRepository.ftl">
-</#if>
+
+<configuration>
+    <property name="log.context.name" value="shardingsphere-example" />
+    <property name="log.charset" value="UTF-8" />
+    <property name="log.pattern" value="[%-5level] %date --%thread-- [%logger] %msg %n" />
+    <contextName>${log.context.name}</contextName>
+    
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder charset="${log.charset}">
+            <pattern>${log.pattern}</pattern>
+        </encoder>
+    </appender>
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/pom.xml
@@ -20,22 +20,38 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>shardingsphere-jdbc-memory-local-example</artifactId>
+        <artifactId>shardingsphere-jdbc-memory-local-encrypt-example</artifactId>
         <groupId>org.apache.shardingsphere.example</groupId>
         <version>5.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>pom</packaging>
-    <artifactId>shardingsphere-jdbc-memory-local-encrypt-example</artifactId>
+    <artifactId>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>shardingsphere-jdbc-memory-local-encrypt-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-spring-namespace-mybatis-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jdbc-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-jpa-example</module>
-        <module>shardingsphere-jdbc-memory-local-encrypt-springboot-starter-mybatis-example</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core-spring-namespace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-orm</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context-support</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaExample.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaExample.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jpa;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+import java.sql.SQLException;
+
+public class MemoryLocalEncryptSpringNamespaceJpaExample {
+    
+    public static void main(final String[] args) throws SQLException {
+        try (ConfigurableApplicationContext applicationContext = new ClassPathXmlApplicationContext("application.xml")) {
+            MemoryLocalEncryptSpringNamespaceJpaExampleService exampleService = applicationContext.getBean(MemoryLocalEncryptSpringNamespaceJpaExampleService.class);
+            exampleService.run();
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaExampleService.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaExampleService.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jpa;
+
+import org.apache.shardingsphere.example.encrypt.spring.namespace.jpa.entity.User;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public final class MemoryLocalEncryptSpringNamespaceJpaExampleService {
+
+    @Resource
+    private MemoryLocalEncryptSpringNamespaceJpaRepository repository;
+
+    /**
+     * Execute test.
+     */
+    public void run() {
+        System.out.println("-------------- Process Success Begin ---------------");
+        List<Integer> usersIds = insertData();
+        printData(); 
+        deleteData(usersIds);
+        printData();
+        System.out.println("-------------- Process Success Finish --------------");
+    }
+
+    private List<Integer> insertData() {
+        System.out.println("---------------------------- Insert Data ----------------------------");
+        List<Integer> result = new ArrayList<>(10);
+        for (int i = 1; i <= 10; i++) {
+            User user = new User();
+            user.setUserName("test_" + i);
+            user.setPwd("pwd" + i);
+            repository.insertUser(user);
+            result.add(user.getUserId());
+        }
+        return result;
+    }
+
+    private void deleteData(final List<Integer> userIds) {
+        System.out.println("---------------------------- Delete Data ----------------------------");
+        for (Integer each : userIds) {
+            repository.deleteUser(each);
+        }
+    }
+    
+    private void printData() {
+        System.out.println("---------------------------- Print User Data -----------------------");
+        for (Object each : repository.selectAllUsers()) {
+            System.out.println(each);
+        }
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaRepository.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/MemoryLocalEncryptSpringNamespaceJpaRepository.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jpa;
+
+import org.apache.shardingsphere.example.encrypt.spring.namespace.jpa.entity.User;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Repository
+@Transactional
+public class MemoryLocalEncryptSpringNamespaceJpaRepository {
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    public int insertUser(final User user) {
+        entityManager.persist(user);
+        return user.getUserId();
+    }
+    
+    public List<User> selectAllUsers() {
+        return (List<User>) entityManager.createQuery("SELECT o FROM User o").getResultList();
+    }
+
+    public void deleteUser(final int userId) {
+        Query query = entityManager.createQuery("DELETE FROM User o WHERE o.userId = ?1");
+        query.setParameter(1, userId);
+        query.executeUpdate();
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/TestQueryAssistedShardingEncryptAlgorithm.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/TestQueryAssistedShardingEncryptAlgorithm.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jpa;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.encrypt.spi.QueryAssistedEncryptAlgorithm;
+
+import java.util.Properties;
+
+public final class TestQueryAssistedShardingEncryptAlgorithm implements QueryAssistedEncryptAlgorithm<Object, String> {
+
+    @Getter
+    @Setter
+    private Properties props;
+
+    @Override
+    public void init() {
+    }
+    
+    @Override
+    public String encrypt(final Object plainValue) {
+        return "encryptValue";
+    }
+    
+    @Override
+    public Object decrypt(final String cipherValue) {
+        return "decryptValue";
+    }
+    
+    @Override
+    public String queryAssistedEncrypt(final Object plainValue) {
+        return "assistedEncryptValue";
+    }
+    
+    @Override
+    public String getType() {
+        return "assistedTest";
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/entity/User.java
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/java/org/apache/shardingsphere/example/encrypt/spring/namespace/jpa/entity/User.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.example.encrypt.spring.namespace.jpa.entity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.io.Serializable;
+
+@Entity
+@Table(name = "t_user")
+public class User implements Serializable {
+    
+    private static final long serialVersionUID = 263434701950670170L;
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int userId;
+
+    @Column(name = "user_name")
+    private String userName;
+
+    @Column(name = "pwd")
+    private String pwd;
+    
+    public int getUserId() {
+        return userId;
+    }
+    
+    public void setUserId(final int userId) {
+        this.userId = userId;
+    }
+    
+    public String getUserName() {
+        return userName;
+    }
+    
+    public void setUserName(final String userName) {
+        this.userName = userName;
+    }
+    
+    public String getPwd() {
+        return pwd;
+    }
+    
+    public void setPwd(final String pwd) {
+        this.pwd = pwd;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("user_id: %d, user_name: %s, pwd: %s", userId, userName, pwd);
+    }
+}

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/META-INF/services/org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm
@@ -15,8 +15,4 @@
 # limitations under the License.
 #
 
-mode: memory
-transaction: local
-feature: encrypt
-framework: spring-namespace-jdbc
-
+org.apache.shardingsphere.example.encrypt.spring.namespace.jpa.TestQueryAssistedShardingEncryptAlgorithm

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/application.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/application.xml
@@ -41,14 +41,13 @@
                            http://shardingsphere.apache.org/schema/shardingsphere/encrypt/encrypt.xsd
                            ">
     <context:annotation-config />
-    <context:component-scan base-package="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}"/>
-<#if framework=="spring-namespace-jpa">
+    <context:component-scan base-package="org.apache.shardingsphere.example.encrypt.spring.namespace.jpa"/>
     <bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
         <property name="dataSource" ref="dataSource" />
         <property name="jpaVendorAdapter">
             <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter" p:database="MYSQL" />
         </property>
-        <property name="packagesToScan" value="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.entity" />
+        <property name="packagesToScan" value="org.apache.shardingsphere.example.encrypt.spring.namespace.jpa.entity" />
         <property name="jpaProperties">
             <props>
                 <prop key="hibernate.dialect">org.hibernate.dialect.MySQL5Dialect</prop>
@@ -59,13 +58,12 @@
     </bean>
     <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager" p:entityManagerFactory-ref="entityManagerFactory" />
     <tx:annotation-driven />
-</#if>
     
     <bean id="demo_ds_0" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
         <property name="driverClassName" value="com.mysql.jdbc.Driver"/>
-        <property name="jdbcUrl" value="jdbc:mysql://localhost:3307/demo_ds_0?serverTimezone=UTC&amp;useSSL=false&amp;useUnicode=true&amp;characterEncoding=UTF-8"/>
+        <property name="jdbcUrl" value="jdbc:mysql://localhost:3306/demo_ds_0?serverTimezone=UTC&amp;useSSL=false&amp;useUnicode=true&amp;characterEncoding=UTF-8"/>
         <property name="username" value="root"/>
-        <property name="password" value="123456"/>
+        <property name="password" value="root"/>
     </bean>
     
     <bean id="demo_ds_1" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
@@ -74,28 +72,22 @@
         <property name="username" value="root"/>
         <property name="password" value="123456"/>
     </bean>
-<#if feature=="sharding">
-    <#include "shardingApplication.ftl">
-<#elseif feature=="readwrite-splitting">
-    <#include "readwriteSplittingApplication.ftl">
-<#elseif feature=="encrypt">
-    <#include "encryptApplication.ftl">
-</#if>
     
-<#if framework=="spring-namespace-mybatis">
-    <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-        <property name="dataSource" ref="dataSource" />
-    </bean>
-    <tx:annotation-driven />
+    <encrypt:encrypt-algorithm id="name_encryptor" type="AES">
+        <props>
+            <prop key="aes-key-value">123456</prop>
+        </props>
+    </encrypt:encrypt-algorithm>
+    <encrypt:encrypt-algorithm id="pwd_encryptor" type="assistedTest" />
+    
+    <encrypt:rule id="encryptRule">
+        <encrypt:table name="t_user">
+            <encrypt:column logic-column="user_name" cipher-column="user_name" plain-column="user_name_plain" encrypt-algorithm-ref="name_encryptor" />
+            <encrypt:column logic-column="pwd" cipher-column="pwd" assisted-query-column="assisted_query_pwd" encrypt-algorithm-ref="pwd_encryptor" />
+        </encrypt:table>
+    </encrypt:rule>
+    
+    <shardingsphere:data-source id="dataSource" data-source-names="demo_ds_0" rule-refs="encryptRule" />
 
-    <bean id="sqlSessionFactory" class="org.mybatis.spring.SqlSessionFactoryBean">
-        <property name="dataSource" ref="dataSource"/>
-        <property name="mapperLocations" value="classpath*:mappers/*.xml"/>
-    </bean>
-
-    <bean class="org.mybatis.spring.mapper.MapperScannerConfigurer">
-        <property name="basePackage" value="org.apache.shardingsphere.example.${feature?replace('-', '.')}.${framework?replace('-', '.')}.repository"/>
-        <property name="sqlSessionFactoryBeanName" value="sqlSessionFactory"/>
-    </bean>
-</#if>
+    
 </beans>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/logback.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jpa-example/src/main/resources/logback.xml
@@ -1,4 +1,5 @@
-<#--
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
   ~ Licensed to the Apache Software Foundation (ASF) under one or more
   ~ contributor license agreements.  See the NOTICE file distributed with
   ~ this work for additional information regarding copyright ownership.
@@ -14,8 +15,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<#if feature=="encrypt">
-    <#include "encryptRepository.ftl">
-<#else>
-    <#include "otherRepository.ftl">
-</#if>
+
+<configuration>
+    <property name="log.context.name" value="shardingsphere-example" />
+    <property name="log.charset" value="UTF-8" />
+    <property name="log.pattern" value="[%-5level] %date --%thread-- [%logger] %msg %n" />
+    <contextName>${log.context.name}</contextName>
+    
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder charset="${log.charset}">
+            <pattern>${log.pattern}</pattern>
+        </encoder>
+    </appender>
+    <root>
+        <level value="INFO" />
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-readwrite-splitting-example/shardingsphere-jdbc-memory-local-readwrite-splitting-spring-namespace-jpa-example/src/main/resources/application.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-readwrite-splitting-example/shardingsphere-jdbc-memory-local-readwrite-splitting-spring-namespace-jpa-example/src/main/resources/application.xml
@@ -44,7 +44,7 @@
         <property name="jpaVendorAdapter">
             <bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter" p:database="MYSQL" />
         </property>
-        <property name="packagesToScan" value="org.apache.shardingsphere.example.readwrite-splitting.spring.namespace.jpa.entity" />
+        <property name="packagesToScan" value="org.apache.shardingsphere.example.readwrite.splitting.spring.namespace.jpa.entity" />
         <property name="jpaProperties">
             <props>
                 <prop key="hibernate.dialect">org.hibernate.dialect.MySQL5Dialect</prop>


### PR DESCRIPTION
For #12366.

Changes proposed in this pull request:
- add local-memory-spring-namespace-jdbc-example and template
- add local-memory-spring-namespace-jda-example and template
