### PR TITLE
For #14605: The binary type is abnormal during the data migration data check phase

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
@@ -97,10 +97,11 @@ public final class JDBCRowsLoader {
             case Types.CLOB:
                 return resultSet.getClob(columnIndex);
             case Types.BLOB:
+                return resultSet.getBlob(columnIndex);
             case Types.BINARY:
             case Types.VARBINARY:
             case Types.LONGVARBINARY:
-                return resultSet.getBlob(columnIndex);
+                return resultSet.getBytes(columnIndex);
             case Types.ARRAY:
                 return resultSet.getArray(columnIndex);
             default:

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
@@ -276,33 +276,33 @@ public final class JDBCMemoryQueryResultTest {
     @Test
     public void assertGetValueByBinary() throws SQLException {
         ResultSet resultSet = getMockedResultSet(Types.BINARY);
-        Blob value = mock(Blob.class);
-        when(resultSet.getBlob(1)).thenReturn(value);
+        byte[] value = new byte[10];
+        when(resultSet.getBytes(1)).thenReturn(value);
         JDBCMemoryQueryResult actual = new JDBCMemoryQueryResult(resultSet);
         assertTrue(actual.next());
-        assertThat(actual.getValue(1, Blob.class), is(value));
+        assertThat(actual.getValue(1, byte[].class), is(value));
         assertFalse(actual.next());
     }
     
     @Test
     public void assertGetValueByVarBinary() throws SQLException {
         ResultSet resultSet = getMockedResultSet(Types.VARBINARY);
-        Blob value = mock(Blob.class);
-        when(resultSet.getBlob(1)).thenReturn(value);
+        byte[] value = new byte[10];
+        when(resultSet.getBytes(1)).thenReturn(value);
         JDBCMemoryQueryResult actual = new JDBCMemoryQueryResult(resultSet);
         assertTrue(actual.next());
-        assertThat(actual.getValue(1, Blob.class), is(value));
+        assertThat(actual.getValue(1, byte[].class), is(value));
         assertFalse(actual.next());
     }
     
     @Test
     public void assertGetValueByLongVarBinary() throws SQLException {
         ResultSet resultSet = getMockedResultSet(Types.LONGVARBINARY);
-        Blob value = mock(Blob.class);
-        when(resultSet.getBlob(1)).thenReturn(value);
+        byte[] value = new byte[10];
+        when(resultSet.getBytes(1)).thenReturn(value);
         JDBCMemoryQueryResult actual = new JDBCMemoryQueryResult(resultSet);
         assertTrue(actual.next());
-        assertThat(actual.getValue(1, Blob.class), is(value));
+        assertThat(actual.getValue(1, byte[].class), is(value));
         assertFalse(actual.next());
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/check/consistency/AbstractStreamingSingleTableDataCalculator.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/check/consistency/AbstractStreamingSingleTableDataCalculator.java
@@ -82,7 +82,7 @@ public abstract class AbstractStreamingSingleTableDataCalculator extends Abstrac
             Optional<Object> nextResult = this.nextResult;
             dataCalculateParameter.setPreviousCalculatedResult(nextResult.orElse(null));
             this.nextResult = null;
-            return nextResult;
+            return nextResult.orElse(null);
         }
         
         private void calculateIfNecessary() {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/check/consistency/DataMatchSingleTableDataCalculator.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/check/consistency/DataMatchSingleTableDataCalculator.java
@@ -141,11 +141,17 @@ public final class DataMatchSingleTableDataCalculator extends AbstractStreamingS
             if (!equalsFirst) {
                 return false;
             }
+            
             Iterator<Collection<Object>> thisIterator = this.records.iterator();
             Iterator<Collection<Object>> thatIterator = that.records.iterator();
             while (thisIterator.hasNext() && thatIterator.hasNext()) {
-                Iterator<Object> thisNextIterator = thisIterator.next().iterator();
-                Iterator<Object> thatNextIterator = thatIterator.next().iterator();
+                Collection<Object> thisNext = thisIterator.next();
+                Collection<Object> thatNext = thatIterator.next();
+                if (thisNext.size() != thatNext.size()) {
+                    return false;
+                }
+                Iterator<Object> thisNextIterator = thisNext.iterator();
+                Iterator<Object> thatNextIterator = thatNext.iterator();
                 while (thisNextIterator.hasNext() && thatNextIterator.hasNext()) {
                     if (!new EqualsBuilder().append(thisNextIterator.next(), thatNextIterator.next()).isEquals()) {
                         return false;


### PR DESCRIPTION
Fixes #14605.

Changes proposed in this pull request:
- Override equals and hashCode methods of "org.apache.shardingsphere.data.pipeline.core.spi.check.consistency.DataMatchSingleTableDataCalculator.CalculatedResult"
- Modify the use of "JDBCRowsLoader" for the return type of BINARY, VARBINARY, LONGVARBINARY
- Modify class "JDBCMemoryQueryResult"
