### PR TITLE
Constrain SingletonSPIRegistry generic T with SingletonSPI

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-tracing/shardingsphere-agent-tracing-test/src/main/java/org/apache/shardingsphere/agent/plugin/tracing/MockDataSourceMetaData.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-tracing/shardingsphere-agent-tracing-test/src/main/java/org/apache/shardingsphere/agent/plugin/tracing/MockDataSourceMetaData.java
@@ -47,4 +47,9 @@ public final class MockDataSourceMetaData implements DataSourceMetaData {
     public Properties getQueryProperties() {
         return new Properties();
     }
+    
+    @Override
+    public Properties getDefaultQueryProperties() {
+        return new Properties();
+    }
 }

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/singleton/SingletonSPIRegistry.java
@@ -42,7 +42,7 @@ public final class SingletonSPIRegistry {
      * @param <T> the type of the input elements
      * @return singleton instances map
      */
-    public static <K, T> Map<K, T> getSingletonInstancesMap(final Class<T> singletonSPIClass, final Function<? super T, ? extends K> keyMapper) {
+    public static <K, T extends SingletonSPI> Map<K, T> getSingletonInstancesMap(final Class<T> singletonSPIClass, final Function<? super T, ? extends K> keyMapper) {
         ShardingSphereServiceLoader.register(singletonSPIClass);
         Collection<T> instances = ShardingSphereServiceLoader.getSingletonServiceInstances(singletonSPIClass);
         return instances.stream().collect(Collectors.toMap(keyMapper, Function.identity()));
@@ -55,7 +55,7 @@ public final class SingletonSPIRegistry {
      * @param <T> the type of the input elements
      * @return singleton instances map
      */
-    public static <T extends TypedSPI> Map<String, T> getTypedSingletonInstancesMap(final Class<T> singletonSPIClass) {
+    public static <T extends TypedSPI & SingletonSPI> Map<String, T> getTypedSingletonInstancesMap(final Class<T> singletonSPIClass) {
         return getSingletonInstancesMap(singletonSPIClass, TypedSPI::getType);
     }
 }


### PR DESCRIPTION
Purpose:
- Avoid `SingletonSPIRegistry` to be used by mistake

Changes proposed in this pull request:
- Constrain SingletonSPIRegistry generic T with SingletonSPI
