### PR TITLE
For #14641：Fix "show scaling status jobId" might respond "Malformed packet"

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
@@ -56,6 +56,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
                         list.add("");
                         list.add("");
                         list.add("");
+                        list.add("");
                     }
                     return list;
                 }).collect(Collectors.toList()).iterator();


### PR DESCRIPTION
Fixes #14641.

Changes proposed in this pull request:
- Add list.add() when entry.value() is empty for ShowScalingJobStatusQueryResultSet class
-
-
