### PR TITLE
Add MySQL parse support for `EXPLAIN TABLE Statement`

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -408,10 +408,9 @@ shutdown
 explainType
     : FORMAT EQ_ formatName
     ;
-
-// TODO support table statement
+    
 explainableStatement
-    : select | delete | insert | replace | update
+    : table | select | delete | insert | replace | update
     ;
 
 formatName

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
@@ -542,7 +542,9 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
     
     @Override
     public ASTNode visitExplainableStatement(final ExplainableStatementContext ctx) {
-        if (null != ctx.select()) {
+        if (null != ctx.table()) {
+            return visit(ctx.table());
+        } else if (null != ctx.select()) {
             return visit(ctx.select());
         } else if (null != ctx.delete()) {
             return visit(ctx.delete());

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDMLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDMLStatementSQLVisitor.java
@@ -23,14 +23,9 @@ import org.apache.shardingsphere.sql.parser.api.visitor.operation.SQLStatementVi
 import org.apache.shardingsphere.sql.parser.api.visitor.type.DMLSQLVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.CallContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.DoStatementContext;
-import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.TableContext;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.limit.LimitSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLCallStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLDoStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLTableStatement;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,14 +51,5 @@ public final class MySQLDMLStatementSQLVisitor extends MySQLStatementSQLVisitor 
     @Override
     public ASTNode visitDoStatement(final DoStatementContext ctx) {
         return new MySQLDoStatement();
-    }
-    
-    @Override
-    public ASTNode visitTable(final TableContext ctx) {
-        MySQLTableStatement result = new MySQLTableStatement();
-        result.setTable((SimpleTableSegment) visit(ctx.tableName()));
-        result.setColumn((ColumnSegment) visit(ctx.columnName()));
-        result.setLimit((LimitSegment) visit(ctx.limitClause()));
-        return result;
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -200,6 +200,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.parametermarker.Par
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLDeleteStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLInsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLSelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLUpdateStatement;
 
 import java.util.Collection;
@@ -1571,6 +1572,15 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
             return new NumberLiteralLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((NumberLiteralValue) visit(ctx.numberLiterals())).getValue().longValue());
         }
         return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerValue) visit(ctx.parameterMarker())).getValue());
+    }
+    
+    @Override
+    public ASTNode visitTable(final MySQLStatementParser.TableContext ctx) {
+        MySQLTableStatement result = new MySQLTableStatement();
+        result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+        result.setColumn((ColumnSegment) visit(ctx.columnName()));
+        result.setLimit((LimitSegment) visit(ctx.limitClause()));
+        return result;
     }
     
     /**

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
@@ -62,7 +62,7 @@ public final class ExplainStatementAssert {
         } else if (null != expected.getCreateTableAsSelectClause()) {
             assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
             SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getCreateTableAsSelectClause());
-        } else if (actual instanceof MySQLExplainStatement && null != expected.getTableName()) {
+        } else if (actual instanceof MySQLExplainStatement && null != expected.getTable()) {
             mysqlExplainStatementAssert(assertContext, (MySQLExplainStatement) actual, expected);
         } else {
             assertFalse(assertContext.getText("Actual statement should not exist."), actual.getStatement().isPresent());
@@ -71,7 +71,7 @@ public final class ExplainStatementAssert {
     
     private static void mysqlExplainStatementAssert(final SQLCaseAssertContext assertContext, final MySQLExplainStatement actual, final ExplainStatementTestCase expected) {
         if (actual.getTable().isPresent()) {
-            TableAssert.assertIs(assertContext, actual.getTable().get(), expected.getTableName());
+            TableAssert.assertIs(assertContext, actual.getTable().get(), expected.getTable());
             if (actual.getColumnWild().isPresent()) {
                 ColumnAssert.assertIs(assertContext, actual.getColumnWild().get(), expected.getColumn());
             } else {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dal/impl/ExplainStatementAssert.java
@@ -44,7 +44,10 @@ public final class ExplainStatementAssert {
      * @param expected expected explain statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ExplainStatement actual, final ExplainStatementTestCase expected) {
-        if (null != expected.getSelectClause()) {
+        if (null != expected.getTableClause()) {
+            assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
+            SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getTableClause());
+        } else if (null != expected.getSelectClause()) {
             assertTrue(assertContext.getText("Actual statement should exist."), actual.getStatement().isPresent());
             SQLStatementAssert.assertIs(assertContext, actual.getStatement().get(), expected.getSelectClause());
         } else if (null != expected.getUpdateClause()) {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
@@ -56,8 +56,8 @@ public final class ExplainStatementTestCase extends SQLParserTestCase {
     @XmlElement(name = "create-table")
     private CreateTableStatementTestCase createTableAsSelectClause;
     
-    @XmlElement(name = "table")
-    private ExpectedSimpleTable tableName;
+    @XmlElement(name = "simple-table")
+    private ExpectedSimpleTable table;
     
     @XmlElement(name = "column-wild")
     private ExpectedColumn column;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dal/ExplainStatementTestCase.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.DeleteStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.InsertStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.SelectStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.TableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.UpdateStatementTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -36,7 +37,10 @@ import javax.xml.bind.annotation.XmlElement;
 @Getter
 @Setter
 public final class ExplainStatementTestCase extends SQLParserTestCase {
-
+    
+    @XmlElement(name = "table")
+    private TableStatementTestCase tableClause;
+    
     @XmlElement(name = "select")
     private SelectStatementTestCase selectClause;
 

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
@@ -239,33 +239,33 @@
         </select>
     </describe>
     <describe sql-case-id="desc_table">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
     </describe>
     <describe sql-case-id="desc_table_with_col_name">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="colName" start-index="15" stop-index="21" />
     </describe>
     <describe sql-case-id="desc_table_with_placeholder">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="___" start-index="15" stop-index="17" />
     </describe>
     <describe sql-case-id="desc_table_with_wild">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="u%" start-delimiter="`" end-delimiter="`" start-index="15" stop-index="18" />
     </describe>
     <describe sql-case-id="describe_table">
-        <table name="tableName" start-index="9" stop-index="17" />
+        <simple-table name="tableName" start-index="9" stop-index="17" />
     </describe>
     <describe sql-case-id="describe_table_with_col_name">
-        <table name="tableName" start-index="9" stop-index="17" />
+        <simple-table name="tableName" start-index="9" stop-index="17" />
         <column-wild name="colName" start-index="19" stop-index="25" />
     </describe>
     <describe sql-case-id="describe_table_with_placeholder">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="___" start-index="15" stop-index="17" />
     </describe>
     <describe sql-case-id="describe_table_with_wild">
-        <table name="tableName" start-index="5" stop-index="13" />
+        <simple-table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="u%" start-delimiter="`" end-delimiter="`" start-index="15" stop-index="18" />
     </describe>
     <describe sql-case-id="explain_table">

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/explain.xml
@@ -268,4 +268,14 @@
         <table name="tableName" start-index="5" stop-index="13" />
         <column-wild name="u%" start-delimiter="`" end-delimiter="`" start-index="15" stop-index="18" />
     </describe>
+    <describe sql-case-id="explain_table">
+        <table>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
+            <column name="order_id" start-index="31" stop-index="38"/>
+            <limit literal-start-index="40" literal-stop-index="55">
+                <offset value="2" literal-start-index="55" literal-stop-index="55" />
+                <row-count value="1" literal-start-index="46" literal-stop-index="46" />
+            </limit>
+        </table>
+    </describe>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/explain.xml
@@ -27,6 +27,7 @@
     <sql-case id="explain_create_remote_table_as_select" value="EXPLAIN CREATE REMOTE TABLE t_order_new AT ('Data Source = ds_0, 3306; User ID = ROOT; Password = 123456;') AS SELECT i.* FROM t_order_item i JOIN t_order o ON i.order_id = o.order_id" db-types="SQLServer" />
     <sql-case id="explain_with_analyze" value="EXPLAIN ANALYZE SELECT * FROM t_order WHERE order_id > 8" db-types="MySQL" />
     <sql-case id="explain_with_analyze_format" value="EXPLAIN ANALYZE FORMAT = TREE SELECT * FROM t_order WHERE order_id > 8" db-types="MySQL" />
+    <sql-case id="explain_table" value="EXPLAIN TABLE t_order ORDER BY order_id LIMIT 1 OFFSET 2" db-types="MySQL" />
     <sql-case id="desc_table" value="DESC tableName" db-types="MySQL" />
     <sql-case id="desc_table_with_col_name" value="DESC tableName colName" db-types="MySQL" />
     <sql-case id="desc_table_with_placeholder" value="DESC tableName ___" db-types="MySQL" />


### PR DESCRIPTION
For #14110.

Changes proposed in this pull request:
- add MySQL parse support for `EXPLAIN TABLE Statement`
- add test case
