### PR TITLE
Optimize the return content of the `show scaling list` and `show scaling status {JobId}` commands of Scaling DistSQL

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/progress/JobProgress.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/progress/JobProgress.java
@@ -43,6 +43,8 @@ public final class JobProgress {
     
     private String sourceDatabaseType;
     
+    private boolean active;
+    
     private Map<String, InventoryTaskProgress> inventoryTaskProgressMap;
     
     private Map<String, IncrementalTaskProgress> incrementalTaskProgressMap;

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
@@ -184,8 +184,14 @@ public final class PipelineJobAPIImpl implements PipelineJobAPI {
     
     @Override
     public Map<Integer, JobProgress> getProgress(final long jobId) {
-        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed()
-                .collect(LinkedHashMap::new, (map, each) -> map.put(each, PipelineAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each)), LinkedHashMap::putAll);
+        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed().collect(LinkedHashMap::new, (map, each) -> {
+            JobProgress jobProgress = PipelineAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each);
+            JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
+            if (jobProgress != null) {
+                jobProgress.setActive(!jobConfigPOJO.isDisabled());
+            }
+            map.put(each, jobProgress);
+        }, LinkedHashMap::putAll);
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
@@ -47,6 +47,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
                     if (null != entry.getValue()) {
                         list.add(entry.getValue().getDataSource());
                         list.add(entry.getValue().getStatus());
+                        list.add(entry.getValue().isActive() ? "true" : "false");
                         list.add(entry.getValue().getInventoryFinishedPercentage());
                         long latestActiveTimeMillis = entry.getValue().getIncrementalLatestActiveTimeMillis();
                         list.add(latestActiveTimeMillis > 0 ? TimeUnit.MILLISECONDS.toMinutes(currentTimeMillis - latestActiveTimeMillis) : 0);
@@ -62,7 +63,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("item", "data_source", "status", "inventory_finished_percentage", "incremental_idle_minutes");
+        return Arrays.asList("item", "data_source", "status", "active", "inventory_finished_percentage", "incremental_idle_minutes");
     }
     
     @Override

--- a/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
+++ b/shardingsphere-scaling/shardingsphere-scaling-distsql/shardingsphere-scaling-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
@@ -44,7 +44,7 @@ public final class ShowScalingListQueryResultSet implements DistSQLResultSet {
                     list.add(each.getJobId());
                     list.add(each.getTables());
                     list.add(each.getShardingTotalCount());
-                    list.add(each.isActive() ? 1 : 0);
+                    list.add(each.isActive() ? "true" : "false");
                     list.add(each.getCreateTime());
                     list.add(each.getStopTime());
                     return list;


### PR DESCRIPTION
Changes proposed in this pull request:
- Modify the init() and getColumnNames() methods of ShowScalingJobStatusQueryResultSet
- Modify the init() and getColumnNames() methods of ShowScalingListQueryResultSet
- Modify PipelineJobAPIImpl.getProgress() method to add active variable to JobProcess
