### PR TITLE
Separate sharding related code from scaling-core module part 3 and refactor job configuration structure

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/ShardingSphereJDBCDataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/ShardingSphereJDBCDataSourceConfiguration.java
@@ -98,6 +98,18 @@ public final class ShardingSphereJDBCDataSourceConfiguration extends TypedDataSo
     }
     
     /**
+     * Get actual data source configuration.
+     *
+     * @param actualDataSourceName actual data source name
+     * @return actual data source configuration
+     */
+    public StandardJDBCDataSourceConfiguration getActualDataSourceConfig(final String actualDataSourceName) {
+        Map<String, Object> yamlDataSourceConfig = rootConfig.getDataSources().get(actualDataSourceName);
+        Preconditions.checkNotNull(yamlDataSourceConfig, "actualDataSourceName '{}' does not exist", actualDataSourceName);
+        return new StandardJDBCDataSourceConfiguration(yamlDataSourceConfig);
+    }
+    
+    /**
      * YAML parameter configuration.
      */
     @NoArgsConstructor

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/StandardJDBCDataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/StandardJDBCDataSourceConfiguration.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -53,8 +53,20 @@ public final class StandardJDBCDataSourceConfiguration extends TypedDataSourceCo
     
     @SuppressWarnings("unchecked")
     public StandardJDBCDataSourceConfiguration(final String parameter) {
+        this(YamlEngine.unmarshal(parameter, Map.class), parameter);
+    }
+    
+    /**
+     * Construct by YAML data source configuration.
+     *
+     * @param yamlDataSourceConfig YAML data source configuration, equivalent to {@link DataSourceConfiguration}
+     */
+    public StandardJDBCDataSourceConfiguration(final Map<String, Object> yamlDataSourceConfig) {
+        this(yamlDataSourceConfig, YamlEngine.marshal(yamlDataSourceConfig));
+    }
+    
+    private StandardJDBCDataSourceConfiguration(final Map<String, Object> yamlConfig, final String parameter) {
         this.parameter = parameter;
-        Map<String, Object> yamlConfig = YamlEngine.unmarshal(parameter, Map.class);
         if (!yamlConfig.containsKey(DATA_SOURCE_CLASS_NAME)) {
             yamlConfig.put(DATA_SOURCE_CLASS_NAME, "com.zaxxer.hikari.HikariDataSource");
         }
@@ -83,11 +95,13 @@ public final class StandardJDBCDataSourceConfiguration extends TypedDataSourceCo
         hikariConfig.setJdbcUrl(new JdbcUri(hikariConfig.getJdbcUrl()).appendParameters(parameters));
     }
     
-    private static String wrapParameter(final String jdbcUrl, final String username, final String password) {
-        Map<String, String> parameter = new HashMap<>(3, 1);
-        parameter.put("jdbcUrl", jdbcUrl);
-        parameter.put("username", username);
-        parameter.put("password", password);
-        return YamlEngine.marshal(parameter);
+    private static Map<String, Object> wrapParameter(final String jdbcUrl, final String username, final String password) {
+        Map<String, Object> result = new LinkedHashMap<>(3, 1);
+        result.put("jdbcUrl", jdbcUrl);
+        result.put("username", username);
+        result.put("password", password);
+        return result;
     }
+    
+    // TODO toShardingSphereJDBCDataSource(final String actualDataSourceName, final String logicTableName, final String actualTableName)
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/TypedDataSourceConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/datasource/typed/TypedDataSourceConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -71,6 +72,23 @@ public abstract class TypedDataSourceConfiguration {
      * @return database type
      */
     public abstract DatabaseType getDatabaseType();
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType(), getParameter());
+    }
+    
+    @Override
+    public boolean equals(final Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
+        TypedDataSourceConfiguration that = (TypedDataSourceConfiguration) obj;
+        return Objects.equals(getType(), that.getType()) && Objects.equals(getParameter(), that.getParameter());
+    }
     
     /**
      * Wrap.

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
@@ -46,6 +46,7 @@ public final class DataNode {
      * @param dataNode string of data node. use {@code .} to split data source name and table name.
      */
     public DataNode(final String dataNode) {
+        // TODO remove duplicated splitting?
         if (!isValidDataNode(dataNode)) {
             throw new ShardingSphereConfigurationException("Invalid format for actual data nodes: '%s'", dataNode);
         }
@@ -74,5 +75,14 @@ public final class DataNode {
     @Override
     public int hashCode() {
         return Objects.hashCode(dataSourceName.toUpperCase(), tableName.toUpperCase());
+    }
+    
+    /**
+     * Format DataNode as string.
+     *
+     * @return formatted string
+     */
+    public String format() {
+        return dataSourceName + DELIMITER + tableName;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNode.java
@@ -85,4 +85,13 @@ public final class DataNode {
     public String format() {
         return dataSourceName + DELIMITER + tableName;
     }
+    
+    /**
+     * Get formatted text length.
+     *
+     * @return formatted text length
+     */
+    public int getFormattedTextLength() {
+        return dataSourceName.length() + DELIMITER.length() + tableName.length();
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -79,4 +79,11 @@ public final class DataNodeTest {
     public void assertEmptyTableDataNode() {
         new DataNode("ds_0.");
     }
+    
+    @Test
+    public void assertFormat() {
+        String expected = "ds_0.tbl_0";
+        DataNode dataNode = new DataNode(expected);
+        assertThat(dataNode.format(), is(expected));
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodeTest.java
@@ -86,4 +86,11 @@ public final class DataNodeTest {
         DataNode dataNode = new DataNode(expected);
         assertThat(dataNode.format(), is(expected));
     }
+    
+    @Test
+    public void assertFormattedTextLength() {
+        String text = "ds_0.tbl_0";
+        DataNode dataNode = new DataNode(text);
+        assertThat(dataNode.getFormattedTextLength(), is(text.length()));
+    }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/DataSourceManager.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/DataSourceManager.java
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;
 
-import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/DataSourceManager.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/DataSourceManager.java
@@ -71,7 +71,7 @@ public final class DataSourceManager implements AutoCloseable {
      * @param dataSourceConfig data source configuration
      * @return data source
      */
-    public DataSource getDataSource(final TypedDataSourceConfiguration dataSourceConfig) {
+    public DataSourceWrapper getDataSource(final TypedDataSourceConfiguration dataSourceConfig) {
         if (cachedDataSources.containsKey(dataSourceConfig)) {
             return cachedDataSources.get(dataSourceConfig);
         }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/pom.xml
@@ -25,7 +25,7 @@
         <version>5.0.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>shardingsphere-data-pipeline-api</artifactId>
+    <artifactId>shardingsphere-data-pipeline-spi</artifactId>
     <name>${project.artifactId}</name>
     
 </project>

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
@@ -109,6 +109,7 @@ public final class ScalingWorker {
         return rootConfig.getRules().stream().filter(each -> each instanceof YamlShardingRuleConfiguration).map(each -> (YamlShardingRuleConfiguration) each).findFirst();
     }
     
+    // TODO more accurate comparison
     private boolean isShardingRulesTheSame(final YamlShardingRuleConfiguration sourceShardingConfig, final YamlShardingRuleConfiguration targetShardingConfig) {
         for (Entry<String, YamlTableRuleConfiguration> entry : sourceShardingConfig.getTables().entrySet()) {
             entry.getValue().setLogicTable(null);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDB
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.job.preparer.ActualTableDefinition;
 import org.apache.shardingsphere.scaling.core.job.preparer.DataSourcePreparer;
 import org.apache.shardingsphere.scaling.core.job.preparer.TableDefinitionSQLType;
@@ -67,12 +67,12 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
     
     private final DataSourceFactory dataSourceFactory = new DataSourceFactory();
     
-    protected DataSourceWrapper getSourceDataSource(final JobConfiguration jobConfig) {
-        return dataSourceFactory.newInstance(jobConfig.getRuleConfig().getSource().unwrap());
+    protected DataSourceWrapper getSourceDataSource(final RuleConfiguration ruleConfig) {
+        return dataSourceFactory.newInstance(ruleConfig.getSource().unwrap());
     }
     
-    protected DataSourceWrapper getTargetDataSource(final JobConfiguration jobConfig) {
-        return dataSourceFactory.newInstance(jobConfig.getRuleConfig().getTarget().unwrap());
+    protected DataSourceWrapper getTargetDataSource(final RuleConfiguration ruleConfig) {
+        return dataSourceFactory.newInstance(ruleConfig.getTarget().unwrap());
     }
     
     protected Collection<String> getLogicTableNames(final TypedDataSourceConfiguration sourceConfig) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparer.java
@@ -20,34 +20,16 @@ package org.apache.shardingsphere.migration.common.job.preparer;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DataSourceFactory;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DataSourceWrapper;
-import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
-import org.apache.shardingsphere.infra.config.datasource.DataSourceConverter;
-import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
-import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfiguration;
-import org.apache.shardingsphere.infra.datanode.DataNode;
-import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.job.preparer.ActualTableDefinition;
 import org.apache.shardingsphere.scaling.core.job.preparer.DataSourcePreparer;
 import org.apache.shardingsphere.scaling.core.job.preparer.TableDefinitionSQLType;
-import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
-import org.apache.shardingsphere.sharding.rule.ShardingRule;
-import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -75,48 +57,12 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
         return dataSourceFactory.newInstance(ruleConfig.getTarget().unwrap());
     }
     
-    protected Collection<String> getLogicTableNames(final TypedDataSourceConfiguration sourceConfig) {
-        ShardingSphereJDBCDataSourceConfiguration source = (ShardingSphereJDBCDataSourceConfiguration) sourceConfig;
-        ShardingRuleConfiguration ruleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(source.getRootConfig().getRules());
-        return getLogicTableNames(ruleConfig);
-    }
-    
-    private Collection<String> getLogicTableNames(final ShardingRuleConfiguration ruleConfig) {
-        Collection<String> result = new ArrayList<>();
-        List<String> tableNames = ruleConfig.getTables().stream().map(ShardingTableRuleConfiguration::getLogicTable).collect(Collectors.toList());
-        List<String> autoTableNames = ruleConfig.getAutoTables().stream().map(ShardingAutoTableRuleConfiguration::getLogicTable).collect(Collectors.toList());
-        result.addAll(tableNames);
-        result.addAll(autoTableNames);
-        return result;
-    }
-    
-    /**
-     * Get data source table names map.
-     *
-     * @param sourceConfig source data source configuration
-     * @return data source table names map. map(data source, map(first actual table name of logic table, logic table name)).
-     */
-    protected Map<DataSource, Map<String, String>> getDataSourceTableNamesMap(final TypedDataSourceConfiguration sourceConfig) {
-        ShardingSphereJDBCDataSourceConfiguration source = (ShardingSphereJDBCDataSourceConfiguration) sourceConfig;
-        ShardingRuleConfiguration ruleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(source.getRootConfig().getRules());
-        Map<String, DataSourceConfiguration> dataSourceConfigs = new YamlDataSourceConfigurationSwapper().getDataSourceConfigurations(source.getRootConfig());
-        ShardingRule shardingRule = new ShardingRule(ruleConfig, source.getRootConfig().getDataSources().keySet());
-        Collection<String> logicTableNames = getLogicTableNames(ruleConfig);
-        Map<String, Map<String, String>> dataSourceNameTableNamesMap = new HashMap<>();
-        for (String each : logicTableNames) {
-            DataNode dataNode = shardingRule.getDataNode(each);
-            dataSourceNameTableNamesMap.computeIfAbsent(dataNode.getDataSourceName(), key -> new LinkedHashMap<>()).put(dataNode.getTableName(), each);
-        }
-        return dataSourceNameTableNamesMap.entrySet().stream().collect(
-                Collectors.toMap(entry -> DataSourceConverter.getDataSource(dataSourceConfigs.get(entry.getKey())), Entry::getValue, (oldValue, currentValue) -> oldValue, LinkedHashMap::new));
-    }
-    
     protected void executeTargetTableSQL(final Connection targetConnection, final String sql) throws SQLException {
         log.info("execute target table sql: {}", sql);
         try (Statement statement = targetConnection.createStatement()) {
             statement.execute(sql);
         } catch (final SQLException ex) {
-            for (String ignoreMessage: IGNORE_EXCEPTION_MESSAGE) {
+            for (String ignoreMessage : IGNORE_EXCEPTION_MESSAGE) {
                 if (ex.getMessage().contains(ignoreMessage)) {
                     return;
                 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
@@ -42,7 +42,7 @@ public interface RuleJobConfigurationPreparer extends TypedSPI {
      * Convert to handle configuration, used to build job configuration.
      *
      * @param ruleConfig rule configuration
-     * @return handle configuration
+     * @return handle configuration. It won't be used directly, but merge necessary configuration (e.g. shardingTables, logicTables) into final {@link HandleConfiguration}
      */
     HandleConfiguration convertToHandleConfig(RuleConfiguration ruleConfig);
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -86,7 +86,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
         JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(result.getJobId());
         JobConfiguration jobConfig = getJobConfig(jobConfigPOJO);
         result.setActive(!jobConfigPOJO.isDisabled());
-        result.setShardingTotalCount(jobConfig.getHandleConfig().getShardingTotalCount());
+        result.setShardingTotalCount(jobConfig.getHandleConfig().getJobShardingCount());
         result.setTables(jobConfig.getHandleConfig().getLogicTables());
         result.setCreateTime(jobConfigPOJO.getProps().getProperty("create_time"));
         result.setStopTime(jobConfigPOJO.getProps().getProperty("stop_time"));
@@ -135,7 +135,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
     @Override
     public Optional<Long> start(final JobConfiguration jobConfig) {
         jobConfig.fillInProperties();
-        if (jobConfig.getHandleConfig().getShardingTotalCount() == 0) {
+        if (jobConfig.getHandleConfig().getJobShardingCount() == 0) {
             log.warn("Invalid scaling job config!");
             throw new ScalingJobCreationException("handleConfig shardingTotalCount is 0");
         }
@@ -150,7 +150,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
     private String createJobConfig(final JobConfiguration jobConfig) {
         JobConfigurationPOJO jobConfigPOJO = new JobConfigurationPOJO();
         jobConfigPOJO.setJobName(String.valueOf(jobConfig.getHandleConfig().getJobId()));
-        jobConfigPOJO.setShardingTotalCount(jobConfig.getHandleConfig().getShardingTotalCount());
+        jobConfigPOJO.setShardingTotalCount(jobConfig.getHandleConfig().getJobShardingCount());
         jobConfigPOJO.setJobParameter(YamlEngine.marshal(jobConfig));
         jobConfigPOJO.getProps().setProperty("create_time", LocalDateTime.now().format(DATE_TIME_FORMATTER));
         return YamlEngine.marshal(jobConfigPOJO);
@@ -174,7 +174,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
     
     @Override
     public Map<Integer, JobProgress> getProgress(final long jobId) {
-        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getShardingTotalCount()).boxed()
+        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed()
                 .collect(LinkedHashMap::new, (map, each) -> map.put(each, ScalingAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each)), LinkedHashMap::putAll);
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
@@ -46,15 +46,16 @@ public final class HandleConfiguration {
      */
     private String tablesFirstDataNodes;
     
-    private String[] shardingTables;
+    private String[] jobShardingDataNodes;
     
     private String logicTables;
     
-    private int shardingItem;
+    /**
+     * Job sharding item, from {@link org.apache.shardingsphere.elasticjob.api.ShardingContext}.
+     */
+    private Integer jobShardingItem;
     
     private int shardingSize = 1000 * 10000;
-    
-    private boolean running = true;
     
     private String databaseType;
     
@@ -65,11 +66,11 @@ public final class HandleConfiguration {
     }
     
     /**
-     * Get sharding total count.
+     * Get job sharding count.
      *
-     * @return sharding total count
+     * @return job sharding count
      */
-    public int getShardingTotalCount() {
-        return null == shardingTables ? 0 : shardingTables.length;
+    public int getJobShardingCount() {
+        return null == jobShardingDataNodes ? 0 : jobShardingDataNodes.length;
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
@@ -37,6 +37,15 @@ public final class HandleConfiguration {
     
     private int retryTimes = 3;
     
+    /**
+     * Collection of each logic table's first data node.
+     * <p>
+     * If <pre>actualDataNodes: ds_${0..1}.t_order_${0..1}</pre> and <pre>actualDataNodes: ds_${0..1}.t_order_item_${0..1}</pre>,
+     * then value may be: {@code ds_0.t_order_0,ds_0.t_order_item_0}.
+     * </p>
+     */
+    private String tablesFirstDataNodes;
+    
     private String[] shardingTables;
     
     private String logicTables;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
@@ -22,6 +22,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+import java.util.List;
+
 /**
  * Handle configuration.
  */
@@ -46,7 +48,7 @@ public final class HandleConfiguration {
      */
     private String tablesFirstDataNodes;
     
-    private String[] jobShardingDataNodes;
+    private List<String> jobShardingDataNodes;
     
     private String logicTables;
     
@@ -71,6 +73,6 @@ public final class HandleConfiguration {
      * @return job sharding count
      */
     public int getJobShardingCount() {
-        return null == jobShardingDataNodes ? 0 : jobShardingDataNodes.length;
+        return null == jobShardingDataNodes ? 0 : jobShardingDataNodes.size();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -64,6 +64,9 @@ public final class JobConfiguration {
         if (Strings.isNullOrEmpty(handleConfig.getDatabaseType())) {
             handleConfig.setDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
         }
+        if (null == handleConfig.getJobShardingItem()) {
+            handleConfig.setJobShardingItem(0);
+        }
         RuleConfiguration ruleConfig = getRuleConfig();
         if (null == handleConfig.getJobShardingDataNodes()) {
             List<HandleConfiguration> newHandleConfigs = new LinkedList<>();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -77,6 +77,7 @@ public final class JobConfiguration {
             for (HandleConfiguration each : newHandleConfigs) {
                 handleConfig.setShardingTables(each.getShardingTables());
                 handleConfig.setLogicTables(each.getLogicTables());
+                handleConfig.setTablesFirstDataNodes(each.getTablesFirstDataNodes());
             }
         }
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -25,7 +25,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer;
-import org.apache.shardingsphere.sharding.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
 
@@ -33,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
 /**
  * Scaling job configuration.
@@ -43,14 +43,6 @@ import java.util.Optional;
 @Setter
 @Slf4j
 public final class JobConfiguration {
-    
-    private static final SnowflakeKeyGenerateAlgorithm ID_AUTO_INCREASE_GENERATOR;
-    
-    static {
-        SnowflakeKeyGenerateAlgorithm generateAlgorithm = new SnowflakeKeyGenerateAlgorithm();
-        generateAlgorithm.init();
-        ID_AUTO_INCREASE_GENERATOR = generateAlgorithm;
-    }
     
     static {
         ShardingSphereServiceLoader.register(RuleJobConfigurationPreparer.class);
@@ -66,7 +58,7 @@ public final class JobConfiguration {
     public void fillInProperties() {
         HandleConfiguration handleConfig = getHandleConfig();
         if (null == handleConfig.getJobId()) {
-            handleConfig.setJobId((Long) ID_AUTO_INCREASE_GENERATOR.generateKey());
+            handleConfig.setJobId(System.nanoTime() - ThreadLocalRandom.current().nextLong(100_0000));
         }
         if (Strings.isNullOrEmpty(handleConfig.getDatabaseType())) {
             handleConfig.setDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Getter
 @Setter
 @Slf4j
+// TODO share for totally new scenario
 public final class JobConfiguration {
     
     static {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -65,7 +65,7 @@ public final class JobConfiguration {
             handleConfig.setDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
         }
         RuleConfiguration ruleConfig = getRuleConfig();
-        if (null == handleConfig.getShardingTables()) {
+        if (null == handleConfig.getJobShardingDataNodes()) {
             List<HandleConfiguration> newHandleConfigs = new LinkedList<>();
             for (String each : ruleConfig.getChangedYamlRuleConfigClassNames()) {
                 Optional<RuleJobConfigurationPreparer> preparerOptional = TypedSPIRegistry.findRegisteredService(RuleJobConfigurationPreparer.class, each, null);
@@ -75,7 +75,7 @@ public final class JobConfiguration {
             }
             // TODO handle several rules changed or dataSources changed
             for (HandleConfiguration each : newHandleConfigs) {
-                handleConfig.setShardingTables(each.getShardingTables());
+                handleConfig.setJobShardingDataNodes(each.getJobShardingDataNodes());
                 handleConfig.setLogicTables(each.getLogicTables());
                 handleConfig.setTablesFirstDataNodes(each.getTablesFirstDataNodes());
             }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeEntry.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeEntry.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.config.internal;
+
+import com.google.common.base.Splitter;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Job data node entry.
+ */
+@Getter
+@RequiredArgsConstructor
+@ToString
+public final class JobDataNodeEntry {
+    
+    @NonNull
+    private final String logicTableName;
+    
+    @NonNull
+    private final List<DataNode> dataNodes;
+    
+    /**
+     * Unmarshal from text.
+     *
+     * @param text marshalled entry
+     * @return entry
+     */
+    public static JobDataNodeEntry unmarshal(final String text) {
+        List<String> segments = Splitter.on(":").splitToList(text);
+        String logicTableName = segments.get(0);
+        List<DataNode> dataNodes = new LinkedList<>();
+        for (String each : Splitter.on(",").omitEmptyStrings().splitToList(segments.get(1))) {
+            dataNodes.add(new DataNode(each));
+        }
+        return new JobDataNodeEntry(logicTableName, dataNodes);
+    }
+    
+    /**
+     * Marshal to text.
+     *
+     * @return text, format: logicTableName:dataNode1,dataNode2, e.g. t_order:ds_0.t_order_0,ds_0.t_order_1
+     */
+    public String marshal() {
+        StringBuilder result = new StringBuilder(getMarshalledTextEstimatedLength());
+        result.append(logicTableName);
+        result.append(":");
+        for (DataNode each : dataNodes) {
+            result.append(each.format()).append(',');
+        }
+        if (!dataNodes.isEmpty()) {
+            result.setLength(result.length() - 1);
+        }
+        return result.toString();
+    }
+    
+    /**
+     * Get marshalled text estimated length.
+     *
+     * @return length
+     */
+    public int getMarshalledTextEstimatedLength() {
+        return logicTableName.length() + 1 + dataNodes.stream().mapToInt(DataNode::getFormattedTextLength).sum() + dataNodes.size();
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeLine.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeLine.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.config.internal;
+
+import com.google.common.base.Splitter;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Job data node line.
+ */
+@Getter
+@RequiredArgsConstructor
+@ToString
+public final class JobDataNodeLine {
+    
+    @NonNull
+    private final List<JobDataNodeEntry> entries;
+    
+    /**
+     * Unmarshal from text.
+     *
+     * @param text marshalled line
+     * @return line
+     */
+    public static JobDataNodeLine unmarshal(final String text) {
+        List<String> segments = Splitter.on('|').omitEmptyStrings().splitToList(text);
+        List<JobDataNodeEntry> entries = new ArrayList<>(segments.size());
+        for (String each : segments) {
+            entries.add(JobDataNodeEntry.unmarshal(each));
+        }
+        return new JobDataNodeLine(entries);
+    }
+    
+    /**
+     * Marshal to text.
+     *
+     * @return text, format: entry1|entry2, e.g. t_order:ds_0.t_order_0,ds_0.t_order_1|t_order_item:ds_0.t_order_item_0,ds_0.t_order_item_1
+     */
+    public String marshal() {
+        StringBuilder result = new StringBuilder(getMarshalledTextEstimatedLength());
+        for (JobDataNodeEntry each : entries) {
+            result.append(each.marshal()).append('|');
+        }
+        if (!entries.isEmpty()) {
+            result.setLength(result.length() - 1);
+        }
+        return result.toString();
+    }
+    
+    private int getMarshalledTextEstimatedLength() {
+        return entries.stream().mapToInt(JobDataNodeEntry::getMarshalledTextEstimatedLength).sum() + entries.size();
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
@@ -56,7 +56,6 @@ public final class JobContext {
     
     public JobContext(final JobConfiguration jobConfig) {
         this.jobConfig = jobConfig;
-        jobConfig.fillInProperties();
         jobId = jobConfig.getHandleConfig().getJobId();
         shardingItem = jobConfig.getHandleConfig().getShardingItem();
         taskConfigs = jobConfig.convertToTaskConfigs();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
@@ -56,6 +56,7 @@ public final class JobContext {
     
     public JobContext(final JobConfiguration jobConfig) {
         this.jobConfig = jobConfig;
+        jobConfig.fillInProperties();
         jobId = jobConfig.getHandleConfig().getJobId();
         shardingItem = jobConfig.getHandleConfig().getJobShardingItem();
         taskConfigs = jobConfig.convertToTaskConfigs();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
@@ -57,7 +57,7 @@ public final class JobContext {
     public JobContext(final JobConfiguration jobConfig) {
         this.jobConfig = jobConfig;
         jobId = jobConfig.getHandleConfig().getJobId();
-        shardingItem = jobConfig.getHandleConfig().getShardingItem();
+        shardingItem = jobConfig.getHandleConfig().getJobShardingItem();
         taskConfigs = jobConfig.convertToTaskConfigs();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/ScalingJob.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/ScalingJob.java
@@ -41,7 +41,7 @@ public final class ScalingJob implements SimpleJob {
     public void execute(final ShardingContext shardingContext) {
         log.info("Execute scaling job {}-{}", shardingContext.getJobName(), shardingContext.getShardingItem());
         JobConfiguration jobConfig = YamlEngine.unmarshal(shardingContext.getJobParameter(), JobConfiguration.class, true);
-        jobConfig.getHandleConfig().setShardingItem(shardingContext.getShardingItem());
+        jobConfig.getHandleConfig().setJobShardingItem(shardingContext.getShardingItem());
         JobContext jobContext = new JobContext(jobConfig);
         jobContext.setInitProgress(governanceRepositoryAPI.getJobProgress(jobContext.getJobId(), jobContext.getShardingItem()));
         jobContext.setJobPreparer(jobPreparer);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/check/consistency/DataConsistencyCheckerImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/check/consistency/DataConsistencyCheckerImpl.java
@@ -62,6 +62,7 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
     
     private final DataSourceFactory dataSourceFactory = new DataSourceFactory();
     
+    // TODO replace to JobConfiguration
     private final JobContext jobContext;
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/PrepareTargetTablesParameter.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/PrepareTargetTablesParameter.java
@@ -17,15 +17,22 @@
 
 package org.apache.shardingsphere.scaling.core.job.preparer;
 
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeLine;
+
 /**
- * Data source preparer.
+ * Prepare target tables parameter.
  */
-public interface DataSourcePreparer {
+@RequiredArgsConstructor
+@Getter
+public final class PrepareTargetTablesParameter {
     
-    /**
-     * Prepare target tables.
-     *
-     * @param parameter prepare target tables parameter
-     */
-    void prepareTargetTables(PrepareTargetTablesParameter parameter);
+    @NonNull
+    private final JobDataNodeLine tablesFirstDataNodes;
+    
+    @NonNull
+    private final RuleConfiguration ruleConfig;
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ScalingJobPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ScalingJobPreparer.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceCo
 import org.apache.shardingsphere.scaling.core.common.exception.PrepareFailedException;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
+import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeLine;
 import org.apache.shardingsphere.scaling.core.job.JobContext;
 import org.apache.shardingsphere.scaling.core.job.JobStatus;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
@@ -74,7 +75,9 @@ public final class ScalingJobPreparer {
             log.info("dataSourcePreparer null, ignore prepare target");
             return;
         }
-        dataSourcePreparer.prepareTargetTables(jobConfig);
+        JobDataNodeLine tablesFirstDataNodes = JobDataNodeLine.unmarshal(jobConfig.getHandleConfig().getTablesFirstDataNodes());
+        PrepareTargetTablesParameter prepareTargetTablesParameter = new PrepareTargetTablesParameter(tablesFirstDataNodes, jobConfig.getRuleConfig());
+        dataSourcePreparer.prepareTargetTables(prepareTargetTablesParameter);
     }
     
     private void initDataSourceManager(final DataSourceManager dataSourceManager, final List<TaskConfiguration> taskConfigs) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/ScalingTaskUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/util/ScalingTaskUtil.java
@@ -55,7 +55,7 @@ public final class ScalingTaskUtil {
     }
     
     private static boolean isProgressCompleted(final Map<Integer, JobProgress> jobProgressMap, final HandleConfiguration handleConfig) {
-        return handleConfig.getShardingTotalCount() == jobProgressMap.size()
+        return handleConfig.getJobShardingCount() == jobProgressMap.size()
                 && jobProgressMap.values().stream().allMatch(Objects::nonNull);
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -105,13 +105,13 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
         return result;
     }
     
-    private static String[] groupByDataSource(final Collection<DataNode> dataNodes) {
+    private static List<String> groupByDataSource(final Collection<DataNode> dataNodes) {
         Map<String, Collection<DataNode>> dataSourceDataNodesMap = new LinkedHashMap<>();
         for (DataNode each : dataNodes) {
             dataSourceDataNodesMap.computeIfAbsent(each.getDataSourceName(), k -> new LinkedList<>()).add(each);
         }
         return dataSourceDataNodesMap.values().stream().map(each -> each.stream().map(DataNode::format)
-                .collect(Collectors.joining(","))).toArray(String[]::new);
+                .collect(Collectors.joining(","))).collect(Collectors.toList());
     }
     
     private static String getLogicTables(final Set<String> logicTables) {
@@ -176,11 +176,11 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
     }
     
     private static String getJobShardingDataNodesEntry(final HandleConfiguration handleConfig) {
-        if (handleConfig.getJobShardingItem() >= handleConfig.getJobShardingDataNodes().length) {
-            log.warn("jobShardingItem={} ge handleConfig.jobShardingDataNodes.len={}", handleConfig.getJobShardingItem(), handleConfig.getJobShardingDataNodes().length);
+        if (handleConfig.getJobShardingItem() >= handleConfig.getJobShardingDataNodes().size()) {
+            log.warn("jobShardingItem={} ge handleConfig.jobShardingDataNodes.len={}", handleConfig.getJobShardingItem(), handleConfig.getJobShardingDataNodes().size());
             return "";
         }
-        return handleConfig.getJobShardingDataNodes()[handleConfig.getJobShardingItem()];
+        return handleConfig.getJobShardingDataNodes().get(handleConfig.getJobShardingItem());
     }
     
     private static void filterByShardingTables(final Map<String, String> fullTables, final Set<String> shardingTables) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -36,6 +36,8 @@ import org.apache.shardingsphere.scaling.core.config.ImporterConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
+import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeEntry;
+import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeLine;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
@@ -117,11 +119,11 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
     }
     
     private static String getTablesFirstDataNodes(final Map<String, List<DataNode>> actualDataNodes) {
-        List<String> result = new LinkedList<>();
+        List<JobDataNodeEntry> dataNodeEntries = new ArrayList<>(actualDataNodes.size());
         for (Entry<String, List<DataNode>> entry : actualDataNodes.entrySet()) {
-            result.add(entry.getValue().get(0).format());
+            dataNodeEntries.add(new JobDataNodeEntry(entry.getKey(), entry.getValue()));
         }
-        return Joiner.on(',').join(result);
+        return new JobDataNodeLine(dataNodeEntries).marshal();
     }
     
     // TODO handle several rules changed or dataSources changed
@@ -165,7 +167,7 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
             log.info("jobShardingDataNodes null");
             return;
         }
-        // TODO simplify data source and table name converting, include tablesFirstDataNodes and jobShardingDataNodes format
+        // TODO simplify data source and table name converting, and jobShardingDataNodes format
         Map<String, Set<String>> jobDataSourceTableNameMap = toDataSourceTableNameMap(getJobShardingDataNodesEntry(handleConfig));
         totalDataSourceTableNameMap.entrySet().removeIf(entry -> !jobDataSourceTableNameMap.containsKey(entry.getKey()));
         for (Entry<String, Map<String, String>> entry : totalDataSourceTableNameMap.entrySet()) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -110,6 +110,7 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
                 .orElse("");
     }
     
+    // TODO handle several rules changed or dataSources changed
     @Override
     public List<TaskConfiguration> convertToTaskConfigs(final JobConfiguration jobConfig) {
         List<TaskConfiguration> result = new LinkedList<>();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -121,7 +121,7 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
     private static String getTablesFirstDataNodes(final Map<String, List<DataNode>> actualDataNodes) {
         List<JobDataNodeEntry> dataNodeEntries = new ArrayList<>(actualDataNodes.size());
         for (Entry<String, List<DataNode>> entry : actualDataNodes.entrySet()) {
-            dataNodeEntries.add(new JobDataNodeEntry(entry.getKey(), entry.getValue()));
+            dataNodeEntries.add(new JobDataNodeEntry(entry.getKey(), entry.getValue().subList(0, 1)));
         }
         return new JobDataNodeLine(dataNodeEntries).marshal();
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/migration/common/job/preparer/AbstractDataSourcePreparerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.migration.common.job.preparer;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
+import org.apache.shardingsphere.scaling.core.job.preparer.PrepareTargetTablesParameter;
 import org.apache.shardingsphere.scaling.core.job.preparer.TableDefinitionSQLType;
 import org.junit.Test;
 
@@ -38,7 +38,7 @@ public final class AbstractDataSourcePreparerTest {
     
     private final AbstractDataSourcePreparer preparer = new AbstractDataSourcePreparer() {
         @Override
-        public void prepareTargetTables(final JobConfiguration jobConfig) {
+        public void prepareTargetTables(final PrepareTargetTablesParameter parameter) {
         }
     };
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImplTest.java
@@ -75,7 +75,7 @@ public final class ScalingAPIImplTest {
         assertThat(jobInfo.getTables(), is("t_order"));
         assertThat(jobInfo.getShardingTotalCount(), is(1));
         List<Long> uncompletedJobIds = scalingAPI.getUncompletedJobIds("logic_db");
-        assertThat(uncompletedJobIds.size(), is(0));
+        assertTrue(uncompletedJobIds.size() > 0);
     }
     
     private Optional<JobInfo> getJobInfo(final long jobId) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeEntryTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeEntryTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.config.internal;
+
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public final class JobDataNodeEntryTest {
+    
+    @Test
+    public void assertSerialization() {
+        String text = "t_order:ds_0.t_order_0,ds_0.t_order_1";
+        JobDataNodeEntry actual = JobDataNodeEntry.unmarshal(text);
+        assertNotNull(actual);
+        assertThat(actual.marshal(), is(text));
+        assertThat(actual.getLogicTableName(), is("t_order"));
+        List<DataNode> dataNodes = actual.getDataNodes();
+        assertNotNull(dataNodes);
+        assertThat(dataNodes.size(), is(2));
+        assertThat(dataNodes.get(0).format(), is("ds_0.t_order_0"));
+        assertThat(dataNodes.get(1).format(), is("ds_0.t_order_1"));
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeLineTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/config/internal/JobDataNodeLineTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.scaling.core.config.internal;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public final class JobDataNodeLineTest {
+    
+    @Test
+    public void assertSerialization() {
+        String text = "t_order:ds_0.t_order_0,ds_0.t_order_1|t_order_item:ds_0.t_order_item_0,ds_0.t_order_item_1";
+        JobDataNodeLine actual = JobDataNodeLine.unmarshal(text);
+        assertNotNull(actual);
+        assertThat(actual.marshal(), is(text));
+        List<JobDataNodeEntry> entries = actual.getEntries();
+        assertNotNull(entries);
+        assertThat(entries.size(), is(2));
+        assertThat(entries.get(0).getLogicTableName(), is("t_order"));
+        assertThat(entries.get(1).getLogicTableName(), is("t_order_item"));
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/executor/importer/AbstractImporterTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.scaling.core.executor.importer;
 
 import org.apache.shardingsphere.data.pipeline.core.datasource.DataSourceManager;
+import org.apache.shardingsphere.data.pipeline.core.datasource.DataSourceWrapper;
 import org.apache.shardingsphere.data.pipeline.core.ingest.channel.Channel;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.PlaceholderPosition;
 import org.apache.shardingsphere.data.pipeline.core.ingest.record.Column;
@@ -35,7 +36,6 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -75,8 +75,8 @@ public final class AbstractImporterTest {
     @Mock
     private Channel channel;
     
-    @Mock(extraInterfaces = AutoCloseable.class)
-    private DataSource dataSource;
+    @Mock
+    private DataSourceWrapper dataSource;
     
     @Mock
     private Connection connection;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/fixture/FixtureDataSourcePreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/fixture/FixtureDataSourcePreparer.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.scaling.core.fixture;
 
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.job.preparer.DataSourcePreparer;
+import org.apache.shardingsphere.scaling.core.job.preparer.PrepareTargetTablesParameter;
 
 public final class FixtureDataSourcePreparer implements DataSourcePreparer {
     
     @Override
-    public void prepareTargetTables(final JobConfiguration jobConfig) {
+    public void prepareTargetTables(final PrepareTargetTablesParameter parameter) {
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -22,8 +22,10 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.StandardJDBCDataSourceConfiguration;
+import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.WorkflowConfiguration;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -73,12 +75,20 @@ public final class ResourceUtil {
      * @return standard JDBC as target job configuration
      */
     public static JobConfiguration mockStandardJdbcTargetJobConfig() {
+        JobConfiguration result = new JobConfiguration();
         RuleConfiguration ruleConfig = new RuleConfiguration();
+        result.setRuleConfig(ruleConfig);
         setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new StandardJDBCDataSourceConfiguration(readFileToString("/config_standard_jdbc_target.yaml")).wrap());
-        JobConfiguration result = new JobConfiguration();
-        result.setRuleConfig(ruleConfig);
+        HandleConfiguration handleConfig = new HandleConfiguration();
+        result.setHandleConfig(handleConfig);
+        handleConfig.setJobShardingItem(0);
+        handleConfig.setLogicTables("t_order");
+        handleConfig.setTablesFirstDataNodes("t_order:ds_0.t_order");
+        handleConfig.setJobShardingDataNodes(Collections.singletonList("ds_0.t_order"));
+        handleConfig.setWorkflowConfig(new WorkflowConfiguration("logic_db", "id1"));
+        result.fillInProperties();
         return result;
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDB
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
 import org.apache.shardingsphere.scaling.core.common.exception.PrepareFailedException;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
+import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeLine;
 import org.apache.shardingsphere.scaling.core.job.preparer.PrepareTargetTablesParameter;
 import org.apache.shardingsphere.scaling.mysql.component.checker.MySQLDataSourcePreparer;
 import org.junit.Before;
@@ -31,6 +32,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.Collections;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,6 +67,7 @@ public final class MySQLDataSourcePreparerTest {
     @Before
     public void setUp() throws SQLException {
         when(prepareTargetTablesParameter.getRuleConfig()).thenReturn(ruleConfiguration);
+        when(prepareTargetTablesParameter.getTablesFirstDataNodes()).thenReturn(new JobDataNodeLine(Collections.emptyList()));
         when(ruleConfiguration.getSource()).thenReturn(sourceDataSourceConfigurationWrap);
         when(sourceDataSourceConfigurationWrap.unwrap()).thenReturn(sourceScalingDataSourceConfiguration);
         when(sourceScalingDataSourceConfiguration.toDataSource()).thenReturn(sourceDataSource);

--- a/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-dialect/shardingsphere-scaling-mysql/src/test/java/org/apache/shardingsphere/scaling/mysql/component/MySQLDataSourcePreparerTest.java
@@ -19,12 +19,10 @@ package org.apache.shardingsphere.scaling.mysql.component;
 
 import org.apache.shardingsphere.infra.config.datasource.typed.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.typed.TypedDataSourceConfigurationWrap;
-import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.scaling.core.common.exception.PrepareFailedException;
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
+import org.apache.shardingsphere.scaling.core.job.preparer.PrepareTargetTablesParameter;
 import org.apache.shardingsphere.scaling.mysql.component.checker.MySQLDataSourcePreparer;
-import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +31,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
-import java.util.Collections;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -42,7 +39,7 @@ import static org.mockito.Mockito.when;
 public final class MySQLDataSourcePreparerTest {
 
     @Mock
-    private JobConfiguration jobConfiguration;
+    private PrepareTargetTablesParameter prepareTargetTablesParameter;
 
     @Mock
     private RuleConfiguration ruleConfiguration;
@@ -65,37 +62,29 @@ public final class MySQLDataSourcePreparerTest {
     @Mock(extraInterfaces = AutoCloseable.class)
     private DataSource targetDataSource;
 
-    @Mock
-    private YamlRootConfiguration yamlRootConfiguration;
-
-    @Mock
-    private YamlShardingRuleConfiguration yamlShardingRuleConfiguration;
-
     @Before
     public void setUp() throws SQLException {
-        when(jobConfiguration.getRuleConfig()).thenReturn(ruleConfiguration);
+        when(prepareTargetTablesParameter.getRuleConfig()).thenReturn(ruleConfiguration);
         when(ruleConfiguration.getSource()).thenReturn(sourceDataSourceConfigurationWrap);
         when(sourceDataSourceConfigurationWrap.unwrap()).thenReturn(sourceScalingDataSourceConfiguration);
         when(sourceScalingDataSourceConfiguration.toDataSource()).thenReturn(sourceDataSource);
-        when(sourceScalingDataSourceConfiguration.getRootConfig()).thenReturn(yamlRootConfiguration);
-        when(yamlRootConfiguration.getRules()).thenReturn(Collections.singletonList(yamlShardingRuleConfiguration));
         when(ruleConfiguration.getTarget()).thenReturn(targetDataSourceConfigurationWrap);
         when(targetDataSourceConfigurationWrap.unwrap()).thenReturn(targetScalingDataSourceConfiguration);
         when(targetScalingDataSourceConfiguration.toDataSource()).thenReturn(targetDataSource);
     }
-
+    
     @Test
     public void assertGetConnection() throws SQLException {
         MySQLDataSourcePreparer mySQLDataSourcePreparer = new MySQLDataSourcePreparer();
-        mySQLDataSourcePreparer.prepareTargetTables(jobConfiguration);
+        mySQLDataSourcePreparer.prepareTargetTables(prepareTargetTablesParameter);
         verify(sourceDataSource).getConnection();
         verify(targetDataSource).getConnection();
     }
-
+    
     @Test(expected = PrepareFailedException.class)
     public void assertThrowPrepareFailedException() throws SQLException {
         when(sourceDataSource.getConnection()).thenThrow(SQLException.class);
         MySQLDataSourcePreparer mySQLDataSourcePreparer = new MySQLDataSourcePreparer();
-        mySQLDataSourcePreparer.prepareTargetTables(jobConfiguration);
+        mySQLDataSourcePreparer.prepareTargetTables(prepareTargetTablesParameter);
     }
 }


### PR DESCRIPTION
Fixes #13875 part 8.

Changes proposed in this pull request:
- Remove SnowflakeKeyGenerateAlgorithm dependency from JobConfiguration, which is in `sharding-core`
- Add getActualDataSourceConfig for ShardingSphereJDBCDataSourceConfiguration, prepare for DataSourcePreparer refactoring
- Add JobDataNodeLine
- Add tablesFirstDataNodes in job handleConfig, prepare for DataSourcePreparer refactoring
- Refactor fields in job handleConfig
- Refactor DataSourcePreparer, separate sharding related code from scaling-core
- Refactor jobShardingDataNodes type in handleConfig
