### PR TITLE
Add SingletonSPI and SingletonSPIRegistry; RequiredSPIRegistry.getRegisteredService support SingletonSPI; Refactor part of existing SPI loading

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/spi/DialectTableMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/spi/DialectTableMetaDataLoader.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.metadata.schema.builder.spi;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeAwareSPI;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * Dialect table meta data loader.
  */
-public interface DialectTableMetaDataLoader extends DatabaseTypeAwareSPI {
+public interface DialectTableMetaDataLoader extends DatabaseTypeAwareSPI, SingletonSPI {
     
     /**
      * Load table meta data.

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/MySQLTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/MySQLTableMetaDataLoaderTest.java
@@ -21,8 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.spi.DialectTableM
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.junit.BeforeClass;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -39,10 +38,8 @@ import static org.mockito.Mockito.when;
 
 public final class MySQLTableMetaDataLoaderTest {
     
-    @BeforeClass
-    public static void setUp() {
-        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
-    }
+    private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
+            DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);
     
     @Test
     public void assertLoadWithoutTables() throws SQLException {
@@ -108,10 +105,9 @@ public final class MySQLTableMetaDataLoaderTest {
     }
 
     private DialectTableMetaDataLoader getTableMetaDataLoader() {
-        for (DialectTableMetaDataLoader each : ShardingSphereServiceLoader.getSingletonServiceInstances(DialectTableMetaDataLoader.class)) {
-            if ("MySQL".equals(each.getDatabaseType())) {
-                return each;
-            }
+        DialectTableMetaDataLoader result = DIALECT_METADATA_LOADER_MAP.get("MySQL");
+        if (null != result) {
+            return result;
         }
         throw new IllegalStateException("Can not find MySQLTableMetaDataLoader");
     }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/OracleTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/OracleTableMetaDataLoaderTest.java
@@ -21,8 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.spi.DialectTableM
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.junit.BeforeClass;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -72,10 +71,8 @@ public final class OracleTableMetaDataLoaderTest {
     private static final String ALL_TAB_COLUMNS_SQL_CONDITION6 = "SELECT OWNER AS TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, COLUMN_ID  FROM ALL_TAB_COLUMNS"
             + " WHERE OWNER = ? AND TABLE_NAME IN ('tbl') ORDER BY COLUMN_ID";
     
-    @BeforeClass
-    public static void setUp() {
-        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
-    }
+    private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
+            DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);
     
     @Test
     public void assertLoadCondition1() throws SQLException {
@@ -222,10 +219,9 @@ public final class OracleTableMetaDataLoaderTest {
     }
     
     private DialectTableMetaDataLoader getTableMetaDataLoader() {
-        for (DialectTableMetaDataLoader each : ShardingSphereServiceLoader.getSingletonServiceInstances(DialectTableMetaDataLoader.class)) {
-            if ("Oracle".equals(each.getDatabaseType())) {
-                return each;
-            }
+        DialectTableMetaDataLoader result = DIALECT_METADATA_LOADER_MAP.get("Oracle");
+        if (null != result) {
+            return result;
         }
         throw new IllegalStateException("Can not find OracleTableMetaDataLoader");
     }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/SQLServerTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/loader/dialect/SQLServerTableMetaDataLoaderTest.java
@@ -21,8 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.builder.spi.DialectTableM
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.junit.BeforeClass;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -39,10 +38,8 @@ import static org.mockito.Mockito.when;
 
 public final class SQLServerTableMetaDataLoaderTest {
     
-    @BeforeClass
-    public static void setUp() {
-        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
-    }
+    private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
+            DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);
     
     @Test
     public void assertLoadWithoutTables() throws SQLException {
@@ -119,10 +116,9 @@ public final class SQLServerTableMetaDataLoaderTest {
     }
     
     private DialectTableMetaDataLoader getTableMetaDataLoader() {
-        for (DialectTableMetaDataLoader each : ShardingSphereServiceLoader.getSingletonServiceInstances(DialectTableMetaDataLoader.class)) {
-            if ("SQLServer".equals(each.getDatabaseType())) {
-                return each;
-            }
+        DialectTableMetaDataLoader result = DIALECT_METADATA_LOADER_MAP.get("SQLServer");
+        if (null != result) {
+            return result;
         }
         throw new IllegalStateException("Can not find SQLServerTableMetaDataLoader");
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverState.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverState.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.driver.state;
 
 import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 import org.apache.shardingsphere.spi.typed.TypedSPI;
 
 import java.sql.Connection;
@@ -25,7 +26,7 @@ import java.sql.Connection;
 /**
  * Driver state.
  */
-public interface DriverState extends TypedSPI {
+public interface DriverState extends TypedSPI, SingletonSPI {
     
     /**
      * Get connection.

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverStateContext.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverStateContext.java
@@ -20,11 +20,9 @@ package org.apache.shardingsphere.driver.state;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mode.manager.ContextManager;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 
 import java.sql.Connection;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -36,13 +34,7 @@ public final class DriverStateContext {
     private static final Map<String, DriverState> STATES;
     
     static {
-        // TODO add singleton cache with TypedSPI init
-        ShardingSphereServiceLoader.register(DriverState.class);
-        Collection<DriverState> driverStates = ShardingSphereServiceLoader.getSingletonServiceInstances(DriverState.class);
-        STATES = new HashMap<>();
-        for (DriverState each : driverStates) {
-            STATES.put(each.getType(), each);
-        }
+        STATES = SingletonSPIRegistry.getTypedSingletonInstancesMap(DriverState.class);
     }
     
     /**

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/datasource/prop/DataSourcePropertiesSetter.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/datasource/prop/DataSourcePropertiesSetter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.spring.boot.datasource.prop;
 
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 import org.springframework.core.env.Environment;
 
 import javax.sql.DataSource;
@@ -24,7 +25,7 @@ import javax.sql.DataSource;
 /**
  * Different datasource properties setter.
  */
-public interface DataSourcePropertiesSetter {
+public interface DataSourcePropertiesSetter extends SingletonSPI {
     
     /**
      * Set datasource custom properties.

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/datasource/prop/impl/DataSourcePropertiesSetterHolder.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-spring-infra/shardingsphere-jdbc-spring-boot-starter-infra/src/main/java/org/apache/shardingsphere/spring/boot/datasource/prop/impl/DataSourcePropertiesSetterHolder.java
@@ -19,10 +19,9 @@ package org.apache.shardingsphere.spring.boot.datasource.prop.impl;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 import org.apache.shardingsphere.spring.boot.datasource.prop.DataSourcePropertiesSetter;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -32,13 +31,10 @@ import java.util.Optional;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DataSourcePropertiesSetterHolder {
     
-    private static final Map<String, DataSourcePropertiesSetter> DATA_SOURCE_PROPERTIES_SETTER_MAP = new HashMap<>();
+    private static final Map<String, DataSourcePropertiesSetter> DATA_SOURCE_PROPERTIES_SETTER_MAP;
     
     static {
-        ShardingSphereServiceLoader.register(DataSourcePropertiesSetter.class);
-        for (DataSourcePropertiesSetter each : ShardingSphereServiceLoader.getSingletonServiceInstances(DataSourcePropertiesSetter.class)) {
-            DATA_SOURCE_PROPERTIES_SETTER_MAP.put(each.getType(), each);
-        }
+        DATA_SOURCE_PROPERTIES_SETTER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(DataSourcePropertiesSetter.class, DataSourcePropertiesSetter::getType);
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreator.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreator.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.datasource.creator;
 
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 import org.apache.shardingsphere.spi.typed.TypedSPI;
 
 import javax.sql.DataSource;
@@ -25,7 +26,7 @@ import java.sql.SQLException;
 /**
  * Pipeline data source creator.
  */
-public interface PipelineDataSourceCreator extends TypedSPI {
+public interface PipelineDataSourceCreator extends TypedSPI, SingletonSPI {
     
     /**
      * Create pipeline data source.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreatorFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreatorFactory.java
@@ -17,17 +17,16 @@
 
 package org.apache.shardingsphere.data.pipeline.core.datasource.creator;
 
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.apache.shardingsphere.spi.typed.TypedSPIRegistry;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
+
+import java.util.Map;
 
 /**
  * Pipeline data source creator factory.
  */
 public final class PipelineDataSourceCreatorFactory {
     
-    static {
-        ShardingSphereServiceLoader.register(PipelineDataSourceCreator.class);
-    }
+    private static final Map<String, PipelineDataSourceCreator> DATA_SOURCE_CREATOR_MAP = SingletonSPIRegistry.getTypedSingletonInstancesMap(PipelineDataSourceCreator.class);
     
     /**
      * Get pipeline data source creator instance.
@@ -36,6 +35,6 @@ public final class PipelineDataSourceCreatorFactory {
      * @return pipeline data source creator instance
      */
     public static PipelineDataSourceCreator getInstance(final String type) {
-        return TypedSPIRegistry.getRegisteredService(PipelineDataSourceCreator.class, type, null);
+        return DATA_SOURCE_CREATOR_MAP.get(type);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
@@ -45,7 +45,7 @@ import org.apache.shardingsphere.infra.yaml.config.swapper.YamlRuleConfiguration
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cache.event.StartScalingEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -65,19 +65,14 @@ import java.util.stream.Collectors;
 @Slf4j
 public final class RuleAlteredJobWorker {
     
-    static {
-        ShardingSphereServiceLoader.register(RuleAlteredDetector.class);
-    }
-    
     private static final RuleAlteredJobWorker INSTANCE = new RuleAlteredJobWorker();
     
-    // TODO refactor
-    private static final Map<String, RuleAlteredDetector> RULE_CLASS_NAME_DETECTOR_MAP = ShardingSphereServiceLoader.getSingletonServiceInstances(RuleAlteredDetector.class).stream()
-            .collect(Collectors.toMap(RuleAlteredDetector::getRuleConfigClassName, Function.identity()));
+    private static final Map<String, RuleAlteredDetector> RULE_CLASS_NAME_DETECTOR_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
+            RuleAlteredDetector.class, RuleAlteredDetector::getRuleConfigClassName);
     
-    private static final Map<String, RuleAlteredDetector> YAML_RULE_CLASS_NAME_DETECTOR_MAP = ShardingSphereServiceLoader.getSingletonServiceInstances(RuleAlteredDetector.class).stream()
-            .collect(Collectors.toMap(RuleAlteredDetector::getYamlRuleConfigClassName, Function.identity()));
-    
+    private static final Map<String, RuleAlteredDetector> YAML_RULE_CLASS_NAME_DETECTOR_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
+            RuleAlteredDetector.class, RuleAlteredDetector::getYamlRuleConfigClassName);
+        
     private static final YamlRuleConfigurationSwapperEngine SWAPPER_ENGINE = new YamlRuleConfigurationSwapperEngine();
     
     private static final AtomicBoolean WORKER_INITIALIZED = new AtomicBoolean(false);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
@@ -49,7 +49,7 @@ import org.apache.shardingsphere.data.pipeline.mysql.ingest.column.value.ValueHa
 import org.apache.shardingsphere.data.pipeline.spi.ingest.dumper.IncrementalDumper;
 import org.apache.shardingsphere.infra.config.datasource.url.JdbcUrl;
 import org.apache.shardingsphere.infra.config.datasource.url.JdbcUrlParser;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 
 import java.io.Serializable;
 import java.security.SecureRandom;
@@ -57,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 /**
  * MySQL incremental dumper.
@@ -79,9 +78,7 @@ public final class MySQLIncrementalDumper extends AbstractLifecycleExecutor impl
     private PipelineChannel channel;
     
     static {
-        ShardingSphereServiceLoader.register(ValueHandler.class);
-        VALUE_HANDLER_MAP = ShardingSphereServiceLoader.getSingletonServiceInstances(ValueHandler.class)
-                .stream().collect(Collectors.toMap(ValueHandler::getTypeName, v -> v));
+        VALUE_HANDLER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(ValueHandler.class, ValueHandler::getTypeName);
     }
     
     public MySQLIncrementalDumper(final DumperConfiguration dumperConfig, final IngestPosition<BinlogPosition> binlogPosition) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/column/value/ValueHandler.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/column/value/ValueHandler.java
@@ -17,12 +17,14 @@
 
 package org.apache.shardingsphere.data.pipeline.mysql.ingest.column.value;
 
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
+
 import java.io.Serializable;
 
 /**
  * Value handler.
  */
-public interface ValueHandler {
+public interface ValueHandler extends SingletonSPI {
     
     /**
      * Get support type name.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/rulealtered/JobConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/rulealtered/JobConfiguration.java
@@ -26,7 +26,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfigurationFactory;
 import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredJobConfigurationPreparer;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.required.RequiredSPIRegistry;
 
 import java.util.Collection;
@@ -42,10 +41,6 @@ import java.util.concurrent.ThreadLocalRandom;
 @Slf4j
 // TODO share for totally new scenario
 public final class JobConfiguration {
-    
-    static {
-        ShardingSphereServiceLoader.register(RuleAlteredJobConfigurationPreparer.class);
-    }
     
     private WorkflowConfiguration workflowConfig;
     
@@ -65,7 +60,6 @@ public final class JobConfiguration {
         PipelineConfiguration pipelineConfig = getPipelineConfig();
         HandleConfiguration handleConfig = getHandleConfig();
         if (null == handleConfig || null == handleConfig.getJobShardingDataNodes()) {
-            // TODO singleton
             RuleAlteredJobConfigurationPreparer preparer = RequiredSPIRegistry.getRegisteredService(RuleAlteredJobConfigurationPreparer.class);
             handleConfig = preparer.createHandleConfiguration(pipelineConfig);
             this.handleConfig = handleConfig;

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredDetector.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredDetector.java
@@ -20,13 +20,14 @@ package org.apache.shardingsphere.data.pipeline.spi.rulealtered;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.rulealtered.OnRuleAlteredActionConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import java.util.Optional;
 
 /**
  * Rule altered detector, SPI interface.
  */
-public interface RuleAlteredDetector {
+public interface RuleAlteredDetector extends SingletonSPI {
     
     /**
      * Get YAML rule configuration class name.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredJobConfigurationPreparer.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/rulealtered/RuleAlteredJobConfigurationPreparer.java
@@ -21,13 +21,14 @@ import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.HandleConf
 import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.PipelineConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.TaskConfiguration;
 import org.apache.shardingsphere.spi.required.RequiredSPI;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import java.util.Collection;
 
 /**
  * Rule altered job configuration preparer.
  */
-public interface RuleAlteredJobConfigurationPreparer extends RequiredSPI {
+public interface RuleAlteredJobConfigurationPreparer extends RequiredSPI, SingletonSPI {
     
     /**
      * Create handle configuration, used to build job configuration.

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/JDBCBackendConnection.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/connection/JDBCBackendConnection.java
@@ -35,8 +35,7 @@ import org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction.JD
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.BackendConnectionException;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.apache.shardingsphere.spi.typed.TypedSPI;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 
 import java.sql.Connection;
@@ -51,8 +50,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 /**
  * JDBC backend connection.
@@ -60,10 +57,6 @@ import java.util.stream.Collectors;
 @Getter
 @Setter
 public final class JDBCBackendConnection implements BackendConnection<Void>, ExecutorJDBCManager {
-    
-    static {
-        ShardingSphereServiceLoader.register(StatementMemoryStrictlyFetchSizeSetter.class);
-    }
     
     private final ConnectionSession connectionSession;
     
@@ -85,8 +78,7 @@ public final class JDBCBackendConnection implements BackendConnection<Void>, Exe
     
     public JDBCBackendConnection(final ConnectionSession connectionSession) {
         this.connectionSession = connectionSession;
-        fetchSizeSetters = ShardingSphereServiceLoader.getSingletonServiceInstances(StatementMemoryStrictlyFetchSizeSetter.class).stream()
-                .collect(Collectors.toMap(TypedSPI::getType, Function.identity()));
+        fetchSizeSetters = SingletonSPIRegistry.getTypedSingletonInstancesMap(StatementMemoryStrictlyFetchSizeSetter.class);
     }
     
     @Override

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/statement/StatementMemoryStrictlyFetchSizeSetter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/statement/StatementMemoryStrictlyFetchSizeSetter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.communication.jdbc.statement;
 
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 import org.apache.shardingsphere.spi.typed.TypedSPI;
 
 import java.sql.SQLException;
@@ -25,7 +26,7 @@ import java.sql.Statement;
 /**
  * Statement memory strictly fetch size setter.
  */
-public interface StatementMemoryStrictlyFetchSizeSetter extends TypedSPI {
+public interface StatementMemoryStrictlyFetchSizeSetter extends TypedSPI, SingletonSPI {
     
     /**
      * Set fetch size.

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -21,58 +21,58 @@
 # 
 ######################################################################################################
 
-mode:
-  type: Cluster
-  repository:
-    type: ZooKeeper
-    props:
-      namespace: governance_ds
-      server-lists: localhost:2181
-      retryIntervalMilliseconds: 500
-      timeToLiveSeconds: 60
-      maxRetries: 3
-      operationTimeoutMilliseconds: 500
-  overwrite: false
+#mode:
+#  type: Cluster
+#  repository:
+#    type: ZooKeeper
+#    props:
+#      namespace: governance_ds
+#      server-lists: localhost:2181
+#      retryIntervalMilliseconds: 500
+#      timeToLiveSeconds: 60
+#      maxRetries: 3
+#      operationTimeoutMilliseconds: 500
+#  overwrite: false
+#
+#rules:
+#  - !AUTHORITY
+#    users:
+#      - root@%:root
+#      - sharding@:sharding
+#    provider:
+#      type: ALL_PRIVILEGES_PERMITTED
+#  - !TRANSACTION
+#    defaultType: XA
+#    providerType: Atomikos
+#  - !SQL_PARSER
+#    sqlCommentParseEnabled: true
+#    sqlStatementCache:
+#      initialCapacity: 2000
+#      maximumSize: 65535
+#      concurrencyLevel: 4
+#    parseTreeCache:
+#      initialCapacity: 128
+#      maximumSize: 1024
+#      concurrencyLevel: 4
 
-rules:
-  - !AUTHORITY
-    users:
-      - root@%:root
-      - sharding@:sharding
-    provider:
-      type: ALL_PRIVILEGES_PERMITTED
-  - !TRANSACTION
-    defaultType: XA
-    providerType: Atomikos
-  - !SQL_PARSER
-    sqlCommentParseEnabled: true
-    sqlStatementCache:
-      initialCapacity: 2000
-      maximumSize: 65535
-      concurrencyLevel: 4
-    parseTreeCache:
-      initialCapacity: 128
-      maximumSize: 1024
-      concurrencyLevel: 4
-
-props:
-  max-connections-size-per-query: 1
-  kernel-executor-size: 16  # Infinite by default.
-  proxy-frontend-flush-threshold: 128  # The default value is 128.
-  proxy-opentracing-enabled: false
-  proxy-hint-enabled: false
-  sql-show: false
-  check-table-metadata-enabled: false
-  show-process-list-enabled: false
-    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
-    # The default value is -1, which means set the minimum value for different JDBC drivers.
-  proxy-backend-query-fetch-size: -1
-  check-duplicate-table-enabled: false
-  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
-    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
-    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
-  proxy-backend-executor-suitable: OLAP
-  proxy-frontend-max-connections: 0 # Less than or equal to 0 means no limitation.
-  sql-federation-enabled: false
-  Available proxy backend driver type: JDBC (default), ExperimentalVertx
-  proxy-backend-driver-type: JDBC
+#props:
+#  max-connections-size-per-query: 1
+#  kernel-executor-size: 16  # Infinite by default.
+#  proxy-frontend-flush-threshold: 128  # The default value is 128.
+#  proxy-opentracing-enabled: false
+#  proxy-hint-enabled: false
+#  sql-show: false
+#  check-table-metadata-enabled: false
+#  show-process-list-enabled: false
+#    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
+#    # The default value is -1, which means set the minimum value for different JDBC drivers.
+#  proxy-backend-query-fetch-size: -1
+#  check-duplicate-table-enabled: false
+#  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
+#    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
+#    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
+#  proxy-backend-executor-suitable: OLAP
+#  proxy-frontend-max-connections: 0 # Less than or equal to 0 means no limitation.
+#  sql-federation-enabled: false
+#  Available proxy backend driver type: JDBC (default), ExperimentalVertx
+#  proxy-backend-driver-type: JDBC

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistry.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import java.util.Collection;
 
@@ -38,7 +39,13 @@ public final class RequiredSPIRegistry {
      * @return registered service
      */
     public static <T extends RequiredSPI> T getRegisteredService(final Class<T> requiredSPIClass) {
-        Collection<T> services = ShardingSphereServiceLoader.newServiceInstances(requiredSPIClass);
+        Collection<T> services;
+        if (SingletonSPI.class.isAssignableFrom(requiredSPIClass)) {
+            ShardingSphereServiceLoader.register(requiredSPIClass);
+            services = ShardingSphereServiceLoader.getSingletonServiceInstances(requiredSPIClass);
+        } else {
+            services = ShardingSphereServiceLoader.newServiceInstances(requiredSPIClass);
+        }
         if (services.isEmpty()) {
             throw new ServiceProviderNotFoundException(requiredSPIClass);
         }

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPI.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPI.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.singleton;
+
+/**
+ * Singleton SPI.
+ */
+public interface SingletonSPI {
+}

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistry.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.singleton;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.typed.TypedSPI;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Singleton SPI registry.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SingletonSPIRegistry {
+    
+    /**
+     * Get singleton instances map.
+     *
+     * @param singletonSPIClass singleton SPI class
+     * @param keyMapper key mapper
+     * @param <K> the output type of the key mapping function
+     * @param <T> the type of the input elements
+     * @return singleton instances map
+     */
+    public static <K, T> Map<K, T> getSingletonInstancesMap(final Class<T> singletonSPIClass, final Function<? super T, ? extends K> keyMapper) {
+        ShardingSphereServiceLoader.register(singletonSPIClass);
+        Collection<T> instances = ShardingSphereServiceLoader.getSingletonServiceInstances(singletonSPIClass);
+        return instances.stream().collect(Collectors.toMap(keyMapper, Function.identity()));
+    }
+    
+    /**
+     * Get typed singleton instances map.
+     *
+     * @param singletonSPIClass singleton SPI class
+     * @param <T> the type of the input elements
+     * @return singleton instances map
+     */
+    public static <T extends TypedSPI> Map<String, T> getTypedSingletonInstancesMap(final Class<T> singletonSPIClass) {
+        return getSingletonInstancesMap(singletonSPIClass, TypedSPI::getType);
+    }
+}

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/required/RequiredSingletonSPIFixture.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/required/RequiredSingletonSPIFixture.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.fixture.required;
+
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
+
+public interface RequiredSingletonSPIFixture extends RequiredSPIFixture, SingletonSPI {
+}

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/required/RequiredSingletonSPIFixtureImpl.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/required/RequiredSingletonSPIFixtureImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.fixture.required;
+
+public final class RequiredSingletonSPIFixtureImpl implements RequiredSingletonSPIFixture {
+    
+    @Override
+    public boolean isDefault() {
+        return false;
+    }
+}

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/singleton/SingletonSPIFixture.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/singleton/SingletonSPIFixture.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.fixture.singleton;
+
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
+import org.apache.shardingsphere.spi.typed.TypedSPI;
+
+public interface SingletonSPIFixture extends SingletonSPI, TypedSPI {
+}

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/singleton/SingletonSPIFixtureImpl.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/fixture/singleton/SingletonSPIFixtureImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.fixture.singleton;
+
+public final class SingletonSPIFixtureImpl implements SingletonSPIFixture {
+    
+    @Override
+    public String getType() {
+        return "SINGLETON_FIXTURE";
+    }
+}

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistryTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/required/RequiredSPIRegistryTest.java
@@ -23,8 +23,11 @@ import org.apache.shardingsphere.spi.fixture.required.NoImplRequiredSPIFixture;
 import org.apache.shardingsphere.spi.fixture.required.RequiredSPIFixture;
 import org.apache.shardingsphere.spi.fixture.required.RequiredSPIFixtureDefaultTrueImpl;
 import org.apache.shardingsphere.spi.fixture.required.RequiredSPIImpl;
+import org.apache.shardingsphere.spi.fixture.required.RequiredSingletonSPIFixture;
+import org.apache.shardingsphere.spi.fixture.required.RequiredSingletonSPIFixtureImpl;
 import org.junit.Test;
 
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public final class RequiredSPIRegistryTest {
@@ -32,6 +35,7 @@ public final class RequiredSPIRegistryTest {
     static {
         ShardingSphereServiceLoader.register(RequiredSPIFixture.class);
         ShardingSphereServiceLoader.register(RequiredSPI.class);
+        ShardingSphereServiceLoader.register(RequiredSingletonSPIFixture.class);
     }
     
     @Test(expected = ServiceProviderNotFoundException.class)
@@ -49,5 +53,14 @@ public final class RequiredSPIRegistryTest {
     public void assertRegisteredServiceMoreThanOne() {
         RequiredSPIFixture actualRegisteredService = RequiredSPIRegistry.getRegisteredService(RequiredSPIFixture.class);
         assertTrue(actualRegisteredService instanceof RequiredSPIFixtureDefaultTrueImpl);
+    }
+    
+    @Test
+    public void assertRegisteredServiceSingleton() {
+        RequiredSPIFixture actualOne = RequiredSPIRegistry.getRegisteredService(RequiredSingletonSPIFixture.class);
+        assertTrue(actualOne instanceof RequiredSingletonSPIFixtureImpl);
+        RequiredSPIFixture actualTwo = RequiredSPIRegistry.getRegisteredService(RequiredSingletonSPIFixture.class);
+        assertTrue(actualTwo instanceof RequiredSingletonSPIFixtureImpl);
+        assertSame(actualOne, actualTwo);
     }
 }

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistryTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistryTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spi.singleton;
+
+import org.apache.shardingsphere.spi.fixture.singleton.SingletonSPIFixture;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class SingletonSPIRegistryTest {
+    
+    @Test
+    public void assertGetSingletonInstancesMap() {
+        Map<String, SingletonSPIFixture> singletonSPIFixtureMap = SingletonSPIRegistry.getSingletonInstancesMap(
+                SingletonSPIFixture.class, SingletonSPIFixture::getType);
+        assertThat(singletonSPIFixtureMap.size(), is(1));
+        assertTrue(singletonSPIFixtureMap.containsKey("SINGLETON_FIXTURE"));
+    }
+    
+    @Test
+    public void assertGetTypedSingletonInstancesMap() {
+        Map<String, SingletonSPIFixture> singletonSPIFixtureMap = SingletonSPIRegistry.getTypedSingletonInstancesMap(SingletonSPIFixture.class);
+        assertThat(singletonSPIFixtureMap.size(), is(1));
+        assertTrue(singletonSPIFixtureMap.containsKey("SINGLETON_FIXTURE"));
+    }
+}

--- a/shardingsphere-spi/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.fixture.required.RequiredSingletonSPIFixture
+++ b/shardingsphere-spi/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.fixture.required.RequiredSingletonSPIFixture
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.spi.fixture.required.RequiredSingletonSPIFixtureImpl

--- a/shardingsphere-spi/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.fixture.singleton.SingletonSPIFixture
+++ b/shardingsphere-spi/src/test/resources/META-INF/services/org.apache.shardingsphere.spi.fixture.singleton.SingletonSPIFixture
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.spi.fixture.singleton.SingletonSPIFixtureImpl


### PR DESCRIPTION
Purpose:
- Simplify singleton SPI loading
- Simplify singleton SPI registration. `SingletonSPIRegistry` will register SPI class automatically, there is not side effect for singleton spi.

Changes proposed in this pull request:
- Add `SingletonSPI` and `SingletonSPIRegistry`
- Refactor `ShardingSphereServiceLoader.getSingletonServiceInstances` to `SingletonSPIRegistry` invocation
- Refactor part of `TypedSPIRegistry.getRegisteredService` to `SingletonSPIRegistry` invocation for pipeline modules
- `RequiredSPIRegistry.getRegisteredService` support `SingletonSPI`. Just integrate with pipeline modules for now.
