### PR TITLE
 fix issue[14566]: TablesContext#findTableNameFromMetaData() can not find the correct table name for column names when column names are in upper case. #14575

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
@@ -29,7 +29,17 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Sim
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.TreeSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
@@ -29,17 +29,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Sim
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -122,7 +112,7 @@ public final class TablesContext {
         }
         Map<String, String> result = new HashMap<>(columns.size(), 1);
         result.putAll(findTableNameFromSQL(getOwnerColumnNames(columns)));
-        Collection<String> columnNames = new LinkedHashSet<>();
+        Collection<String> columnNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         for (ColumnProjection each : columns) {
             if (null == each.getOwner()) {
                 columnNames.add(each.getName());

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContextTest.java
@@ -42,13 +42,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class TablesContextTest {
-
+    
     @Test
     public void assertGetTableNames() {
         TablesContext tablesContext = new TablesContext(Arrays.asList(createTableSegment("table_1", "tbl_1"), createTableSegment("table_2", "tbl_2")));
         assertThat(tablesContext.getTableNames(), is(Sets.newHashSet("table_1", "table_2")));
     }
-
+    
     @Test
     public void assertInstanceCreatedWhenNoExceptionThrown() {
         SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 10, new IdentifierValue("tbl")));
@@ -56,7 +56,7 @@ public final class TablesContextTest {
         new TablesContext(Collections.singleton(tableSegment));
         // TODO add assertion
     }
-
+    
     @Test
     public void assertFindTableNameWhenSingleTable() {
         SimpleTableSegment tableSegment = createTableSegment("table_1", "tbl_1");
@@ -65,7 +65,7 @@ public final class TablesContextTest {
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("table_1"));
     }
-
+    
     @Test
     public void assertFindTableNameWhenColumnSegmentOwnerPresent() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -75,7 +75,7 @@ public final class TablesContextTest {
         assertFalse(actual.isEmpty());
         assertThat(actual.get("table_1.col"), is("table_1"));
     }
-
+    
     @Test
     public void assertFindTableNameWhenColumnSegmentOwnerAbsent() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -84,7 +84,7 @@ public final class TablesContextTest {
         Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2)).findTableName(Collections.singletonList(columnProjection), mock(ShardingSphereSchema.class));
         assertTrue(actual.isEmpty());
     }
-
+    
     @Test
     public void assertFindTableNameWhenColumnSegmentOwnerAbsentAndSchemaMetaDataContainsColumn() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -96,7 +96,7 @@ public final class TablesContextTest {
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("table_1"));
     }
-
+    
     @Test
     public void assertFindTableNameWhenColumnSegmentOwnerAbsentAndSchemaMetaDataContainsColumnInUpperCase() {
         SimpleTableSegment tableSegment1 = createTableSegment("TABLE_1", "TBL_1");
@@ -110,18 +110,18 @@ public final class TablesContextTest {
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("TABLE_1"));
     }
-
+    
     private SimpleTableSegment createTableSegment(final String tableName, final String alias) {
         SimpleTableSegment result = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue(tableName)));
         AliasSegment aliasSegment = new AliasSegment(0, 0, new IdentifierValue(alias));
         result.setAlias(aliasSegment);
         return result;
     }
-
+    
     private ColumnProjection createColumnProjection(final String owner, final String name, final String alias) {
         return new ColumnProjection(owner, name, alias);
     }
-
+    
     @Test
     public void assertGetSchemaNameWithSameSchemaAndSameTable() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -132,7 +132,7 @@ public final class TablesContextTest {
         assertTrue(tablesContext.getSchemaName().isPresent());
         assertThat(tablesContext.getSchemaName().get(), is("sharding_db_1"));
     }
-
+    
     @Test
     public void assertGetSchemaNameWithSameSchemaAndDifferentTable() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -143,7 +143,7 @@ public final class TablesContextTest {
         assertTrue(tablesContext.getSchemaName().isPresent());
         assertThat(tablesContext.getSchemaName().get(), is("sharding_db_1"));
     }
-
+    
     @Test(expected = IllegalStateException.class)
     public void assertGetSchemaNameWithDifferentSchemaAndSameTable() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");
@@ -152,7 +152,7 @@ public final class TablesContextTest {
         tableSegment2.setOwner(new OwnerSegment(0, 0, new IdentifierValue("sharding_db_2")));
         new TablesContext(Arrays.asList(tableSegment1, tableSegment2)).getSchemaName();
     }
-
+    
     @Test(expected = IllegalStateException.class)
     public void assertGetSchemaNameWithDifferentSchemaAndDifferentTable() {
         SimpleTableSegment tableSegment1 = createTableSegment("table_1", "tbl_1");

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContextTest.java
@@ -31,12 +31,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -108,13 +109,6 @@ public final class TablesContextTest {
         Map<String, String> actual = new TablesContext(Arrays.asList(tableSegment1, tableSegment2)).findTableName(Collections.singletonList(columnProjection), schema);
         assertFalse(actual.isEmpty());
         assertThat(actual.get("col"), is("TABLE_1"));
-    }
-
-    private TableMetaData createTableMetaData(String tableName, List<String> columnNames) {
-        return new TableMetaData(
-                tableName,
-                columnNames.stream().map(colName -> new ColumnMetaData(colName, 0, false, false, true)).collect(Collectors.toList()),
-                Collections.EMPTY_LIST);
     }
 
     private SimpleTableSegment createTableSegment(final String tableName, final String alias) {


### PR DESCRIPTION
Fixes #14566.

Changes proposed in this pull request:
-
-
-
