### PR TITLE
Reduce computing overhead in SingleTableRule

### DIFF
--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -38,9 +38,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -97,9 +95,21 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
      * @return whether single tables are in same data source or not
      */
     public boolean isSingleTablesInSameDataSource(final Collection<String> singleTableNames) {
-        Set<String> dataSourceNames = singleTableNames.stream().map(each -> findSingleTableDataNode(each)
-                .orElse(null)).filter(Objects::nonNull).map(DataNode::getDataSourceName).collect(Collectors.toSet());
-        return dataSourceNames.size() <= 1;
+        String firstFoundDataSourceName = null;
+        for (String each : singleTableNames) {
+            Optional<DataNode> dataNode = findSingleTableDataNode(each);
+            if (!dataNode.isPresent()) {
+                continue;
+            }
+            if (null == firstFoundDataSourceName) {
+                firstFoundDataSourceName = dataNode.get().getDataSourceName();
+                continue;
+            }
+            if (!firstFoundDataSourceName.equals(dataNode.get().getDataSourceName())) {
+                return false;
+            }
+        }
+        return true;
     }
     
     /**


### PR DESCRIPTION
Related to #13848

## Stack trace

### Before
![image](https://user-images.githubusercontent.com/20503072/148487729-c608edb8-3af0-4371-bac4-7b3eafe21483.png)

### After
![image](https://user-images.githubusercontent.com/20503072/148487683-2a1bf036-5dac-47f4-ac18-9c967eaf93bd.png)


## sysbench oltp_point_select

### Before

```
sysbench 1.1.0-ead2689 (using bundled LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 64
Warmup time: 5s
Report intermediate results every 5 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

Warming up for 5 seconds...

[ 5s ] thds: 64 tps: 51984.63 qps: 51984.63 (r/w/o: 51984.63/0.00/0.00) lat (ms,99%): 2.39 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 64 tps: 65955.44 qps: 65955.44 (r/w/o: 65955.44/0.00/0.00) lat (ms,99%): 2.30 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 64 tps: 65384.57 qps: 65384.57 (r/w/o: 65384.57/0.00/0.00) lat (ms,99%): 2.43 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 64 tps: 64986.17 qps: 64986.17 (r/w/o: 64986.17/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 64 tps: 65162.35 qps: 65162.35 (r/w/o: 65162.35/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 64 tps: 65651.71 qps: 65651.91 (r/w/o: 65651.91/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 64 tps: 65399.72 qps: 65399.52 (r/w/o: 65399.52/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 64 tps: 65434.12 qps: 65434.12 (r/w/o: 65434.12/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 64 tps: 64831.41 qps: 64831.41 (r/w/o: 64831.41/0.00/0.00) lat (ms,99%): 2.48 err/s: 0.00 reconn/s: 0.00
[ 50s ] thds: 64 tps: 65487.00 qps: 65487.00 (r/w/o: 65487.00/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 55s ] thds: 64 tps: 65249.13 qps: 65249.13 (r/w/o: 65249.13/0.00/0.00) lat (ms,99%): 2.43 err/s: 0.00 reconn/s: 0.00
[ 60s ] thds: 64 tps: 64967.23 qps: 64967.23 (r/w/o: 64967.23/0.00/0.00) lat (ms,99%): 2.43 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            3984241
        write:                           0
        other:                           0
        total:                           3984241
    transactions:                        3984241 (65309.48 per sec.)
    queries:                             3984241 (65309.48 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

Throughput:
    events/s (eps):                      65309.4756
    time elapsed:                        61.0057s
    total number of events:              3984241

Latency (ms):
         min:                                    0.14
         avg:                                    0.98
         max:                                   28.05
         99th percentile:                        2.39
         sum:                              3902175.82

Threads fairness:
    events (avg/stddev):           62253.3125/152.96
    execution time (avg/stddev):   60.9715/0.00

```

### After

```
sysbench 1.1.0-ead2689 (using bundled LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 64
Warmup time: 5s
Report intermediate results every 5 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

Warming up for 5 seconds...

[ 5s ] thds: 64 tps: 52364.15 qps: 52364.15 (r/w/o: 52364.15/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 10s ] thds: 64 tps: 66194.06 qps: 66194.06 (r/w/o: 66194.06/0.00/0.00) lat (ms,99%): 2.39 err/s: 0.00 reconn/s: 0.00
[ 15s ] thds: 64 tps: 67063.43 qps: 67063.43 (r/w/o: 67063.43/0.00/0.00) lat (ms,99%): 2.30 err/s: 0.00 reconn/s: 0.00
[ 20s ] thds: 64 tps: 67044.83 qps: 67045.03 (r/w/o: 67045.03/0.00/0.00) lat (ms,99%): 2.30 err/s: 0.00 reconn/s: 0.00
[ 25s ] thds: 64 tps: 66797.42 qps: 66797.22 (r/w/o: 66797.22/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 30s ] thds: 64 tps: 66255.15 qps: 66255.35 (r/w/o: 66255.35/0.00/0.00) lat (ms,99%): 2.43 err/s: 0.00 reconn/s: 0.00
[ 35s ] thds: 64 tps: 67069.20 qps: 67069.00 (r/w/o: 67069.00/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 40s ] thds: 64 tps: 66991.57 qps: 66991.57 (r/w/o: 66991.57/0.00/0.00) lat (ms,99%): 2.30 err/s: 0.00 reconn/s: 0.00
[ 45s ] thds: 64 tps: 66708.81 qps: 66708.81 (r/w/o: 66708.81/0.00/0.00) lat (ms,99%): 2.35 err/s: 0.00 reconn/s: 0.00
[ 50s ] thds: 64 tps: 66244.74 qps: 66244.74 (r/w/o: 66244.74/0.00/0.00) lat (ms,99%): 2.39 err/s: 0.00 reconn/s: 0.00
[ 55s ] thds: 64 tps: 66708.01 qps: 66708.01 (r/w/o: 66708.01/0.00/0.00) lat (ms,99%): 2.39 err/s: 0.00 reconn/s: 0.00
[ 60s ] thds: 64 tps: 65301.56 qps: 65301.56 (r/w/o: 65301.56/0.00/0.00) lat (ms,99%): 2.57 err/s: 0.00 reconn/s: 0.00
SQL statistics:
    queries performed:
        read:                            4056398
        write:                           0
        other:                           0
        total:                           4056398
    transactions:                        4056398 (66487.48 per sec.)
    queries:                             4056398 (66487.48 per sec.)
    ignored errors:                      0      (0.00 per sec.)
    reconnects:                          0      (0.00 per sec.)

Throughput:
    events/s (eps):                      66487.4827
    time elapsed:                        61.0102s
    total number of events:              4056398

Latency (ms):
         min:                                    0.13
         avg:                                    0.96
         max:                                   31.72
         99th percentile:                        2.39
         sum:                              3902090.81

Threads fairness:
    events (avg/stddev):           63380.6094/4278.77
    execution time (avg/stddev):   60.9702/0.00
```