### PR TITLE
Ignore DataSource property name which value is null when building DataSourceConfiguration from DataSource

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/creator/impl/AbstractDataSourceCreator.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/creator/impl/AbstractDataSourceCreator.java
@@ -108,7 +108,10 @@ public abstract class AbstractDataSourceCreator implements DataSourceCreator {
         for (Method each : allGetterMethods) {
             String propertyName = CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_CAMEL, each.getName().substring(GETTER_PREFIX.length()));
             if (GENERAL_CLASS_TYPE.contains(each.getReturnType()) && !SKIPPED_PROPERTY_NAMES.contains(propertyName)) {
-                result.put(propertyName, each.invoke(target));
+                Object propertyValue = each.invoke(target);
+                if (null != propertyValue) {
+                    result.put(propertyName, propertyValue);
+                }
             }
         }
         return result;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/datasource/creator/DefaultDataSourceCreatorTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/datasource/creator/DefaultDataSourceCreatorTest.java
@@ -29,28 +29,27 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class DefaultDataSourceCreatorTest {
+    
     @Test
-    public void assertCreateDataSourceConfiguration() {
+    public void assertDataSourceConfigurationEquals() {
         DefaultDataSourceCreator defaultDataSourceCreator = new DefaultDataSourceCreator();
         DataSourceConfiguration generateDataSourceConfiguration = defaultDataSourceCreator.createDataSourceConfiguration(createDataSource());
-
         DataSourceConfiguration targetDataSourceConfiguration = createDataSourceConfiguration();
         assertThat(generateDataSourceConfiguration, is(targetDataSourceConfiguration));
     }
-
+    
     @Test
     public void assertCreateDataSource() {
         DefaultDataSourceCreator defaultDataSourceCreator = new DefaultDataSourceCreator();
         DataSource generateDataSource = defaultDataSourceCreator.createDataSource(createDataSourceConfiguration());
         assertThat(generateDataSource, instanceOf(HikariDataSource.class));
-
         HikariDataSource targetDataSource = (HikariDataSource) generateDataSource;
         assertThat(targetDataSource.getUsername(), is("root"));
         assertThat(targetDataSource.getPassword(), is("root"));
         assertThat(targetDataSource.getDriverClassName(), is("org.h2.Driver"));
         assertThat(targetDataSource.getJdbcUrl(), is("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL"));
     }
-
+    
     private DataSource createDataSource() {
         HikariDataSource dataSource = new HikariDataSource();
         dataSource.setDriverClassName("org.h2.Driver");
@@ -59,7 +58,7 @@ public final class DefaultDataSourceCreatorTest {
         dataSource.setPassword("root");
         return dataSource;
     }
-
+    
     private DataSourceConfiguration createDataSourceConfiguration() {
         DataSourceConfiguration dataSourceConfiguration = new DataSourceConfiguration(HikariDataSource.class.getName());
         dataSourceConfiguration.getProps().put("jdbcUrl", "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/creator/HikariDataSourceCreatorTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/creator/HikariDataSourceCreatorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.datasource.creator;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.creator.DataSourceCreator;
+import org.apache.shardingsphere.infra.config.datasource.creator.impl.DefaultDataSourceCreator;
 import org.apache.shardingsphere.infra.config.datasource.creator.impl.HikariDataSourceCreator;
 import org.junit.Test;
 
@@ -29,9 +30,21 @@ import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 public final class HikariDataSourceCreatorTest {
+    
+    @Test
+    public void assertCreateDataSourceConfigurationWithoutDriverClassName() {
+        HikariDataSource dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL");
+        dataSource.setUsername("root");
+        dataSource.setPassword("root");
+        DataSourceConfiguration dataSourceConfiguration = new DefaultDataSourceCreator().createDataSourceConfiguration(dataSource);
+        Map<String, Object> props = dataSourceConfiguration.getProps();
+        assertFalse(props.containsKey("driverClassName") && null == props.get("driverClassName"));
+    }
     
     @Test
     public void assertCreateDataSourceConfiguration() {


### PR DESCRIPTION
Fixes #13632.

Changes proposed in this pull request:
- Ignore DataSource property name which value is null. Make sure keys like `driverClassName: null` won't be persisted into `/metadata/sharding_db/dataSources`, it will cause NullPointerException from `HikariConfig.setDriverClassName` when initializing HikariDataSource.
