### PR TITLE
Add more unit test for EncryptAlgorithmMetaData, EncryptRule and EncryptTable

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaDataTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaDataTest.java
@@ -112,4 +112,14 @@ public final class EncryptAlgorithmMetaDataTest {
         Optional<EncryptAlgorithm> actualEncryptor = encryptAlgorithmMetaData.findEncryptor(1);
         assertFalse(actualEncryptor.isPresent());
     }
+    
+    @Test
+    public void assertIsQueryWithCipherColumn() {
+        Map<String, String> columnTableNames = new HashMap<>();
+        columnTableNames.put(columnProjection.getExpression(), "t_order");
+        when(tablesContext.findTableName(Collections.singletonList(columnProjection), schema)).thenReturn(columnTableNames);
+        when(encryptRule.isQueryWithCipherColumn("t_order")).thenReturn(true);
+        EncryptAlgorithmMetaData encryptAlgorithmMetaData = new EncryptAlgorithmMetaData(schema, encryptRule, selectStatementContext);
+        assertTrue(encryptAlgorithmMetaData.isQueryWithCipherColumn(1));
+    }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptRuleTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptRuleTest.java
@@ -141,6 +141,16 @@ public final class EncryptRuleTest {
     }
     
     @Test
+    public void assertIsQueryWithCipherColumn() {
+        EncryptColumnRuleConfiguration encryptColumnConfig = new EncryptColumnRuleConfiguration("encrypt_column", "encrypt_cipher", "", "", "test_encryptor");
+        EncryptTableRuleConfiguration tableConfig = new EncryptTableRuleConfiguration("t_encrypt", Collections.singletonList(encryptColumnConfig), true);
+        AlgorithmProvidedEncryptRuleConfiguration ruleConfig = new AlgorithmProvidedEncryptRuleConfiguration(
+                Collections.singleton(tableConfig), ImmutableMap.of("test_encryptor", new TestEncryptAlgorithm()), true);
+        EncryptRule actual = new EncryptRule(ruleConfig);
+        assertTrue(actual.isQueryWithCipherColumn("t_encrypt"));
+    }
+    
+    @Test
     public void assertGetTables() {
         assertThat(new EncryptRule(createEncryptRuleConfiguration()).getTables(), is(Collections.singleton("t_encrypt")));
     }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
@@ -121,4 +121,11 @@ public final class EncryptTableTest {
     public void assertGetLogicAndCipherColumns() {
         assertThat(encryptTable.getLogicAndCipherColumns(), is(ImmutableMap.of("logicColumn", "cipherColumn")));
     }
+    
+    @Test
+    public void assertGetQueryWithCipherColumn() {
+        encryptTable = new EncryptTable(new EncryptTableRuleConfiguration("t_encrypt",
+                Collections.singleton(new EncryptColumnRuleConfiguration("logicColumn", "cipherColumn", "assistedQueryColumn", "plainColumn", "myEncryptor")), true));
+        assertTrue(encryptTable.getQueryWithCipherColumn().get());
+    }
 }


### PR DESCRIPTION
Add more unit test for EncryptAlgorithmMetaData, EncryptRule and EncryptTable #13807.

Changes proposed in this pull request:
- Add unit test for EncryptAlgorithmMetaData#isQueryWithCipherColumn
- Add unit test for EncryptRule#isQueryWithCipherColumn
- Add unit test for EncryptTable#getQueryWithCipherColumn
