### PR TITLE
Fix caching too many connections in openGauss batch bind

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/extended/bind/OpenGaussComBatchBindExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/extended/bind/OpenGaussComBatchBindExecutor.java
@@ -77,6 +77,9 @@ public final class OpenGaussComBatchBindExecutor implements QueryCommandExecutor
                     updateCount += ((UpdateResponseHeader) responseHeader).getUpdateCount();
                 }
             } finally {
+                if (!connectionSession.getTransactionStatus().isInConnectionHeldTransaction()) {
+                    ((JDBCBackendConnection) connectionSession.getBackendConnection()).closeConnections(false);
+                }
                 ((JDBCBackendConnection) connectionSession.getBackendConnection()).closeDatabaseCommunicationEngines(false);
             }
         }


### PR DESCRIPTION
Fixes #14229.

Changes proposed in this pull request:
- Return connections to DataSource when executing batch bind without transaction.