### PR TITLE
Improve data nodes visitor for sharding table rule.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -358,7 +358,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     }
     
     private Collection<String> getDataNodes(final DataNodesContext ctx) {
-        return ctx.dataNode().stream().map(each -> getIdentifierValue(each)).collect(Collectors.toCollection(LinkedList::new));
+        return ctx.dataNode().stream().map(each -> each.getText()).collect(Collectors.toCollection(LinkedList::new));
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -358,7 +358,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     }
     
     private Collection<String> getDataNodes(final DataNodesContext ctx) {
-        return ctx.dataNode().stream().map(each -> each.getText()).collect(Collectors.toCollection(LinkedList::new));
+        return ctx.dataNode().stream().map(each -> getIdentifierValueWithBracketReserved(each)).collect(Collectors.toCollection(LinkedList::new));
     }
     
     @Override
@@ -371,6 +371,13 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
             return null;
         }
         return new IdentifierValue(context.getText()).getValue();
+    }
+
+    private String getIdentifierValueWithBracketReserved(final ParseTree context) {
+        if (null == context) {
+            return null;
+        }
+        return new IdentifierValue(context.getText(), "[]").getValue();
     }
     
     private Properties getAlgorithmProperties(final AlgorithmDefinitionContext ctx) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
@@ -73,6 +73,8 @@ public final class SQLUtil {
     
     private static final String COMMENT_SUFFIX = "*/";
     
+    private static final String EXCLUDED_CHARACTERS = "[]`'\"";
+    
     private static final Pattern SINGLE_CHARACTER_PATTERN = Pattern.compile("^_|([^\\\\])_");
     
     private static final Pattern SINGLE_CHARACTER_ESCAPE_PATTERN = Pattern.compile("\\\\_");
@@ -116,7 +118,24 @@ public final class SQLUtil {
      * @return exactly SQL expression
      */
     public static String getExactlyValue(final String value) {
-        return null == value ? null : CharMatcher.anyOf("[]`'\"").removeFrom(value);
+        return null == value ? null : CharMatcher.anyOf(EXCLUDED_CHARACTERS).removeFrom(value);
+    }
+
+    /**
+     * Get exactly value for SQL expression.
+     *
+     * <p>remove special char for SQL expression</p>
+     *
+     * @param value SQL expression
+     * @param reservedCharacters characters to be reserved
+     * @return exactly SQL expression
+     */
+    public static String getExactlyValue(final String value, final String reservedCharacters) {
+        if (null == value) {
+            return null;
+        }
+        String toBeExcludedCharacters = CharMatcher.anyOf(reservedCharacters).removeFrom(EXCLUDED_CHARACTERS);
+        return CharMatcher.anyOf(toBeExcludedCharacters).removeFrom(value);
     }
     
     /**
@@ -218,7 +237,7 @@ public final class SQLUtil {
     }
     
     private static boolean isReadOnly(final DALStatement sqlStatement) {
-        if (sqlStatement instanceof SetStatement
+        return !(sqlStatement instanceof SetStatement
                 | sqlStatement instanceof MySQLUseStatement
                 | sqlStatement instanceof MySQLUninstallPluginStatement
                 | sqlStatement instanceof MySQLResetStatement
@@ -229,10 +248,7 @@ public final class SQLUtil {
                 | sqlStatement instanceof MySQLInstallPluginStatement
                 | sqlStatement instanceof MySQLFlushStatement
                 | sqlStatement instanceof MySQLChecksumTableStatement
-                | sqlStatement instanceof MySQLCacheIndexStatement) {
-            return false;
-        }
-        return true;
+                | sqlStatement instanceof MySQLCacheIndexStatement);
     }
     
     /**

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/identifier/IdentifierValue.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/identifier/IdentifierValue.java
@@ -39,6 +39,10 @@ public final class IdentifierValue implements ValueASTNode<String> {
     public IdentifierValue(final String text) {
         this(SQLUtil.getExactlyValue(text), QuoteCharacter.getQuoteCharacter(text));
     }
+
+    public IdentifierValue(final String text, final String reservedCharacters) {
+        this(SQLUtil.getExactlyValue(text, reservedCharacters), QuoteCharacter.getQuoteCharacter(text));
+    }
     
     /**
      * Get value with quote characters, i.e. `table1` or `field1`

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtilTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtilTest.java
@@ -64,6 +64,14 @@ public final class SQLUtilTest {
         assertThat(SQLUtil.getExactlyValue("\"xxx\""), is("xxx"));
         assertThat(SQLUtil.getExactlyValue("'xxx'"), is("xxx"));
     }
+
+    @Test
+    public void assertGetExactlyValueWithReservedCharacters() {
+        assertThat(SQLUtil.getExactlyValue("`xxx`", "`"), is("`xxx`"));
+        assertThat(SQLUtil.getExactlyValue("[xxx]", "[]"), is("[xxx]"));
+        assertThat(SQLUtil.getExactlyValue("\"xxx\"", "\""), is("\"xxx\""));
+        assertThat(SQLUtil.getExactlyValue("'xxx'", "'"), is("'xxx'"));
+    }
     
     @Test
     public void assertGetExactlyValueUsingNull() {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/value/identifier/IdentifierValueTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/value/identifier/IdentifierValueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.value.identifier;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class IdentifierValueTest {
+    
+    @Test
+    public void assertGetIdentifierValueWithSingleQuote() {
+        String text = "'ms_group_${0..1}'";
+        assertThat(new IdentifierValue(text).getValue(), is("ms_group_${0..1}"));
+    }
+
+    @Test
+    public void assertGetIdentifierValueWithQuote() {
+        String text = "\"ms_group_${0..1}\"";
+        assertThat(new IdentifierValue(text).getValue(), is("ms_group_${0..1}"));
+    }
+
+    @Test
+    public void assertGetIdentifierValueWithBackQuote() {
+        String text = "`t_order`";
+        assertThat(new IdentifierValue(text).getValue(), is("t_order"));
+    }
+    
+    @Test
+    public void assertGetIdentifierValueWithBracket() {
+        String text = "ds_${[1,2]}.t_order";
+        assertThat(new IdentifierValue(text).getValue(), is("ds_${1,2}.t_order"));
+    }
+
+    @Test
+    public void assertGetIdentifierValueWithReservedBracket() {
+        String text = "ds_${[1,2]}.t_order";
+        assertThat(new IdentifierValue(text, "[]").getValue(), is("ds_${[1,2]}.t_order"));
+    }
+}


### PR DESCRIPTION
####  1. Improve data nodes visitor for sharding table rule.

Now, `DATANODES("ds_${[256181,256182]}.t_order")` will be parsed to `DATANODES("ds_${256181,256182}.t_order")`,  the BRACKETS  `[]` were lost.
It will cause InlineExpressionParser exception.

#### 2.  Add reserved characters when get identifier value.
Add a new method to specify which characters want to reserved when get Identifier value.

