### PR TITLE
merge disabled datasource discovery with normal datasources for openGauss

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-opengauss/src/main/java/org/apache/shardingsphere/dbdiscovery/opengauss/OpenGaussDatabaseDiscoveryType.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-opengauss/src/main/java/org/apache/shardingsphere/dbdiscovery/opengauss/OpenGaussDatabaseDiscoveryType.java
@@ -122,9 +122,6 @@ public final class OpenGaussDatabaseDiscoveryType implements DatabaseDiscoveryTy
     public void updateMemberState(final String schemaName, final Map<String, DataSource> dataSourceMap,
             final Collection<String> disabledDataSourceNames) {
         Map<String, DataSource> activeDataSourceMap = new HashMap<>(dataSourceMap);
-        if (!disabledDataSourceNames.isEmpty()) {
-            activeDataSourceMap.entrySet().removeIf(each -> disabledDataSourceNames.contains(each.getKey()));
-        }
         determineDisabledDataSource(schemaName, activeDataSourceMap);
     }
     


### PR DESCRIPTION
merge disabled datasource discovery with normal datasources for openGauss。

if one DataSource disabled before，now it could come back as soon as standby status normal。