### PR TITLE
For 14352: Fix the problem of "Sharding value must implements Comparabl" during incremental migration of PostgreSQL

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWalDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/OpenGaussWalDumper.java
@@ -24,11 +24,8 @@ import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.Standa
 import org.apache.shardingsphere.data.pipeline.api.executor.AbstractLifecycleExecutor;
 import org.apache.shardingsphere.data.pipeline.api.ingest.channel.Channel;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IngestPosition;
-import org.apache.shardingsphere.data.pipeline.api.ingest.record.Column;
-import org.apache.shardingsphere.data.pipeline.api.ingest.record.DataRecord;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.Record;
 import org.apache.shardingsphere.data.pipeline.core.datasource.creator.PipelineDataSourceCreatorFactory;
-import org.apache.shardingsphere.data.pipeline.core.ingest.IngestDataChangeType;
 import org.apache.shardingsphere.data.pipeline.core.ingest.exception.IngestException;
 import org.apache.shardingsphere.data.pipeline.core.util.ThreadUtil;
 import org.apache.shardingsphere.data.pipeline.opengauss.ingest.wal.OpenGaussLogicalReplication;
@@ -122,7 +119,6 @@ public final class OpenGaussWalDumper extends AbstractLifecycleExecutor implemen
                 if (!(event instanceof PlaceholderEvent) && log.isDebugEnabled()) {
                     log.debug("dump, event={}, record={}", event, record);
                 }
-                updateRecordOldValue(record);
                 pushRecord(record);
             }
         } catch (final SQLException ex) {
@@ -130,21 +126,6 @@ public final class OpenGaussWalDumper extends AbstractLifecycleExecutor implemen
                 return;
             }
             throw new IngestException(ex);
-        }
-    }
-    
-    private void updateRecordOldValue(final Record record) {
-        if (!(record instanceof DataRecord)) {
-            return;
-        }
-        DataRecord dataRecord = (DataRecord) record;
-        if (!IngestDataChangeType.UPDATE.equals(dataRecord.getType())) {
-            return;
-        }
-        for (Column each: dataRecord.getColumns()) {
-            if (each.isPrimaryKey() && each.isUpdated()) {
-                each.setOldValue(each.getValue());
-            }
         }
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WalEventConverter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WalEventConverter.java
@@ -126,9 +126,7 @@ public final class WalEventConverter {
     private void putColumnsIntoDataRecord(final DataRecord dataRecord, final TableMetaData tableMetaData, final List<Object> values) {
         for (int i = 0; i < values.size(); i++) {
             Object primaryKeyOldValue = tableMetaData.isPrimaryKey(i) ? values.get(i) : null;
-            Column column = new Column(tableMetaData.getColumnMetaData(i).getName(),
-                    primaryKeyOldValue,
-                    values.get(i), true, tableMetaData.isPrimaryKey(i));
+            Column column = new Column(tableMetaData.getColumnMetaData(i).getName(), primaryKeyOldValue, values.get(i), true, tableMetaData.isPrimaryKey(i));
             dataRecord.addColumn(column);
         }
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WalEventConverter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/WalEventConverter.java
@@ -125,7 +125,11 @@ public final class WalEventConverter {
     
     private void putColumnsIntoDataRecord(final DataRecord dataRecord, final TableMetaData tableMetaData, final List<Object> values) {
         for (int i = 0; i < values.size(); i++) {
-            dataRecord.addColumn(new Column(tableMetaData.getColumnMetaData(i).getName(), values.get(i), true, tableMetaData.isPrimaryKey(i)));
+            Object primaryKeyOldValue = tableMetaData.isPrimaryKey(i) ? values.get(i) : null;
+            Column column = new Column(tableMetaData.getColumnMetaData(i).getName(),
+                    primaryKeyOldValue,
+                    values.get(i), true, tableMetaData.isPrimaryKey(i));
+            dataRecord.addColumn(column);
         }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/record/Column.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/record/Column.java
@@ -18,11 +18,12 @@
 package org.apache.shardingsphere.data.pipeline.api.ingest.record;
 
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Column.
  */
+@RequiredArgsConstructor
 @Getter
 public final class Column {
     
@@ -31,8 +32,7 @@ public final class Column {
     /**
      * Value are available only when the primary key column is updated.
      */
-    @Setter
-    private Object oldValue;
+    private final Object oldValue;
     
     private final Object value;
     
@@ -42,14 +42,6 @@ public final class Column {
     
     public Column(final String name, final Object value, final boolean updated, final boolean primaryKey) {
         this(name, null, value, updated, primaryKey);
-    }
-    
-    public Column(final String name, final Object oldValue, final Object value, final boolean updated, final boolean primaryKey) {
-        this.name = name;
-        this.oldValue = oldValue;
-        this.value = value;
-        this.updated = updated;
-        this.primaryKey = primaryKey;
     }
     
     @Override


### PR DESCRIPTION
Fix the problem of "Sharding value must implements Comparabl" during incremental migration of PostgreSQL

Fixes #14352

Changes proposed in this pull request:
- Modify the `oldValue` parameter in the `Column` class
- Modify the `WalEventConverter` class so that it can set the value for `oldValue`
- Delete the useless methods in the `OpenGaussWalDumper` class

Notice:
- Does not support updating the primary key for the time being
