### PR TITLE
CosIdKeyGenerateAlgorithm support key of String type.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <guava.version>29.0-jre</guava.version>
         <gson.version>2.8.6</gson.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <cosid.version>1.4.14</cosid.version>
+        <cosid.version>1.6.6</cosid.version>
         <antlr4.version>4.9.2</antlr4.version>
         
         <groovy.version>2.4.19</groovy.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -234,7 +234,7 @@ The text of each license is the standard Apache 2.0 license.
     curator-client 5.1.0:  https://github.com/apache/curator, Apache 2.0
     curator-framework 5.1.0:  https://github.com/apache/curator, Apache 2.0
     curator-recipes 5.1.0:  https://github.com/apache/curator, Apache 2.0
-    CosId 1.4.14: https://github.com/Ahoo-Wang/CosId, Apache 2.0
+    CosId 1.6.6: https://github.com/Ahoo-Wang/CosId, Apache 2.0
     error_prone_annotations 2.3.4: https://github.com/google/error-prone, Apache 2.0
     esri-geometry-api 2.2.0: https://github.com/Esri/geometry-api-java, Apache 2.0
     failsafe 2.3.3: https://github.com/jhalterman/failsafe, Apache 2.0

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/CosIdKeyGenerateAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/CosIdKeyGenerateAlgorithm.java
@@ -32,20 +32,29 @@ public final class CosIdKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
 
     public static final String TYPE = CosId.COSID.toUpperCase();
 
+    public static final String AS_STRING_KEY = "as-string";
+
     @Getter
     @Setter
     private Properties props = new Properties();
 
     private volatile LazyIdGenerator cosIdProvider;
 
+    private volatile boolean asString;
+
     @Override
     public void init() {
         cosIdProvider = new LazyIdGenerator(getProps().getOrDefault(CosIdAlgorithm.ID_NAME_KEY, IdGeneratorProvider.SHARE).toString());
+        String asStringStr = getProps().getProperty(AS_STRING_KEY, Boolean.FALSE.toString());
+        this.asString = Boolean.parseBoolean(asStringStr);
         cosIdProvider.tryGet(false);
     }
 
     @Override
     public Comparable<?> generateKey() {
+        if (this.asString) {
+            return cosIdProvider.generateAsString();
+        }
         return cosIdProvider.generate();
     }
 

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/keygen/CosIdKeyGenerateAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/keygen/CosIdKeyGenerateAlgorithmTest.java
@@ -19,13 +19,16 @@ import me.ahoo.cosid.CosIdException;
 import me.ahoo.cosid.provider.DefaultIdGeneratorProvider;
 import me.ahoo.cosid.segment.DefaultSegmentId;
 import me.ahoo.cosid.segment.IdSegmentDistributor;
+import me.ahoo.cosid.util.MockIdGenerator;
 import org.apache.shardingsphere.sharding.algorithm.sharding.cosid.CosIdAlgorithm;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class CosIdKeyGenerateAlgorithmTest {
 
@@ -63,5 +66,21 @@ public final class CosIdKeyGenerateAlgorithmTest {
         keyGenerateAlgorithm.setProps(properties);
         keyGenerateAlgorithm.init();
         keyGenerateAlgorithm.generateKey();
+    }
+
+    @Test
+    public void assertGenerateKeyAsString() {
+        String idName = "test-cosid-as-string";
+        DefaultIdGeneratorProvider.INSTANCE.set(idName, MockIdGenerator.INSTANCE);
+        CosIdKeyGenerateAlgorithm keyGenerateAlgorithm = new CosIdKeyGenerateAlgorithm();
+        Properties properties = new Properties();
+        properties.setProperty(CosIdAlgorithm.ID_NAME_KEY, idName);
+        properties.setProperty(CosIdKeyGenerateAlgorithm.AS_STRING_KEY, "true");
+        keyGenerateAlgorithm.setProps(properties);
+        keyGenerateAlgorithm.init();
+        Comparable<?> actual = keyGenerateAlgorithm.generateKey();
+        assertThat(actual, Matchers.instanceOf(String.class));
+        assertThat(actual.toString(), Matchers.startsWith("test_"));
+        assertTrue(actual.toString().length() <= 16);
     }
 }


### PR DESCRIPTION
Fixes #14427 .

Changes proposed in this pull request:

`CosIdKeyGenerateAlgorithm` currently only supports generating `long` type keys. We want to support string type keys.

such as `266691111261569024` `JhRmZIPe3k`  `20211229221515806-0-0`
