### PR TITLE
Reduce unnecessary method invoke and stream

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/payload/MySQLPacketPayload.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/payload/MySQLPacketPayload.java
@@ -279,8 +279,9 @@ public final class MySQLPacketPayload implements PacketPayload {
             byteBuf.writeByte(0);
             return;
         }
-        writeIntLenenc(value.getBytes().length);
-        byteBuf.writeBytes(value.getBytes(charset));
+        byte[] valueBytes = value.getBytes(charset);
+        writeIntLenenc(valueBytes.length);
+        byteBuf.writeBytes(valueBytes);
     }
     
     /**

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -238,7 +238,12 @@ public final class ShardingRule implements SchemaRule, DataNodeContainedRule, Ta
      * @return table rule
      */
     public Optional<TableRule> findTableRuleByActualTable(final String actualTableName) {
-        return tableRules.values().stream().filter(each -> each.isExisted(actualTableName)).findFirst();
+        for (TableRule each : tableRules.values()) {
+            if (each.isExisted(actualTableName)) {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaData.java
@@ -47,13 +47,13 @@ public final class ShardingSphereRuleMetaData {
      * @return found rules
      */
     public <T extends ShardingSphereRule> Collection<T> findRules(final Class<T> clazz) {
-        List<T> list = new LinkedList<>();
+        List<T> result = new LinkedList<>();
         for (ShardingSphereRule each : rules) {
             if (clazz.isAssignableFrom(each.getClass())) {
-                list.add(clazz.cast(each));
+                result.add(clazz.cast(each));
             }
         }
-        return list;
+        return result;
     }
     
     /**

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaData.java
@@ -23,6 +23,8 @@ import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -45,7 +47,13 @@ public final class ShardingSphereRuleMetaData {
      * @return found rules
      */
     public <T extends ShardingSphereRule> Collection<T> findRules(final Class<T> clazz) {
-        return rules.stream().filter(each -> clazz.isAssignableFrom(each.getClass())).map(clazz::cast).collect(Collectors.toList());
+        List<T> list = new LinkedList<>();
+        for (ShardingSphereRule each : rules) {
+            if (clazz.isAssignableFrom(each.getClass())) {
+                list.add(clazz.cast(each));
+            }
+        }
+        return list;
     }
     
     /**

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/execute/MySQLComStmtExecuteExecutor.java
@@ -40,6 +40,7 @@ import org.apache.shardingsphere.proxy.backend.communication.DatabaseCommunicati
 import org.apache.shardingsphere.proxy.backend.communication.SQLStatementSchemaHolder;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseCell;
 import org.apache.shardingsphere.proxy.backend.response.data.QueryResponseRow;
 import org.apache.shardingsphere.proxy.backend.response.data.impl.BinaryQueryResponseCell;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
@@ -55,11 +56,12 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.tcl.TCLStatement;
 
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * COM_STMT_EXECUTE command executor for MySQL.
@@ -141,8 +143,11 @@ public final class MySQLComStmtExecuteExecutor implements QueryCommandExecutor {
     }
     
     private BinaryRow createBinaryRow(final QueryResponseRow queryResponseRow) {
-        return new BinaryRow(queryResponseRow.getCells().stream().map(
-            each -> new BinaryCell(MySQLBinaryColumnType.valueOfJDBCType(((BinaryQueryResponseCell) each).getJdbcType()), each.getData())).collect(Collectors.toList()));
+        List<BinaryCell> result = new ArrayList<>(queryResponseRow.getCells().size());
+        for (QueryResponseCell each : queryResponseRow.getCells()) {
+            result.add(new BinaryCell(MySQLBinaryColumnType.valueOfJDBCType(((BinaryQueryResponseCell) each).getJdbcType()), each.getData()));
+        }
+        return new BinaryRow(result);
     }
     
     @Override


### PR DESCRIPTION
Related to #13848 

`String.getBytes` was invoked twice, which increased the unnecessary overhead.

![image](https://user-images.githubusercontent.com/20503072/146145568-25ac863f-58db-438f-93a1-8085b1350b95.png)
