### PR TITLE
fix en doc typo

### DIFF
--- a/docs/document/content/dev-manual/data-source.en.md
+++ b/docs/document/content/dev-manual/data-source.en.md
@@ -1,6 +1,6 @@
 +++
 pre = "<b>6.4. </b>"
-title = "Kernel"
+title = "DataSource"
 weight = 4
 chapter = true
 +++

--- a/docs/document/content/dev-manual/mode.en.md
+++ b/docs/document/content/dev-manual/mode.en.md
@@ -1,7 +1,7 @@
 +++
 pre = "<b>6.1. </b>"
 title = "Mode"
-weight = 2
+weight = 1
 chapter = true
 +++
 

--- a/docs/document/content/reference/test/_index.en.md
+++ b/docs/document/content/reference/test/_index.en.md
@@ -1,7 +1,7 @@
 +++
-pre = "<b>7.6. </b>"
+pre = "<b>7.7. </b>"
 title = "Test"
-weight = 6
+weight = 7
 chapter = true
 +++
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix en doc typo 6.4 left menu should be DataSource
 refer: https://shardingsphere.apache.org/document/current/en/dev-manual/data-source/
