### PR TITLE
fix ClassCastException when use jdbc execute getTimestamp

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
@@ -55,14 +55,11 @@ public final class ResultSetUtil {
         if (value.getClass() == convertType) {
             return value;
         }
-        if (LocalDateTime.class.equals(convertType)) {
-            return convertLocalDateTimeValue(value);
+        if (value instanceof LocalDateTime) {
+            return convertLocalDateTimeValue(value, convertType);
         }
-        if (LocalDate.class.equals(convertType)) {
-            return convertLocalDateValue(value);
-        }
-        if (LocalTime.class.equals(convertType)) {
-            return convertLocalTimeValue(value);
+        if (value instanceof Timestamp) {
+            return convertTimestampValue(value, convertType);
         }
         if (URL.class.equals(convertType)) {
             return convertURL(value);
@@ -124,22 +121,29 @@ public final class ResultSetUtil {
         }
         return value;
     }
-
-    private static Object convertLocalDateTimeValue(final Object value) {
-        Timestamp timestamp = (Timestamp) value;
-        return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+    
+    private static Object convertLocalDateTimeValue(final Object value, final Class<?> convertType) {
+        LocalDateTime localDateTime = (LocalDateTime) value;
+        if (Timestamp.class.equals(convertType)) {
+            return Timestamp.valueOf(localDateTime);
+        }
+        return value;
     }
-
-    private static Object convertLocalDateValue(final Object value) {
+    
+    private static Object convertTimestampValue(final Object value, final Class<?> convertType) {
         Timestamp timestamp = (Timestamp) value;
-        return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        if (LocalDateTime.class.equals(convertType)) {
+            return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+        }
+        if (LocalDate.class.equals(convertType)) {
+            return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+        }
+        if (LocalTime.class.equals(convertType)) {
+            return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalTime();
+        }
+        return value;
     }
-
-    private static Object convertLocalTimeValue(final Object value) {
-        Timestamp timestamp = (Timestamp) value;
-        return timestamp.toInstant().atZone(ZoneId.systemDefault()).toLocalTime();
-    }
-
+    
     private static Object convertNullValue(final Class<?> convertType) {
         switch (convertType.getName()) {
             case "boolean":

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
@@ -29,7 +29,10 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
 import java.util.Date;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -48,11 +51,17 @@ public final class ResultSetUtilTest {
     }
     
     @Test
-    public void assertConvertLocalDateTime() {
-        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        LocalDateTime dateTime = (LocalDateTime) ResultSetUtil.convertValue(timestamp, LocalDateTime.class);
-        assertNotNull(dateTime);
-        assertThat(dateTime.toString(), is(timestamp.toLocalDateTime().toString()));
+    public void assertConvertLocalDateTimeValue() {
+        LocalDateTime localDateTime = LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30);
+        assertThat(ResultSetUtil.convertValue(localDateTime, Timestamp.class), is(new Timestamp(1640259000000L)));
+    }
+    
+    @Test
+    public void assertConvertTimestampValue() {
+        Timestamp timestamp = new Timestamp(1640259000000L);
+        assertThat(ResultSetUtil.convertValue(timestamp, LocalDateTime.class), is(LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30)));
+        assertThat(ResultSetUtil.convertValue(timestamp, LocalDate.class), is(LocalDate.of(2021, Month.DECEMBER, 23)));
+        assertThat(ResultSetUtil.convertValue(timestamp, LocalTime.class), is(LocalTime.of(19, 30)));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
@@ -53,13 +53,14 @@ public final class ResultSetUtilTest {
     @Test
     public void assertConvertLocalDateTimeValue() {
         LocalDateTime localDateTime = LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30);
-        assertThat(ResultSetUtil.convertValue(localDateTime, Timestamp.class), is(new Timestamp(1640259000000L)));
+        assertThat(ResultSetUtil.convertValue(localDateTime, Timestamp.class), is(Timestamp.valueOf(localDateTime)));
     }
     
     @Test
     public void assertConvertTimestampValue() {
-        Timestamp timestamp = new Timestamp(1640259000000L);
-        assertThat(ResultSetUtil.convertValue(timestamp, LocalDateTime.class), is(LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30)));
+        LocalDateTime localDateTime = LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30);
+        Timestamp timestamp = Timestamp.valueOf(localDateTime);
+        assertThat(ResultSetUtil.convertValue(timestamp, LocalDateTime.class), is(localDateTime));
         assertThat(ResultSetUtil.convertValue(timestamp, LocalDate.class), is(LocalDate.of(2021, Month.DECEMBER, 23)));
         assertThat(ResultSetUtil.convertValue(timestamp, LocalTime.class), is(LocalTime.of(19, 30)));
     }


### PR DESCRIPTION
Fixes #14175.

Changes proposed in this pull request:
- fix ClassCastException when use jdbc execute getTimestamp
- add unit test
