### PR TITLE
Separate sharding related code from scaling-core module part 2

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/creator/StandardJDBCTypedDataSourceCreator.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/creator/StandardJDBCTypedDataSourceCreator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.config.datasource.typed.creator;
+
+import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.DataSourceConverter;
+import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
+
+import javax.sql.DataSource;
+
+/**
+ * Standard JDBC typed data source creator.
+ */
+public final class StandardJDBCTypedDataSourceCreator implements TypedDataSourceCreator {
+    
+    @Override
+    public DataSource createDataSource(final String parameter, final Object dataSourceConfig) {
+        return DataSourceConverter.getDataSource((DataSourceConfiguration) dataSourceConfig);
+    }
+    
+    @Override
+    public String getType() {
+        return StandardJDBCDataSourceConfiguration.TYPE;
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/creator/TypedDataSourceCreator.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/creator/TypedDataSourceCreator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.config.datasource.typed.creator;
+
+import org.apache.shardingsphere.spi.typed.TypedSPI;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+
+/**
+ * Typed data source creator, SPI interface.
+ */
+public interface TypedDataSourceCreator extends TypedSPI {
+    
+    /**
+     * Create data source by data source configuration.
+     *
+     * @param parameter data source configuration
+     * @param dataSourceConfig configuration parsed from parameter
+     * @return data source
+     * @throws SQLException if create data source failed
+     */
+    DataSource createDataSource(String parameter, Object dataSourceConfig) throws SQLException;
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/YamlDataSourceConfigurationSwapper.java
@@ -20,9 +20,11 @@ package org.apache.shardingsphere.infra.yaml.config.swapper;
 import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConverter;
+import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 
 import javax.sql.DataSource;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
@@ -42,6 +44,19 @@ public final class YamlDataSourceConfigurationSwapper {
      */
     public Map<String, DataSource> swapToDataSources(final Map<String, Map<String, Object>> yamlDataSources) {
         return DataSourceConverter.getDataSourceMap(yamlDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> swapToDataSourceConfiguration(entry.getValue()))));
+    }
+    
+    /**
+     * Get data source configurations.
+     *
+     * @param yamlRootConfig yaml root configuration
+     * @return data source name to data source configuration map
+     */
+    public Map<String, DataSourceConfiguration> getDataSourceConfigurations(final YamlRootConfiguration yamlRootConfig) {
+        Map<String, Map<String, Object>> yamlDataSourceConfigs = yamlRootConfig.getDataSources();
+        Map<String, DataSourceConfiguration> result = new LinkedHashMap<>(yamlDataSourceConfigs.size());
+        yamlDataSourceConfigs.forEach((key, value) -> result.put(key, swapToDataSourceConfiguration(value)));
+        return result;
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.datasource.typed.creator.TypedDataSourceCreator
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.datasource.typed.creator.TypedDataSourceCreator
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration
+org.apache.shardingsphere.infra.config.datasource.typed.creator.StandardJDBCTypedDataSourceCreator

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/datasource/typed/ShardingSphereJDBCDataSourceConfigurationTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/config/datasource/typed/ShardingSphereJDBCDataSourceConfigurationTest.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.driver.config.datasource;
+package org.apache.shardingsphere.infra.config.datasource.typed;
 
 import com.google.common.collect.ImmutableMap;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/config/datasource/ShardingSphereJDBCTypedDataSourceCreator.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/config/datasource/ShardingSphereJDBCTypedDataSourceCreator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.driver.config.datasource;
+
+import org.apache.shardingsphere.driver.api.ShardingSphereDataSourceFactory;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.creator.TypedDataSourceCreator;
+import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
+import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.Collections;
+
+/**
+ * ShardingSphere JDBC typed data source creator.
+ */
+public final class ShardingSphereJDBCTypedDataSourceCreator implements TypedDataSourceCreator {
+    
+    @Override
+    public DataSource createDataSource(final String parameter, final Object dataSourceConfig) throws SQLException {
+        YamlRootConfiguration rootConfig = (YamlRootConfiguration) dataSourceConfig;
+        return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getSchemaName(), new YamlDataSourceConfigurationSwapper().swapToDataSources(
+                rootConfig.getDataSources()), Collections.singletonList(ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(rootConfig.getRules())), null);
+    }
+    
+    @Override
+    public String getType() {
+        return ShardingSphereJDBCDataSourceConfiguration.TYPE;
+    }
+}

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.datasource.typed.creator.TypedDataSourceCreator
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.datasource.typed.creator.TypedDataSourceCreator
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration
+org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCTypedDataSourceCreator

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
@@ -21,7 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.Subscribe;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.JdbcUri;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
@@ -21,8 +21,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.eventbus.Subscribe;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.JdbcUri;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
@@ -43,6 +43,7 @@ import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurat
 import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -122,6 +123,8 @@ public final class ScalingWorker {
     
     private RuleConfiguration getRuleConfiguration(final YamlRootConfiguration sourceRootConfig, final YamlRootConfiguration targetRootConfig) {
         RuleConfiguration result = new RuleConfiguration();
+        // TODO handle several rules changed or dataSources changed
+        result.setChangedYamlRuleConfigClassNames(Collections.singletonList(YamlShardingRuleConfiguration.class.getName()));
         result.setSource(new ShardingSphereJDBCDataSourceConfiguration(sourceRootConfig).wrap());
         result.setTarget(new ShardingSphereJDBCDataSourceConfiguration(targetRootConfig).wrap());
         return result;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.migration.common.job.preparer;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConverter;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
@@ -18,23 +18,23 @@
 package org.apache.shardingsphere.migration.common.job.preparer;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConverter;
-import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.scaling.core.common.datasource.DataSourceFactory;
 import org.apache.shardingsphere.scaling.core.common.datasource.DataSourceWrapper;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
-import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 import org.apache.shardingsphere.scaling.core.job.preparer.ActualTableDefinition;
 import org.apache.shardingsphere.scaling.core.job.preparer.DataSourcePreparer;
 import org.apache.shardingsphere.scaling.core.job.preparer.TableDefinitionSQLType;
-import org.apache.shardingsphere.scaling.core.util.JobConfigurationUtil;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
+import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -99,7 +99,7 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
     protected Map<DataSource, Map<String, String>> getDataSourceTableNamesMap(final TypedDataSourceConfiguration sourceConfig) {
         ShardingSphereJDBCDataSourceConfiguration source = (ShardingSphereJDBCDataSourceConfiguration) sourceConfig;
         ShardingRuleConfiguration ruleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(source.getRootConfig().getRules());
-        Map<String, DataSourceConfiguration> dataSourceConfigs = JobConfigurationUtil.getDataSourceConfigurations(source.getRootConfig());
+        Map<String, DataSourceConfiguration> dataSourceConfigs = new YamlDataSourceConfigurationSwapper().getDataSourceConfigurations(source.getRootConfig());
         ShardingRule shardingRule = new ShardingRule(ruleConfig, source.getRootConfig().getDataSources().keySet());
         Collection<String> logicTableNames = getLogicTableNames(ruleConfig);
         Map<String, Map<String, String>> dataSourceNameTableNamesMap = new HashMap<>();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.migration.common.spi;
+
+import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
+import org.apache.shardingsphere.spi.typed.TypedSPI;
+
+import java.util.List;
+
+/**
+ * Rule job configuration preparer, SPI interface.
+ */
+public interface RuleJobConfigurationPreparer extends TypedSPI {
+    
+    /**
+     * Get type.
+     *
+     * @return {@link YamlRuleConfiguration} implementation class full name
+     */
+    String getType();
+    
+    /**
+     * Convert to handle configuration, used to build job configuration.
+     *
+     * @param ruleConfig rule configuration
+     * @return handle configuration
+     */
+    HandleConfiguration convertToHandleConfig(RuleConfiguration ruleConfig);
+    
+    /**
+     * Convert to task configurations, used by underlying scheduler.
+     *
+     * @param jobConfig job configuration
+     * @return task configurations
+     */
+    List<TaskConfiguration> convertToTaskConfigs(JobConfiguration jobConfig);
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.elasticjob.lite.lifecycle.domain.JobBriefInfo;
 import org.apache.shardingsphere.infra.config.TypedSPIConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
+import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
 import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
@@ -40,7 +41,6 @@ import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ScalingContext;
 import org.apache.shardingsphere.scaling.core.config.WorkflowConfiguration;
-import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
 import org.apache.shardingsphere.scaling.core.job.JobContext;
 import org.apache.shardingsphere.scaling.core.job.JobStatus;
 import org.apache.shardingsphere.scaling.core.job.ScalingJob;
@@ -50,7 +50,6 @@ import org.apache.shardingsphere.scaling.core.job.check.consistency.DataConsiste
 import org.apache.shardingsphere.scaling.core.job.environment.ScalingEnvironmentManager;
 import org.apache.shardingsphere.scaling.core.job.progress.JobProgress;
 import org.apache.shardingsphere.scaling.core.job.schedule.JobSchedulerCenter;
-import org.apache.shardingsphere.scaling.core.util.JobConfigurationUtil;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
 import java.sql.SQLException;
@@ -135,7 +134,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
     
     @Override
     public Optional<Long> start(final JobConfiguration jobConfig) {
-        JobConfigurationUtil.fillInProperties(jobConfig);
+        jobConfig.fillInProperties();
         if (jobConfig.getHandleConfig().getShardingTotalCount() == 0) {
             log.warn("Invalid scaling job config!");
             throw new ScalingJobCreationException("handleConfig shardingTotalCount is 0");

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -17,10 +17,22 @@
 
 package org.apache.shardingsphere.scaling.core.config;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer;
+import org.apache.shardingsphere.sharding.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Scaling job configuration.
@@ -29,9 +41,67 @@ import lombok.Setter;
 @AllArgsConstructor
 @Getter
 @Setter
+@Slf4j
 public final class JobConfiguration {
+    
+    private static final SnowflakeKeyGenerateAlgorithm ID_AUTO_INCREASE_GENERATOR;
+    
+    static {
+        SnowflakeKeyGenerateAlgorithm generateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
+        generateAlgorithm.init();
+        ID_AUTO_INCREASE_GENERATOR = generateAlgorithm;
+    }
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleJobConfigurationPreparer.class);
+    }
     
     private RuleConfiguration ruleConfig;
     
     private HandleConfiguration handleConfig = new HandleConfiguration();
+    
+    /**
+     * Fill in properties.
+     */
+    public void fillInProperties() {
+        HandleConfiguration handleConfig = getHandleConfig();
+        if (null == handleConfig.getJobId()) {
+            handleConfig.setJobId((Long) ID_AUTO_INCREASE_GENERATOR.generateKey());
+        }
+        if (Strings.isNullOrEmpty(handleConfig.getDatabaseType())) {
+            handleConfig.setDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
+        }
+        RuleConfiguration ruleConfig = getRuleConfig();
+        if (null == handleConfig.getShardingTables()) {
+            List<HandleConfiguration> newHandleConfigs = new LinkedList<>();
+            for (String each : ruleConfig.getChangedYamlRuleConfigClassNames()) {
+                Optional<RuleJobConfigurationPreparer> preparerOptional = TypedSPIRegistry.findRegisteredService(RuleJobConfigurationPreparer.class, each, null);
+                Preconditions.checkArgument(preparerOptional.isPresent(), "Could not find registered service for type '%s'", each);
+                HandleConfiguration newHandleConfig = preparerOptional.get().convertToHandleConfig(ruleConfig);
+                newHandleConfigs.add(newHandleConfig);
+            }
+            // TODO handle several rules changed or dataSources changed
+            for (HandleConfiguration each : newHandleConfigs) {
+                handleConfig.setShardingTables(each.getShardingTables());
+                handleConfig.setLogicTables(each.getLogicTables());
+            }
+        }
+    }
+    
+    /**
+     * Split job configuration to task configurations.
+     *
+     * @return task configurations
+     */
+    public List<TaskConfiguration> convertToTaskConfigs() {
+        RuleConfiguration ruleConfig = getRuleConfig();
+        // TODO handle several rules changed or dataSources changed
+        for (String each : ruleConfig.getChangedYamlRuleConfigClassNames()) {
+            Optional<RuleJobConfigurationPreparer> preparerOptional = TypedSPIRegistry.findRegisteredService(RuleJobConfigurationPreparer.class, each, null);
+            Preconditions.checkArgument(preparerOptional.isPresent(), "Could not find registered service for type '%s'", each);
+            return preparerOptional.get().convertToTaskConfigs(this);
+        }
+        log.warn("return empty task configurations");
+        return Collections.emptyList();
+    }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/RuleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/RuleConfiguration.java
@@ -19,13 +19,22 @@ package org.apache.shardingsphere.scaling.core.config;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Rule configuration.
  */
 @Getter
 public final class RuleConfiguration {
+    
+    @Setter
+    @NonNull
+    private List<String> changedYamlRuleConfigClassNames = Collections.emptyList();
     
     private TypedDataSourceConfigurationWrap source;
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.scaling.core.job.preparer.ScalingJobPreparer;
 import org.apache.shardingsphere.scaling.core.job.progress.JobProgress;
 import org.apache.shardingsphere.scaling.core.job.task.incremental.IncrementalTask;
 import org.apache.shardingsphere.scaling.core.job.task.inventory.InventoryTask;
-import org.apache.shardingsphere.scaling.core.util.JobConfigurationUtil;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -57,9 +56,9 @@ public final class JobContext {
     
     public JobContext(final JobConfiguration jobConfig) {
         this.jobConfig = jobConfig;
-        JobConfigurationUtil.fillInProperties(jobConfig);
+        jobConfig.fillInProperties();
         jobId = jobConfig.getHandleConfig().getJobId();
         shardingItem = jobConfig.getHandleConfig().getShardingItem();
-        taskConfigs = JobConfigurationUtil.toTaskConfigs(jobConfig);
+        taskConfigs = jobConfig.convertToTaskConfigs();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/JobConfigurationUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/JobConfigurationUtil.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Sets;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -15,28 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.scaling.core.util;
+package org.apache.shardingsphere.sharding.schedule;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer;
 import org.apache.shardingsphere.scaling.core.config.DumperConfiguration;
 import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ImporterConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
-import org.apache.shardingsphere.sharding.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
@@ -46,6 +44,7 @@ import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardS
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
 import org.apache.shardingsphere.sharding.support.InlineExpressionParser;
+import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 
 import java.util.ArrayList;
@@ -63,50 +62,26 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Job configuration util.
+ * Sharding rule job configuration preparer.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
-public final class JobConfigurationUtil {
+public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfigurationPreparer {
     
-    private static final SnowflakeKeyGenerateAlgorithm ID_AUTO_INCREASE_GENERATOR = initIdAutoIncreaseGenerator();
-    
-    private static SnowflakeKeyGenerateAlgorithm initIdAutoIncreaseGenerator() {
-        SnowflakeKeyGenerateAlgorithm result = new SnowflakeKeyGenerateAlgorithm();
-        result.init();
+    @Override
+    public HandleConfiguration convertToHandleConfig(final RuleConfiguration ruleConfig) {
+        HandleConfiguration result = new HandleConfiguration();
+        Map<String, List<DataNode>> shouldScalingActualDataNodes = getShouldScalingActualDataNodes(ruleConfig);
+        Collection<DataNode> dataNodes = new ArrayList<>();
+        for (Entry<String, List<DataNode>> entry : shouldScalingActualDataNodes.entrySet()) {
+            dataNodes.addAll(entry.getValue());
+        }
+        result.setShardingTables(groupByDataSource(dataNodes));
+        result.setLogicTables(getLogicTables(shouldScalingActualDataNodes.keySet()));
         return result;
     }
     
-    private static Long generateKey() {
-        return (Long) ID_AUTO_INCREASE_GENERATOR.generateKey();
-    }
-    
-    /**
-     * Fill in properties for job configuration.
-     *
-     * @param jobConfig job configuration
-     */
-    public static void fillInProperties(final JobConfiguration jobConfig) {
-        HandleConfiguration handleConfig = jobConfig.getHandleConfig();
-        if (null == handleConfig.getJobId()) {
-            handleConfig.setJobId(generateKey());
-        }
-        if (Strings.isNullOrEmpty(handleConfig.getDatabaseType())) {
-            handleConfig.setDatabaseType(jobConfig.getRuleConfig().getSource().unwrap().getDatabaseType().getName());
-        }
-        if (null == jobConfig.getHandleConfig().getShardingTables()) {
-            Map<String, List<DataNode>> shouldScalingActualDataNodes = getShouldScalingActualDataNodes(jobConfig);
-            Collection<DataNode> dataNodes = new ArrayList<>();
-            for (Entry<String, List<DataNode>> entry : shouldScalingActualDataNodes.entrySet()) {
-                dataNodes.addAll(entry.getValue());
-            }
-            handleConfig.setShardingTables(groupByDataSource(dataNodes));
-            handleConfig.setLogicTables(getLogicTables(shouldScalingActualDataNodes.keySet()));
-        }
-    }
-    
-    private static Map<String, List<DataNode>> getShouldScalingActualDataNodes(final JobConfiguration jobConfig) {
-        TypedDataSourceConfiguration sourceConfig = jobConfig.getRuleConfig().getSource().unwrap();
+    private static Map<String, List<DataNode>> getShouldScalingActualDataNodes(final RuleConfiguration ruleConfig) {
+        TypedDataSourceConfiguration sourceConfig = ruleConfig.getSource().unwrap();
         Preconditions.checkState(sourceConfig instanceof ShardingSphereJDBCDataSourceConfiguration,
                 "Only ShardingSphereJdbc type of source TypedDataSourceConfiguration is supported.");
         ShardingSphereJDBCDataSourceConfiguration source = (ShardingSphereJDBCDataSourceConfiguration) sourceConfig;
@@ -135,13 +110,8 @@ public final class JobConfigurationUtil {
                 .orElse("");
     }
     
-    /**
-     * Split job configuration to task configurations.
-     *
-     * @param jobConfig job configuration
-     * @return list of task configurations
-     */
-    public static List<TaskConfiguration> toTaskConfigs(final JobConfiguration jobConfig) {
+    @Override
+    public List<TaskConfiguration> convertToTaskConfigs(final JobConfiguration jobConfig) {
         List<TaskConfiguration> result = new LinkedList<>();
         ShardingSphereJDBCDataSourceConfiguration sourceConfig = getSourceConfiguration(jobConfig);
         ShardingRuleConfiguration sourceRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(sourceConfig.getRootConfig().getRules());
@@ -293,5 +263,10 @@ public final class JobConfigurationUtil {
         result.setShardingColumnsMap(shardingColumnsMap);
         result.setRetryTimes(jobConfig.getHandleConfig().getRetryTimes());
         return result;
+    }
+    
+    @Override
+    public String getType() {
+        return YamlShardingRuleConfiguration.class.getName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.sharding.schedule.ShardingRuleJobConfigurationPreparer

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.scaling.core.util;
 import lombok.SneakyThrows;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
-import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,6 +31,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 /**
@@ -53,12 +54,17 @@ public final class ResourceUtil {
      * @return ShardingSphere-JDBC target job configuration
      */
     public static JobConfiguration mockShardingSphereJdbcTargetJobConfig() {
-        JobConfiguration result = new JobConfiguration();
         RuleConfiguration ruleConfig = new RuleConfiguration();
+        setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_target.yaml")).wrap());
+        JobConfiguration result = new JobConfiguration();
         result.setRuleConfig(ruleConfig);
         return result;
+    }
+    
+    private static void setupChangedYamlRuleConfigClassNames(final RuleConfiguration ruleConfig) {
+        ruleConfig.setChangedYamlRuleConfigClassNames(Collections.singletonList("org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"));
     }
     
     /**
@@ -67,10 +73,11 @@ public final class ResourceUtil {
      * @return standard JDBC as target job configuration
      */
     public static JobConfiguration mockStandardJdbcTargetJobConfig() {
-        JobConfiguration result = new JobConfiguration();
         RuleConfiguration ruleConfig = new RuleConfiguration();
+        setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new StandardJDBCDataSourceConfiguration(readFileToString("/config_standard_jdbc_target.yaml")).wrap());
+        JobConfiguration result = new JobConfiguration();
         result.setRuleConfig(ruleConfig);
         return result;
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.scaling.core.common.exception.PrepareFailedExce
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.scaling.mysql.component.checker.MySQLDataSourcePreparer;
 import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 import org.junit.Before;

--- a/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/ITEnvironmentContext.java
+++ b/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/ITEnvironmentContext.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigur
 import javax.sql.DataSource;
 import javax.xml.bind.JAXBContext;
 import java.io.FileReader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -79,11 +80,16 @@ public final class ITEnvironmentContext {
     }
     
     private static String createScalingConfiguration(final Map<String, YamlTableRuleConfiguration> tableRules) {
-        JobConfiguration jobConfiguration = new JobConfiguration();
         RuleConfiguration ruleConfiguration = new RuleConfiguration();
+        setupChangedYamlRuleConfigClassNames(ruleConfiguration);
         ruleConfiguration.setSource(SourceConfiguration.getDockerConfiguration(tableRules).wrap());
         ruleConfiguration.setTarget(TargetConfiguration.getDockerConfiguration().wrap());
+        JobConfiguration jobConfiguration = new JobConfiguration();
         jobConfiguration.setRuleConfig(ruleConfiguration);
         return new Gson().toJson(jobConfiguration);
+    }
+    
+    private static void setupChangedYamlRuleConfigClassNames(final RuleConfiguration ruleConfig) {
+        ruleConfig.setChangedYamlRuleConfigClassNames(Collections.singletonList("org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"));
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/config/SourceConfiguration.java
+++ b/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/config/SourceConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigu
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlRuleConfigurationSwapperEngine;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.integration.scaling.test.mysql.env.IntegrationTestEnvironment;
-import org.apache.shardingsphere.driver.config.datasource.ShardingSphereJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration;
 


### PR DESCRIPTION
Fixes #13875 part 3.

Changes proposed in this pull request:
- Refactor ShardingSphereJDBCDataSourceConfiguration (refactor it from `sharding-jdbc-core` module to `infra-common` module), prepare to be used in `sharding-core` module.
- Refactor `JobConfigurationUtil` into `JobConfiguration` and `RuleJobConfigurationPreparer` SPI; Persist changed rule type in registry center job configuration; JobConfiguration structure and registry center structure might be changed more to support several related jobs concurrent running or merged running.
- Refactor JobConfigurationUtil.getDataSourceConfigurations
