### PR TITLE
Add input and output in scaling config; Refactor JobRateLimitAlgorithm SPI; Add rateLimiter TPS impl

### DIFF
--- a/docs/document/content/dev-manual/scaling.cn.md
+++ b/docs/document/content/dev-manual/scaling.cn.md
@@ -17,16 +17,6 @@ chapter = true
 | PostgreSQLScalingEntry | 基于 PostgreSQL 的弹性伸缩入口 |
 | OpenGaussScalingEntry  | 基于 openGauss 的弹性伸缩入口  |
 
-## JobRateLimitAlgorithm
-
-| *SPI 名称*                                   | *详细说明*                                   |
-| ------------------------------------------- | ------------------------------------------- |
-| JobRateLimitAlgorithm                       | 任务限流算法                                  |
-
-| *已知实现类*                                  | *详细说明*                                   |
-| ------------------------------------------- | ------------------------------------------- |
-| SourceJobRateLimitAlgorithm                 | 源端限流算法                                  |
-
 ## JobCompletionDetectAlgorithm
 
 | *SPI 名称*                                   | *详细说明*                                   |

--- a/docs/document/content/dev-manual/scaling.en.md
+++ b/docs/document/content/dev-manual/scaling.en.md
@@ -17,16 +17,6 @@ chapter = true
 | PostgreSQLScalingEntry | PostgreSQL entry of scaling |
 | OpenGaussScalingEntry  | openGauss entry of scaling |
 
-## JobRateLimitAlgorithm
-
-| *SPI Name*                                   | *Description*                              |
-| ------------------------------------------- | ------------------------------------------- |
-| JobRateLimitAlgorithm                       | job rate limit algorithm                    |
-
-| *Implementation Class*                      | *Description*                               |
-| ------------------------------------------- | ------------------------------------------- |
-| SourceJobRateLimitAlgorithm                 | rate limit algorithm for source side        |
-
 ## JobCompletionDetectAlgorithm
 
 | *SPI Name*                                  | *Description*                               |

--- a/docs/document/content/user-manual/shardingsphere-scaling/build.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-scaling/build.cn.md
@@ -54,12 +54,20 @@ rules:
   scaling:
     <scaling-action-config-name> (+):
       blockQueueSize: # 数据通道阻塞队列大小
-      workerThread: # 给全量数据摄取和数据导入使用的工作线程池大小
-      readBatchSize: # 一次查询操作返回的最大记录数
-      rateLimiter: # 限流算法
-        type: # 算法类型。可选项：SOURCE
-        props: # 算法属性
-          qps: # QPS属性。适用算法类型：SOURCE
+      input:
+        workerThread: # 从源端摄取全量数据的线程池大小
+        batchSize: # 一次查询操作返回的最大记录数
+        rateLimiter: # 限流算法
+          type: # 算法类型。可选项：QPS
+          props: # 算法属性
+            qps: # qps属性。适用算法类型：QPS
+      output:
+        workerThread: # 数据导入到目标端的线程池大小
+        batchSize: # 一次批量写入操作的最大记录数
+        rateLimiter: # 限流算法
+          type: # 算法类型。可选项：TPS
+          props: # 算法属性
+            tps: # tps属性。适用算法类型：TPS
       completionDetector: # 作业是否接近完成检测算法。如果不配置，那么系统无法自动进行后续步骤，可以通过 DistSQL 手动操作。
         type: # 算法类型。可选项：IDLE
         props: # 算法属性
@@ -80,12 +88,20 @@ rules:
   scaling:
     default_scaling:
       blockQueueSize: 10000
-      workerThread: 40
-      readBatchSize: 1000
-      rateLimiter:
-        type: SOURCE
-        props:
-          qps: 50
+      input:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: QPS
+          props:
+            qps: 50
+      output:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: TPS
+          props:
+            tps: 2000
       completionDetector:
         type: IDLE
         props:

--- a/docs/document/content/user-manual/shardingsphere-scaling/build.en.md
+++ b/docs/document/content/user-manual/shardingsphere-scaling/build.en.md
@@ -53,12 +53,20 @@ rules:
   scaling:
     <scaling-action-config-name> (+):
       blockQueueSize: # Data channel blocking queue size
-      workerThread: # Worker thread pool size for inventory data ingestion and data importing
-      readBatchSize: # Maximum records count of a query operation returning
-      rateLimiter: # Rate limit algorithm
-        type: # Algorithm type. Options: SOURCE
-        props: # Algorithm properties
-          qps: # QPS property. Available for types: SOURCE
+      input:
+        workerThread: # Worker thread pool size for inventory data ingestion from source
+        batchSize: # Maximum records count of a DML select operation
+        rateLimiter: # Rate limit algorithm
+          type: # Algorithm type. Options: QPS
+          props: # Algorithm properties
+            qps: # QPS property. Available for types: QPS
+      output:
+        workerThread: # Worker thread pool size for data importing to target
+        batchSize: # Maximum records count of a DML insert/delete/update operation
+        rateLimiter: # Rate limit algorithm
+          type: # Algorithm type. Options: TPS
+          props: # Algorithm properties
+            tps: # TPS property. Available for types: TPS
       completionDetector: # Completion detect algorithm. If it's not configured, then system won't continue to do next steps automatically.
         type: # Algorithm type. Options: IDLE
         props: # Algorithm properties
@@ -79,12 +87,20 @@ rules:
   scaling:
     default_scaling:
       blockQueueSize: 10000
-      workerThread: 40
-      readBatchSize: 1000
-      rateLimiter:
-        type: SOURCE
-        props:
-          qps: 50
+      input:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: QPS
+          props:
+            qps: 50
+      output:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: TPS
+          props:
+            tps: 2000
       completionDetector:
         type: IDLE
         props:

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/resources/yaml/encrypt-dataConverters.yaml
@@ -19,12 +19,20 @@ dataConverterName: default_convert
 dataConverters:
   default_convert:
     blockQueueSize: 10000
-    workerThread: 40
-    readBatchSize: 1000
-    rateLimiter:
-      type: SOURCE
-      props:
-        qps: 50
+    input:
+      workerThread: 40
+      batchSize: 1000
+      rateLimiter:
+        type: QPS
+        props:
+          qps: 50
+    output:
+      workerThread: 40
+      batchSize: 1000
+      rateLimiter:
+        type: TPS
+        props:
+          tps: 2000
     completionDetector:
       type: IDLE
       props:

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-rule.yaml
@@ -109,12 +109,20 @@ rules:
   scaling:
     default_scaling:
       blockQueueSize: 10000
-      workerThread: 40
-      readBatchSize: 1000
-      rateLimiter:
-        type: SOURCE
-        props:
-          qps: 50
+      input:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: QPS
+          props:
+            qps: 50
+      output:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: TPS
+          props:
+            tps: 2000
       completionDetector:
         type: IDLE
         props:

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/resources/yaml/sharding-scaling.yaml
@@ -19,12 +19,20 @@ scalingName: default_scaling
 scaling:
   default_scaling:
     blockQueueSize: 10000
-    workerThread: 40
-    readBatchSize: 1000
-    rateLimiter:
-      type: SOURCE
-      props:
-        qps: 50
+    input:
+      workerThread: 40
+      batchSize: 1000
+      rateLimiter:
+        type: QPS
+        props:
+          qps: 50
+    output:
+      workerThread: 40
+      batchSize: 1000
+      rateLimiter:
+        type: TPS
+        props:
+          tps: 2000
     completionDetector:
       type: IDLE
       props:

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.config.rulealtered;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 
 /**
@@ -26,17 +27,40 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmC
  */
 @RequiredArgsConstructor
 @Getter
+@ToString
 public final class OnRuleAlteredActionConfiguration {
     
     private final int blockQueueSize;
     
-    private final int workerThread;
+    private final InputConfiguration inputConfig;
     
-    private final int readBatchSize;
-    
-    private final ShardingSphereAlgorithmConfiguration rateLimiter;
+    private final OutputConfiguration outputConfig;
     
     private final ShardingSphereAlgorithmConfiguration completionDetector;
     
     private final ShardingSphereAlgorithmConfiguration dataConsistencyChecker;
+    
+    @RequiredArgsConstructor
+    @Getter
+    @ToString
+    public static final class InputConfiguration {
+        
+        private final int workerThread;
+        
+        private final int batchSize;
+        
+        private final ShardingSphereAlgorithmConfiguration rateLimiter;
+    }
+    
+    @RequiredArgsConstructor
+    @Getter
+    @ToString
+    public static final class OutputConfiguration {
+        
+        private final int workerThread;
+        
+        private final int batchSize;
+        
+        private final ShardingSphereAlgorithmConfiguration rateLimiter;
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
@@ -32,9 +32,9 @@ public final class OnRuleAlteredActionConfiguration {
     
     private final int blockQueueSize;
     
-    private final InputConfiguration inputConfig;
+    private final InputConfiguration input;
     
-    private final OutputConfiguration outputConfig;
+    private final OutputConfiguration output;
     
     private final ShardingSphereAlgorithmConfiguration completionDetector;
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
@@ -17,8 +17,10 @@
 
 package org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered;
 
+import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlShardingSphereAlgorithmConfiguration;
 
@@ -27,17 +29,36 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlShardingSp
  */
 @Getter
 @Setter
+@ToString
 public final class YamlOnRuleAlteredActionConfiguration implements YamlConfiguration {
     
     private int blockQueueSize = 10000;
     
-    private int workerThread = 40;
+    private YamlInputConfiguration inputConfig;
     
-    private int readBatchSize = 1000;
-    
-    private YamlShardingSphereAlgorithmConfiguration rateLimiter;
+    private YamlOutputConfiguration outputConfig;
     
     private YamlShardingSphereAlgorithmConfiguration completionDetector;
     
     private YamlShardingSphereAlgorithmConfiguration dataConsistencyChecker;
+    
+    @Data
+    public static final class YamlInputConfiguration implements YamlConfiguration {
+        
+        private int workerThread = 40;
+        
+        private int batchSize = 1000;
+        
+        private YamlShardingSphereAlgorithmConfiguration rateLimiter;
+    }
+    
+    @Data
+    public static final class YamlOutputConfiguration implements YamlConfiguration {
+        
+        private int workerThread = 40;
+        
+        private int batchSize = 1000;
+        
+        private YamlShardingSphereAlgorithmConfiguration rateLimiter;
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
@@ -34,9 +34,9 @@ public final class YamlOnRuleAlteredActionConfiguration implements YamlConfigura
     
     private int blockQueueSize = 10000;
     
-    private YamlInputConfiguration inputConfig;
+    private YamlInputConfiguration input;
     
-    private YamlOutputConfiguration outputConfig;
+    private YamlOutputConfiguration output;
     
     private YamlShardingSphereAlgorithmConfiguration completionDetector;
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
@@ -18,7 +18,11 @@
 package org.apache.shardingsphere.infra.yaml.config.swapper.rulealtered;
 
 import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration;
+import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration.InputConfiguration;
+import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration.OutputConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlInputConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlOutputConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.config.swapper.algorithm.ShardingSphereAlgorithmConfigurationYamlSwapper;
 
@@ -29,6 +33,10 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
     
     private static final ShardingSphereAlgorithmConfigurationYamlSwapper ALGORITHM_CONFIG_YAML_SWAPPER = new ShardingSphereAlgorithmConfigurationYamlSwapper();
     
+    private static final InputConfigurationSwapper INPUT_CONFIG_SWAPPER = new InputConfigurationSwapper();
+    
+    private static final OutputConfigurationSwapper OUTPUT_CONFIG_SWAPPER = new OutputConfigurationSwapper();
+    
     @Override
     public YamlOnRuleAlteredActionConfiguration swapToYamlConfiguration(final OnRuleAlteredActionConfiguration data) {
         if (null == data) {
@@ -36,9 +44,8 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         }
         YamlOnRuleAlteredActionConfiguration result = new YamlOnRuleAlteredActionConfiguration();
         result.setBlockQueueSize(data.getBlockQueueSize());
-        result.setWorkerThread(data.getWorkerThread());
-        result.setReadBatchSize(data.getReadBatchSize());
-        result.setRateLimiter(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getRateLimiter()));
+        result.setInputConfig(INPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getInputConfig()));
+        result.setOutputConfig(OUTPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getOutputConfig()));
         result.setCompletionDetector(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getCompletionDetector()));
         result.setDataConsistencyChecker(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getDataConsistencyChecker()));
         return result;
@@ -49,9 +56,56 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         if (null == yamlConfig) {
             return null;
         }
-        return new OnRuleAlteredActionConfiguration(yamlConfig.getBlockQueueSize(), yamlConfig.getWorkerThread(), yamlConfig.getReadBatchSize(),
-                ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getRateLimiter()),
+        return new OnRuleAlteredActionConfiguration(yamlConfig.getBlockQueueSize(),
+                INPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getInputConfig()),
+                OUTPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getOutputConfig()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getCompletionDetector()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getDataConsistencyChecker()));
+    }
+    
+    public static class InputConfigurationSwapper implements YamlConfigurationSwapper<YamlInputConfiguration, InputConfiguration> {
+        
+        @Override
+        public YamlInputConfiguration swapToYamlConfiguration(final InputConfiguration data) {
+            if (null == data) {
+                return null;
+            }
+            YamlInputConfiguration result = new YamlInputConfiguration();
+            result.setWorkerThread(data.getWorkerThread());
+            result.setBatchSize(data.getBatchSize());
+            result.setRateLimiter(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getRateLimiter()));
+            return result;
+        }
+        
+        @Override
+        public InputConfiguration swapToObject(final YamlInputConfiguration yamlConfig) {
+            if (null == yamlConfig) {
+                return null;
+            }
+            return new InputConfiguration(yamlConfig.getWorkerThread(), yamlConfig.getBatchSize(), ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getRateLimiter()));
+        }
+    }
+    
+    public static class OutputConfigurationSwapper implements YamlConfigurationSwapper<YamlOutputConfiguration, OutputConfiguration> {
+        
+        @Override
+        public YamlOutputConfiguration swapToYamlConfiguration(final OutputConfiguration data) {
+            if (null == data) {
+                return null;
+            }
+            YamlOutputConfiguration result = new YamlOutputConfiguration();
+            result.setWorkerThread(data.getWorkerThread());
+            result.setBatchSize(data.getBatchSize());
+            result.setRateLimiter(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getRateLimiter()));
+            return result;
+        }
+        
+        @Override
+        public OutputConfiguration swapToObject(final YamlOutputConfiguration yamlConfig) {
+            if (null == yamlConfig) {
+                return null;
+            }
+            return new OutputConfiguration(yamlConfig.getWorkerThread(), yamlConfig.getBatchSize(), ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getRateLimiter()));
+        }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapper.java
@@ -44,8 +44,8 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
         }
         YamlOnRuleAlteredActionConfiguration result = new YamlOnRuleAlteredActionConfiguration();
         result.setBlockQueueSize(data.getBlockQueueSize());
-        result.setInputConfig(INPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getInputConfig()));
-        result.setOutputConfig(OUTPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getOutputConfig()));
+        result.setInput(INPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getInput()));
+        result.setOutput(OUTPUT_CONFIG_SWAPPER.swapToYamlConfiguration(data.getOutput()));
         result.setCompletionDetector(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getCompletionDetector()));
         result.setDataConsistencyChecker(ALGORITHM_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(data.getDataConsistencyChecker()));
         return result;
@@ -57,8 +57,8 @@ public final class OnRuleAlteredActionConfigurationYamlSwapper implements YamlCo
             return null;
         }
         return new OnRuleAlteredActionConfiguration(yamlConfig.getBlockQueueSize(),
-                INPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getInputConfig()),
-                OUTPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getOutputConfig()),
+                INPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getInput()),
+                OUTPUT_CONFIG_SWAPPER.swapToObject(yamlConfig.getOutput()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getCompletionDetector()),
                 ALGORITHM_CONFIG_YAML_SWAPPER.swapToObject(yamlConfig.getDataConsistencyChecker()));
     }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.infra.yaml.config.swapper.rulealtered;
 import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlInputConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlOutputConfiguration;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.junit.Test;
 
@@ -37,12 +39,19 @@ public final class OnRuleAlteredActionConfigurationYamlSwapperTest {
     public void assertSwap() {
         YamlOnRuleAlteredActionConfiguration yamlConfig = new YamlOnRuleAlteredActionConfiguration();
         yamlConfig.setBlockQueueSize(1000);
-        yamlConfig.setWorkerThread(20);
-        yamlConfig.setReadBatchSize(100);
         Properties rateLimiterProps = new Properties();
         rateLimiterProps.setProperty("batch-size", "1000");
         rateLimiterProps.setProperty("qps", "50");
-        yamlConfig.setRateLimiter(new YamlShardingSphereAlgorithmConfiguration("SOURCE", rateLimiterProps));
+        YamlInputConfiguration yamlInputConfig = new YamlInputConfiguration();
+        yamlInputConfig.setWorkerThread(40);
+        yamlInputConfig.setBatchSize(1000);
+        yamlInputConfig.setRateLimiter(new YamlShardingSphereAlgorithmConfiguration("INPUT", rateLimiterProps));
+        yamlConfig.setInputConfig(yamlInputConfig);
+        YamlOutputConfiguration yamlOutputConfig = new YamlOutputConfiguration();
+        yamlOutputConfig.setWorkerThread(40);
+        yamlOutputConfig.setBatchSize(1000);
+        yamlOutputConfig.setRateLimiter(new YamlShardingSphereAlgorithmConfiguration("OUTPUT", rateLimiterProps));
+        yamlConfig.setOutputConfig(yamlOutputConfig);
         Properties completionDetectorProps = new Properties();
         completionDetectorProps.setProperty("incremental-task-idle-minute-threshold", "30");
         yamlConfig.setCompletionDetector(new YamlShardingSphereAlgorithmConfiguration("IDLE", completionDetectorProps));

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/yaml/config/swapper/rulealtered/OnRuleAlteredActionConfigurationYamlSwapperTest.java
@@ -46,12 +46,12 @@ public final class OnRuleAlteredActionConfigurationYamlSwapperTest {
         yamlInputConfig.setWorkerThread(40);
         yamlInputConfig.setBatchSize(1000);
         yamlInputConfig.setRateLimiter(new YamlShardingSphereAlgorithmConfiguration("INPUT", rateLimiterProps));
-        yamlConfig.setInputConfig(yamlInputConfig);
+        yamlConfig.setInput(yamlInputConfig);
         YamlOutputConfiguration yamlOutputConfig = new YamlOutputConfiguration();
         yamlOutputConfig.setWorkerThread(40);
         yamlOutputConfig.setBatchSize(1000);
         yamlOutputConfig.setRateLimiter(new YamlShardingSphereAlgorithmConfiguration("OUTPUT", rateLimiterProps));
-        yamlConfig.setOutputConfig(yamlOutputConfig);
+        yamlConfig.setOutput(yamlOutputConfig);
         Properties completionDetectorProps = new Properties();
         completionDetectorProps.setProperty("incremental-task-idle-minute-threshold", "30");
         yamlConfig.setCompletionDetector(new YamlShardingSphereAlgorithmConfiguration("IDLE", completionDetectorProps));

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
@@ -143,7 +143,7 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
         Map<String, Boolean> result = new HashMap<>();
         ThreadFactory threadFactory = ExecutorThreadFactoryBuilder.build("job" + getJobIdPrefix(jobContext.getJobId()) + "-dataCheck-%d");
         ThreadPoolExecutor executor = new ThreadPoolExecutor(2, 2, 60, TimeUnit.SECONDS, new ArrayBlockingQueue<>(2), threadFactory);
-        JobRateLimitAlgorithm rateLimitAlgorithm = jobContext.getRuleAlteredContext().getRateLimitAlgorithm();
+        JobRateLimitAlgorithm inputRateLimitAlgorithm = jobContext.getRuleAlteredContext().getInputRateLimitAlgorithm();
         try (PipelineDataSourceWrapper sourceDataSource = dataSourceFactory.newInstance(sourceDataSourceConfig);
              PipelineDataSourceWrapper targetDataSource = dataSourceFactory.newInstance(targetDataSourceConfig)) {
             Map<String, TableMetaData> tableMetaDataMap = getTableMetaDataMap(jobContext.getJobConfig().getWorkflowConfig().getSchemaName());
@@ -165,8 +165,8 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
                 Iterator<Object> targetCalculatedResultIterator = targetCalculator.calculate(targetCalculateParameter).iterator();
                 boolean calculateResultsEquals = true;
                 while (sourceCalculatedResultIterator.hasNext() && targetCalculatedResultIterator.hasNext()) {
-                    if (null != rateLimitAlgorithm) {
-                        rateLimitAlgorithm.onQuery();
+                    if (null != inputRateLimitAlgorithm) {
+                        inputRateLimitAlgorithm.onQuery();
                     }
                     Future<Object> sourceFuture = executor.submit(sourceCalculatedResultIterator::next);
                     Future<Object> targetFuture = executor.submit(targetCalculatedResultIterator::next);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsist
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceWrapper;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfigurationFactory;
+import org.apache.shardingsphere.data.pipeline.api.job.JobOperationType;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceFactory;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineDataConsistencyCheckFailedException;
 import org.apache.shardingsphere.data.pipeline.scenario.rulealtered.RuleAlteredContext;
@@ -166,7 +167,7 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
                 boolean calculateResultsEquals = true;
                 while (sourceCalculatedResultIterator.hasNext() && targetCalculatedResultIterator.hasNext()) {
                     if (null != inputRateLimitAlgorithm) {
-                        inputRateLimitAlgorithm.onQuery();
+                        inputRateLimitAlgorithm.intercept(JobOperationType.SELECT, 1);
                     }
                     Future<Object> sourceFuture = executor.submit(sourceCalculatedResultIterator::next);
                     Future<Object> targetFuture = executor.submit(targetCalculatedResultIterator::next);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/AbstractInventoryDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/AbstractInventoryDumper.java
@@ -58,7 +58,7 @@ public abstract class AbstractInventoryDumper extends AbstractLifecycleExecutor 
     @Getter(AccessLevel.PROTECTED)
     private final InventoryDumperConfiguration inventoryDumperConfig;
     
-    private final int readBatchSize;
+    private final int batchSize;
     
     private final JobRateLimitAlgorithm rateLimitAlgorithm;
     
@@ -74,7 +74,7 @@ public abstract class AbstractInventoryDumper extends AbstractLifecycleExecutor 
             throw new UnsupportedOperationException("AbstractInventoryDumper only support StandardPipelineDataSourceConfiguration");
         }
         this.inventoryDumperConfig = inventoryDumperConfig;
-        this.readBatchSize = inventoryDumperConfig.getReadBatchSize();
+        this.batchSize = inventoryDumperConfig.getBatchSize();
         this.rateLimitAlgorithm = inventoryDumperConfig.getRateLimitAlgorithm();
         this.dataSourceManager = dataSourceManager;
         tableMetaData = createTableMetaData();
@@ -126,7 +126,7 @@ public abstract class AbstractInventoryDumper extends AbstractLifecycleExecutor 
         try (PreparedStatement preparedStatement = createPreparedStatement(conn, sql)) {
             preparedStatement.setObject(1, startUniqueKeyValue);
             preparedStatement.setObject(2, getPositionEndValue(inventoryDumperConfig.getPosition()));
-            preparedStatement.setInt(3, readBatchSize);
+            preparedStatement.setInt(3, batchSize);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 ResultSetMetaData metaData = resultSet.getMetaData();
                 int rowCount = 0;

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/AbstractInventoryDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/AbstractInventoryDumper.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.data.pipeline.api.ingest.record.Column;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.DataRecord;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.FinishedRecord;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.Record;
+import org.apache.shardingsphere.data.pipeline.api.job.JobOperationType;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineMetaDataManager;
 import org.apache.shardingsphere.data.pipeline.core.ingest.IngestDataChangeType;
@@ -121,7 +122,7 @@ public abstract class AbstractInventoryDumper extends AbstractLifecycleExecutor 
     
     private Optional<Number> dump0(final Connection conn, final String sql, final Number startUniqueKeyValue) throws SQLException {
         if (null != rateLimitAlgorithm) {
-            rateLimitAlgorithm.onQuery();
+            rateLimitAlgorithm.intercept(JobOperationType.SELECT, 1);
         }
         try (PreparedStatement preparedStatement = createPreparedStatement(conn, sql)) {
             preparedStatement.setObject(1, startUniqueKeyValue);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
@@ -102,7 +102,7 @@ public final class InventoryTaskSplitter {
     private Collection<InventoryDumperConfiguration> splitByPrimaryKey(
             final RuleAlteredJobContext jobContext, final DataSource dataSource, final PipelineMetaDataManager metaDataManager, final InventoryDumperConfiguration dumperConfig) {
         Collection<InventoryDumperConfiguration> result = new LinkedList<>();
-        InputConfiguration inputConfig = jobContext.getRuleAlteredContext().getOnRuleAlteredActionConfig().getInputConfig();
+        InputConfiguration inputConfig = jobContext.getRuleAlteredContext().getOnRuleAlteredActionConfig().getInput();
         if (null == inputConfig) {
             inputConfig = new InputConfigurationSwapper().swapToObject(new YamlInputConfiguration());
         }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ratelimit/QPSJobRateLimitAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ratelimit/QPSJobRateLimitAlgorithm.java
@@ -21,14 +21,15 @@ import com.google.common.base.Strings;
 import com.google.common.util.concurrent.RateLimiter;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.data.pipeline.api.job.JobOperationType;
 import org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm;
 
 import java.util.Properties;
 
 /**
- * Source rule altered job rate limit algorithm for SPI.
+ * QPS job rate limit algorithm for SPI.
  */
-public final class SourceJobRateLimitAlgorithm implements JobRateLimitAlgorithm {
+public final class QPSJobRateLimitAlgorithm implements JobRateLimitAlgorithm {
     
     private static final String QPS_KEY = "qps";
     
@@ -51,16 +52,19 @@ public final class SourceJobRateLimitAlgorithm implements JobRateLimitAlgorithm 
     
     @Override
     public String getType() {
-        return "SOURCE";
+        return "QPS";
     }
     
     @Override
-    public void onQuery() {
+    public void intercept(final JobOperationType type, final Number data) {
+        if (type != JobOperationType.SELECT) {
+            return;
+        }
         rateLimiter.acquire();
     }
     
     @Override
     public String toString() {
-        return "SourceJobRateLimitAlgorithm{" + "props=" + props + '}';
+        return "QPSJobRateLimitAlgorithm{" + "props=" + props + '}';
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ratelimit/TPSJobRateLimitAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ratelimit/TPSJobRateLimitAlgorithm.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.spi.ratelimit;
+
+import com.google.common.base.Strings;
+import com.google.common.util.concurrent.RateLimiter;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.data.pipeline.api.job.JobOperationType;
+import org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm;
+
+import java.util.Properties;
+
+/**
+ * TPS job rate limit algorithm for SPI.
+ */
+public final class TPSJobRateLimitAlgorithm implements JobRateLimitAlgorithm {
+    
+    private static final String TPS_KEY = "tps";
+    
+    private int tps = 2000;
+    
+    private RateLimiter rateLimiter;
+    
+    @Getter
+    @Setter
+    private Properties props = new Properties();
+    
+    @Override
+    public void init() {
+        String tpsValue = props.getProperty(TPS_KEY);
+        if (!Strings.isNullOrEmpty(tpsValue)) {
+            tps = Integer.parseInt(tpsValue);
+        }
+        rateLimiter = RateLimiter.create(tps);
+    }
+    
+    @Override
+    public String getType() {
+        return "TPS";
+    }
+    
+    @Override
+    public void intercept(final JobOperationType type, final Number data) {
+        switch (type) {
+            case INSERT:
+            case DELETE:
+            case UPDATE:
+                break;
+            default:
+                return;
+        }
+        rateLimiter.acquire();
+    }
+    
+    @Override
+    public String toString() {
+        return "TPSJobRateLimitAlgorithm{" + "props=" + props + '}';
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -30,6 +30,12 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmC
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmFactory;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration;
+import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration.InputConfiguration;
+import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration.OutputConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlInputConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rulealtered.YamlOnRuleAlteredActionConfiguration.YamlOutputConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rulealtered.OnRuleAlteredActionConfigurationYamlSwapper.InputConfigurationSwapper;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rulealtered.OnRuleAlteredActionConfigurationYamlSwapper.OutputConfigurationSwapper;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 
@@ -55,7 +61,9 @@ public final class RuleAlteredContext {
     
     private final OnRuleAlteredActionConfiguration onRuleAlteredActionConfig;
     
-    private final JobRateLimitAlgorithm rateLimitAlgorithm;
+    private final JobRateLimitAlgorithm inputRateLimitAlgorithm;
+    
+    private final JobRateLimitAlgorithm outputRateLimitAlgorithm;
     
     private final JobCompletionDetectAlgorithm<RuleAlteredJobAlmostCompletedParameter> completionDetectAlgorithm;
     
@@ -73,29 +81,27 @@ public final class RuleAlteredContext {
     
     public RuleAlteredContext(final OnRuleAlteredActionConfiguration onRuleAlteredActionConfig) {
         this.onRuleAlteredActionConfig = onRuleAlteredActionConfig;
-        ShardingSphereAlgorithmConfiguration rateLimiter = onRuleAlteredActionConfig.getRateLimiter();
-        if (null != rateLimiter) {
-            rateLimitAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(rateLimiter, JobRateLimitAlgorithm.class);
-        } else {
-            rateLimitAlgorithm = null;
+        InputConfiguration inputConfig = onRuleAlteredActionConfig.getInputConfig();
+        if (null == inputConfig) {
+            inputConfig = new InputConfigurationSwapper().swapToObject(new YamlInputConfiguration());
         }
+        ShardingSphereAlgorithmConfiguration inputRateLimiter = inputConfig.getRateLimiter();
+        inputRateLimitAlgorithm = null != inputRateLimiter ? ShardingSphereAlgorithmFactory.createAlgorithm(inputRateLimiter, JobRateLimitAlgorithm.class) : null;
+        OutputConfiguration outputConfig = onRuleAlteredActionConfig.getOutputConfig();
+        if (null == outputConfig) {
+            outputConfig = new OutputConfigurationSwapper().swapToObject(new YamlOutputConfiguration());
+        }
+        ShardingSphereAlgorithmConfiguration outputRateLimiter = outputConfig.getRateLimiter();
+        outputRateLimitAlgorithm = null != outputRateLimiter ? ShardingSphereAlgorithmFactory.createAlgorithm(outputRateLimiter, JobRateLimitAlgorithm.class) : null;
         ShardingSphereAlgorithmConfiguration completionDetector = onRuleAlteredActionConfig.getCompletionDetector();
-        if (null != completionDetector) {
-            completionDetectAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(completionDetector, JobCompletionDetectAlgorithm.class);
-        } else {
-            completionDetectAlgorithm = null;
-        }
+        completionDetectAlgorithm = null != completionDetector ? ShardingSphereAlgorithmFactory.createAlgorithm(completionDetector, JobCompletionDetectAlgorithm.class) : null;
         sourceWritingStopAlgorithm = null;
         ShardingSphereAlgorithmConfiguration dataConsistencyChecker = onRuleAlteredActionConfig.getDataConsistencyChecker();
-        if (null != dataConsistencyChecker) {
-            dataConsistencyCheckAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(dataConsistencyChecker, DataConsistencyCheckAlgorithm.class);
-        } else {
-            dataConsistencyCheckAlgorithm = null;
-        }
+        dataConsistencyCheckAlgorithm = null != dataConsistencyChecker ? ShardingSphereAlgorithmFactory.createAlgorithm(dataConsistencyChecker, DataConsistencyCheckAlgorithm.class) : null;
         checkoutLockAlgorithm = null;
-        inventoryDumperExecuteEngine = ExecuteEngine.newFixedThreadInstance(onRuleAlteredActionConfig.getWorkerThread());
+        inventoryDumperExecuteEngine = ExecuteEngine.newFixedThreadInstance(inputConfig.getWorkerThread());
         incrementalDumperExecuteEngine = ExecuteEngine.newCachedThreadInstance();
-        importerExecuteEngine = ExecuteEngine.newFixedThreadInstance(onRuleAlteredActionConfig.getWorkerThread());
+        importerExecuteEngine = ExecuteEngine.newFixedThreadInstance(outputConfig.getWorkerThread());
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -81,13 +81,13 @@ public final class RuleAlteredContext {
     
     public RuleAlteredContext(final OnRuleAlteredActionConfiguration onRuleAlteredActionConfig) {
         this.onRuleAlteredActionConfig = onRuleAlteredActionConfig;
-        InputConfiguration inputConfig = onRuleAlteredActionConfig.getInputConfig();
+        InputConfiguration inputConfig = onRuleAlteredActionConfig.getInput();
         if (null == inputConfig) {
             inputConfig = new InputConfigurationSwapper().swapToObject(new YamlInputConfiguration());
         }
         ShardingSphereAlgorithmConfiguration inputRateLimiter = inputConfig.getRateLimiter();
         inputRateLimitAlgorithm = null != inputRateLimiter ? ShardingSphereAlgorithmFactory.createAlgorithm(inputRateLimiter, JobRateLimitAlgorithm.class) : null;
-        OutputConfiguration outputConfig = onRuleAlteredActionConfig.getOutputConfig();
+        OutputConfiguration outputConfig = onRuleAlteredActionConfig.getOutput();
         if (null == outputConfig) {
             outputConfig = new OutputConfigurationSwapper().swapToObject(new YamlOutputConfiguration());
         }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.data.pipeline.core.spi.ratelimit.SourceJobRateLimitAlgorithm
+org.apache.shardingsphere.data.pipeline.core.spi.ratelimit.QPSJobRateLimitAlgorithm

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.data.pipeline.core.spi.ratelimit.QPSJobRateLimitAlgorithm
+org.apache.shardingsphere.data.pipeline.core.spi.ratelimit.TPSJobRateLimitAlgorithm

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/ingest/InventoryDumperConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/ingest/InventoryDumperConfiguration.java
@@ -36,7 +36,7 @@ public final class InventoryDumperConfiguration extends DumperConfiguration {
     
     private Integer shardingItem;
     
-    private int readBatchSize = 1000;
+    private int batchSize = 1000;
     
     private JobRateLimitAlgorithm rateLimitAlgorithm;
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/JobOperationType.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/JobOperationType.java
@@ -15,22 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.spi.ratelimit;
+package org.apache.shardingsphere.data.pipeline.api.job;
 
-import org.apache.shardingsphere.data.pipeline.api.job.JobOperationType;
-import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
-import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Job rate limit algorithm, SPI.
+ * Job operation type.
  */
-public interface JobRateLimitAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
+@RequiredArgsConstructor
+@Getter
+public enum JobOperationType {
     
-    /**
-     * Intercept.
-     *
-     * @param type job operation type
-     * @param data it's delta that means how much changed if type is INSERT, DELETE, UPDATE, SELECT; it's current metrics if type is SYSTEM_LOAD, CPU_USAGE
-     */
-    void intercept(JobOperationType type, Number data);
+    INSERT, DELETE, UPDATE, SELECT,
+    SYSTEM_LOAD, CPU_USAGE,
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/ratelimit/JobRateLimitAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/ratelimit/JobRateLimitAlgorithm.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmP
 /**
  * Job rate limit algorithm, SPI.
  */
+// TODO rename
 public interface JobRateLimitAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/ratelimit/JobRateLimitAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/ratelimit/JobRateLimitAlgorithm.java
@@ -30,7 +30,7 @@ public interface JobRateLimitAlgorithm extends ShardingSphereAlgorithm, Sharding
      * Intercept.
      *
      * @param type job operation type
-     * @param data it's delta that means how much changed if type is INSERT, DELETE, UPDATE, SELECT; it's current metrics if type is SYSTEM_LOAD, CPU_USAGE
+     * @param data it's delta that means how much changed if type is INSERT, DELETE, UPDATE, SELECT; it's null if type is SYSTEM_LOAD, CPU_USAGE
      */
     void intercept(JobOperationType type, Number data);
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/config-sharding.yaml
@@ -98,12 +98,20 @@
 #  scaling:
 #    default_scaling:
 #      blockQueueSize: 10000
-#      workerThread: 40
-#      readBatchSize: 1000
-#      rateLimiter:
-#        type: SOURCE
-#        props:
-#          qps: 50
+#      input:
+#        workerThread: 40
+#        batchSize: 1000
+#        rateLimiter:
+#          type: QPS
+#          props:
+#            qps: 50
+#      output:
+#        workerThread: 40
+#        batchSize: 1000
+#        rateLimiter:
+#          type: TPS
+#          props:
+#            tps: 2000
 #      completionDetector:
 #        type: IDLE
 #        props:
@@ -195,12 +203,20 @@
 #  scaling:
 #    default_scaling:
 #      blockQueueSize: 10000
-#      workerThread: 40
-#      readBatchSize: 1000
-#      rateLimiter:
-#        type: SOURCE
-#        props:
-#          qps: 50
+#      input:
+#        workerThread: 40
+#        batchSize: 1000
+#        rateLimiter:
+#          type: QPS
+#          props:
+#            qps: 50
+#      output:
+#        workerThread: 40
+#        batchSize: 1000
+#        rateLimiter:
+#          type: TPS
+#          props:
+#            tps: 2000
 #      completionDetector:
 #        type: IDLE
 #        props:

--- a/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/resources/docker/scaling/conf/server.yaml
+++ b/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/resources/docker/scaling/conf/server.yaml
@@ -15,11 +15,6 @@
 # limitations under the License.
 #
 
-scaling:
-  port: 8888
-  blockQueueSize: 10000
-  workerThread: 30
-
 mode:
   type: Cluster
   repository:

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/config_sharding_sphere_jdbc_source.yaml
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/config_sharding_sphere_jdbc_source.yaml
@@ -52,12 +52,20 @@ rules:
   scaling:
     default_scaling:
       blockQueueSize: 10000
-      workerThread: 40
-      readBatchSize: 1000
-      rateLimiter:
-        type: SOURCE
-        props:
-          qps: 50
+      input:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: QPS
+          props:
+            qps: 50
+      output:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: TPS
+          props:
+            tps: 2000
       completionDetector:
         type: FIXTURE
       dataConsistencyChecker:

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/config_sharding_sphere_jdbc_target.yaml
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/config_sharding_sphere_jdbc_target.yaml
@@ -55,12 +55,20 @@ rules:
   scaling:
     default_scaling:
       blockQueueSize: 10000
-      workerThread: 40
-      readBatchSize: 1000
-      rateLimiter:
-        type: SOURCE
-        props:
-          qps: 50
+      input:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: QPS
+          props:
+            qps: 50
+      output:
+        workerThread: 40
+        batchSize: 1000
+        rateLimiter:
+          type: TPS
+          props:
+            tps: 2000
       completionDetector:
         type: FIXTURE
       dataConsistencyChecker:


### PR DESCRIPTION
Fixes #13875 part 25.

Changes proposed in this pull request:
- Add input and output in scaling config. Refactor `workerThread`, `readBatchSize` and `rateLimiter` into `input` and `output`
- Refactor JobRateLimitAlgorithm SPI. Prepare to support more types of rate limiter.
- Add rateLimiter TPS impl which is used for `output`
- Update input and output of scaling config in doc
