### PR TITLE
Get table metadata from context on scaling data consistency check

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmC
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration;
+import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
 /**
@@ -49,6 +50,8 @@ public final class RuleAlteredContext {
     }
     
     private static volatile ModeConfiguration modeConfig;
+    
+    private static volatile ContextManager contextManager;
     
     private final OnRuleAlteredActionConfiguration onRuleAlteredActionConfig;
     
@@ -111,5 +114,23 @@ public final class RuleAlteredContext {
      */
     public static void initModeConfig(final ModeConfiguration modeConfig) {
         RuleAlteredContext.modeConfig = modeConfig;
+    }
+    
+    /**
+     * Get context manager.
+     *
+     * @return context manager
+     */
+    public static ContextManager getContextManager() {
+        return contextManager;
+    }
+    
+    /**
+     * Initialize context manager.
+     *
+     * @param contextManager context manager
+     */
+    public static void initContextManager(final ContextManager contextManager) {
+        RuleAlteredContext.contextManager = contextManager;
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/PipelineDataSourceWrapper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/PipelineDataSourceWrapper.java
@@ -36,6 +36,7 @@ import java.util.logging.Logger;
 @Slf4j
 public final class PipelineDataSourceWrapper implements DataSource, AutoCloseable {
     
+    @Getter
     private final DataSource dataSource;
     
     @Getter

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
@@ -68,19 +68,23 @@ public final class BootstrapInitializer {
     public void init(final YamlProxyConfiguration yamlConfig, final int port) throws SQLException {
         ModeConfiguration modeConfig = null == yamlConfig.getServerConfiguration().getMode()
                 ? null : new ModeConfigurationYamlSwapper().swapToObject(yamlConfig.getServerConfiguration().getMode());
-        initContext(yamlConfig, modeConfig, port);
-        initRuleAlteredJobWorker(modeConfig);
+        ContextManager contextManager = createContextManager(yamlConfig, modeConfig, port);
+        initContext(contextManager);
+        initRuleAlteredJobWorker(modeConfig, contextManager);
         setDatabaseServerInfo();
     }
     
-    private void initContext(final YamlProxyConfiguration yamlConfig, final ModeConfiguration modeConfig, final int port) throws SQLException {
+    private ContextManager createContextManager(final YamlProxyConfiguration yamlConfig, final ModeConfiguration modeConfig, final int port) throws SQLException {
         ProxyConfiguration proxyConfig = new YamlProxyConfigurationSwapper().swap(yamlConfig);
         boolean isOverwrite = null == modeConfig || modeConfig.isOverwrite();
         Map<String, Map<String, DataSource>> dataSourcesMap = getDataSourcesMap(proxyConfig.getSchemaDataSources());
         ContextManagerBuilderParameter parameter = ContextManagerBuilderParameter.builder().modeConfig(modeConfig).dataSourcesMap(dataSourcesMap).schemaRuleConfigs(proxyConfig.getSchemaRules())
                 .globalRuleConfigs(proxyConfig.getGlobalRules()).props(proxyConfig.getProps()).isOverwrite(isOverwrite).labels(proxyConfig.getLabels())
                 .instanceDefinition(new InstanceDefinition(InstanceType.PROXY, port)).build();
-        ContextManager contextManager = ContextManagerBuilderFactory.newInstance(modeConfig).build(parameter);
+        return ContextManagerBuilderFactory.newInstance(modeConfig).build(parameter);
+    }
+    
+    private void initContext(final ContextManager contextManager) {
         ProxyContext.getInstance().init(contextManager);
     }
     
@@ -93,7 +97,7 @@ public final class BootstrapInitializer {
         return result;
     }
     
-    private void initRuleAlteredJobWorker(final ModeConfiguration modeConfig) {
+    private void initRuleAlteredJobWorker(final ModeConfiguration modeConfig, final ContextManager contextManager) {
         if (null == modeConfig) {
             return;
         }
@@ -103,6 +107,7 @@ public final class BootstrapInitializer {
             return;
         }
         RuleAlteredContext.initModeConfig(modeConfig);
+        RuleAlteredContext.initContextManager(contextManager);
         // TODO init worker only if necessary, e.g. 1) rule altered action configured, 2) enabled job exists, 3) stopped job restarted
         RuleAlteredJobWorker.initWorkerIfNecessary();
     }

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/PipelineJobAPIImplTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/PipelineJobAPIImplTest.java
@@ -141,6 +141,7 @@ public final class PipelineJobAPIImplTest {
         assertTrue(jobId.isPresent());
         JobConfiguration jobConfig = pipelineJobAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getPipelineConfig());
+        RuleAlteredContextUtil.mockContextManager();
         Map<String, DataConsistencyCheckResult> checkResultMap = pipelineJobAPI.dataConsistencyCheck(jobId.get());
         assertThat(checkResultMap.size(), is(1));
     }
@@ -151,6 +152,7 @@ public final class PipelineJobAPIImplTest {
         assertTrue(jobId.isPresent());
         JobConfiguration jobConfig = pipelineJobAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getPipelineConfig());
+        RuleAlteredContextUtil.mockContextManager();
         Map<String, DataConsistencyCheckResult> checkResultMap = pipelineJobAPI.dataConsistencyCheck(jobId.get(), FixtureDataConsistencyCheckAlgorithm.TYPE);
         assertThat(checkResultMap.size(), is(1));
         assertTrue(checkResultMap.get("t_order").isRecordsCountMatched());

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImplTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImplTest.java
@@ -19,12 +19,14 @@ package org.apache.shardingsphere.data.pipeline.core.check.consistency;
 
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfiguration;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.fixture.FixtureDataConsistencyCheckAlgorithm;
 import org.apache.shardingsphere.data.pipeline.core.util.ResourceUtil;
+import org.apache.shardingsphere.data.pipeline.core.util.RuleAlteredContextUtil;
 import org.apache.shardingsphere.data.pipeline.scenario.rulealtered.RuleAlteredJobContext;
-import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfiguration;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -42,6 +44,11 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class DataConsistencyCheckerImplTest {
+    
+    @BeforeClass
+    public static void beforeClass() {
+        RuleAlteredContextUtil.mockContextManager();
+    }
     
     @Test
     public void assertCountAndDataCheck() {

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/ResourceUtil.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/ResourceUtil.java
@@ -76,9 +76,18 @@ public final class ResourceUtil {
         return result;
     }
     
+    /**
+     * Read file to string.
+     *
+     * @param fileName file name
+     * @return file content
+     */
     @SneakyThrows(IOException.class)
-    private static String readFileToString(final String fileName) {
+    public static String readFileToString(final String fileName) {
         try (InputStream in = ResourceUtil.class.getResourceAsStream(fileName)) {
+            if (null == in) {
+                throw new NullPointerException("get " + fileName + " as stream return null");
+            }
             return IOUtils.toString(in, StandardCharsets.UTF_8);
         }
     }


### PR DESCRIPTION

Changes proposed in this pull request:
- Get table metadata from context on scaling data consistency check. Since `ShardingSphereDatabaseMetaData.getPrimaryKeys` might throw exception on `ShardingSphereDataSource`, so get a workaround for now.
