### PR TITLE
fix openGauss proxy connect with jdbc use postgreSql parseEngine.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMerger.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMerger.java
@@ -124,7 +124,7 @@ public final class ShardingDQLResultMerger implements ResultMerger {
             return mergedResult;
         }
         String trunkDatabaseName = DatabaseTypeRegistry.getTrunkDatabaseType(databaseType.getName()).getName();
-        if ("MySQL".equals(trunkDatabaseName) || "PostgreSQL".equals(trunkDatabaseName)) {
+        if ("MySQL".equals(trunkDatabaseName) || "PostgreSQL".equals(trunkDatabaseName) || "openGauss".equals(trunkDatabaseName)) {
             return new LimitDecoratorMergedResult(mergedResult, paginationContext);
         }
         if ("Oracle".equals(trunkDatabaseName)) {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/type/dialect/OpenGaussDatabaseType.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/type/dialect/OpenGaussDatabaseType.java
@@ -18,9 +18,7 @@
 package org.apache.shardingsphere.infra.database.type.dialect;
 
 import org.apache.shardingsphere.infra.database.metadata.dialect.OpenGaussDataSourceMetaData;
-import org.apache.shardingsphere.infra.database.type.BranchDatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.QuoteCharacter;
 
 import java.util.Collection;
@@ -29,7 +27,7 @@ import java.util.Collections;
 /**
  * Database type of openGauss.
  */
-public final class OpenGaussDatabaseType implements BranchDatabaseType {
+public final class OpenGaussDatabaseType implements DatabaseType {
     
     @Override
     public String getName() {
@@ -49,10 +47,5 @@ public final class OpenGaussDatabaseType implements BranchDatabaseType {
     @Override
     public OpenGaussDataSourceMetaData getDataSourceMetaData(final String url, final String username) {
         return new OpenGaussDataSourceMetaData(url);
-    }
-    
-    @Override
-    public DatabaseType getTrunkDatabaseType() {
-        return DatabaseTypeRegistry.getActualDatabaseType("PostgreSQL");
     }
 }


### PR DESCRIPTION
Fixes #14597.

Changes proposed in this pull request:
- fix openGauss proxy connect with jdbc use postgreSql parseEngine.
