### PR TITLE
Add default cacheOption

### DIFF
--- a/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-core/src/main/java/org/apache/shardingsphere/parser/rule/builder/DefaultSQLParserRuleConfigurationBuilder.java
+++ b/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-core/src/main/java/org/apache/shardingsphere/parser/rule/builder/DefaultSQLParserRuleConfigurationBuilder.java
@@ -26,12 +26,14 @@ import org.apache.shardingsphere.sql.parser.api.CacheOption;
  * Default SQL parser rule configuration builder.
  */
 public final class DefaultSQLParserRuleConfigurationBuilder implements DefaultGlobalRuleConfigurationBuilder<SQLParserRuleConfiguration, SQLParserRuleBuilder> {
+
+    public static final CacheOption PARSER_TREE_CACHE_OPTION = new CacheOption(128, 1024L, 4);
+    
+    public static final CacheOption SQL_STATEMENT_CACHE_OPTION = new CacheOption(2000, 65535L, 4);
     
     @Override
     public SQLParserRuleConfiguration build() {
-        CacheOption parseTreeCacheOption = new CacheOption(128, 1024L, 4);
-        CacheOption sqlStatementCacheOption = new CacheOption(2000, 65535L, 4);
-        return new SQLParserRuleConfiguration(false, parseTreeCacheOption, sqlStatementCacheOption);
+        return new SQLParserRuleConfiguration(false, PARSER_TREE_CACHE_OPTION, SQL_STATEMENT_CACHE_OPTION);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-core/src/main/java/org/apache/shardingsphere/parser/yaml/swapper/SQLParserRuleConfigurationYamlSwapper.java
+++ b/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-core/src/main/java/org/apache/shardingsphere/parser/yaml/swapper/SQLParserRuleConfigurationYamlSwapper.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.parser.yaml.swapper;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlRuleConfigurationSwapper;
 import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
 import org.apache.shardingsphere.parser.constant.SQLParserOrder;
+import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder;
 import org.apache.shardingsphere.parser.yaml.config.YamlSQLParserRuleConfiguration;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 
@@ -41,8 +42,10 @@ public final class SQLParserRuleConfigurationYamlSwapper implements YamlRuleConf
 
     @Override
     public SQLParserRuleConfiguration swapToObject(final YamlSQLParserRuleConfiguration yamlConfig) {
-        CacheOption parseTreeCacheOption = cacheOptionSwapper.swapToObject(yamlConfig.getParserTreeCache());
-        CacheOption sqlStatementCacheOption = cacheOptionSwapper.swapToObject(yamlConfig.getSqlStatementCache());
+        CacheOption parseTreeCacheOption = null == yamlConfig.getParserTreeCache() 
+                ? DefaultSQLParserRuleConfigurationBuilder.PARSER_TREE_CACHE_OPTION : cacheOptionSwapper.swapToObject(yamlConfig.getParserTreeCache());
+        CacheOption sqlStatementCacheOption = null == yamlConfig.getSqlStatementCache()
+                ? DefaultSQLParserRuleConfigurationBuilder.SQL_STATEMENT_CACHE_OPTION : cacheOptionSwapper.swapToObject(yamlConfig.getSqlStatementCache());
         return new SQLParserRuleConfiguration(yamlConfig.isSqlCommentParseEnabled(), parseTreeCacheOption, sqlStatementCacheOption);
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -55,6 +55,7 @@
 #    defaultType: XA
 #    providerType: Atomikos
 #  - !SQL_PARSER
+#    sqlCommentParseEnabled: true
 #    sqlStatementCache:
 #      initialCapacity: 2000
 #      maximumSize: 65535


### PR DESCRIPTION
For #13725.

Changes proposed in this pull request:
- If only sqlCommentParseEnabled is configured, the cacheOption configuration needs to have a default value.

