### PR TITLE
Avoid frequently invoking native method Class.getCanonicalName

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterIndexStatementSchemaRefresher.java
@@ -42,6 +42,8 @@ import java.util.Optional;
  */
 public final class AlterIndexStatementSchemaRefresher implements MetaDataRefresher<AlterIndexStatement> {
     
+    private static final String TYPE = AlterIndexStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final AlterIndexStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -69,6 +71,6 @@ public final class AlterIndexStatementSchemaRefresher implements MetaDataRefresh
     
     @Override
     public String getType() {
-        return AlterIndexStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
@@ -43,6 +43,8 @@ import java.util.Optional;
  */
 public final class AlterTableStatementSchemaRefresher implements MetaDataRefresher<AlterTableStatement> {
     
+    private static final String TYPE = AlterTableStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final AlterTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -87,6 +89,6 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
     
     @Override
     public String getType() {
-        return AlterTableStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateIndexStatementSchemaRefresher.java
@@ -38,6 +38,8 @@ import java.util.Map;
  */
 public final class CreateIndexStatementSchemaRefresher implements MetaDataRefresher<CreateIndexStatement> {
     
+    private static final String TYPE = CreateIndexStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final CreateIndexStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -54,6 +56,6 @@ public final class CreateIndexStatementSchemaRefresher implements MetaDataRefres
     
     @Override
     public String getType() {
-        return CreateIndexStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -43,6 +43,8 @@ import java.util.Optional;
  */
 public final class CreateTableStatementSchemaRefresher implements MetaDataRefresher<CreateTableStatement> {
     
+    private static final String TYPE = CreateTableStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final CreateTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -69,6 +71,6 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
     
     @Override
     public String getType() {
-        return CreateTableStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -38,6 +38,8 @@ import java.util.Map;
  */
 public final class CreateViewStatementSchemaRefresher implements MetaDataRefresher<CreateViewStatement> {
     
+    private static final String TYPE = CreateViewStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final CreateViewStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -58,6 +60,6 @@ public final class CreateViewStatementSchemaRefresher implements MetaDataRefresh
     
     @Override
     public String getType() {
-        return CreateViewStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropIndexStatementSchemaRefresher.java
@@ -44,6 +44,8 @@ import java.util.stream.Collectors;
  */
 public final class DropIndexStatementSchemaRefresher implements MetaDataRefresher<DropIndexStatement> {
     
+    private static final String TYPE = DropIndexStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final DropIndexStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -89,6 +91,6 @@ public final class DropIndexStatementSchemaRefresher implements MetaDataRefreshe
     
     @Override
     public String getType() {
-        return DropIndexStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
@@ -38,6 +38,8 @@ import java.util.Map;
  */
 public final class DropTableStatementSchemaRefresher implements MetaDataRefresher<DropTableStatement> {
     
+    private static final String TYPE = DropTableStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final DropTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -57,6 +59,6 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
     
     @Override
     public String getType() {
-        return DropTableStatement.class.getCanonicalName();
+        return TYPE;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
@@ -37,6 +37,8 @@ import java.util.Map;
  */
 public final class DropViewStatementSchemaRefresher implements MetaDataRefresher<DropViewStatement> {
     
+    private static final String TYPE = DropViewStatement.class.getCanonicalName();
+    
     @Override
     public void refresh(final ShardingSphereMetaData schemaMetaData, final FederationSchemaMetaData schema, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
                         final Collection<String> logicDataSourceNames, final DropViewStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
@@ -54,6 +56,6 @@ public final class DropViewStatementSchemaRefresher implements MetaDataRefresher
     
     @Override
     public String getType() {
-        return DropViewStatement.class.getCanonicalName();
+        return TYPE;
     }
 }


### PR DESCRIPTION
JMH
```java
import org.apache.shardingsphere.infra.context.refresher.MetaDataRefreshEngine;
import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.dml.PostgreSQLSelectStatement;
import org.openjdk.jmh.Main;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Warmup;

import java.io.IOException;
import java.sql.SQLException;
import java.util.Collections;

@Fork(1)
@Warmup(iterations = 3, time = 5)
@Measurement(iterations = 3, time = 5)
public class MetaDataRefreshEngineBenchmark {
    
    @Benchmark
    public void benchMetaDataRefreshEngine() throws SQLException {
        new MetaDataRefreshEngine(null, null, null, null).refresh(new PostgreSQLSelectStatement(), Collections.emptyList());
    }
    
    public static void main(String[] args) throws IOException {
        Main.main(new String[]{MetaDataRefreshEngineBenchmark.class.getName()});
    }
}
```



Before
```
# JMH version: 1.33
# VM version: JDK 1.8.0_311, Java HotSpot(TM) 64-Bit Server VM, 25.311-b11
# VM invoker: /usr/local/java/jdk1.8.0_311/jre/bin/java
# VM options: -Dvisualvm.id=969101021478860 -javaagent:/home/wuweijie/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/213.6461.79/lib/idea_rt.jar=33363:/home/wuweijie/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/213.6461.79/bin -Dfile.encoding=UTF-8
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: icu.wwj.jmh.shardingsphere5.code.MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine

# Run progress: 0.00% complete, ETA 00:00:30
# Fork: 1 of 1
# Warmup Iteration   1: 1299798.492 ops/s
# Warmup Iteration   2: 1338106.480 ops/s
# Warmup Iteration   3: 1344558.141 ops/s
Iteration   1: 1339599.239 ops/s
Iteration   2: 1346211.703 ops/s
Iteration   3: 1325070.599 ops/s


Result "icu.wwj.jmh.shardingsphere5.code.MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine":
  1336960.514 ±(99.9%) 197301.223 ops/s [Average]
  (min, avg, max) = (1325070.599, 1336960.514, 1346211.703), stdev = 10814.746
  CI (99.9%): [1139659.291, 1534261.736] (assumes normal distribution)


# Run complete. Total time: 00:00:30

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                                   Mode  Cnt        Score        Error  Units
MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine  thrpt    3  1336960.514 ± 197301.223  ops/s
```

After
```
# JMH version: 1.33
# VM version: JDK 1.8.0_311, Java HotSpot(TM) 64-Bit Server VM, 25.311-b11
# VM invoker: /usr/local/java/jdk1.8.0_311/jre/bin/java
# VM options: -Dvisualvm.id=969201975455607 -javaagent:/home/wuweijie/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/213.6461.79/lib/idea_rt.jar=33947:/home/wuweijie/.local/share/JetBrains/Toolbox/apps/IDEA-U/ch-0/213.6461.79/bin -Dfile.encoding=UTF-8
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: icu.wwj.jmh.shardingsphere5.code.MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine

# Run progress: 0.00% complete, ETA 00:00:30
# Fork: 1 of 1
# Warmup Iteration   1: 3323610.420 ops/s
# Warmup Iteration   2: 3429276.304 ops/s
# Warmup Iteration   3: 3462827.935 ops/s
Iteration   1: 3473882.914 ops/s
Iteration   2: 3391025.244 ops/s
Iteration   3: 3372679.362 ops/s


Result "icu.wwj.jmh.shardingsphere5.code.MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine":
  3412529.173 ±(99.9%) 983699.426 ops/s [Average]
  (min, avg, max) = (3372679.362, 3412529.173, 3473882.914), stdev = 53919.885
  CI (99.9%): [2428829.748, 4396228.599] (assumes normal distribution)


# Run complete. Total time: 00:00:30

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                                   Mode  Cnt        Score        Error  Units
MetaDataRefreshEngineBenchmark.benchMetaDataRefreshEngine  thrpt    3  3412529.173 ± 983699.426  ops/s
```
