### PR TITLE
For #13737, Improve RQL results for readwrite_splitting rules.

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-api/src/main/java/org/apache/shardingsphere/readwritesplitting/constant/ReadwriteSplittingRuleConstants.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-api/src/main/java/org/apache/shardingsphere/readwritesplitting/constant/ReadwriteSplittingRuleConstants.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.readwritesplitting.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Readwrite-splitting rule constants.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ReadwriteSplittingRuleConstants {
+    
+    public static final String AUTO_AWARE_DATA_SOURCE_KEY = "auto_aware_data_source_key";
+    
+    public static final String PRIMARY_DATA_SOURCE_NAME = "primary_data_source_name";
+    
+    public static final String REPLICA_DATA_SOURCE_NAMES = "replica_data_source_names";
+}

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRule.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRule.java
@@ -24,9 +24,11 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.aware.DataSourceNameAware;
 import org.apache.shardingsphere.infra.aware.DataSourceNameAwareFactory;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.constant.ReadwriteSplittingRuleConstants;
 import org.apache.shardingsphere.readwritesplitting.spi.ReplicaLoadBalanceAlgorithm;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -114,5 +116,21 @@ public final class ReadwriteSplittingDataSourceRule {
         }
         result.put(name, actualDataSourceNames);
         return result;
+    }
+
+    /**
+     * Get auto aware data sources.
+     *
+     * @return auto aware data sources
+     */
+    public Map<String, String> getAutoAwareDataSources() {
+        Optional<DataSourceNameAware> dataSourceNameAware = DataSourceNameAwareFactory.getInstance().getDataSourceNameAware();
+        if (dataSourceNameAware.isPresent()) {
+            Map<String, String> result = new HashMap<>(2, 1);
+            result.put(ReadwriteSplittingRuleConstants.PRIMARY_DATA_SOURCE_NAME, dataSourceNameAware.get().getPrimaryDataSourceName(autoAwareDataSourceName));
+            result.put(ReadwriteSplittingRuleConstants.REPLICA_DATA_SOURCE_NAMES, String.join(",", dataSourceNameAware.get().getReplicaDataSourceNames(autoAwareDataSourceName)));
+            return result;
+        }
+        return Collections.emptyMap();
     }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
@@ -24,10 +24,12 @@ import org.apache.shardingsphere.infra.rule.event.DataSourceStatusChangedEvent;
 import org.apache.shardingsphere.infra.rule.event.impl.DataSourceNameDisabledEvent;
 import org.apache.shardingsphere.infra.rule.identifier.scope.SchemaRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.StatusContainedRule;
 import org.apache.shardingsphere.readwritesplitting.algorithm.config.AlgorithmProvidedReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.constant.ReadwriteSplittingRuleConstants;
 import org.apache.shardingsphere.readwritesplitting.spi.ReplicaLoadBalanceAlgorithm;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.required.RequiredSPIRegistry;
@@ -42,7 +44,7 @@ import java.util.Optional;
 /**
  * Readwrite-splitting rule.
  */
-public final class ReadwriteSplittingRule implements SchemaRule, DataSourceContainedRule, StatusContainedRule {
+public final class ReadwriteSplittingRule implements SchemaRule, DataSourceContainedRule, StatusContainedRule, ExportableRule {
     
     static {
         ShardingSphereServiceLoader.register(ReplicaLoadBalanceAlgorithm.class);
@@ -111,6 +113,19 @@ public final class ReadwriteSplittingRule implements SchemaRule, DataSourceConta
                 entry.getValue().updateDisabledDataSourceNames(((DataSourceNameDisabledEvent) event).getDataSourceName(), ((DataSourceNameDisabledEvent) event).isDisabled());
             }
         }
+    }
+    
+    @Override
+    public Map<String, Object> export() {
+        Map<String, Object> result = new HashMap<>(1, 1);
+        result.put(ReadwriteSplittingRuleConstants.AUTO_AWARE_DATA_SOURCE_KEY, exportAutoAwareDataSourceMap());
+        return result;
+    }
+
+    private Map<String, Map<String, String>> exportAutoAwareDataSourceMap() {
+        Map<String, Map<String, String>> result = new HashMap<>(dataSourceRules.size(), 1);
+        dataSourceRules.forEach((name, dataSourceRule) -> result.put(dataSourceRule.getName(), dataSourceRule.getAutoAwareDataSources()));
+        return result;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
@@ -20,14 +20,18 @@ package org.apache.shardingsphere.readwritesplitting.distsql.handler.query;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.constant.ReadwriteSplittingRuleConstants;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.ShowReadwriteSplittingRulesStatement;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -42,13 +46,15 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
     @Test
     public void assertGetRowData() {
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        ExportableRule exportableRule = mock(ExportableRule.class);
+        when(metaData.getRuleMetaData().getRules()).thenReturn(Arrays.asList(exportableRule));
+        when(exportableRule.export()).thenReturn(Collections.emptyMap());
         when(metaData.getRuleMetaData().getConfigurations()).thenReturn(Collections.singleton(createRuleConfiguration()));
         ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
         resultSet.init(metaData, mock(ShowReadwriteSplittingRulesStatement.class));
         Collection<Object> actual = resultSet.getRowData();
         assertThat(actual.size(), is(6));
         assertTrue(actual.contains("pr_ds"));
-        assertTrue(actual.contains("ms_group"));
         assertTrue(actual.contains("ds_primary"));
         assertTrue(actual.contains("ds_slave_0,ds_slave_1"));
         assertTrue(actual.contains("random"));
@@ -57,7 +63,7 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
     
     private RuleConfiguration createRuleConfiguration() {
         ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig =
-                new ReadwriteSplittingDataSourceRuleConfiguration("pr_ds", "ms_group", "ds_primary", Arrays.asList("ds_slave_0", "ds_slave_1"), "test");
+                new ReadwriteSplittingDataSourceRuleConfiguration("pr_ds", null, "ds_primary", Arrays.asList("ds_slave_0", "ds_slave_1"), "test");
         Properties props = new Properties();
         props.setProperty("read_weight", "2:1");
         ShardingSphereAlgorithmConfiguration shardingSphereAlgorithmConfiguration = new ShardingSphereAlgorithmConfiguration("random", props);
@@ -67,6 +73,9 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
     @Test
     public void assertGetRowDataWithoutLoadBalancer() {
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        ExportableRule exportableRule = mock(ExportableRule.class);
+        when(metaData.getRuleMetaData().getRules()).thenReturn(Arrays.asList(exportableRule));
+        when(exportableRule.export()).thenReturn(Collections.emptyMap());
         when(metaData.getRuleMetaData().getConfigurations()).thenReturn(Collections.singleton(createRuleConfigurationWithoutLoadBalancer()));
         ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
         resultSet.init(metaData, mock(ShowReadwriteSplittingRulesStatement.class));
@@ -81,5 +90,48 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
         ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig =
                 new ReadwriteSplittingDataSourceRuleConfiguration("pr_ds", null, "write_ds", Arrays.asList("read_ds_0", "read_ds_1"), null);
         return new ReadwriteSplittingRuleConfiguration(Collections.singleton(dataSourceRuleConfig), null);
+    }
+
+    @Test
+    public void assertGetRowDataWithAutoAwareDataSource() {
+        ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        ExportableRule exportableRule = mock(ExportableRule.class);
+        
+        when(metaData.getRuleMetaData().getRules()).thenReturn(Arrays.asList(exportableRule));
+        when(exportableRule.export()).thenReturn(createAutoAwareDataSources());
+        when(metaData.getRuleMetaData().getConfigurations()).thenReturn(Collections.singleton(createRuleConfigurationWithAutoAwareDataSource()));
+        ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
+        resultSet.init(metaData, mock(ShowReadwriteSplittingRulesStatement.class));
+        Collection<Object> actual = resultSet.getRowData();
+        assertThat(actual.size(), is(6));
+        assertTrue(actual.contains("pr_ds"));
+        assertTrue(actual.contains("rd_rs"));
+        assertTrue(actual.contains("write_ds"));
+        assertTrue(actual.contains("read_ds_0,read_ds_1"));
+    }
+
+    private RuleConfiguration createRuleConfigurationWithAutoAwareDataSource() {
+        ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig =
+                new ReadwriteSplittingDataSourceRuleConfiguration("pr_ds", "rd_rs", null, Collections.emptyList(), null);
+        return new ReadwriteSplittingRuleConfiguration(Collections.singleton(dataSourceRuleConfig), null);
+    }
+    
+    private Map<String, Object> createAutoAwareDataSources() {
+        Map<String, Object> result = new HashMap<>(1, 1);
+        result.put(ReadwriteSplittingRuleConstants.AUTO_AWARE_DATA_SOURCE_KEY, exportAutoAwareDataSourceMap());
+        return result;
+    }
+
+    private Map<String, Map<String, String>> exportAutoAwareDataSourceMap() {
+        Map<String, Map<String, String>> result = new HashMap<>(1, 1);
+        result.put("pr_ds", getAutoAwareDataSources());
+        return result;
+    }
+        
+    private Map<String, String> getAutoAwareDataSources() {
+        Map<String, String> result = new HashMap<>(2, 1);
+        result.put(ReadwriteSplittingRuleConstants.PRIMARY_DATA_SOURCE_NAME, "write_ds");
+        result.put(ReadwriteSplittingRuleConstants.REPLICA_DATA_SOURCE_NAMES, "read_ds_0,read_ds_1");
+        return result;
     }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
@@ -96,7 +96,6 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
     public void assertGetRowDataWithAutoAwareDataSource() {
         ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
         ExportableRule exportableRule = mock(ExportableRule.class);
-        
         when(metaData.getRuleMetaData().getRules()).thenReturn(Arrays.asList(exportableRule));
         when(exportableRule.export()).thenReturn(createAutoAwareDataSources());
         when(metaData.getRuleMetaData().getConfigurations()).thenReturn(Collections.singleton(createRuleConfigurationWithAutoAwareDataSource()));


### PR DESCRIPTION
Fixes #13737.

When `readwrite_splitting` and `database_discovery` are used in combination, `write_data_source_name` and `read_data_source_names` are displayed according to the actual status of auto aware in the result of `show readwrite_splitting rules`, 

# Before
```sql
mysql> show readwrite_splitting rules from database_discovery_db;
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
| name  | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
| rd_rs | pr_ds                       | NULL                   |                        | NULL               |                     |
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
1 row in set (3.11 sec)
```


# After
```sql
mysql> show readwrite_splitting rules from database_discovery_db;
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
| name  | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
| rd_rs | pr_ds                       | ds_0                   | ds_1,ds_2              | NULL               |                     |
+-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
1 row in set (11.04 sec)
```