### PR TITLE
fix full data node route when use sharding condition that contains mysql binary keyword

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -34,45 +34,45 @@
 #      operationTimeoutMilliseconds: 500
 #  overwrite: false
 #
-#rules:
-#  - !AUTHORITY
-#    users:
-#      - root@%:root
-#      - sharding@:sharding
-#    provider:
-#      type: ALL_PRIVILEGES_PERMITTED
-#  - !TRANSACTION
-#    defaultType: XA
-#    providerType: Atomikos
-#  - !SQL_PARSER
-#    sqlCommentParseEnabled: true
-#    sqlStatementCache:
-#      initialCapacity: 2000
-#      maximumSize: 65535
-#      concurrencyLevel: 4
-#    parseTreeCache:
-#      initialCapacity: 128
-#      maximumSize: 1024
-#      concurrencyLevel: 4
+rules:
+- !AUTHORITY
+  users:
+    - root@%:root
+    - sharding@:sharding
+  provider:
+    type: ALL_PRIVILEGES_PERMITTED
+- !TRANSACTION
+  defaultType: XA
+  providerType: Atomikos
+- !SQL_PARSER
+  sqlCommentParseEnabled: true
+  sqlStatementCache:
+    initialCapacity: 2000
+    maximumSize: 65535
+    concurrencyLevel: 4
+  parseTreeCache:
+    initialCapacity: 128
+    maximumSize: 1024
+    concurrencyLevel: 4
 
-#props:
-#  max-connections-size-per-query: 1
-#  kernel-executor-size: 16  # Infinite by default.
-#  proxy-frontend-flush-threshold: 128  # The default value is 128.
-#  proxy-opentracing-enabled: false
-#  proxy-hint-enabled: false
-#  sql-show: false
-#  check-table-metadata-enabled: false
-#  show-process-list-enabled: false
-#    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
-#    # The default value is -1, which means set the minimum value for different JDBC drivers.
-#  proxy-backend-query-fetch-size: -1
-#  check-duplicate-table-enabled: false
-#  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
-#    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
-#    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
-#  proxy-backend-executor-suitable: OLAP
-#  proxy-frontend-max-connections: 0 # Less than or equal to 0 means no limitation.
-#  sql-federation-enabled: false
-#    # Available proxy backend driver type: JDBC (default), ExperimentalVertx
-#  proxy-backend-driver-type: JDBC
+props:
+  max-connections-size-per-query: 1
+  kernel-executor-size: 16  # Infinite by default.
+  proxy-frontend-flush-threshold: 128  # The default value is 128.
+  proxy-opentracing-enabled: false
+  proxy-hint-enabled: false
+  sql-show: true
+  check-table-metadata-enabled: false
+  show-process-list-enabled: false
+    # Proxy backend query fetch size. A larger value may increase the memory usage of ShardingSphere Proxy.
+    # The default value is -1, which means set the minimum value for different JDBC drivers.
+  proxy-backend-query-fetch-size: -1
+  check-duplicate-table-enabled: false
+  proxy-frontend-executor-size: 0 # Proxy frontend executor size. The default value is 0, which means let Netty decide.
+    # Available options of proxy backend executor suitable: OLAP(default), OLTP. The OLTP option may reduce time cost of writing packets to client, but it may increase the latency of SQL execution
+    # if client connections are more than proxy-frontend-netty-executor-size, especially executing slow SQL.
+  proxy-backend-executor-suitable: OLAP
+  proxy-frontend-max-connections: 0 # Less than or equal to 0 means no limitation.
+  sql-federation-enabled: true
+    # Available proxy backend driver type: JDBC (default), ExperimentalVertx
+  proxy-backend-driver-type: JDBC

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -905,6 +905,9 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
             String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
             return new CommonExpressionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), text);
         }
+        if (null != ctx.BINARY()) {
+            return visit(ctx.simpleExpr(0));
+        }
         for (ExprContext each : ctx.expr()) {
             visit(each);
         }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-expression.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-expression.xml
@@ -1468,7 +1468,34 @@
         </projections>
         <where start-index="22" stop-index="50">
             <expr>
-                <common-expression text="BINARY t_order.order_id" start-index="28" stop-index="50"/>
+                <column name="order_id" start-index="35" stop-index="50">
+                    <owner name="t_order" start-index="35" stop-index="41" />
+                </column>
+            </expr>
+        </where>
+    </select>
+
+    <select sql-case-id="select_where_with_simple_expr_with_binary_value" parameters="1">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="54">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="54">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="43">
+                            <owner name="t_order" start-index="28" stop-index="34" />
+                        </column>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <parameter-marker-expression value="0" start-index="54" stop-index="54" />
+                        <literal-expression value="1" start-index="54" stop-index="54" />
+                    </right>
+                </binary-operation-expression>
             </expr>
         </where>
     </select>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select.xml
@@ -3940,4 +3940,12 @@
             </expr>
         </where>
     </select>
+
+    <select sql-case-id="select_with_binary_keyword" >
+        <projections start-index="7" stop-index="70">
+            <!-- TODO parse position function in projection -->
+            <expression-projection text="position(binary 'll' in 'hello')" start-index="7" stop-index="38" />
+            <expression-projection text="position('a' in binary 'hello')" start-index="40" stop-index="70" />
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-expression.xml
@@ -68,6 +68,7 @@
     <sql-case id="select_where_with_simple_expr_with_tilde" value="SELECT * FROM t_order WHERE ~t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_not" value="SELECT * FROM t_order WHERE !t_order.order_id" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_binary" value="SELECT * FROM t_order WHERE BINARY t_order.order_id" db-types="MySQL"/>
+    <sql-case id="select_where_with_simple_expr_with_binary_value" value="SELECT * FROM t_order WHERE t_order.order_id = BINARY ?" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_row" value="SELECT * FROM t_order WHERE ROW(?, now()) = (order_id, status)" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_subquery" value="SELECT * FROM t_order WHERE (SELECT order_id FROM t_order_item WHERE status &gt; ?)" db-types="MySQL"/>
     <sql-case id="select_where_with_simple_expr_with_exists_subquery" value="SELECT * FROM t_order WHERE EXISTS (SELECT order_id FROM t_order_item WHERE status &gt; ? )" db-types="MySQL"/>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select.xml
@@ -112,4 +112,5 @@
     <sql-case id="select_with_comments" value="-- begin comments&#x000A;SELECT * FROM # middle comments&#x000A; t_order; -- end comments" db-types="MySQL"/>
     <sql-case id="select_with_model_in" value="SELECT order_id_value,order_item_id_value FROM (select 1001 as order_id_value, 100001 as order_item_id_value from dual) MODEL RETURN UPDATED ROWS DIMENSION BY(order_item_id_value) MEASURES(order_id_value) RULES(order_id_value[1] = 10001)" db-types="Oracle" />
     <sql-case id="select_with_dollar_parameter_for_postgresql" value="SELECT order_id FROM t_order WHERE user_id = $2 AND order_id = $1 OR user_id = $2" db-types="PostgreSQL,openGauss" />
+    <sql-case id="select_with_binary_keyword" value="select position(binary 'll' in 'hello'),position('a' in binary 'hello')" db-types="MySQL" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -2560,7 +2560,6 @@
     <sql-case id="select_by_mysql_source_test_case1076" value="select mysqltest_db.f_does_not_exist()" db-types="MySQL"/>
     <sql-case id="select_by_mysql_source_test_case1077" value="select position(&quot;0&quot; in &quot;baaa&quot; in (1)),position(&quot;0&quot; in &quot;1&quot; in (1,2,3)),position(&quot;sql&quot; in (&quot;mysql&quot;))" db-types="MySQL"/>
     <sql-case id="select_by_mysql_source_test_case1078" value="select position((&quot;1&quot; in (1,2,3)) in &quot;01&quot;)" db-types="MySQL"/>
-    <sql-case id="select_by_mysql_source_test_case1079" value="select position(binary &apos;ll&apos; in &apos;hello&apos;),position(&apos;a&apos; in binary &apos;hello&apos;)" db-types="MySQL"/>
     <sql-case id="select_by_mysql_source_test_case1080" value="select repeat(&quot;a&quot;,0),repeat(&quot;ab&quot;,5+5),repeat(&quot;ab&quot;,-1),reverse(NULL)" db-types="MySQL"/>
     <sql-case id="select_by_mysql_source_test_case1081" value="select repeat(&apos;a&apos;, cast(2 as unsigned int))" db-types="MySQL"/>
     <sql-case id="select_by_mysql_source_test_case1082" value="select repeat(&apos;a&apos;,2000)" db-types="MySQL"/>

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/select.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/sharding/case/select.xml
@@ -552,4 +552,24 @@
         <output sql="SELECT * FROM ( SELECT TMP.*, ROWNUM ROW_ID FROM ( SELECT  account_id  FROM t_account_0 ) TMP WHERE ROWNUM &lt;=?) WHERE ROW_ID &gt; ?" parameters="10,0" />
         <output sql="SELECT * FROM ( SELECT TMP.*, ROWNUM ROW_ID FROM ( SELECT  account_id  FROM t_account_1 ) TMP WHERE ROWNUM &lt;=?) WHERE ROW_ID &gt; ?" parameters="10,0" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_with_sharding_value_and_binary_column_for_parameters" db-types="MySQL">
+        <input sql="SELECT * FROM t_account WHERE BINARY account_id = ?" parameters="100" />
+        <output sql="SELECT * FROM t_account_0 WHERE BINARY account_id = ?" parameters="100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_with_sharding_value_and_binary_column_for_literals" db-types="MySQL">
+        <input sql="SELECT * FROM t_account WHERE BINARY account_id = 100" />
+        <output sql="SELECT * FROM t_account_0 WHERE BINARY account_id = 100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_with_sharding_value_and_binary_value_for_parameters" db-types="MySQL">
+        <input sql="SELECT * FROM t_account WHERE account_id = BINARY ?" parameters="100" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id = BINARY ?" parameters="100" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_with_sharding_value_and_binary_value_for_literals" db-types="MySQL">
+        <input sql="SELECT * FROM t_account WHERE account_id = BINARY 100" />
+        <output sql="SELECT * FROM t_account_0 WHERE account_id = BINARY 100" />
+    </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #14694.

Changes proposed in this pull request:
- fix full data node route when use sharding condition that contains mysql binary keyword
- add sql parse test case
- add sql rewrite test case
