### PR TITLE
For #14281: Fix the problem that the replication stream slot of incremental tasks in PostgreSQL is occupied in the case of multiple data sources.

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializer.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializer.java
@@ -60,7 +60,7 @@ public final class PostgreSQLPositionInitializer implements PositionInitializer 
             log.info("replication slot already exist, slot name: {}", SLOT_NAME);
             return;
         }
-        try (PreparedStatement ps = connection.prepareStatement(String.format("SELECT * FROM pg_create_logical_replication_slot('%s', '%s')", SLOT_NAME, DECODE_PLUGIN))) {
+        try (PreparedStatement ps = connection.prepareStatement(String.format("SELECT * FROM pg_create_logical_replication_slot('%s', '%s')", getUniqueSlotName(connection), DECODE_PLUGIN))) {
             ps.execute();
         } catch (final PSQLException ex) {
             if (!DUPLICATE_OBJECT_ERROR_CODE.equals(ex.getSQLState())) {
@@ -72,7 +72,7 @@ public final class PostgreSQLPositionInitializer implements PositionInitializer 
     private boolean checkSlotExistsOrNot(final Connection connection) throws SQLException {
         String checkSlotSQL = "SELECT slot_name FROM pg_replication_slots WHERE slot_name=? AND plugin=?";
         try (PreparedStatement preparedStatement = connection.prepareStatement(checkSlotSQL)) {
-            preparedStatement.setString(1, SLOT_NAME);
+            preparedStatement.setString(1, getUniqueSlotName(connection));
             preparedStatement.setString(2, DECODE_PLUGIN);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 return resultSet.next();
@@ -113,8 +113,19 @@ public final class PostgreSQLPositionInitializer implements PositionInitializer 
         log.info("drop, slot exist, slot name: {}", SLOT_NAME);
         String dropSlotSQL = "SELECT pg_drop_replication_slot(?)";
         try (PreparedStatement preparedStatement = connection.prepareStatement(dropSlotSQL)) {
-            preparedStatement.setString(1, SLOT_NAME);
+            preparedStatement.setString(1, getUniqueSlotName(connection));
             preparedStatement.execute();
         }
+    }
+    
+    /**
+     * Get the unique slot name by connection.
+     *
+     * @param conn the connection
+     * @return the unique name by connection
+     * @throws SQLException failed when getCatalog
+     */
+    public static String getUniqueSlotName(final Connection conn) throws SQLException {
+        return String.format("%s_%s", SLOT_NAME, conn.getCatalog());
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializer.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializer.java
@@ -121,11 +121,11 @@ public final class PostgreSQLPositionInitializer implements PositionInitializer 
     /**
      * Get the unique slot name by connection.
      *
-     * @param conn the connection
+     * @param connection the connection
      * @return the unique name by connection
      * @throws SQLException failed when getCatalog
      */
-    public static String getUniqueSlotName(final Connection conn) throws SQLException {
-        return String.format("%s_%s", SLOT_NAME, conn.getCatalog());
+    public static String getUniqueSlotName(final Connection connection) throws SQLException {
+        return String.format("%s_%s", SLOT_NAME, connection.getCatalog());
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLWalDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLWalDumper.java
@@ -78,7 +78,7 @@ public final class PostgreSQLWalDumper extends AbstractLifecycleExecutor impleme
     
     private void dump() {
         try (Connection pgConnection = logicalReplication.createPgConnection((StandardJDBCDataSourceConfiguration) dumperConfig.getDataSourceConfig());
-             PGReplicationStream stream = logicalReplication.createReplicationStream(pgConnection, PostgreSQLPositionInitializer.SLOT_NAME, walPosition.getLogSequenceNumber())) {
+             PGReplicationStream stream = logicalReplication.createReplicationStream(pgConnection, PostgreSQLPositionInitializer.getUniqueSlotName(pgConnection), walPosition.getLogSequenceNumber())) {
             PostgreSQLTimestampUtils utils = new PostgreSQLTimestampUtils(pgConnection.unwrap(PgConnection.class).getTimestampUtils());
             DecodingPlugin decodingPlugin = new TestDecodingPlugin(utils);
             while (isRunning()) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializerTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLPositionInitializerTest.java
@@ -61,7 +61,7 @@ public final class PostgreSQLPositionInitializerTest {
         when(connection.getCatalog()).thenReturn("sharding_db");
         when(connection.getMetaData()).thenReturn(databaseMetaData);
         PreparedStatement lsn96PreparedStatement = mockPostgreSQL96LSN();
-        when(connection.prepareStatement(String.format("SELECT * FROM pg_create_logical_replication_slot('%s', '%s')", getUniqueSlotName(connection), "test_decoding")))
+        when(connection.prepareStatement(String.format("SELECT * FROM pg_create_logical_replication_slot('%s', '%s')", PostgreSQLPositionInitializer.getUniqueSlotName(connection), "test_decoding")))
                 .thenReturn(mock(PreparedStatement.class));
         when(connection.prepareStatement("SELECT PG_CURRENT_XLOG_LOCATION()")).thenReturn(lsn96PreparedStatement);
         PreparedStatement lsn10PreparedStatement = mockPostgreSQL10LSN();
@@ -129,16 +129,5 @@ public final class PostgreSQLPositionInitializerTest {
         when(connection.prepareStatement("SELECT pg_drop_replication_slot(?)")).thenReturn(preparedStatement);
         new PostgreSQLPositionInitializer().destroy(dataSource);
         verify(preparedStatement).execute();
-    }
-    
-    /**
-     * Get the unique slot name by connection.
-     *
-     * @param conn the connection
-     * @return the unique name by connection
-     * @throws SQLException failed when getCatalog
-     */
-    public static String getUniqueSlotName(final Connection conn) throws SQLException {
-        return String.format("%s_%s", "sharding_scaling", conn.getCatalog());
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLWalDumperTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/PostgreSQLWalDumperTest.java
@@ -102,7 +102,8 @@ public final class PostgreSQLWalDumperTest {
             ReflectionUtil.setFieldValue(walDumper, "logicalReplication", logicalReplication);
             when(logicalReplication.createPgConnection(jdbcDataSourceConfig)).thenReturn(pgConnection);
             when(pgConnection.unwrap(PgConnection.class)).thenReturn(pgConnection);
-            when(logicalReplication.createReplicationStream(pgConnection, PostgreSQLPositionInitializer.SLOT_NAME, position.getLogSequenceNumber())).thenReturn(pgReplicationStream);
+            when(logicalReplication.createReplicationStream(pgConnection, PostgreSQLPositionInitializer.getUniqueSlotName(pgConnection), position.getLogSequenceNumber()))
+                    .thenReturn(pgReplicationStream);
             ByteBuffer data = ByteBuffer.wrap("table public.t_order_0: DELETE: order_id[integer]:1".getBytes());
             when(pgReplicationStream.readPending()).thenReturn(null).thenReturn(data).thenThrow(new SQLException(""));
             when(pgReplicationStream.getLastReceiveLSN()).thenReturn(LogSequenceNumber.valueOf(101L));


### PR DESCRIPTION
Fixes #14281 .

Changes proposed in this pull request:
- Fix the problem that the replication stream slot of incremental tasks in PostgreSQL is occupied in the case of multiple data sources.
- Modify PostgreSQLPositionInitializerTest and PostgreSQLWalDumperTest
