### PR TITLE
Add MySQL parse support for `DESCRIBE Statement`

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
@@ -118,6 +118,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dal.ShowLikeSegme
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dal.VariableAssignSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dal.VariableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.FunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.WhereSegment;
@@ -525,6 +526,11 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
         MySQLExplainStatement result = new MySQLExplainStatement();
         if (null != ctx.tableName()) {
             result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+            if (null != ctx.columnRef()) {
+                result.setColumnWild((ColumnSegment) visit(ctx.columnRef()));
+            } else if (null != ctx.textString()) {
+                result.setColumnWild((ColumnSegment) visit(ctx.textString()));
+            }
         } else if (null != ctx.explainableStatement()) {
             result.setStatement((SQLStatement) visit(ctx.explainableStatement()));
         } else if (null != ctx.select()) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLExplainStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/mysql/dal/MySQLExplainStatement.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal;
 
 import lombok.Setter;
 import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ExplainStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
@@ -34,6 +35,8 @@ public final class MySQLExplainStatement extends ExplainStatement implements MyS
     
     private SimpleTableSegment table;
     
+    private ColumnSegment columnWild;
+    
     /**
      * Get simple table segment.
      * 
@@ -41,5 +44,14 @@ public final class MySQLExplainStatement extends ExplainStatement implements MyS
      */
     public Optional<SimpleTableSegment> getTable() {
         return Optional.ofNullable(table);
+    }
+
+    /**
+     * Get column segment.
+     *
+     * @return column segment
+     */
+    public Optional<ColumnSegment> getColumnWild() {
+        return Optional.ofNullable(columnWild);
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
@@ -20,7 +20,10 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ExplainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLExplainStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.column.ColumnAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.SQLStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dal.ExplainStatementTestCase;
 
@@ -56,8 +59,23 @@ public final class ExplainStatementAssert {
         } else if (null != expected.getCreateTableAsSelectClause()) {
             assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
             SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getCreateTableAsSelectClause());
+        } else if (actual instanceof MySQLExplainStatement && null != expected.getTableName()) {
+            mysqlExplainStatementAssert(assertContext, (MySQLExplainStatement) actual, expected);
         } else {
             assertFalse(assertContext.getText("Actual statement should not exist."), actual.getStatement().isPresent());
+        }
+    }
+    
+    private static void mysqlExplainStatementAssert(final SQLCaseAssertContext assertContext, final MySQLExplainStatement actual, final ExplainStatementTestCase expected) {
+        if (actual.getTable().isPresent()) {
+            TableAssert.assertIs(assertContext, actual.getTable().get(), expected.getTableName());
+            if (actual.getColumnWild().isPresent()) {
+                ColumnAssert.assertIs(assertContext, actual.getColumnWild().get(), expected.getColumn());
+            } else {
+                assertFalse(assertContext.getText("Actual column wild should not exist."), actual.getColumnWild().isPresent());
+            }
+        } else {
+            assertFalse(assertContext.getText("Actual table should not exist."), actual.getTable().isPresent());
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.CreateTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.DeleteStatementTestCase;
@@ -49,4 +51,10 @@ public final class ExplainStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "create-table")
     private CreateTableStatementTestCase createTableAsSelectClause;
+    
+    @XmlElement(name = "table")
+    private ExpectedSimpleTable tableName;
+    
+    @XmlElement(name = "column-wild")
+    private ExpectedColumn column;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
@@ -192,4 +192,34 @@
             </select>
         </create-table>
     </describe>
+    <describe sql-case-id="desc_table">
+        <table name="tableName" start-index="5" stop-index="13" />
+    </describe>
+    <describe sql-case-id="desc_table_with_col_name">
+        <table name="tableName" start-index="5" stop-index="13" />
+        <column-wild name="colName" start-index="15" stop-index="21" />
+    </describe>
+    <describe sql-case-id="desc_table_with_placeholder">
+        <table name="tableName" start-index="5" stop-index="13" />
+        <column-wild name="___" start-index="15" stop-index="17" />
+    </describe>
+    <describe sql-case-id="desc_table_with_wild">
+        <table name="tableName" start-index="5" stop-index="13" />
+        <column-wild name="u%" start-delimiter="`" end-delimiter="`" start-index="15" stop-index="18" />
+    </describe>
+    <describe sql-case-id="describe_table">
+        <table name="tableName" start-index="9" stop-index="17" />
+    </describe>
+    <describe sql-case-id="describe_table_with_col_name">
+        <table name="tableName" start-index="9" stop-index="17" />
+        <column-wild name="colName" start-index="19" stop-index="25" />
+    </describe>
+    <describe sql-case-id="describe_table_with_placeholder">
+        <table name="tableName" start-index="5" stop-index="13" />
+        <column-wild name="___" start-index="15" stop-index="17" />
+    </describe>
+    <describe sql-case-id="describe_table_with_wild">
+        <table name="tableName" start-index="5" stop-index="13" />
+        <column-wild name="u%" start-delimiter="`" end-delimiter="`" start-index="15" stop-index="18" />
+    </describe>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
@@ -25,4 +25,12 @@
     <sql-case id="explain_create_table_as_select" value="EXPLAIN CREATE TABLE t_order_new WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT * FROM t_order" db-types="SQLServer" />
     <sql-case id="explain_create_table_as_select_with_explicit_column_names" value="EXPLAIN CREATE TABLE t_order_new (order_id_new, user_id_new) WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT order_id, user_id FROM t_order" db-types="SQLServer" />
     <sql-case id="explain_create_remote_table_as_select" value="EXPLAIN CREATE REMOTE TABLE t_order_new AT ('Data Source = ds_0, 3306; User ID = ROOT; Password = 123456;') AS SELECT i.* FROM t_order_item i JOIN t_order o ON i.order_id = o.order_id" db-types="SQLServer" />
+    <sql-case id="desc_table" value="DESC tableName" db-types="MySQL" />
+    <sql-case id="desc_table_with_col_name" value="DESC tableName colName" db-types="MySQL" />
+    <sql-case id="desc_table_with_placeholder" value="DESC tableName ___" db-types="MySQL" />
+    <sql-case id="desc_table_with_wild" value="DESC tableName `u%`" db-types="MySQL" />
+    <sql-case id="describe_table" value="DESCRIBE tableName" db-types="MySQL" />
+    <sql-case id="describe_table_with_col_name" value="DESCRIBE tableName colName" db-types="MySQL" />
+    <sql-case id="describe_table_with_placeholder" value="DESC tableName ___" db-types="MySQL" />
+    <sql-case id="describe_table_with_wild" value="DESC tableName `u%`" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
For #14110.

Changes proposed in this pull request:
- add MySQL parse support for `DESCRIBE Statement`
- add test case
