### PR TITLE
fix empty result when execute getResultSet method for some sql that handle with JDBCMemoryQueryResult

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatement.java
@@ -178,6 +178,7 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
     
     @Override
     public ResultSet executeQuery() throws SQLException {
+        ResultSet result;
         try {
             if (statementsCacheable && !statements.isEmpty()) {
                 resetParameters();
@@ -197,10 +198,12 @@ public final class ShardingSpherePreparedStatement extends AbstractPreparedState
             }
             List<QueryResult> queryResults = executeQuery0();
             MergedResult mergedResult = mergeQuery(queryResults);
-            return new ShardingSphereResultSet(getShardingSphereResultSet(), mergedResult, this, executionContext);
+            result = new ShardingSphereResultSet(getShardingSphereResultSet(), mergedResult, this, executionContext);
         } finally {
             clearBatch();
         }
+        currentResultSet = result;
+        return result;
     }
     
     private JDBCExecutionUnit createTrafficExecutionUnit(final TrafficContext trafficContext) throws SQLException {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
@@ -57,6 +57,8 @@ public final class ShardingSpherePreparedStatementTest extends AbstractShardingS
     
     private static final String SELECT_SQL_WITH_PARAMETER_MARKER_RETURN_STATUS = "SELECT item_id, user_id, status FROM t_order_item WHERE  order_id= ? AND user_id = ?";
     
+    private static final String SELECT_WITH_ORDER_BY = "SELECT order_id, user_id, status FROM t_order ORDER BY order_id";
+    
     private static final String SELECT_AUTO_SQL = "SELECT item_id, order_id, status FROM t_order_item_auto WHERE order_id >= ?";
 
     private static final String SELECT_SQL_COLUMN_WITH_PARAMETER_MARKER = "SELECT ?, order_id, status FROM t_order_item_auto";
@@ -504,6 +506,21 @@ public final class ShardingSpherePreparedStatementTest extends AbstractShardingS
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 while (resultSet.next()) {
                     assertTrue(result.contains(resultSet.getInt(2)));
+                    count++;
+                }
+            }
+            assertThat(result.size(), is(count));
+        }
+    }
+    
+    @Test
+    public void assertExecuteSelectWithOrderByAndExecuteGetResultSet() throws SQLException {
+        Collection<Integer> result = Arrays.asList(1000, 1001, 1100, 1101);
+        try (PreparedStatement preparedStatement = getShardingSphereDataSource().getConnection().prepareStatement(SELECT_WITH_ORDER_BY)) {
+            int count = 0;
+            preparedStatement.executeQuery();
+            try (ResultSet resultSet = preparedStatement.getResultSet()) {
+                while (resultSet.next()) {
                     count++;
                 }
             }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
@@ -516,16 +516,16 @@ public final class ShardingSpherePreparedStatementTest extends AbstractShardingS
     @Test
     public void assertExecuteSelectWithOrderByAndExecuteGetResultSet() throws SQLException {
         Collection<Integer> result = Arrays.asList(1000, 1001, 1100, 1101);
+        int count = 0;
         try (PreparedStatement preparedStatement = getShardingSphereDataSource().getConnection().prepareStatement(SELECT_WITH_ORDER_BY)) {
-            int count = 0;
             preparedStatement.executeQuery();
             try (ResultSet resultSet = preparedStatement.getResultSet()) {
                 while (resultSet.next()) {
                     count++;
                 }
             }
-            assertThat(result.size(), is(count));
         }
+        assertThat(count, is(result.size()));
     }
     
     @Test

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/resources/META-INF/services/org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/resources/META-INF/services/org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.traffic.algorithm.loadbalance.RandomTrafficLoadBalanceAlgorithm
+org.apache.shardingsphere.traffic.algorithm.loadbalance.RoundRobinTrafficLoadBalanceAlgorithm


### PR DESCRIPTION
Fixes #14593.

Changes proposed in this pull request:
- fix empty result when execute getResultSet method for some sql that handle with JDBCMemoryQueryResult
- add unit test
