### PR TITLE
Separate sharding related code from scaling-core module part 4, support several rules altered, refactor job configuration structure

### DIFF
--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/JobRuleAlteredDetector.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/JobRuleAlteredDetector.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.spi;
+
+import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
+import org.apache.shardingsphere.spi.typed.TypedSPI;
+
+/**
+ * Job rule altered detector, SPI interface.
+ */
+public interface JobRuleAlteredDetector extends TypedSPI {
+    
+    /**
+     * Is rule altered.
+     *
+     * @param sourceRuleConfig source YAML rule configuration, may be null
+     * @param targetRuleConfig target YAML rule configuration, may be null
+     * @return whether is rule altered or not
+     */
+    boolean isRuleAltered(YamlRuleConfiguration sourceRuleConfig, YamlRuleConfiguration targetRuleConfig);
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
@@ -33,7 +33,6 @@ import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cache.event.StartScalingEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
 import org.apache.shardingsphere.scaling.core.api.ScalingAPIFactory;
-import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.WorkflowConfiguration;
@@ -100,9 +99,9 @@ public final class ScalingWorker {
             log.info("source and target sharding configuration is the same, ignore");
             return Optional.empty();
         }
+        WorkflowConfiguration workflowConfig = new WorkflowConfiguration(event.getSchemaName(), event.getRuleCacheId());
         RuleConfiguration ruleConfig = getRuleConfiguration(sourceRootConfig, targetRootConfig);
-        HandleConfiguration handleConfig = new HandleConfiguration(new WorkflowConfiguration(event.getSchemaName(), event.getRuleCacheId()));
-        return Optional.of(new JobConfiguration(ruleConfig, handleConfig));
+        return Optional.of(new JobConfiguration(workflowConfig, ruleConfig));
     }
     
     private Optional<YamlShardingRuleConfiguration> getYamlShardingRuleConfiguration(final YamlRootConfiguration rootConfig) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/api/ScalingWorker.java
@@ -42,7 +42,6 @@ import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfigurat
 import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -123,8 +122,6 @@ public final class ScalingWorker {
     
     private RuleConfiguration getRuleConfiguration(final YamlRootConfiguration sourceRootConfig, final YamlRootConfiguration targetRootConfig) {
         RuleConfiguration result = new RuleConfiguration();
-        // TODO handle several rules changed or dataSources changed
-        result.setChangedYamlRuleConfigClassNames(Collections.singletonList(YamlShardingRuleConfiguration.class.getName()));
         result.setSource(new ShardingSphereJDBCDataSourceConfiguration(sourceRootConfig).wrap());
         result.setTarget(new ShardingSphereJDBCDataSourceConfiguration(targetRootConfig).wrap());
         return result;

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/JobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/JobConfigurationPreparer.java
@@ -17,25 +17,17 @@
 
 package org.apache.shardingsphere.migration.common.spi;
 
-import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
-import org.apache.shardingsphere.spi.typed.TypedSPI;
+import org.apache.shardingsphere.spi.required.RequiredSPI;
 
 import java.util.List;
 
 /**
- * Rule job configuration preparer, SPI interface.
+ * Job configuration preparer, SPI interface.
  */
-public interface RuleJobConfigurationPreparer extends TypedSPI {
-    
-    /**
-     * Get type.
-     *
-     * @return {@link YamlRuleConfiguration} implementation class full name
-     */
-    String getType();
+public interface JobConfigurationPreparer extends RequiredSPI {
     
     /**
      * Create handle configuration, used to build job configuration.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/migration/common/spi/RuleJobConfigurationPreparer.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.migration.common.spi;
 
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
 import org.apache.shardingsphere.spi.typed.TypedSPI;
@@ -39,18 +38,19 @@ public interface RuleJobConfigurationPreparer extends TypedSPI {
     String getType();
     
     /**
-     * Convert to handle configuration, used to build job configuration.
+     * Create handle configuration, used to build job configuration.
      *
      * @param ruleConfig rule configuration
-     * @return handle configuration. It won't be used directly, but merge necessary configuration (e.g. shardingTables, logicTables) into final {@link HandleConfiguration}
+     * @return handle configuration
      */
-    HandleConfiguration convertToHandleConfig(RuleConfiguration ruleConfig);
+    HandleConfiguration createHandleConfig(RuleConfiguration ruleConfig);
     
     /**
-     * Convert to task configurations, used by underlying scheduler.
+     * Create task configurations, used by underlying scheduler.
      *
-     * @param jobConfig job configuration
+     * @param ruleConfig rule configuration
+     * @param handleConfig handle configuration
      * @return task configurations
      */
-    List<TaskConfiguration> convertToTaskConfigs(JobConfiguration jobConfig);
+    List<TaskConfiguration> createTaskConfigs(RuleConfiguration ruleConfig, HandleConfiguration handleConfig);
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -49,7 +49,7 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     public void persistJobProgress(final JobContext jobContext) {
         JobProgress jobProgress = new JobProgress();
         jobProgress.setStatus(jobContext.getStatus());
-        jobProgress.setDatabaseType(jobContext.getJobConfig().getHandleConfig().getDatabaseType());
+        jobProgress.setSourceDatabaseType(jobContext.getJobConfig().getHandleConfig().getSourceDatabaseType());
         jobProgress.setIncrementalTaskProgressMap(getIncrementalTaskProgressMap(jobContext));
         jobProgress.setInventoryTaskProgressMap(getInventoryTaskProgressMap(jobContext));
         repository.persist(getOffsetPath(jobContext.getJobId(), jobContext.getShardingItem()), jobProgress.toString());

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -113,7 +113,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
         JobConfiguration jobConfig = getJobConfig(jobConfigPOJO);
         HandleConfiguration handleConfig = jobConfig.getHandleConfig();
         WorkflowConfiguration workflowConfig;
-        if (null == handleConfig || null == (workflowConfig = handleConfig.getWorkflowConfig())) {
+        if (null == handleConfig || null == (workflowConfig = jobConfig.getWorkflowConfig())) {
             log.warn("handleConfig or workflowConfig null, jobId={}", jobId);
             return false;
         }
@@ -262,7 +262,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
         optionalJobContexts.ifPresent(jobContexts -> jobContexts.forEach(each -> each.setStatus(JobStatus.ALMOST_FINISHED)));
         JDBCDataSourceConfigurationWrapper targetConfig = jobConfig.getRuleConfig().getTarget();
         YamlRootConfiguration yamlRootConfig = YamlEngine.unmarshal(targetConfig.getParameter(), YamlRootConfiguration.class);
-        WorkflowConfiguration workflowConfig = jobConfig.getHandleConfig().getWorkflowConfig();
+        WorkflowConfiguration workflowConfig = jobConfig.getWorkflowConfig();
         String schemaName = workflowConfig.getSchemaName();
         String ruleCacheId = workflowConfig.getRuleCacheId();
         ScalingTaskFinishedEvent taskFinishedEvent = new ScalingTaskFinishedEvent(schemaName, yamlRootConfig, ruleCacheId);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/api/impl/ScalingAPIImpl.java
@@ -134,7 +134,7 @@ public final class ScalingAPIImpl implements ScalingAPI {
     
     @Override
     public Optional<Long> start(final JobConfiguration jobConfig) {
-        jobConfig.fillInProperties();
+        jobConfig.buildHandleConfig();
         if (jobConfig.getHandleConfig().getJobShardingCount() == 0) {
             log.warn("Invalid scaling job config!");
             throw new ScalingJobCreationException("handleConfig shardingTotalCount is 0");

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
@@ -43,7 +43,7 @@ public final class HandleConfiguration {
      * Collection of each logic table's first data node.
      * <p>
      * If <pre>actualDataNodes: ds_${0..1}.t_order_${0..1}</pre> and <pre>actualDataNodes: ds_${0..1}.t_order_item_${0..1}</pre>,
-     * then value may be: {@code ds_0.t_order_0,ds_0.t_order_item_0}.
+     * then value may be: {@code t_order:ds_0.t_order_0|t_order_item:ds_0.t_order_item_0}.
      * </p>
      */
     private String tablesFirstDataNodes;
@@ -53,19 +53,13 @@ public final class HandleConfiguration {
     private String logicTables;
     
     /**
-     * Job sharding item, from {@link org.apache.shardingsphere.elasticjob.api.ShardingContext}.
+     * Job sharding item, from {@link org.apache.shardingsphere.elasticjob.api.ShardingContext#getShardingItem()}.
      */
     private Integer jobShardingItem;
     
     private int shardingSize = 1000 * 10000;
     
     private String databaseType;
-    
-    private WorkflowConfiguration workflowConfig;
-    
-    public HandleConfiguration(final WorkflowConfiguration workflowConfig) {
-        this.workflowConfig = workflowConfig;
-    }
     
     /**
      * Get job sharding count.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/HandleConfiguration.java
@@ -59,7 +59,9 @@ public final class HandleConfiguration {
     
     private int shardingSize = 1000 * 10000;
     
-    private String databaseType;
+    private String sourceDatabaseType;
+    
+    private String targetDatabaseType;
     
     /**
      * Get job sharding count.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -49,9 +49,16 @@ public final class JobConfiguration {
         ShardingSphereServiceLoader.register(RuleJobConfigurationPreparer.class);
     }
     
+    private WorkflowConfiguration workflowConfig;
+    
     private RuleConfiguration ruleConfig;
     
     private HandleConfiguration handleConfig = new HandleConfiguration();
+    
+    public JobConfiguration(final WorkflowConfiguration workflowConfig, final RuleConfiguration ruleConfig) {
+        this.workflowConfig = workflowConfig;
+        this.ruleConfig = ruleConfig;
+    }
     
     /**
      * Fill in properties.

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -68,8 +68,11 @@ public final class JobConfiguration {
         if (null == handleConfig.getJobId()) {
             handleConfig.setJobId(System.nanoTime() - ThreadLocalRandom.current().nextLong(100_0000));
         }
-        if (Strings.isNullOrEmpty(handleConfig.getDatabaseType())) {
-            handleConfig.setDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
+        if (Strings.isNullOrEmpty(handleConfig.getSourceDatabaseType())) {
+            handleConfig.setSourceDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
+        }
+        if (Strings.isNullOrEmpty(handleConfig.getTargetDatabaseType())) {
+            handleConfig.setSourceDatabaseType(getRuleConfig().getTarget().unwrap().getDatabaseType().getName());
         }
         if (null == handleConfig.getJobShardingItem()) {
             handleConfig.setJobShardingItem(0);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -61,9 +61,9 @@ public final class JobConfiguration {
     }
     
     /**
-     * Fill in properties.
+     * Build handle configuration.
      */
-    public void fillInProperties() {
+    public void buildHandleConfig() {
         HandleConfiguration handleConfig = getHandleConfig();
         if (null == handleConfig.getJobId()) {
             handleConfig.setJobId(System.nanoTime() - ThreadLocalRandom.current().nextLong(100_0000));
@@ -83,7 +83,7 @@ public final class JobConfiguration {
             for (String each : ruleConfig.getChangedYamlRuleConfigClassNames()) {
                 Optional<RuleJobConfigurationPreparer> preparerOptional = TypedSPIRegistry.findRegisteredService(RuleJobConfigurationPreparer.class, each, null);
                 Preconditions.checkArgument(preparerOptional.isPresent(), "Could not find registered service for type '%s'", each);
-                HandleConfiguration newHandleConfig = preparerOptional.get().convertToHandleConfig(ruleConfig);
+                HandleConfiguration newHandleConfig = preparerOptional.get().createHandleConfig(ruleConfig);
                 newHandleConfigs.add(newHandleConfig);
             }
             // TODO handle several rules changed or dataSources changed
@@ -100,13 +100,13 @@ public final class JobConfiguration {
      *
      * @return task configurations
      */
-    public List<TaskConfiguration> convertToTaskConfigs() {
+    public List<TaskConfiguration> buildTaskConfigs() {
         RuleConfiguration ruleConfig = getRuleConfig();
         // TODO handle several rules changed or dataSources changed
         for (String each : ruleConfig.getChangedYamlRuleConfigClassNames()) {
             Optional<RuleJobConfigurationPreparer> preparerOptional = TypedSPIRegistry.findRegisteredService(RuleJobConfigurationPreparer.class, each, null);
             Preconditions.checkArgument(preparerOptional.isPresent(), "Could not find registered service for type '%s'", each);
-            return preparerOptional.get().convertToTaskConfigs(this);
+            return preparerOptional.get().createTaskConfigs(ruleConfig, handleConfig);
         }
         log.warn("return empty task configurations");
         return Collections.emptyList();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/JobConfiguration.java
@@ -72,7 +72,7 @@ public final class JobConfiguration {
             handleConfig.setSourceDatabaseType(getRuleConfig().getSource().unwrap().getDatabaseType().getName());
         }
         if (Strings.isNullOrEmpty(handleConfig.getTargetDatabaseType())) {
-            handleConfig.setSourceDatabaseType(getRuleConfig().getTarget().unwrap().getDatabaseType().getName());
+            handleConfig.setTargetDatabaseType(getRuleConfig().getTarget().unwrap().getDatabaseType().getName());
         }
         if (null == handleConfig.getJobShardingItem()) {
             handleConfig.setJobShardingItem(0);

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/RuleConfiguration.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/config/RuleConfiguration.java
@@ -19,22 +19,13 @@ package org.apache.shardingsphere.scaling.core.config;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
-import lombok.NonNull;
-import lombok.Setter;
 import org.apache.shardingsphere.infra.config.datasource.jdbc.config.JDBCDataSourceConfigurationWrapper;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * Rule configuration.
  */
 @Getter
 public final class RuleConfiguration {
-    
-    @Setter
-    @NonNull
-    private List<String> changedYamlRuleConfigClassNames = Collections.emptyList();
     
     private JDBCDataSourceConfigurationWrapper source;
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/JobContext.java
@@ -56,9 +56,9 @@ public final class JobContext {
     
     public JobContext(final JobConfiguration jobConfig) {
         this.jobConfig = jobConfig;
-        jobConfig.fillInProperties();
+        jobConfig.buildHandleConfig();
         jobId = jobConfig.getHandleConfig().getJobId();
         shardingItem = jobConfig.getHandleConfig().getJobShardingItem();
-        taskConfigs = jobConfig.convertToTaskConfigs();
+        taskConfigs = jobConfig.buildTaskConfigs();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/environment/ScalingEnvironmentManager.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/environment/ScalingEnvironmentManager.java
@@ -46,7 +46,7 @@ public final class ScalingEnvironmentManager {
         try (DataSourceWrapper dataSource = dataSourceFactory.newInstance(jobContext.getJobConfig().getRuleConfig().getTarget().unwrap());
              Connection connection = dataSource.getConnection()) {
             for (String each : tables) {
-                String sql = ScalingSQLBuilderFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getDatabaseType()).buildTruncateSQL(each);
+                String sql = ScalingSQLBuilderFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getTargetDatabaseType()).buildTruncateSQL(each);
                 try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
                     preparedStatement.execute();
                 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ScalingJobPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/ScalingJobPreparer.java
@@ -70,7 +70,7 @@ public final class ScalingJobPreparer {
     }
     
     private void prepareTarget(final JobConfiguration jobConfig) {
-        DataSourcePreparer dataSourcePreparer = EnvironmentCheckerFactory.getDataSourcePreparer(jobConfig.getHandleConfig().getDatabaseType());
+        DataSourcePreparer dataSourcePreparer = EnvironmentCheckerFactory.getDataSourcePreparer(jobConfig.getHandleConfig().getTargetDatabaseType());
         if (null == dataSourcePreparer) {
             log.info("dataSourcePreparer null, ignore prepare target");
             return;
@@ -97,14 +97,14 @@ public final class ScalingJobPreparer {
     }
     
     private void checkSourceDataSources(final JobContext jobContext, final DataSourceManager dataSourceManager) {
-        DataSourceChecker dataSourceChecker = EnvironmentCheckerFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getDatabaseType());
+        DataSourceChecker dataSourceChecker = EnvironmentCheckerFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getSourceDatabaseType());
         dataSourceChecker.checkConnection(dataSourceManager.getCachedDataSources().values());
         dataSourceChecker.checkPrivilege(dataSourceManager.getSourceDataSources().values());
         dataSourceChecker.checkVariable(dataSourceManager.getSourceDataSources().values());
     }
     
     private void checkTargetDataSources(final JobContext jobContext, final DataSourceManager dataSourceManager) {
-        DataSourceChecker dataSourceChecker = EnvironmentCheckerFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getDatabaseType());
+        DataSourceChecker dataSourceChecker = EnvironmentCheckerFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getTargetDatabaseType());
         dataSourceChecker.checkTargetTable(dataSourceManager.getTargetDataSources().values(), jobContext.getTaskConfigs().iterator().next().getImporterConfig().getShardingColumnsMap().keySet());
     }
     
@@ -130,7 +130,7 @@ public final class ScalingJobPreparer {
                 return positionOptional.get();
             }
         }
-        return PositionInitializerFactory.newInstance(taskConfig.getHandleConfig().getDatabaseType()).init(dataSourceManager.getDataSource(taskConfig.getDumperConfig().getDataSourceConfig()));
+        return PositionInitializerFactory.newInstance(taskConfig.getHandleConfig().getSourceDatabaseType()).init(dataSourceManager.getDataSource(taskConfig.getDumperConfig().getDataSourceConfig()));
     }
     
     /**
@@ -142,7 +142,7 @@ public final class ScalingJobPreparer {
         try (DataSourceManager dataSourceManager = new DataSourceManager()) {
             initDataSourceManager(dataSourceManager, jobContext.getTaskConfigs());
             for (TaskConfiguration each : jobContext.getTaskConfigs()) {
-                PositionInitializer positionInitializer = PositionInitializerFactory.newInstance(each.getHandleConfig().getDatabaseType());
+                PositionInitializer positionInitializer = PositionInitializerFactory.newInstance(each.getHandleConfig().getSourceDatabaseType());
                 positionInitializer.destroy(dataSourceManager.getDataSource(each.getDumperConfig().getDataSourceConfig()));
             }
         } catch (final SQLException ex) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/splitter/InventoryTaskSplitter.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/preparer/splitter/InventoryTaskSplitter.java
@@ -159,7 +159,7 @@ public final class InventoryTaskSplitter {
     
     private Collection<IngestPosition<?>> getPositionByPrimaryKeyRange(final JobContext jobContext, final DataSource dataSource, final InventoryDumperConfiguration dumperConfig) {
         Collection<IngestPosition<?>> result = new ArrayList<>();
-        String sql = ScalingSQLBuilderFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getDatabaseType())
+        String sql = ScalingSQLBuilderFactory.newInstance(jobContext.getJobConfig().getHandleConfig().getSourceDatabaseType())
                 .buildSplitByPrimaryKeyRangeSQL(dumperConfig.getTableName(), dumperConfig.getPrimaryKey());
         try (Connection connection = dataSource.getConnection();
              PreparedStatement ps = connection.prepareStatement(sql)) {

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/JobProgress.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/JobProgress.java
@@ -46,7 +46,7 @@ public final class JobProgress {
     
     private JobStatus status = JobStatus.RUNNING;
     
-    private String databaseType;
+    private String sourceDatabaseType;
     
     private Map<String, InventoryTaskProgress> inventoryTaskProgressMap;
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/yaml/JobProgressYamlSwapper.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/yaml/JobProgressYamlSwapper.java
@@ -49,7 +49,7 @@ public final class JobProgressYamlSwapper {
     public YamlJobProgress swapToYaml(final JobProgress jobProgress) {
         YamlJobProgress result = new YamlJobProgress();
         result.setStatus(jobProgress.getStatus().name());
-        result.setDatabaseType(jobProgress.getDatabaseType());
+        result.setSourceDatabaseType(jobProgress.getSourceDatabaseType());
         result.setInventory(getYamlInventory(jobProgress.getInventoryTaskProgressMap()));
         result.setIncremental(getYamlIncremental(jobProgress.getIncrementalTaskProgressMap()));
         return result;
@@ -94,9 +94,9 @@ public final class JobProgressYamlSwapper {
     public JobProgress swapToObject(final YamlJobProgress yamlJobProgress) {
         JobProgress result = new JobProgress();
         result.setStatus(JobStatus.valueOf(yamlJobProgress.getStatus()));
-        result.setDatabaseType(yamlJobProgress.getDatabaseType());
+        result.setSourceDatabaseType(yamlJobProgress.getSourceDatabaseType());
         result.setInventoryTaskProgressMap(getInventoryTaskProgressMap(yamlJobProgress.getInventory()));
-        result.setIncrementalTaskProgressMap(getIncrementalTaskProgressMap(yamlJobProgress.getDatabaseType(), yamlJobProgress.getIncremental()));
+        result.setIncrementalTaskProgressMap(getIncrementalTaskProgressMap(yamlJobProgress.getSourceDatabaseType(), yamlJobProgress.getIncremental()));
         return result;
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/yaml/YamlJobProgress.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/scaling/core/job/progress/yaml/YamlJobProgress.java
@@ -33,7 +33,7 @@ public final class YamlJobProgress {
     
     private String status;
     
-    private String databaseType;
+    private String sourceDatabaseType;
     
     private YamlInventory inventory;
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/JobShardingRuleAlteredDetector.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/JobShardingRuleAlteredDetector.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.schedule;
+
+import org.apache.shardingsphere.data.pipeline.spi.JobRuleAlteredDetector;
+import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfiguration;
+
+import java.util.Map.Entry;
+
+/**
+ * Job sharding rule altered detector.
+ */
+public final class JobShardingRuleAlteredDetector implements JobRuleAlteredDetector {
+    
+    @Override
+    public boolean isRuleAltered(final YamlRuleConfiguration sourceRuleConfig, final YamlRuleConfiguration targetRuleConfig) {
+        if ((null == sourceRuleConfig) ^ (null == targetRuleConfig)) {
+            return true;
+        }
+        if (null == sourceRuleConfig) {
+            return false;
+        }
+        return isShardingRulesTheSame((YamlShardingRuleConfiguration) sourceRuleConfig, (YamlShardingRuleConfiguration) targetRuleConfig);
+    }
+    
+    // TODO more accurate comparison
+    private boolean isShardingRulesTheSame(final YamlShardingRuleConfiguration sourceShardingConfig, final YamlShardingRuleConfiguration targetShardingConfig) {
+        for (Entry<String, YamlTableRuleConfiguration> entry : sourceShardingConfig.getTables().entrySet()) {
+            entry.getValue().setLogicTable(null);
+        }
+        for (Entry<String, YamlTableRuleConfiguration> entry : targetShardingConfig.getTables().entrySet()) {
+            entry.getValue().setLogicTable(null);
+        }
+        String sourceShardingConfigYaml = YamlEngine.marshal(sourceShardingConfig);
+        String targetShardingConfigYaml = YamlEngine.marshal(targetShardingConfig);
+        return sourceShardingConfigYaml.equals(targetShardingConfigYaml);
+    }
+    
+    @Override
+    public String getType() {
+        return YamlShardingRuleConfiguration.class.getName();
+    }
+}

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingJobConfigurationPreparer.java
@@ -30,7 +30,7 @@ import org.apache.shardingsphere.infra.config.datasource.jdbc.config.impl.Standa
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
-import org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer;
+import org.apache.shardingsphere.migration.common.spi.JobConfigurationPreparer;
 import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ImporterConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
@@ -46,7 +46,6 @@ import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardS
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
 import org.apache.shardingsphere.sharding.support.InlineExpressionParser;
-import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 
 import java.util.ArrayList;
@@ -64,10 +63,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * Sharding rule job configuration preparer.
+ * Sharding job configuration preparer.
  */
 @Slf4j
-public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfigurationPreparer {
+public final class ShardingJobConfigurationPreparer implements JobConfigurationPreparer {
     
     @Override
     public HandleConfiguration createHandleConfig(final RuleConfiguration ruleConfig) {
@@ -125,7 +124,6 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
         return new JobDataNodeLine(dataNodeEntries).marshal();
     }
     
-    // TODO handle several rules changed or dataSources changed
     @Override
     public List<TaskConfiguration> createTaskConfigs(final RuleConfiguration ruleConfig, final HandleConfiguration handleConfig) {
         List<TaskConfiguration> result = new LinkedList<>();
@@ -277,10 +275,5 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
         result.setShardingColumnsMap(shardingColumnsMap);
         result.setRetryTimes(handleConfig.getRetryTimes());
         return result;
-    }
-    
-    @Override
-    public String getType() {
-        return YamlShardingRuleConfiguration.class.getName();
     }
 }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/java/org/apache/shardingsphere/sharding/schedule/ShardingRuleJobConfigurationPreparer.java
@@ -24,16 +24,15 @@ import com.google.common.collect.Sets;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.ingest.config.DumperConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.DataSourceConfiguration;
+import org.apache.shardingsphere.infra.config.datasource.jdbc.config.JDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.jdbc.config.impl.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.jdbc.config.impl.StandardJDBCDataSourceConfiguration;
-import org.apache.shardingsphere.infra.config.datasource.jdbc.config.JDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.migration.common.spi.RuleJobConfigurationPreparer;
 import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.ImporterConfiguration;
-import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.TaskConfiguration;
 import org.apache.shardingsphere.scaling.core.config.internal.JobDataNodeEntry;
@@ -71,7 +70,7 @@ import java.util.stream.Collectors;
 public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfigurationPreparer {
     
     @Override
-    public HandleConfiguration convertToHandleConfig(final RuleConfiguration ruleConfig) {
+    public HandleConfiguration createHandleConfig(final RuleConfiguration ruleConfig) {
         HandleConfiguration result = new HandleConfiguration();
         Map<String, List<DataNode>> shouldScalingActualDataNodes = getShouldScalingActualDataNodes(ruleConfig);
         Collection<DataNode> dataNodes = new ArrayList<>();
@@ -128,33 +127,33 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
     
     // TODO handle several rules changed or dataSources changed
     @Override
-    public List<TaskConfiguration> convertToTaskConfigs(final JobConfiguration jobConfig) {
+    public List<TaskConfiguration> createTaskConfigs(final RuleConfiguration ruleConfig, final HandleConfiguration handleConfig) {
         List<TaskConfiguration> result = new LinkedList<>();
-        ShardingSphereJDBCDataSourceConfiguration sourceConfig = getSourceConfiguration(jobConfig);
+        ShardingSphereJDBCDataSourceConfiguration sourceConfig = getSourceConfiguration(ruleConfig);
         ShardingRuleConfiguration sourceRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(sourceConfig.getRootConfig().getRules());
         Map<String, DataSourceConfiguration> sourceDataSource = new YamlDataSourceConfigurationSwapper().getDataSourceConfigurations(sourceConfig.getRootConfig());
         Map<String, Map<String, String>> dataSourceTableNameMap = toDataSourceTableNameMap(new ShardingRule(sourceRuleConfig, sourceConfig.getRootConfig().getDataSources().keySet()));
-        Optional<ShardingRuleConfiguration> targetRuleConfig = getTargetRuleConfiguration(jobConfig);
-        filterByShardingDataSourceTables(dataSourceTableNameMap, jobConfig.getHandleConfig());
+        Optional<ShardingRuleConfiguration> targetRuleConfig = getTargetRuleConfiguration(ruleConfig);
+        filterByShardingDataSourceTables(dataSourceTableNameMap, handleConfig);
         Map<String, Set<String>> shardingColumnsMap = getShardingColumnsMap(targetRuleConfig.orElse(sourceRuleConfig));
         for (Entry<String, Map<String, String>> entry : dataSourceTableNameMap.entrySet()) {
             DumperConfiguration dumperConfig = createDumperConfig(entry.getKey(), sourceDataSource.get(entry.getKey()).getProps(), entry.getValue());
-            ImporterConfiguration importerConfig = createImporterConfig(jobConfig, shardingColumnsMap);
-            TaskConfiguration taskConfig = new TaskConfiguration(jobConfig.getHandleConfig(), dumperConfig, importerConfig);
+            ImporterConfiguration importerConfig = createImporterConfig(ruleConfig, handleConfig, shardingColumnsMap);
+            TaskConfiguration taskConfig = new TaskConfiguration(handleConfig, dumperConfig, importerConfig);
             log.info("toTaskConfigs, dataSourceName={}, taskConfig={}", entry.getKey(), taskConfig);
             result.add(taskConfig);
         }
         return result;
     }
     
-    private static ShardingSphereJDBCDataSourceConfiguration getSourceConfiguration(final JobConfiguration jobConfig) {
-        JDBCDataSourceConfiguration result = jobConfig.getRuleConfig().getSource().unwrap();
+    private static ShardingSphereJDBCDataSourceConfiguration getSourceConfiguration(final RuleConfiguration ruleConfig) {
+        JDBCDataSourceConfiguration result = ruleConfig.getSource().unwrap();
         Preconditions.checkArgument(result instanceof ShardingSphereJDBCDataSourceConfiguration, "Only support ShardingSphere source data source.");
         return (ShardingSphereJDBCDataSourceConfiguration) result;
     }
     
-    private static Optional<ShardingRuleConfiguration> getTargetRuleConfiguration(final JobConfiguration jobConfig) {
-        JDBCDataSourceConfiguration dataSourceConfig = jobConfig.getRuleConfig().getTarget().unwrap();
+    private static Optional<ShardingRuleConfiguration> getTargetRuleConfiguration(final RuleConfiguration ruleConfig) {
+        JDBCDataSourceConfiguration dataSourceConfig = ruleConfig.getTarget().unwrap();
         if (dataSourceConfig instanceof ShardingSphereJDBCDataSourceConfiguration) {
             return Optional.of(
                     ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(((ShardingSphereJDBCDataSourceConfiguration) dataSourceConfig).getRootConfig().getRules()));
@@ -272,11 +271,11 @@ public final class ShardingRuleJobConfigurationPreparer implements RuleJobConfig
         return result;
     }
     
-    private static ImporterConfiguration createImporterConfig(final JobConfiguration jobConfig, final Map<String, Set<String>> shardingColumnsMap) {
+    private static ImporterConfiguration createImporterConfig(final RuleConfiguration ruleConfig, final HandleConfiguration handleConfig, final Map<String, Set<String>> shardingColumnsMap) {
         ImporterConfiguration result = new ImporterConfiguration();
-        result.setDataSourceConfig(jobConfig.getRuleConfig().getTarget().unwrap());
+        result.setDataSourceConfig(ruleConfig.getTarget().unwrap());
         result.setShardingColumnsMap(shardingColumnsMap);
-        result.setRetryTimes(jobConfig.getHandleConfig().getRetryTimes());
+        result.setRetryTimes(handleConfig.getRetryTimes());
         return result;
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.JobRuleAlteredDetector
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.JobRuleAlteredDetector
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.sharding.schedule.JobShardingRuleAlteredDetector

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.migration.common.spi.JobConfigurationPreparer
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/main/resources/META-INF/services/org.apache.shardingsphere.migration.common.spi.JobConfigurationPreparer
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.sharding.schedule.ShardingRuleJobConfigurationPreparer
+org.apache.shardingsphere.sharding.schedule.ShardingJobConfigurationPreparer

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/progress/JobProgressTest.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/job/progress/JobProgressTest.java
@@ -42,7 +42,7 @@ public final class JobProgressTest {
     public void assertInit() {
         JobProgress jobProgress = JobProgress.init(ResourceUtil.readFileAndIgnoreComments("job-progress.yaml"));
         assertThat(jobProgress.getStatus(), is(JobStatus.RUNNING));
-        assertThat(jobProgress.getDatabaseType(), is("H2"));
+        assertThat(jobProgress.getSourceDatabaseType(), is("H2"));
         assertThat(jobProgress.getInventoryTaskProgressMap().size(), is(4));
         assertThat(jobProgress.getIncrementalTaskProgressMap().size(), is(1));
     }
@@ -68,7 +68,7 @@ public final class JobProgressTest {
     public void assertToString() {
         JobProgress jobProgress = new JobProgress();
         jobProgress.setStatus(JobStatus.RUNNING);
-        jobProgress.setDatabaseType("H2");
+        jobProgress.setSourceDatabaseType("H2");
         jobProgress.setIncrementalTaskProgressMap(mockIncrementalTaskProgressMap());
         jobProgress.setInventoryTaskProgressMap(mockInventoryTaskProgressMap());
         assertThat(jobProgress.toString(), is(ResourceUtil.readFileAndIgnoreComments("job-progress.yaml")));

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -32,7 +32,6 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.stream.Collectors;
 
 /**
@@ -56,16 +55,11 @@ public final class ResourceUtil {
      */
     public static JobConfiguration mockShardingSphereJdbcTargetJobConfig() {
         RuleConfiguration ruleConfig = new RuleConfiguration();
-        setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_target.yaml")).wrap());
         JobConfiguration result = new JobConfiguration();
         result.setRuleConfig(ruleConfig);
         return result;
-    }
-    
-    private static void setupChangedYamlRuleConfigClassNames(final RuleConfiguration ruleConfig) {
-        ruleConfig.setChangedYamlRuleConfigClassNames(Collections.singletonList("org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"));
     }
     
     /**
@@ -79,7 +73,6 @@ public final class ResourceUtil {
         result.setWorkflowConfig(workflowConfig);
         RuleConfiguration ruleConfig = new RuleConfiguration();
         result.setRuleConfig(ruleConfig);
-        setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new StandardJDBCDataSourceConfiguration(readFileToString("/config_standard_jdbc_target.yaml")).wrap());
         result.buildHandleConfig();

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -83,13 +83,14 @@ public final class ResourceUtil {
         setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new StandardJDBCDataSourceConfiguration(readFileToString("/config_standard_jdbc_target.yaml")).wrap());
+        // TODO remove handleConfig manual initialization
         HandleConfiguration handleConfig = new HandleConfiguration();
         result.setHandleConfig(handleConfig);
         handleConfig.setJobShardingItem(0);
         handleConfig.setLogicTables("t_order");
         handleConfig.setTablesFirstDataNodes("t_order:ds_0.t_order");
         handleConfig.setJobShardingDataNodes(Collections.singletonList("ds_0.t_order"));
-        result.fillInProperties();
+        result.buildHandleConfig();
         return result;
     }
     

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -76,6 +76,8 @@ public final class ResourceUtil {
      */
     public static JobConfiguration mockStandardJdbcTargetJobConfig() {
         JobConfiguration result = new JobConfiguration();
+        WorkflowConfiguration workflowConfig = new WorkflowConfiguration("logic_db", "id1");
+        result.setWorkflowConfig(workflowConfig);
         RuleConfiguration ruleConfig = new RuleConfiguration();
         result.setRuleConfig(ruleConfig);
         setupChangedYamlRuleConfigClassNames(ruleConfig);
@@ -87,7 +89,6 @@ public final class ResourceUtil {
         handleConfig.setLogicTables("t_order");
         handleConfig.setTablesFirstDataNodes("t_order:ds_0.t_order");
         handleConfig.setJobShardingDataNodes(Collections.singletonList("ds_0.t_order"));
-        handleConfig.setWorkflowConfig(new WorkflowConfiguration("logic_db", "id1"));
         result.fillInProperties();
         return result;
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/java/org/apache/shardingsphere/scaling/core/util/ResourceUtil.java
@@ -22,7 +22,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.infra.config.datasource.jdbc.config.impl.ShardingSphereJDBCDataSourceConfiguration;
 import org.apache.shardingsphere.infra.config.datasource.jdbc.config.impl.StandardJDBCDataSourceConfiguration;
-import org.apache.shardingsphere.scaling.core.config.HandleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.JobConfiguration;
 import org.apache.shardingsphere.scaling.core.config.RuleConfiguration;
 import org.apache.shardingsphere.scaling.core.config.WorkflowConfiguration;
@@ -83,13 +82,6 @@ public final class ResourceUtil {
         setupChangedYamlRuleConfigClassNames(ruleConfig);
         ruleConfig.setSource(new ShardingSphereJDBCDataSourceConfiguration(readFileToString("/config_sharding_sphere_jdbc_source.yaml")).wrap());
         ruleConfig.setTarget(new StandardJDBCDataSourceConfiguration(readFileToString("/config_standard_jdbc_target.yaml")).wrap());
-        // TODO remove handleConfig manual initialization
-        HandleConfiguration handleConfig = new HandleConfiguration();
-        result.setHandleConfig(handleConfig);
-        handleConfig.setJobShardingItem(0);
-        handleConfig.setLogicTables("t_order");
-        handleConfig.setTablesFirstDataNodes("t_order:ds_0.t_order");
-        handleConfig.setJobShardingDataNodes(Collections.singletonList("ds_0.t_order"));
         result.buildHandleConfig();
         return result;
     }

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/governance-repository.yaml
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/governance-repository.yaml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-databaseType: H2
 incremental:
   ds_0:
     delay:
@@ -25,5 +24,5 @@ incremental:
 inventory:
   unfinished:
     ds_0.t_order#0: ''
+sourceDatabaseType: H2
 status: RUNNING
-

--- a/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/job-progress.yaml
+++ b/shardingsphere-scaling/shardingsphere-scaling-core/src/test/resources/job-progress.yaml
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-databaseType: H2
 incremental:
   ds0:
     delay:
@@ -29,4 +28,5 @@ inventory:
   unfinished:
     ds1.t_2: 1,2
     ds1.t_1: ''
+sourceDatabaseType: H2
 status: RUNNING

--- a/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/ITEnvironmentContext.java
+++ b/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/ITEnvironmentContext.java
@@ -31,7 +31,6 @@ import org.apache.shardingsphere.sharding.yaml.config.rule.YamlTableRuleConfigur
 import javax.sql.DataSource;
 import javax.xml.bind.JAXBContext;
 import java.io.FileReader;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -81,15 +80,10 @@ public final class ITEnvironmentContext {
     
     private static String createScalingConfiguration(final Map<String, YamlTableRuleConfiguration> tableRules) {
         RuleConfiguration ruleConfiguration = new RuleConfiguration();
-        setupChangedYamlRuleConfigClassNames(ruleConfiguration);
         ruleConfiguration.setSource(SourceConfiguration.getDockerConfiguration(tableRules).wrap());
         ruleConfiguration.setTarget(TargetConfiguration.getDockerConfiguration().wrap());
         JobConfiguration jobConfiguration = new JobConfiguration();
         jobConfiguration.setRuleConfig(ruleConfiguration);
         return new Gson().toJson(jobConfiguration);
-    }
-    
-    private static void setupChangedYamlRuleConfigClassNames(final RuleConfiguration ruleConfig) {
-        ruleConfig.setChangedYamlRuleConfigClassNames(Collections.singletonList("org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration"));
     }
 }


### PR DESCRIPTION
Fixes #13875 part 9.

Changes proposed in this pull request:
- Refactor createJobConfig, add JobRuleAlteredDetector SPI, separate sharding related code from scaling-core
- Refactor JobConfigurationPreparer, support several rules altered
- Extract WorkflowConfiguration to JobConfiguration
- Refactor databaseType to sourceDatabaseType and targetDatabaseType
- Refactor RuleJobConfigurationPreparer method signature

P.S. scaling unit test: embeded ZK may cause CI run failure, it could not be done in this PR.
Only 'Cluster' mode is supported by scaling for now, some required feature like `watch` is just supported in `ClusterPersistRepository` for now, scaling unit test dependency on embeded ZK, it will be done after scaling support 3 modes.
