### PR TITLE
Add MySQL parse support for `EXPLAIN Statement`

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -31,7 +31,7 @@ explain
     : (DESC | DESCRIBE | EXPLAIN)
     (tableName (columnRef | textString)?
     | explainType? (explainableStatement | FOR CONNECTION connectionId)
-    | ANALYZE select)
+    | ANALYZE (FORMAT EQ_ TREE)? select)
     ;
 
 showDatabases
@@ -409,6 +409,7 @@ explainType
     : FORMAT EQ_ formatName
     ;
 
+// TODO support table statement
 explainableStatement
     : select | delete | insert | replace | update
     ;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
@@ -192,6 +192,52 @@
             </select>
         </create-table>
     </describe>
+    <describe sql-case-id="explain_with_analyze">
+        <select>
+            <projections start-index="23" stop-index="23">
+                <shorthand-projection start-index="23" stop-index="23" />
+            </projections>
+            <from>
+                <simple-table name="t_order" start-index="30" stop-index="36"/>
+            </from>
+            <where start-index="38" stop-index="55">
+                <expr>
+                    <binary-operation-expression start-index="44" stop-index="55">
+                        <left>
+                            <column name="order_id" start-index="44" stop-index="51" />
+                        </left>
+                        <operator>></operator>
+                        <right>
+                            <literal-expression value="8" start-index="55" stop-index="55" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
+            </where>
+        </select>
+    </describe>
+    <describe sql-case-id="explain_with_analyze_format">
+        <select>
+            <projections start-index="37" stop-index="37">
+                <shorthand-projection start-index="37" stop-index="37" />
+            </projections>
+            <from>
+                <simple-table name="t_order" start-index="44" stop-index="50"/>
+            </from>
+            <where start-index="52" stop-index="69">
+                <expr>
+                    <binary-operation-expression start-index="58" stop-index="69">
+                        <left>
+                            <column name="order_id" start-index="58" stop-index="65" />
+                        </left>
+                        <operator>></operator>
+                        <right>
+                            <literal-expression value="8" start-index="69" stop-index="69" />
+                        </right>
+                    </binary-operation-expression>
+                </expr>
+            </where>
+        </select>
+    </describe>
     <describe sql-case-id="desc_table">
         <table name="tableName" start-index="5" stop-index="13" />
     </describe>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
@@ -25,6 +25,8 @@
     <sql-case id="explain_create_table_as_select" value="EXPLAIN CREATE TABLE t_order_new WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT * FROM t_order" db-types="SQLServer" />
     <sql-case id="explain_create_table_as_select_with_explicit_column_names" value="EXPLAIN CREATE TABLE t_order_new (order_id_new, user_id_new) WITH (DISTRIBUTION = HASH(product_key), CLUSTERED COLUMNSTORE INDEX, PARTITION (order_date RANGE RIGHT FOR VALUES (20000101,20010101))) AS SELECT order_id, user_id FROM t_order" db-types="SQLServer" />
     <sql-case id="explain_create_remote_table_as_select" value="EXPLAIN CREATE REMOTE TABLE t_order_new AT ('Data Source = ds_0, 3306; User ID = ROOT; Password = 123456;') AS SELECT i.* FROM t_order_item i JOIN t_order o ON i.order_id = o.order_id" db-types="SQLServer" />
+    <sql-case id="explain_with_analyze" value="EXPLAIN ANALYZE SELECT * FROM t_order WHERE order_id > 8" db-types="MySQL" />
+    <sql-case id="explain_with_analyze_format" value="EXPLAIN ANALYZE FORMAT = TREE SELECT * FROM t_order WHERE order_id > 8" db-types="MySQL" />
     <sql-case id="desc_table" value="DESC tableName" db-types="MySQL" />
     <sql-case id="desc_table_with_col_name" value="DESC tableName colName" db-types="MySQL" />
     <sql-case id="desc_table_with_placeholder" value="DESC tableName ___" db-types="MySQL" />


### PR DESCRIPTION
For #14110.

Changes proposed in this pull request:
- add MySQL parse support for `EXPLAIN Statement`
- add test case
