### PR TITLE
Add sourceWritingStopAlgorithm SPI and DEFAULT impl, add checkoutLockAlgorithm SPI and DEFAULT impl, add sourceWritingStopper and checkoutLocker in config

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
@@ -35,3 +35,5 @@ dataConverters:
       type: DATA_MATCH
       props:
         chunk-size: 10000
+    checkoutLocker:
+      type: DEFAULT

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
@@ -29,6 +29,8 @@ dataConverters:
       type: IDLE
       props:
         incremental-task-idle-minute-threshold: 1
+    sourceWritingStopper:
+      type: DEFAULT
     dataConsistencyChecker:
       type: DATA_MATCH
       props:

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
@@ -111,10 +111,16 @@ rules:
       blockQueueSize: 10000
       workerThread: 40
       readBatchSize: 1000
+      rateLimiter:
+        type: SOURCE
+        props:
+          qps: 50
       completionDetector:
         type: IDLE
         props:
           incremental-task-idle-minute-threshold: 30
+      sourceWritingStopper:
+        type: DEFAULT
       dataConsistencyChecker:
         type: DATA_MATCH
         props:

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
@@ -125,6 +125,8 @@ rules:
         type: DATA_MATCH
         props:
           chunk-size: 1000
+      checkoutLocker:
+        type: DEFAULT
 
 props:
   sql-show: true

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
@@ -35,3 +35,5 @@ scaling:
       type: DATA_MATCH
       props:
         chunk-size: 1000
+    checkoutLocker:
+      type: DEFAULT

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
@@ -29,6 +29,8 @@ scaling:
       type: IDLE
       props:
         incremental-task-idle-minute-threshold: 30
+    sourceWritingStopper:
+      type: DEFAULT
     dataConsistencyChecker:
       type: DATA_MATCH
       props:

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
@@ -41,4 +41,6 @@ public final class OnRuleAlteredActionConfiguration {
     private final ShardingSphereAlgorithmConfiguration sourceWritingStopper;
     
     private final ShardingSphereAlgorithmConfiguration dataConsistencyChecker;
+    
+    private final ShardingSphereAlgorithmConfiguration checkoutLocker;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
@@ -38,5 +38,7 @@ public final class OnRuleAlteredActionConfiguration {
     
     private final ShardingSphereAlgorithmConfiguration completionDetector;
     
+    private final ShardingSphereAlgorithmConfiguration sourceWritingStopper;
+    
     private final ShardingSphereAlgorithmConfiguration dataConsistencyChecker;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
@@ -42,4 +42,6 @@ public final class YamlOnRuleAlteredActionConfiguration implements YamlConfigura
     private YamlShardingSphereAlgorithmConfiguration sourceWritingStopper;
     
     private YamlShardingSphereAlgorithmConfiguration dataConsistencyChecker;
+    
+    private YamlShardingSphereAlgorithmConfiguration checkoutLocker;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
@@ -39,5 +39,7 @@ public final class YamlOnRuleAlteredActionConfiguration implements YamlConfigura
     
     private YamlShardingSphereAlgorithmConfiguration completionDetector;
     
+    private YamlShardingSphereAlgorithmConfiguration sourceWritingStopper;
+    
     private YamlShardingSphereAlgorithmConfiguration dataConsistencyChecker;
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/algorithm/ShardingSphereAlgorithmConfigurationYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/algorithm/ShardingSphereAlgorithmConfigurationYamlSwapper.java
@@ -28,6 +28,9 @@ public final class ShardingSphereAlgorithmConfigurationYamlSwapper implements Ya
     
     @Override
     public YamlShardingSphereAlgorithmConfiguration swapToYamlConfiguration(final ShardingSphereAlgorithmConfiguration data) {
+        if (null == data) {
+            return null;
+        }
         YamlShardingSphereAlgorithmConfiguration result = new YamlShardingSphereAlgorithmConfiguration();
         result.setType(data.getType());
         result.setProps(data.getProps());
@@ -36,6 +39,9 @@ public final class ShardingSphereAlgorithmConfigurationYamlSwapper implements Ya
     
     @Override
     public ShardingSphereAlgorithmConfiguration swapToObject(final YamlShardingSphereAlgorithmConfiguration yamlConfig) {
+        if (null == yamlConfig) {
+            return null;
+        }
         return new ShardingSphereAlgorithmConfiguration(yamlConfig.getType(), yamlConfig.getProps());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
@@ -39,6 +39,7 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         result.setCompletionDetector(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getCompletionDetector()));
         result.setSourceWritingStopper(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getSourceWritingStopper()));
         result.setDataConsistencyChecker(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getDataConsistencyChecker()));
+        result.setCheckoutLocker(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getCheckoutLocker()));
         return result;
     }
     
@@ -48,6 +49,7 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getRateLimiter()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getCompletionDetector()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getSourceWritingStopper()),
-                ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getDataConsistencyChecker()));
+                ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getDataConsistencyChecker()),
+                ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getCheckoutLocker()));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
@@ -37,6 +37,7 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         result.setReadBatchSize(data.getReadBatchSize());
         result.setRateLimiter(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getRateLimiter()));
         result.setCompletionDetector(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getCompletionDetector()));
+        result.setSourceWritingStopper(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getSourceWritingStopper()));
         result.setDataConsistencyChecker(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getDataConsistencyChecker()));
         return result;
     }
@@ -46,6 +47,7 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         return new OnRuleAlteredActionConfiguration(yamlConfig.getBlockQueueSize(), yamlConfig.getWorkerThread(), yamlConfig.getReadBatchSize(),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getRateLimiter()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getCompletionDetector()),
+                ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getSourceWritingStopper()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getDataConsistencyChecker()));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
@@ -43,6 +43,8 @@ public final class OnRuleAlteredActionConfigurationYamlSwapperTest {
         Properties completionDetectorProps = new Properties();
         completionDetectorProps.setProperty("incremental-task-idle-minute-threshold", "30");
         yamlConfig.setCompletionDetector(new YamlShardingSphereAlgorithmConfiguration("IDLE", completionDetectorProps));
+        Properties sourceWritingStopperProps = new Properties();
+        yamlConfig.setSourceWritingStopper(new YamlShardingSphereAlgorithmConfiguration("DEFAULT", sourceWritingStopperProps));
         Properties dataConsistencyCheckerProps = new Properties();
         dataConsistencyCheckerProps.setProperty("chunk-size", "1000");
         yamlConfig.setDataConsistencyChecker(new YamlShardingSphereAlgorithmConfiguration("DATA_MATCH", dataConsistencyCheckerProps));

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
@@ -48,6 +48,8 @@ public final class OnRuleAlteredActionConfigurationYamlSwapperTest {
         Properties dataConsistencyCheckerProps = new Properties();
         dataConsistencyCheckerProps.setProperty("chunk-size", "1000");
         yamlConfig.setDataConsistencyChecker(new YamlShardingSphereAlgorithmConfiguration("DATA_MATCH", dataConsistencyCheckerProps));
+        Properties checkoutLockerProps = new Properties();
+        yamlConfig.setCheckoutLocker(new YamlShardingSphereAlgorithmConfiguration("DEFAULT", checkoutLockerProps));
         OnRuleAlteredActionConfigurationYamlSwapper yamlSwapper = new OnRuleAlteredActionConfigurationYamlSwapper();
         OnRuleAlteredActionConfiguration actualConfig = yamlSwapper.swapToObject(yamlConfig);
         YamlOnRuleAlteredActionConfiguration actualYamlConfig = yamlSwapper.swapToYamlConfiguration(actualConfig);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 /**
  * Pipeline job API.
  */
+// TODO separate dedicated methods for rule altered job
 public interface PipelineJobAPI extends RequiredSPI {
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJob.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJob.java
@@ -26,9 +26,11 @@ import org.apache.shardingsphere.data.pipeline.api.pojo.JobInfo;
 import org.apache.shardingsphere.data.pipeline.scenario.rulealtered.RuleAlteredContext;
 import org.apache.shardingsphere.data.pipeline.scenario.rulealtered.RuleAlteredJobProgressDetector;
 import org.apache.shardingsphere.data.pipeline.scenario.rulealtered.RuleAlteredJobWorker;
+import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
 import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
 import java.util.List;
 import java.util.Map;
@@ -37,6 +39,10 @@ import java.util.Map;
 public final class FinishedCheckJob implements SimpleJob {
     
     private final PipelineJobAPI pipelineJobAPI = PipelineJobAPIFactory.getPipelineJobAPI();
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleAlteredSourceWritingStopAlgorithm.class);
+    }
     
     @Override
     public void execute(final ShardingContext shardingContext) {
@@ -57,17 +63,27 @@ public final class FinishedCheckJob implements SimpleJob {
                 if (null == ruleAlteredContext.getCompletionDetectAlgorithm()) {
                     log.info("completionDetector not configured, auto switch will not be enabled. You could query migration progress and switch manually with DistSQL.");
                 }
-                // TODO lock proxy
-                if (!pipelineJobAPI.isDataConsistencyCheckNeeded(jobId)) {
-                    log.info("dataConsistencyCheckAlgorithm is not configured, data consistency check is ignored.");
+                RuleAlteredSourceWritingStopAlgorithm sourceWritingStopAlgorithm = ruleAlteredContext.getSourceWritingStopAlgorithm();
+                String schemaName = jobConfig.getWorkflowConfig().getSchemaName();
+                try {
+                    if (null != sourceWritingStopAlgorithm) {
+                        sourceWritingStopAlgorithm.stopSourceWriting(schemaName, jobId + "");
+                    }
+                    if (!pipelineJobAPI.isDataConsistencyCheckNeeded(jobId)) {
+                        log.info("dataConsistencyCheckAlgorithm is not configured, data consistency check is ignored.");
+                        pipelineJobAPI.switchClusterConfiguration(jobId);
+                        continue;
+                    }
+                    if (!dataConsistencyCheck(jobId)) {
+                        log.error("data consistency check failed, job {}", jobId);
+                        continue;
+                    }
                     pipelineJobAPI.switchClusterConfiguration(jobId);
-                    continue;
+                } finally {
+                    if (null != sourceWritingStopAlgorithm) {
+                        sourceWritingStopAlgorithm.resumeSourceWriting(schemaName, jobId + "");
+                    }
                 }
-                if (!dataConsistencyCheck(jobId)) {
-                    log.error("data consistency check failed, job {}", jobId);
-                    continue;
-                }
-                pipelineJobAPI.switchClusterConfiguration(jobId);
                 // CHECKSTYLE:OFF
             } catch (final Exception ex) {
                 // CHECKSTYLE:ON

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/DefaultRuleAlteredCheckoutLockAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/DefaultRuleAlteredCheckoutLockAlgorithm.java
@@ -17,24 +17,24 @@
 
 package org.apache.shardingsphere.data.pipeline.scenario.rulealtered;
 
-import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
+import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredCheckoutLockAlgorithm;
 
 /**
- * Default rule altered source writing stop algorithm.
+ * Default rule altered checkout lock algorithm.
  */
-public final class DefaultRuleAlteredSourceWritingStopAlgorithm implements RuleAlteredSourceWritingStopAlgorithm {
+public final class DefaultRuleAlteredCheckoutLockAlgorithm implements RuleAlteredCheckoutLockAlgorithm {
     
     @Override
     public void init() {
     }
     
-    // TODO impl default sourceWritingStopAlgorithm
+    // TODO impl default checkoutLockAlgorithm
     @Override
-    public void stopSourceWriting(final String schemaName, final String jobId) {
+    public void lock(final String schemaName, final String jobId) {
     }
     
     @Override
-    public void resumeSourceWriting(final String schemaName, final String jobId) {
+    public void releaseLock(final String schemaName, final String jobId) {
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/DefaultRuleAlteredSourceWritingStopAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/DefaultRuleAlteredSourceWritingStopAlgorithm.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.scenario.rulealtered;
+
+import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
+
+/**
+ * Default rule altered source writing stop algorithm.
+ */
+public final class DefaultRuleAlteredSourceWritingStopAlgorithm implements RuleAlteredSourceWritingStopAlgorithm {
+    
+    // TODO impl sourceWritingStopAlgorithm
+    @Override
+    public void stopSourceWriting(final String schemaName, final String jobId) {
+    }
+    
+    @Override
+    public void resumeSourceWriting(final String schemaName, final String jobId) {
+    }
+    
+    @Override
+    public String getType() {
+        return "DEFAULT";
+    }
+    
+    @Override
+    public void init() {
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.spi.check.consistency.DataConsistencyCheckAlgorithm;
 import org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm;
 import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredJobCompletionDetectAlgorithm;
+import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
@@ -51,6 +52,8 @@ public final class RuleAlteredContext {
     
     private final RuleAlteredJobCompletionDetectAlgorithm completionDetectAlgorithm;
     
+    private final RuleAlteredSourceWritingStopAlgorithm sourceWritingStopAlgorithm;
+    
     private final DataConsistencyCheckAlgorithm dataConsistencyCheckAlgorithm;
     
     private final ExecuteEngine inventoryDumperExecuteEngine;
@@ -72,6 +75,12 @@ public final class RuleAlteredContext {
             completionDetectAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(completionDetector, RuleAlteredJobCompletionDetectAlgorithm.class);
         } else {
             completionDetectAlgorithm = null;
+        }
+        ShardingSphereAlgorithmConfiguration sourceWritingStopper = onRuleAlteredActionConfig.getSourceWritingStopper();
+        if (null != sourceWritingStopper) {
+            sourceWritingStopAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(sourceWritingStopper, RuleAlteredSourceWritingStopAlgorithm.class);
+        } else {
+            sourceWritingStopAlgorithm = null;
         }
         ShardingSphereAlgorithmConfiguration dataConsistencyChecker = onRuleAlteredActionConfig.getDataConsistencyChecker();
         if (null != dataConsistencyChecker) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -22,6 +22,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.spi.check.consistency.DataConsistencyCheckAlgorithm;
 import org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm;
+import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredCheckoutLockAlgorithm;
 import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredJobCompletionDetectAlgorithm;
 import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
@@ -56,6 +57,8 @@ public final class RuleAlteredContext {
     
     private final DataConsistencyCheckAlgorithm dataConsistencyCheckAlgorithm;
     
+    private final RuleAlteredCheckoutLockAlgorithm checkoutLockAlgorithm;
+    
     private final ExecuteEngine inventoryDumperExecuteEngine;
     
     private final ExecuteEngine incrementalDumperExecuteEngine;
@@ -87,6 +90,12 @@ public final class RuleAlteredContext {
             dataConsistencyCheckAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(dataConsistencyChecker, DataConsistencyCheckAlgorithm.class);
         } else {
             dataConsistencyCheckAlgorithm = null;
+        }
+        ShardingSphereAlgorithmConfiguration checkoutLocker = onRuleAlteredActionConfig.getCheckoutLocker();
+        if (null != checkoutLocker) {
+            checkoutLockAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(checkoutLocker, RuleAlteredCheckoutLockAlgorithm.class);
+        } else {
+            checkoutLockAlgorithm = null;
         }
         inventoryDumperExecuteEngine = ExecuteEngine.newFixedThreadInstance(onRuleAlteredActionConfig.getWorkerThread());
         incrementalDumperExecuteEngine = ExecuteEngine.newCachedThreadInstance();

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredCheckoutLockAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredCheckoutLockAlgorithm.java
@@ -15,30 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.scenario.rulealtered;
+package org.apache.shardingsphere.data.pipeline.spi.rulealtered;
 
-import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
 
 /**
- * Default rule altered source writing stop algorithm.
+ * Rule altered checkout lock algorithm, SPI.
  */
-public final class DefaultRuleAlteredSourceWritingStopAlgorithm implements RuleAlteredSourceWritingStopAlgorithm {
+public interface RuleAlteredCheckoutLockAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
     
-    @Override
-    public void init() {
-    }
+    /**
+     * Lock to protect checkout (switch configuration).
+     *
+     * @param schemaName schema name
+     * @param jobId job id
+     */
+    void lock(String schemaName, String jobId);
     
-    // TODO impl default sourceWritingStopAlgorithm
-    @Override
-    public void stopSourceWriting(final String schemaName, final String jobId) {
-    }
-    
-    @Override
-    public void resumeSourceWriting(final String schemaName, final String jobId) {
-    }
-    
-    @Override
-    public String getType() {
-        return "DEFAULT";
-    }
+    /**
+     * Release lock.
+     *
+     * @param schemaName schema name
+     * @param jobId job id
+     */
+    void releaseLock(String schemaName, String jobId);
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredSourceWritingStopAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredSourceWritingStopAlgorithm.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.spi.rulealtered;
+
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
+
+/**
+ * Rule altered source writing stop algorithm, SPI.
+ */
+public interface RuleAlteredSourceWritingStopAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
+    
+    /**
+     * Stop source writing.
+     *
+     * @param schemaName schema name
+     * @param jobId job id
+     */
+    void stopSourceWriting(String schemaName, String jobId);
+    
+    /**
+     * Resume source writing.
+     *
+     * @param schemaName schema name
+     * @param jobId job id
+     */
+    void resumeSourceWriting(String schemaName, String jobId);
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredCheckoutLockAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredCheckoutLockAlgorithm
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.data.pipeline.scenario.rulealtered.DefaultRuleAlteredCheckoutLockAlgorithm

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredSourceWritingStopAlgorithm
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.data.pipeline.scenario.rulealtered.DefaultRuleAlteredSourceWritingStopAlgorithm

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -112,6 +112,8 @@
 #        type: DEFAULT
 #      dataConsistencyChecker:
 #        type: DEFAULT
+#      checkoutLocker:
+#        type: DEFAULT
 
 ######################################################################################################
 #

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -108,6 +108,8 @@
 #        type: IDLE
 #        props:
 #          incremental-task-idle-minute-threshold: 30
+#      sourceWritingStopper:
+#        type: DEFAULT
 #      dataConsistencyChecker:
 #        type: DEFAULT
 


### PR DESCRIPTION
Fixes #13875 part 13.

Changes proposed in this pull request:
- Add sourceWritingStopAlgorithm SPI and DEFAULT impl
- Add sourceWritingStopper in config (sharding scaling and encrypt dataConverters)
- Add checkoutLockAlgorithm SPI and DEFAULT impl
- Add checkoutLocker in config (sharding scaling and encrypt dataConverters)

Notice: The default SPI implementation is empty, it will be improved later. SPI is used for end users to implement by themselvies if necessary.
