### PR TITLE
For #14604：Fix "Data truncated for column" error occurs during the migration of the year type field 

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
@@ -37,6 +37,10 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class JDBCRowsLoader {
     
+    private static final String YEAR_DATA_TYPE = "YEAR";
+    
+    private static final String YEAR_DATA_TYPE_SHORT = "java.lang.Short";
+    
     /**
      * Load rows.
      * 
@@ -89,6 +93,10 @@ public final class JDBCRowsLoader {
             case Types.LONGVARCHAR:
                 return resultSet.getString(columnIndex);
             case Types.DATE:
+                if (isYearDataType(resultSet.getMetaData().getColumnTypeName(columnIndex))) {
+                    return isYearShortDataType(resultSet.getMetaData().getColumnClassName(columnIndex))
+                            ? getYearShortData(resultSet, columnIndex) : getYearDateData(resultSet, columnIndex);
+                }
                 return resultSet.getDate(columnIndex);
             case Types.TIME:
                 return resultSet.getTime(columnIndex);
@@ -107,5 +115,21 @@ public final class JDBCRowsLoader {
             default:
                 return resultSet.getObject(columnIndex);
         }
+    }
+    
+    private static boolean isYearDataType(final String columnDataTypeName) {
+        return YEAR_DATA_TYPE.equalsIgnoreCase(columnDataTypeName);
+    }
+    
+    private static boolean isYearShortDataType(final String columnClassName) {
+        return YEAR_DATA_TYPE_SHORT.equalsIgnoreCase(columnClassName);
+    }
+    
+    private static Object getYearDateData(final ResultSet resultSet, final int index) throws SQLException {
+        return resultSet.getObject(index) == null ? null : resultSet.getDate(index);
+    }
+    
+    private static Object getYearShortData(final ResultSet resultSet, final int index) throws SQLException {
+        return resultSet.getObject(index) == null ? null : resultSet.getShort(index);
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
@@ -39,8 +39,6 @@ public final class JDBCRowsLoader {
     
     private static final String YEAR_DATA_TYPE = "YEAR";
     
-    private static final String YEAR_DATA_TYPE_SHORT = Short.class.getName();
-    
     /**
      * Load rows.
      * 

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCRowsLoader.java
@@ -39,7 +39,7 @@ public final class JDBCRowsLoader {
     
     private static final String YEAR_DATA_TYPE = "YEAR";
     
-    private static final String YEAR_DATA_TYPE_SHORT = "java.lang.Short";
+    private static final String YEAR_DATA_TYPE_SHORT = Short.class.getName();
     
     /**
      * Load rows.
@@ -94,8 +94,8 @@ public final class JDBCRowsLoader {
                 return resultSet.getString(columnIndex);
             case Types.DATE:
                 if (isYearDataType(resultSet.getMetaData().getColumnTypeName(columnIndex))) {
-                    return isYearShortDataType(resultSet.getMetaData().getColumnClassName(columnIndex))
-                            ? getYearShortData(resultSet, columnIndex) : getYearDateData(resultSet, columnIndex);
+                    Object result = resultSet.getObject(columnIndex);
+                    return resultSet.wasNull() ? null : result;
                 }
                 return resultSet.getDate(columnIndex);
             case Types.TIME:
@@ -119,17 +119,5 @@ public final class JDBCRowsLoader {
     
     private static boolean isYearDataType(final String columnDataTypeName) {
         return YEAR_DATA_TYPE.equalsIgnoreCase(columnDataTypeName);
-    }
-    
-    private static boolean isYearShortDataType(final String columnClassName) {
-        return YEAR_DATA_TYPE_SHORT.equalsIgnoreCase(columnClassName);
-    }
-    
-    private static Object getYearDateData(final ResultSet resultSet, final int index) throws SQLException {
-        return resultSet.getObject(index) == null ? null : resultSet.getDate(index);
-    }
-    
-    private static Object getYearShortData(final ResultSet resultSet, final int index) throws SQLException {
-        return resultSet.getObject(index) == null ? null : resultSet.getShort(index);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.data.pipeline.spi.check.consistency.DataConsist
 import org.apache.shardingsphere.data.pipeline.spi.check.consistency.SingleTableDataCalculator;
 import org.apache.shardingsphere.data.pipeline.spi.ratelimit.JobRateLimitAlgorithm;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.executor.kernel.thread.ExecutorThreadFactoryBuilder;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
@@ -52,6 +53,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -136,6 +138,12 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
         PipelineDataSourceConfiguration targetDataSourceConfig = PipelineDataSourceConfigurationFactory.newInstance(
                 jobContext.getJobConfig().getPipelineConfig().getTarget().getType(), jobContext.getJobConfig().getPipelineConfig().getTarget().getParameter());
         checkDatabaseTypeSupportedOrNot(supportedDatabaseTypes, targetDataSourceConfig.getDatabaseType().getName());
+        if (sourceDataSourceConfig.getDatabaseType().getName().equalsIgnoreCase(new MySQLDatabaseType().getName())) {
+            Properties queryProps = new Properties();
+            queryProps.setProperty("yearIsDateType", Boolean.FALSE.toString());
+            sourceDataSourceConfig.appendJDBCQueryProperties(queryProps);
+            targetDataSourceConfig.appendJDBCQueryProperties(queryProps);
+        }
         Collection<String> logicTableNames = jobContext.getTaskConfigs().stream().flatMap(each -> each.getDumperConfig().getTableNameMap().values().stream()).distinct().collect(Collectors.toList());
         String sourceDatabaseType = sourceDataSourceConfig.getDatabaseType().getName();
         String targetDatabaseType = targetDataSourceConfig.getDatabaseType().getName();

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataConsistencyCheckerImpl.java
@@ -138,12 +138,7 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
         PipelineDataSourceConfiguration targetDataSourceConfig = PipelineDataSourceConfigurationFactory.newInstance(
                 jobContext.getJobConfig().getPipelineConfig().getTarget().getType(), jobContext.getJobConfig().getPipelineConfig().getTarget().getParameter());
         checkDatabaseTypeSupportedOrNot(supportedDatabaseTypes, targetDataSourceConfig.getDatabaseType().getName());
-        if (sourceDataSourceConfig.getDatabaseType().getName().equalsIgnoreCase(new MySQLDatabaseType().getName())) {
-            Properties queryProps = new Properties();
-            queryProps.setProperty("yearIsDateType", Boolean.FALSE.toString());
-            sourceDataSourceConfig.appendJDBCQueryProperties(queryProps);
-            targetDataSourceConfig.appendJDBCQueryProperties(queryProps);
-        }
+        addDataSourceConfigToMySQL(sourceDataSourceConfig, targetDataSourceConfig);
         Collection<String> logicTableNames = jobContext.getTaskConfigs().stream().flatMap(each -> each.getDumperConfig().getTableNameMap().values().stream()).distinct().collect(Collectors.toList());
         String sourceDatabaseType = sourceDataSourceConfig.getDatabaseType().getName();
         String targetDatabaseType = targetDataSourceConfig.getDatabaseType().getName();
@@ -208,5 +203,14 @@ public final class DataConsistencyCheckerImpl implements DataConsistencyChecker 
         Preconditions.checkNotNull(contextManager, "contextManager null");
         ShardingSphereMetaData metaData = contextManager.getMetaDataContexts().getMetaData(schemaName);
         return metaData.getSchema().getTables();
+    }
+    
+    private void addDataSourceConfigToMySQL(final PipelineDataSourceConfiguration sourceDataSourceConfig, final PipelineDataSourceConfiguration targetDataSourceConfig) {
+        if (sourceDataSourceConfig.getDatabaseType().getName().equalsIgnoreCase(new MySQLDatabaseType().getName())) {
+            Properties queryProps = new Properties();
+            queryProps.setProperty("yearIsDateType", Boolean.FALSE.toString());
+            sourceDataSourceConfig.appendJDBCQueryProperties(queryProps);
+            targetDataSourceConfig.appendJDBCQueryProperties(queryProps);
+        }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumper.java
@@ -45,7 +45,8 @@ public final class MySQLInventoryDumper extends AbstractInventoryDumper {
     @Override
     public Object readValue(final ResultSet resultSet, final int index) throws SQLException {
         if (isYearDataType(resultSet.getMetaData().getColumnTypeName(index))) {
-            return resultSet.getObject(index) == null ? null : resultSet.getShort(index);
+            Object result = resultSet.getObject(index);
+            return resultSet.wasNull() ? null : result;
         } else if (isDateTimeValue(resultSet.getMetaData().getColumnType(index))) {
             return resultSet.getString(index);
         } else {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumper.java
@@ -33,6 +33,8 @@ import java.util.Properties;
  */
 public final class MySQLInventoryDumper extends AbstractInventoryDumper {
     
+    private static final String YEAR_DATA_TYPE = "YEAR";
+    
     public MySQLInventoryDumper(final InventoryDumperConfiguration inventoryDumperConfig, final PipelineDataSourceManager dataSourceManager) {
         super(inventoryDumperConfig, dataSourceManager);
         Properties queryProps = new Properties();
@@ -42,7 +44,9 @@ public final class MySQLInventoryDumper extends AbstractInventoryDumper {
     
     @Override
     public Object readValue(final ResultSet resultSet, final int index) throws SQLException {
-        if (isDateTimeValue(resultSet.getMetaData().getColumnType(index))) {
+        if (isYearDataType(resultSet.getMetaData().getColumnTypeName(index))) {
+            return resultSet.getObject(index) == null ? null : resultSet.getShort(index);
+        } else if (isDateTimeValue(resultSet.getMetaData().getColumnType(index))) {
             return resultSet.getString(index);
         } else {
             return resultSet.getObject(index);
@@ -51,6 +55,10 @@ public final class MySQLInventoryDumper extends AbstractInventoryDumper {
     
     private boolean isDateTimeValue(final int columnType) {
         return Types.TIME == columnType || Types.DATE == columnType || Types.TIMESTAMP == columnType;
+    }
+    
+    private boolean isYearDataType(final String columnDataTypeName) {
+        return YEAR_DATA_TYPE.equalsIgnoreCase(columnDataTypeName);
     }
     
     @Override


### PR DESCRIPTION
=Fixes #14604.

Changes proposed in this pull request:
- Add MySQL year dataType type judgment for "DataConsistencyCheckerImpl" class
- Modify "JDBCRowsLoader" class to add year type to return short or date
- Modify the "MySQLInventoryDumper" class to add query year type to return short
