### PR TITLE
Fix #14101 Show tables statement return wrong result when mysql is case sensitive

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowTablesExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowTablesExecutor.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.ra
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.type.memory.row.MemoryQueryResultDataRow;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.infra.merge.result.impl.transparent.TransparentMergedResult;
+import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.text.admin.executor.DatabaseAdminQueryExecutor;
@@ -76,7 +77,7 @@ public final class ShowTablesExecutor implements DatabaseAdminQueryExecutor {
     }
     
     private Collection<String> getAllTableNames(final String schemaName) {
-        Collection<String> allTableNames = ProxyContext.getInstance().getMetaData(schemaName).getSchema().getAllTableNames();
+        Collection<String> allTableNames = ProxyContext.getInstance().getMetaData(schemaName).getSchema().getTables().values().stream().map(TableMetaData::getName).collect(Collectors.toList());
         if (showTablesStatement.getFilter().isPresent()) {
             Optional<String> pattern = showTablesStatement.getFilter().get().getLike().map(each -> SQLUtil.convertLikePatternToRegex(each.getPattern()));
             return pattern.isPresent() ? allTableNames.stream().filter(each -> each.matches(pattern.get())).collect(Collectors.toList()) : allTableNames;

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowTablesExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowTablesExecutorTest.java
@@ -51,11 +51,8 @@ public final class ShowTablesExecutorTest {
     
     private static final String SCHEMA_PATTERN = "schema_%s";
     
-    private ShowTablesExecutor showTablesExecutor;
-    
     @Before
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
-        showTablesExecutor = new ShowTablesExecutor(new MySQLShowTablesStatement());
         Map<String, ShardingSphereMetaData> metaDataMap = getMetaDataMap();
         Field contextManagerField = ProxyContext.getInstance().getClass().getDeclaredField("contextManager");
         contextManagerField.setAccessible(true);
@@ -81,7 +78,8 @@ public final class ShowTablesExecutorTest {
     }
     
     @Test
-    public void assertExecute() throws SQLException {
+    public void assertShowTablesExecutorWithoutFilter() throws SQLException {
+        ShowTablesExecutor showTablesExecutor = new ShowTablesExecutor(new MySQLShowTablesStatement());
         showTablesExecutor.execute(mockConnectionSession());
         assertThat(showTablesExecutor.getQueryResultMetaData().getColumnCount(), is(2));
         showTablesExecutor.getMergedResult().next();


### PR DESCRIPTION
Fixes #14101 .

Changes proposed in this pull request:
- show tables statement return correct result when mysql is case sensitive
- add more unit test for ShowTablesExecutor

expected result:

```bash
mysql> show tables;
+-----------------------+------------+
| Tables_in_sharding_db | Table_type |
+-----------------------+------------+
| t_address             | BASE TABLE |
| t_order_item          | BASE TABLE |
| t_order               | BASE TABLE |
| TEST                  | BASE TABLE |
| t_account_0           | BASE TABLE |
| t_account_1           | BASE TABLE |
+-----------------------+------------+
6 rows in set (0.00 sec)

mysql>  SHOW TABLES LIKE 'test';
Empty set (0.01 sec)

mysql>  SHOW TABLES LIKE 'TEST';
+-----------------------+------------+
| Tables_in_sharding_db | Table_type |
+-----------------------+------------+
| TEST                  | BASE TABLE |
+-----------------------+------------+
1 row in set (0.01 sec)
```
