### PR TITLE
[DistSQL] Refactor the show readwrite_splitting read resources statement to be compatible with MGR

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRule.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRule.java
@@ -125,7 +125,7 @@ public final class ReadwriteSplittingDataSourceRule {
      */
     public Map<String, String> getAutoAwareDataSources() {
         Optional<DataSourceNameAware> dataSourceNameAware = DataSourceNameAwareFactory.getInstance().getDataSourceNameAware();
-        if (dataSourceNameAware.isPresent() && dataSourceNameAware.get().getRule().isPresent()) {
+        if (!Strings.isNullOrEmpty(autoAwareDataSourceName) && dataSourceNameAware.isPresent() && dataSourceNameAware.get().getRule().isPresent()) {
             Map<String, String> result = new HashMap<>(2, 1);
             result.put(ReadwriteSplittingRuleConstants.PRIMARY_DATA_SOURCE_NAME, dataSourceNameAware.get().getPrimaryDataSourceName(autoAwareDataSourceName));
             result.put(ReadwriteSplittingRuleConstants.REPLICA_DATA_SOURCE_NAMES, String.join(",", dataSourceNameAware.get().getReplicaDataSourceNames(autoAwareDataSourceName)));

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowReadwriteSplittingReadResourcesExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowReadwriteSplittingReadResourcesExecutor.java
@@ -21,8 +21,10 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.exception.SchemaNotExistedException;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.rule.identifier.type.ExportableRule;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.storage.StorageNodeStatus;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.storage.node.StorageStatusNode;
+import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.NoDatabaseSelectedException;
@@ -30,6 +32,7 @@ import org.apache.shardingsphere.proxy.backend.response.header.query.impl.QueryH
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.constant.ReadwriteSplittingRuleConstants;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.ShowReadwriteSplittingReadResourcesStatement;
 import org.apache.shardingsphere.sharding.merge.dal.common.MultipleLocalDataMergedResult;
 
@@ -40,9 +43,12 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Show readwrite-splitting read resources executor.
@@ -51,6 +57,8 @@ import java.util.stream.Collectors;
 public final class ShowReadwriteSplittingReadResourcesExecutor extends AbstractShowExecutor {
     
     private static final String DELIMITER = "\\.";
+    
+    private static final String SCHEMA_NAME = "schema_name";
     
     private static final String RESOURCE = "resource";
     
@@ -67,6 +75,7 @@ public final class ShowReadwriteSplittingReadResourcesExecutor extends AbstractS
     @Override
     protected List<QueryHeader> createQueryHeaders() {
         return Arrays.asList(
+                new QueryHeader("", "", SCHEMA_NAME, SCHEMA_NAME, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false),
                 new QueryHeader("", "", RESOURCE, RESOURCE, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false),
                 new QueryHeader("", "", STATUS, STATUS, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false));
     }
@@ -80,44 +89,76 @@ public final class ShowReadwriteSplittingReadResourcesExecutor extends AbstractS
         if (!ProxyContext.getInstance().getAllSchemaNames().contains(schemaName)) {
             throw new SchemaNotExistedException(schemaName);
         }
-        ShardingSphereMetaData metaData = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(schemaName);
-        Collection<List<Object>> rows = buildResourceRows(metaData, ENABLE);
-        MetaDataPersistService persistService = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaDataPersistService().orElse(null);
-        if (null == persistService || null == persistService.getRepository()) {
-            return new MultipleLocalDataMergedResult(rows);
-        }
-        Collection<List<Object>> disabledResourceRows = buildResourceRows(persistService, DISABLE);
-        return new MultipleLocalDataMergedResult(mergeRows(rows, disabledResourceRows));
+        MetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
+        ShardingSphereMetaData metaData = metaDataContexts.getMetaData(schemaName);
+        Collection<Object> notShownResourceRows = new LinkedHashSet<>();
+        Collection<List<Object>> enableResourceRows = buildEnableResourceRows(schemaName, metaData, notShownResourceRows);
+        Collection<List<Object>> disabledResourceRows = buildDisableResourceRows(schemaName, metaDataContexts.getMetaDataPersistService().orElse(null), notShownResourceRows);
+        return new MultipleLocalDataMergedResult(mergeRows(enableResourceRows, disabledResourceRows, notShownResourceRows));
     }
     
-    private Collection<List<Object>> buildResourceRows(final ShardingSphereMetaData metaData, final String status) {
+    private Collection<List<Object>> buildEnableResourceRows(final String schemaName, final ShardingSphereMetaData metaData, final Collection<Object> notShownResourceRows) {
+        LinkedList<String> configuredResourceRows = getConfiguredResourceRows(metaData);
+        Collection<String> autoAwareResourceRows = getAutoAwareResourceRows(metaData, notShownResourceRows);
+        return Stream.of(configuredResourceRows, autoAwareResourceRows).flatMap(Collection::stream).distinct()
+                .map(each -> buildRow(schemaName, each, ENABLE)).collect(Collectors.toCollection(LinkedList::new));
+    }
+    
+    private LinkedList<String> getConfiguredResourceRows(final ShardingSphereMetaData metaData) {
         Collection<ReadwriteSplittingRuleConfiguration> ruleConfiguration = metaData.getRuleMetaData().findRuleConfiguration(ReadwriteSplittingRuleConfiguration.class);
-        Set<String> allResources = ruleConfiguration.stream().map(ReadwriteSplittingRuleConfiguration::getDataSources).flatMap(Collection::stream)
-                .map(ReadwriteSplittingDataSourceRuleConfiguration::getReadDataSourceNames).flatMap(Collection::stream).collect(Collectors.toCollection(LinkedHashSet::new));
-        return allResources.stream().map(each -> buildRow(each, status)).collect(Collectors.toCollection(LinkedList::new));
+        return ruleConfiguration.stream().map(ReadwriteSplittingRuleConfiguration::getDataSources).flatMap(Collection::stream).filter(Objects::nonNull)
+                .map(ReadwriteSplittingDataSourceRuleConfiguration::getReadDataSourceNames)
+                .flatMap(Collection::stream).collect(Collectors.toCollection(LinkedList::new));
     }
     
-    private Collection<List<Object>> buildResourceRows(final MetaDataPersistService persistService, final String status) {
-        List<String> instanceIds = persistService.getRepository().getChildrenKeys(StorageStatusNode.getStatusPath(status.equals(DISABLE) ? StorageNodeStatus.DISABLE : StorageNodeStatus.PRIMARY));
-        if (!instanceIds.isEmpty()) {
-            return instanceIds.stream().filter(Objects::nonNull).map(each -> each.split(DELIMITER)[1]).map(each -> buildRow(each, status)).collect(Collectors.toCollection(LinkedList::new));
+    private Collection<String> getAutoAwareResourceRows(final ShardingSphereMetaData metaData, final Collection<Object> notShownResourceRows) {
+        Map<String, Map<String, String>> autoAwareResourceData = getAutoAwareResourceData(metaData);
+        return autoAwareResourceData.entrySet().stream().peek(entry -> notShownResourceRows.add(entry.getValue().get(ReadwriteSplittingRuleConstants.PRIMARY_DATA_SOURCE_NAME)))
+                .map(entry -> entry.getValue().get(ReadwriteSplittingRuleConstants.REPLICA_DATA_SOURCE_NAMES)).filter(Objects::nonNull).map(this::deconstructString)
+                .flatMap(Collection::stream).collect(Collectors.toCollection(LinkedList::new));
+    }
+    
+    private Map<String, Map<String, String>> getAutoAwareResourceData(final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().getRules().stream().filter(each -> each instanceof ExportableRule)
+                .map(each -> ((ExportableRule) each).export().get(ReadwriteSplittingRuleConstants.AUTO_AWARE_DATA_SOURCE_KEY))
+                .filter(Objects::nonNull).map(each -> (Map<String, Map<String, String>>) each)
+                .map(Map::entrySet).flatMap(Collection::stream).filter(entry -> !entry.getValue().isEmpty()).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+    
+    private Collection<List<Object>> buildDisableResourceRows(final String schemaName, final MetaDataPersistService persistService, final Collection<Object> notShownResourceRows) {
+        if (null == persistService || null == persistService.getRepository()) {
+            return Collections.emptyList();
         }
-        return Collections.emptyList();
+        Collection<List<Object>> result = Collections.emptyList();
+        List<String> instanceIds = persistService.getRepository().getChildrenKeys(StorageStatusNode.getStatusPath(StorageNodeStatus.DISABLE));
+        if (!instanceIds.isEmpty()) {
+            return instanceIds.stream().filter(Objects::nonNull).filter(each -> schemaName.equals(each.split(DELIMITER)[0])).map(each -> each.split(DELIMITER)[1])
+                    .map(each -> buildRow(schemaName, each, DISABLE)).collect(Collectors.toCollection(LinkedList::new));
+        }
+        return result;
     }
     
-    private Collection<List<Object>> mergeRows(final Collection<List<Object>> rows, final Collection<List<Object>> disabledResourceRows) {
-        Collection<List<Object>> result;
-        Set<Object> disabledResourceNames = disabledResourceRows.stream().map(each -> getResourceName(each)).collect(Collectors.toSet());
-        result = rows.stream().filter(each -> !disabledResourceNames.contains(getResourceName(each))).collect(Collectors.toCollection(LinkedList::new));
+    private Collection<List<Object>> mergeRows(final Collection<List<Object>> enableResourceRows, final Collection<List<Object>> disabledResourceRows, final Collection<Object> notShownResourceRows) {
+        Collection<List<Object>> result = replaceDisableResourceRows(enableResourceRows, disabledResourceRows);
+        return result.stream().filter(each -> !notShownResourceRows.contains(getResourceName(each))).collect(Collectors.toCollection(LinkedList::new));
+    }
+    
+    private Collection<List<Object>> replaceDisableResourceRows(final Collection<List<Object>> enableResourceRows, final Collection<List<Object>> disabledResourceRows) {
+        Set<Object> disableResourceNames = disabledResourceRows.stream().map(this::getResourceName).collect(Collectors.toSet());
+        Collection<List<Object>> result = enableResourceRows.stream().filter(each -> !disableResourceNames.contains(getResourceName(each))).collect(Collectors.toCollection(LinkedList::new));
         result.addAll(disabledResourceRows);
         return result;
     }
     
-    private List<Object> buildRow(final String resource, final String status) {
-        return Arrays.asList(resource, status);
+    private LinkedList<String> deconstructString(final String str) {
+        return new LinkedList<>(Arrays.asList(str.split(",")));
+    }
+    
+    private List<Object> buildRow(final String schemaName, final String resource, final String status) {
+        return Arrays.asList(schemaName, resource, status);
     }
     
     private Object getResourceName(final List<Object> row) {
-        return row.get(0);
+        return row.get(1);
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- The primary_data_source_name in MGR will not be displayed,
- Add the judgment of whether the `autoAwareDataSourceName` exists

![image](https://user-images.githubusercontent.com/52209337/145358241-14595763-2b80-4772-bd16-4a9c4a8ef755.png)