### PR TITLE
add SQLMatchTrafficAlgorithm for traffic

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/RoundRobinReplicaLoadBalanceAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/RoundRobinReplicaLoadBalanceAlgorithm.java
@@ -17,25 +17,18 @@
 
 package org.apache.shardingsphere.readwritesplitting.algorithm;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.shardingsphere.readwritesplitting.spi.ReplicaLoadBalanceAlgorithm;
 
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Round-robin replica load-balance algorithm.
  */
-@Getter
-@Setter
 public final class RoundRobinReplicaLoadBalanceAlgorithm implements ReplicaLoadBalanceAlgorithm {
     
     private static final ConcurrentHashMap<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
-    
-    private Properties props = new Properties();
     
     @Override
     public String getDataSource(final String name, final String writeDataSourceName, final List<String> readDataSourceNames) {

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
@@ -17,25 +17,18 @@
 
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm;
 
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Round-robin traffic load balance algorithm.
  */
-@Getter
-@Setter
 public final class RoundRobinTrafficLoadBalanceAlgorithm implements TrafficLoadBalanceAlgorithm {
     
     private static final ConcurrentHashMap<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
-    
-    private Properties props = new Properties();
     
     @Override
     public String getInstanceId(final String name, final List<String> instanceIds) {

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/traffic/segment/SQLMatchTrafficAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/traffic/segment/SQLMatchTrafficAlgorithm.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.traffic.algorithm.traffic.segment;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
+import org.apache.shardingsphere.traffic.api.traffic.segment.SegmentTrafficAlgorithm;
+import org.apache.shardingsphere.traffic.api.traffic.segment.SegmentTrafficValue;
+
+import java.util.Collection;
+import java.util.Properties;
+import java.util.TreeSet;
+
+/**
+ * SQL match traffic algorithm.
+ */
+@Getter
+@Setter
+public final class SQLMatchTrafficAlgorithm implements SegmentTrafficAlgorithm {
+    
+    private static final String SQL_PROPS_KEY = "sql";
+    
+    private static final String EXCLUDED_CHARACTERS = "[]`'\" ";
+    
+    private Properties props = new Properties();
+    
+    private Collection<String> sql;
+    
+    @Override
+    public void init() {
+        Preconditions.checkArgument(props.containsKey(SQL_PROPS_KEY), "%s cannot be null.", SQL_PROPS_KEY);
+        sql = getExactlySQL(props.getProperty(SQL_PROPS_KEY));
+    }
+    
+    private Collection<String> getExactlySQL(final String value) {
+        Collection<String> values = Splitter.on(";").trimResults().omitEmptyStrings().splitToList(value);
+        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        for (String each : values) {
+            result.add(CharMatcher.anyOf(EXCLUDED_CHARACTERS).removeFrom(each));
+        }
+        return result;
+    }
+    
+    @Override
+    public boolean match(final SegmentTrafficValue segmentTrafficValue) {
+        return sql.contains(SQLUtil.trimSemicolon(CharMatcher.anyOf(EXCLUDED_CHARACTERS).removeFrom(segmentTrafficValue.getSql())));
+    }
+    
+    @Override
+    public String getType() {
+        return "SQL_MATCH";
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/resources/META-INF/services/org.apache.shardingsphere.traffic.spi.TrafficAlgorithm
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/resources/META-INF/services/org.apache.shardingsphere.traffic.spi.TrafficAlgorithm
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.traffic.algorithm.traffic.hint.SQLHintTrafficAlgorithm
+org.apache.shardingsphere.traffic.algorithm.traffic.segment.SQLMatchTrafficAlgorithm

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/traffic/SQLHintTrafficAlgorithmTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/traffic/SQLHintTrafficAlgorithmTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.traffic.algorithm.traffic;
+
+import org.apache.shardingsphere.traffic.algorithm.traffic.hint.SQLHintTrafficAlgorithm;
+import org.apache.shardingsphere.traffic.api.traffic.hint.HintTrafficValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class SQLHintTrafficAlgorithmTest {
+    
+    private SQLHintTrafficAlgorithm sqlHintAlgorithm;
+    
+    @Before
+    public void setUp() {
+        sqlHintAlgorithm = new SQLHintTrafficAlgorithm();
+        sqlHintAlgorithm.getProps().put("foo", "bar");
+        sqlHintAlgorithm.getProps().put("test", "234");
+        sqlHintAlgorithm.init();
+    }
+    
+    @Test
+    public void assertMatchWhenSQLHintAllMatch() {
+        assertTrue(sqlHintAlgorithm.match(new HintTrafficValue<>("/* ShardingSphere hint: foo=bar , test=234 */")));
+    }
+    
+    @Test
+    public void assertMatchWhenSQLHintOneMatch() {
+        assertFalse(sqlHintAlgorithm.match(new HintTrafficValue<>("/* ShardingSphere hint: foo=bar */")));
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/traffic/SQLMatchTrafficAlgorithmTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/traffic/SQLMatchTrafficAlgorithmTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.traffic.algorithm.traffic;
+
+import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
+import org.apache.shardingsphere.traffic.algorithm.traffic.segment.SQLMatchTrafficAlgorithm;
+import org.apache.shardingsphere.traffic.api.traffic.segment.SegmentTrafficValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public final class SQLMatchTrafficAlgorithmTest {
+    
+    private SQLMatchTrafficAlgorithm sqlMatchAlgorithm;
+    
+    @Before
+    public void setUp() {
+        sqlMatchAlgorithm = new SQLMatchTrafficAlgorithm();
+        sqlMatchAlgorithm.getProps().put("sql", "SELECT * FROM t_order; UPDATE t_order SET order_id = ? WHERE user_id = ?;");
+        sqlMatchAlgorithm.init();
+    }
+    
+    @Test
+    public void assertMatchWhenExistSQLMatch() {
+        SQLStatement sqlStatement = mock(SelectStatement.class);
+        assertTrue(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "SELECT * FROM t_order")));
+        assertTrue(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "select *  from  t_order;")));
+        assertTrue(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "select *  from `t_order`;")));
+        assertTrue(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "UPDATE t_order SET order_id = ? WHERE user_id = ?;")));
+        assertTrue(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "UPDATE `t_order`  SET `order_id` = ? WHERE user_id = ?;")));
+    }
+    
+    @Test
+    public void assertMatchWhenNotExistSQLMatch() {
+        SQLStatement sqlStatement = mock(SelectStatement.class);
+        assertFalse(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "select *  from `t_order` where order_id = ?;")));
+        assertFalse(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "TRUNCATE TABLE `t_order` ")));
+        assertFalse(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "UPDATE `t_order` SET `order_id` = ?;")));
+        assertFalse(sqlMatchAlgorithm.match(new SegmentTrafficValue(sqlStatement, "UPDATE `t_order_item` SET `order_id` = ? WHERE user_id = ?;")));
+    }
+}


### PR DESCRIPTION
Ref #14282.

Changes proposed in this pull request:
- add SQLMatchTrafficAlgorithm for traffic
- remove useless props in RoundRobinReplicaLoadBalanceAlgorithm and RoundRobinTrafficLoadBalanceAlgorithm
- add unit test for SQLMatchTrafficAlgorithm and SQLHintTrafficAlgorithm
