### PR TITLE
For #14429: Fix the "Illegal operation on empty result set" exception that appears in the migration when using MySQL 5.5

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
@@ -45,6 +45,8 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
     
     private static final Map<String, String> REQUIRED_VARIABLES = new HashMap<>(3, 1);
     
+    private static final String BINLOG_ROW_IMAGE = "BINLOG_ROW_IMAGE";
+    
     static {
         REQUIRED_VARIABLES.put("LOG_BIN", "ON");
         REQUIRED_VARIABLES.put("BINLOG_FORMAT", "ROW");
@@ -99,7 +101,9 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
         try (PreparedStatement preparedStatement = connection.prepareStatement(SHOW_VARIABLES_SQL)) {
             preparedStatement.setString(1, key);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                resultSet.next();
+                if (!resultSet.next() && BINLOG_ROW_IMAGE.equalsIgnoreCase(key)) {
+                    return;
+                }
                 String actualValue = resultSet.getString(2);
                 if (!toBeCheckedValue.equalsIgnoreCase(actualValue)) {
                     throw new PipelineJobPrepareFailedException(String.format("Source data source required `%s = %s`, now is `%s`", key, toBeCheckedValue, actualValue));


### PR DESCRIPTION
Fix the "Illegal operation on empty result set" exception that appears in the migration when using MySQL 5.5
When the MySQL version is lower than 5.6 or earlier, there will be problems with data migration
Fixes #14429.

Changes proposed in this pull request:
- Add `BINLOG_ROW_IMAGE` filed in `MySQLDataSourceChecker` class
- If it is "BINLOG_ROW_IMAGE" during the loop and the return Reset is empty, skip the judgment
