### PR TITLE
Separate RuleAlteredJobAPI from PipelineJobAPI; Simplify SPI loading

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ApplyScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ApplyScalingUpdater.java
@@ -28,7 +28,7 @@ public final class ApplyScalingUpdater implements RALUpdater<ApplyScalingStateme
     
     @Override
     public void executeUpdate(final ApplyScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().switchClusterConfiguration(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().switchClusterConfiguration(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/CheckScalingQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/CheckScalingQueryResultSet.java
@@ -43,9 +43,9 @@ public final class CheckScalingQueryResultSet implements DistSQLResultSet {
         CheckScalingStatement checkScalingStatement = (CheckScalingStatement) sqlStatement;
         Map<String, DataConsistencyCheckResult> checkResultMap;
         if (null == checkScalingStatement.getTypeStrategy()) {
-            checkResultMap = PipelineJobAPIFactory.getPipelineJobAPI().dataConsistencyCheck(checkScalingStatement.getJobId());
+            checkResultMap = PipelineJobAPIFactory.getRuleAlteredJobAPI().dataConsistencyCheck(checkScalingStatement.getJobId());
         } else {
-            checkResultMap = PipelineJobAPIFactory.getPipelineJobAPI().dataConsistencyCheck(checkScalingStatement.getJobId(), checkScalingStatement.getTypeStrategy().getName());
+            checkResultMap = PipelineJobAPIFactory.getRuleAlteredJobAPI().dataConsistencyCheck(checkScalingStatement.getJobId(), checkScalingStatement.getTypeStrategy().getName());
         }
         data = checkResultMap.entrySet().stream()
                 .map(each -> {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropScalingUpdater.java
@@ -28,7 +28,7 @@ public final class DropScalingUpdater implements RALUpdater<DropScalingStatement
     
     @Override
     public void executeUpdate(final DropScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().remove(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().remove(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ResetScalingUpdater.java
@@ -28,7 +28,7 @@ public final class ResetScalingUpdater implements RALUpdater<ResetScalingStateme
     
     @Override
     public void executeUpdate(final ResetScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().reset(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().reset(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingCheckAlgorithmsQueryResultSet.java
@@ -39,7 +39,7 @@ public final class ShowScalingCheckAlgorithmsQueryResultSet implements DistSQLRe
     
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
-        data = PipelineJobAPIFactory.getPipelineJobAPI().listDataConsistencyCheckAlgorithms().stream()
+        data = PipelineJobAPIFactory.getRuleAlteredJobAPI().listDataConsistencyCheckAlgorithms().stream()
                 .map(each -> {
                     Collection<Object> list = new LinkedList<>();
                     list.add(each.getType());

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingJobStatusQueryResultSet.java
@@ -40,7 +40,7 @@ public final class ShowScalingJobStatusQueryResultSet implements DistSQLResultSe
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
         long currentTimeMillis = System.currentTimeMillis();
-        data = PipelineJobAPIFactory.getPipelineJobAPI().getProgress(((ShowScalingStatusStatement) sqlStatement).getJobId()).entrySet().stream()
+        data = PipelineJobAPIFactory.getRuleAlteredJobAPI().getProgress(((ShowScalingStatusStatement) sqlStatement).getJobId()).entrySet().stream()
                 .map(entry -> {
                     Collection<Object> list = new LinkedList<>();
                     list.add(entry.getKey());

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/ShowScalingListQueryResultSet.java
@@ -38,7 +38,7 @@ public final class ShowScalingListQueryResultSet implements DistSQLResultSet {
     
     @Override
     public void init(final ShardingSphereMetaData metaData, final SQLStatement sqlStatement) {
-        data = PipelineJobAPIFactory.getPipelineJobAPI().list().stream()
+        data = PipelineJobAPIFactory.getRuleAlteredJobAPI().list().stream()
                 .map(each -> {
                     Collection<Object> list = new LinkedList<>();
                     list.add(each.getJobId());

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
@@ -28,7 +28,7 @@ public final class StartScalingUpdater implements RALUpdater<StartScalingStateme
     
     @Override
     public void executeUpdate(final StartScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().startDisabledJob(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().startDisabledJob(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StartScalingUpdater.java
@@ -28,7 +28,7 @@ public final class StartScalingUpdater implements RALUpdater<StartScalingStateme
     
     @Override
     public void executeUpdate(final StartScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().start(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getPipelineJobAPI().startDisabledJob(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingSourceWritingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingSourceWritingUpdater.java
@@ -28,7 +28,7 @@ public final class StopScalingSourceWritingUpdater implements RALUpdater<StopSca
     
     @Override
     public void executeUpdate(final StopScalingSourceWritingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().stopClusterWriteDB(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().stopClusterWriteDB(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/StopScalingUpdater.java
@@ -28,7 +28,7 @@ public final class StopScalingUpdater implements RALUpdater<StopScalingStatement
     
     @Override
     public void executeUpdate(final StopScalingStatement sqlStatement) {
-        PipelineJobAPIFactory.getPipelineJobAPI().stop(sqlStatement.getJobId());
+        PipelineJobAPIFactory.getRuleAlteredJobAPI().stop(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.api.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.api.PipelineJobAPI;
+import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
+import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobNotFoundException;
+import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+public abstract class AbstractPipelineJobAPIImpl implements PipelineJobAPI {
+    
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    
+    @Override
+    public void startDisabledJob(final String jobId) {
+        log.info("Start disabled pipeline job {}", jobId);
+        JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
+        jobConfigPOJO.setDisabled(false);
+        jobConfigPOJO.getProps().remove("stop_time");
+        PipelineAPIFactory.getJobConfigurationAPI().updateJobConfiguration(jobConfigPOJO);
+    }
+    
+    @Override
+    public void stop(final String jobId) {
+        log.info("Stop pipeline job {}", jobId);
+        JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
+        jobConfigPOJO.setDisabled(true);
+        jobConfigPOJO.getProps().setProperty("stop_time", LocalDateTime.now().format(DATE_TIME_FORMATTER));
+        PipelineAPIFactory.getJobConfigurationAPI().updateJobConfiguration(jobConfigPOJO);
+    }
+    
+    @Override
+    public void remove(final String jobId) {
+        log.info("Remove pipeline job {}", jobId);
+        PipelineAPIFactory.getJobOperateAPI().remove(String.valueOf(jobId), null);
+        PipelineAPIFactory.getGovernanceRepositoryAPI().deleteJob(jobId);
+    }
+    
+    private JobConfigurationPOJO getElasticJobConfigPOJO(final String jobId) {
+        try {
+            return PipelineAPIFactory.getJobConfigurationAPI().getJobConfiguration(jobId);
+        } catch (final NullPointerException ex) {
+            throw new PipelineJobNotFoundException(String.format("Can not find pipeline job %s", jobId), jobId);
+        }
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
@@ -135,8 +135,8 @@ public final class PipelineJobAPIImpl implements PipelineJobAPI {
     }
     
     @Override
-    public void start(final String jobId) {
-        log.info("Start scaling job {}", jobId);
+    public void startDisabledJob(final String jobId) {
+        log.info("Start disabled job {}", jobId);
         JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
         jobConfigPOJO.setDisabled(false);
         jobConfigPOJO.getProps().remove("stop_time");

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineJobAPIImpl.java
@@ -51,7 +51,7 @@ import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
 import org.apache.shardingsphere.scaling.core.job.environment.ScalingEnvironmentManager;
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.spi.singleton.SingletonSPIRegistry;
 
 import java.sql.SQLException;
 import java.time.LocalDateTime;
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -74,9 +75,8 @@ public final class PipelineJobAPIImpl implements PipelineJobAPI {
     
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     
-    static {
-        ShardingSphereServiceLoader.register(DataConsistencyCheckAlgorithm.class);
-    }
+    private static final Map<String, DataConsistencyCheckAlgorithm> DATA_CONSISTENCY_CHECK_ALGORITHM_MAP = new TreeMap<>(
+            SingletonSPIRegistry.getTypedSingletonInstancesMap(DataConsistencyCheckAlgorithm.class));
     
     @Override
     public boolean isDefault() {
@@ -202,7 +202,7 @@ public final class PipelineJobAPIImpl implements PipelineJobAPI {
     
     @Override
     public Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms() {
-        return ShardingSphereServiceLoader.getSingletonServiceInstances(DataConsistencyCheckAlgorithm.class)
+        return DATA_CONSISTENCY_CHECK_ALGORITHM_MAP.values()
                 .stream().map(each -> {
                     DataConsistencyCheckAlgorithmInfo algorithmInfo = new DataConsistencyCheckAlgorithmInfo();
                     algorithmInfo.setType(each.getType());

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -158,6 +158,18 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     }
     
     @Override
+    public Map<Integer, JobProgress> getProgress(final String jobId) {
+        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed().collect(LinkedHashMap::new, (map, each) -> {
+            JobProgress jobProgress = PipelineAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each);
+            JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
+            if (null != jobProgress) {
+                jobProgress.setActive(!jobConfigPOJO.isDisabled());
+            }
+            map.put(each, jobProgress);
+        }, LinkedHashMap::putAll);
+    }
+    
+    @Override
     public void stopClusterWriteDB(final String jobId) {
         //TODO stopClusterWriteDB
     }
@@ -273,18 +285,6 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
         } catch (final SQLException ex) {
             throw new PipelineJobExecutionException("Reset target table failed for job " + jobId);
         }
-    }
-    
-    @Override
-    public Map<Integer, JobProgress> getProgress(final String jobId) {
-        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed().collect(LinkedHashMap::new, (map, each) -> {
-            JobProgress jobProgress = PipelineAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each);
-            JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
-            if (null != jobProgress) {
-                jobProgress.setActive(!jobConfigPOJO.isDisabled());
-            }
-            map.put(each, jobProgress);
-        }, LinkedHashMap::putAll);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJob.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJob.java
@@ -38,11 +38,11 @@ import java.util.Map;
 @Slf4j
 public final class FinishedCheckJob implements SimpleJob {
     
-    private static final RuleAlteredJobAPI RULE_ALTERED_JOB_API = PipelineJobAPIFactory.getRuleAlteredJobAPI();
+    private final RuleAlteredJobAPI ruleAlteredJobAPI = PipelineJobAPIFactory.getRuleAlteredJobAPI();
     
     @Override
     public void execute(final ShardingContext shardingContext) {
-        List<JobInfo> jobInfos = RULE_ALTERED_JOB_API.list();
+        List<JobInfo> jobInfos = ruleAlteredJobAPI.list();
         for (JobInfo jobInfo : jobInfos) {
             if (!jobInfo.isActive()) {
                 continue;
@@ -56,7 +56,7 @@ public final class FinishedCheckJob implements SimpleJob {
                     log.info("completionDetector not configured, auto switch will not be enabled. You could query job progress and switch config manually with DistSQL.");
                     continue;
                 }
-                RuleAlteredJobAlmostCompletedParameter parameter = new RuleAlteredJobAlmostCompletedParameter(jobInfo.getShardingTotalCount(), RULE_ALTERED_JOB_API.getProgress(jobId).values());
+                RuleAlteredJobAlmostCompletedParameter parameter = new RuleAlteredJobAlmostCompletedParameter(jobInfo.getShardingTotalCount(), ruleAlteredJobAPI.getProgress(jobId).values());
                 if (!ruleAlteredContext.getCompletionDetectAlgorithm().isAlmostCompleted(parameter)) {
                     continue;
                 }
@@ -67,9 +67,9 @@ public final class FinishedCheckJob implements SimpleJob {
                     if (null != sourceWritingStopAlgorithm) {
                         sourceWritingStopAlgorithm.lock(schemaName, jobId + "");
                     }
-                    if (!RULE_ALTERED_JOB_API.isDataConsistencyCheckNeeded(jobId)) {
+                    if (!ruleAlteredJobAPI.isDataConsistencyCheckNeeded(jobId)) {
                         log.info("dataConsistencyCheckAlgorithm is not configured, data consistency check is ignored.");
-                        RULE_ALTERED_JOB_API.switchClusterConfiguration(jobId);
+                        ruleAlteredJobAPI.switchClusterConfiguration(jobId);
                         continue;
                     }
                     if (!dataConsistencyCheck(jobId)) {
@@ -93,8 +93,8 @@ public final class FinishedCheckJob implements SimpleJob {
     }
     
     private boolean dataConsistencyCheck(final String jobId) {
-        Map<String, DataConsistencyCheckResult> checkResultMap = RULE_ALTERED_JOB_API.dataConsistencyCheck(jobId);
-        return RULE_ALTERED_JOB_API.aggregateDataConsistencyCheckResults(jobId, checkResultMap);
+        Map<String, DataConsistencyCheckResult> checkResultMap = ruleAlteredJobAPI.dataConsistencyCheck(jobId);
+        return ruleAlteredJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap);
     }
     
     private void switchClusterConfiguration(final String schemaName, final String jobId, final RuleBasedJobLockAlgorithm checkoutLockAlgorithm) {
@@ -102,7 +102,7 @@ public final class FinishedCheckJob implements SimpleJob {
             if (null != checkoutLockAlgorithm) {
                 checkoutLockAlgorithm.lock(schemaName, jobId + "");
             }
-            RULE_ALTERED_JOB_API.switchClusterConfiguration(jobId);
+            ruleAlteredJobAPI.switchClusterConfiguration(jobId);
         } finally {
             if (null != checkoutLockAlgorithm) {
                 checkoutLockAlgorithm.releaseLock(schemaName, jobId + "");

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
@@ -165,7 +165,7 @@ public final class RuleAlteredJobWorker {
     public void start(final StartScalingEvent event) {
         log.info("Start scaling job by {}", event);
         Optional<JobConfiguration> jobConfigOptional = createJobConfig(event);
-        Optional<String> jobId = jobConfigOptional.isPresent() ? PipelineJobAPIFactory.getPipelineJobAPI().start(jobConfigOptional.get()) : Optional.empty();
+        Optional<String> jobId = jobConfigOptional.isPresent() ? PipelineJobAPIFactory.getRuleAlteredJobAPI().start(jobConfigOptional.get()) : Optional.empty();
         if (!jobId.isPresent()) {
             log.info("Switch rule configuration immediately.");
             YamlRootConfiguration targetRootConfig = getYamlRootConfiguration(event.getSchemaName(), event.getTargetDataSource(), event.getTargetRule());

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.api.RuleAlteredJobAPI
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.api.RuleAlteredJobAPI
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.data.pipeline.core.api.impl.PipelineJobAPIImpl
+org.apache.shardingsphere.data.pipeline.core.api.impl.RuleAlteredJobAPIImpl

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
@@ -55,7 +55,7 @@ public interface PipelineJobAPI extends RequiredSPI {
      *
      * @param jobId job id
      */
-    void start(String jobId);
+    void startDisabledJob(String jobId);
     
     /**
      * Start scaling job by config.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
@@ -17,144 +17,29 @@
 
 package org.apache.shardingsphere.data.pipeline.api;
 
-import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
-import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.JobConfiguration;
-import org.apache.shardingsphere.data.pipeline.api.job.progress.JobProgress;
-import org.apache.shardingsphere.data.pipeline.api.pojo.DataConsistencyCheckAlgorithmInfo;
-import org.apache.shardingsphere.data.pipeline.api.pojo.JobInfo;
-import org.apache.shardingsphere.spi.required.RequiredSPI;
-import org.apache.shardingsphere.spi.singleton.SingletonSPI;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
 /**
  * Pipeline job API.
  */
-// TODO separate dedicated methods for rule altered job
-public interface PipelineJobAPI extends RequiredSPI, SingletonSPI {
+public interface PipelineJobAPI {
     
     /**
-     * List all jobs.
-     *
-     * @return job infos
-     */
-    List<JobInfo> list();
-    
-    /**
-     * Get uncompleted job ids of schema.
-     *
-     * @param schemaName schema name
-     * @return uncompleted job ids
-     */
-    List<Long> getUncompletedJobIds(String schemaName);
-    
-    /**
-     * Start scaling job by id.
+     * Start pipeline job by id.
      *
      * @param jobId job id
      */
     void startDisabledJob(String jobId);
     
     /**
-     * Start scaling job by config.
-     *
-     * @param jobConfig job config
-     * @return job id
-     */
-    Optional<String> start(JobConfiguration jobConfig);
-    
-    /**
-     * Stop scaling job.
+     * Stop pipeline job.
      *
      * @param jobId job id
      */
     void stop(String jobId);
     
     /**
-     * Remove scaling job.
+     * Remove pipeline job.
      *
      * @param jobId job id
      */
     void remove(String jobId);
-    
-    /**
-     * Get job progress.
-     *
-     * @param jobId job id
-     * @return each sharding item progress
-     */
-    Map<Integer, JobProgress> getProgress(String jobId);
-    
-    /**
-     * Stop cluster write to job source schema's underlying DB.
-     *
-     * @param jobId job id
-     */
-    void stopClusterWriteDB(String jobId);
-    
-    /**
-     * List all data consistency check algorithms from SPI.
-     *
-     * @return data consistency check algorithms
-     */
-    Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms();
-    
-    /**
-     * Is data consistency check needed.
-     *
-     * @param jobId job id
-     * @return data consistency check needed or not
-     */
-    boolean isDataConsistencyCheckNeeded(String jobId);
-    
-    /**
-     * Do data consistency check.
-     *
-     * @param jobId job id
-     * @return each logic table check result
-     */
-    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(String jobId);
-    
-    /**
-     * Do data consistency check.
-     *
-     * @param jobId job id
-     * @param algorithmType algorithm type
-     * @return each logic table check result
-     */
-    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(String jobId, String algorithmType);
-    
-    /**
-     * Aggregate data consistency check results.
-     *
-     * @param jobId job id
-     * @param checkResultMap check result map
-     * @return check success or not
-     */
-    boolean aggregateDataConsistencyCheckResults(String jobId, Map<String, DataConsistencyCheckResult> checkResultMap);
-    
-    /**
-     * Switch job source schema's configuration to job target configuration.
-     *
-     * @param jobId job id
-     */
-    void switchClusterConfiguration(String jobId);
-    
-    /**
-     * Reset scaling job.
-     *
-     * @param jobId job id
-     */
-    void reset(String jobId);
-    
-    /**
-     * Get job configuration.
-     *
-     * @param jobId job id
-     * @return job configuration
-     */
-    JobConfiguration getJobConfig(String jobId);
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPI.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.data.pipeline.api.job.progress.JobProgress;
 import org.apache.shardingsphere.data.pipeline.api.pojo.DataConsistencyCheckAlgorithmInfo;
 import org.apache.shardingsphere.data.pipeline.api.pojo.JobInfo;
 import org.apache.shardingsphere.spi.required.RequiredSPI;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,7 +34,7 @@ import java.util.Optional;
  * Pipeline job API.
  */
 // TODO separate dedicated methods for rule altered job
-public interface PipelineJobAPI extends RequiredSPI {
+public interface PipelineJobAPI extends RequiredSPI, SingletonSPI {
     
     /**
      * List all jobs.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
@@ -17,19 +17,14 @@
 
 package org.apache.shardingsphere.data.pipeline.api;
 
-import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
-import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
-
-import java.util.Collection;
+import org.apache.shardingsphere.spi.required.RequiredSPIRegistry;
 
 /**
  * Pipeline job API factory.
  */
 public final class PipelineJobAPIFactory {
     
-    static {
-        ShardingSphereServiceLoader.register(PipelineJobAPI.class);
-    }
+    private static final PipelineJobAPI PIPELINE_JOB_API = RequiredSPIRegistry.getRegisteredService(PipelineJobAPI.class);
     
     /**
      * Get {@linkplain PipelineJobAPI}.
@@ -37,11 +32,7 @@ public final class PipelineJobAPIFactory {
      * @return pipeline job API
      */
     public static PipelineJobAPI getPipelineJobAPI() {
-        Collection<PipelineJobAPI> instances = ShardingSphereServiceLoader.getSingletonServiceInstances(PipelineJobAPI.class);
-        if (instances.isEmpty()) {
-            throw new ServiceProviderNotFoundException(PipelineJobAPI.class);
-        }
         // TODO checkServerConfig()
-        return instances.iterator().next();
+        return PIPELINE_JOB_API;
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
@@ -24,15 +24,15 @@ import org.apache.shardingsphere.spi.required.RequiredSPIRegistry;
  */
 public final class PipelineJobAPIFactory {
     
-    private static final PipelineJobAPI PIPELINE_JOB_API = RequiredSPIRegistry.getRegisteredService(PipelineJobAPI.class);
+    private static final RuleAlteredJobAPI RULE_ALTERED_JOB_API = RequiredSPIRegistry.getRegisteredService(RuleAlteredJobAPI.class);
     
     /**
-     * Get {@linkplain PipelineJobAPI}.
+     * Get {@linkplain RuleAlteredJobAPI}.
      *
      * @return pipeline job API
      */
-    public static PipelineJobAPI getPipelineJobAPI() {
+    public static RuleAlteredJobAPI getRuleAlteredJobAPI() {
         // TODO checkServerConfig()
-        return PIPELINE_JOB_API;
+        return RULE_ALTERED_JOB_API;
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
@@ -59,6 +59,14 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
     Optional<String> start(JobConfiguration jobConfig);
     
     /**
+     * Get job progress.
+     *
+     * @param jobId job id
+     * @return each sharding item progress
+     */
+    Map<Integer, JobProgress> getProgress(String jobId);
+    
+    /**
      * Stop cluster write to job source schema's underlying DB.
      *
      * @param jobId job id
@@ -119,14 +127,6 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
      * @param jobId job id
      */
     void reset(String jobId);
-    
-    /**
-     * Get job progress.
-     *
-     * @param jobId job id
-     * @return each sharding item progress
-     */
-    Map<Integer, JobProgress> getProgress(String jobId);
     
     /**
      * Get job configuration.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.api;
+
+import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
+import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.JobConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.job.progress.JobProgress;
+import org.apache.shardingsphere.data.pipeline.api.pojo.DataConsistencyCheckAlgorithmInfo;
+import org.apache.shardingsphere.data.pipeline.api.pojo.JobInfo;
+import org.apache.shardingsphere.spi.required.RequiredSPI;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Rule altered job API.
+ */
+public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, SingletonSPI {
+    
+    /**
+     * List all jobs.
+     *
+     * @return job infos
+     */
+    List<JobInfo> list();
+    
+    /**
+     * Get uncompleted job ids of schema.
+     *
+     * @param schemaName schema name
+     * @return uncompleted job ids
+     */
+    List<Long> getUncompletedJobIds(String schemaName);
+    
+    /**
+     * Start scaling job by config.
+     *
+     * @param jobConfig job config
+     * @return job id
+     */
+    Optional<String> start(JobConfiguration jobConfig);
+    
+    /**
+     * Stop cluster write to job source schema's underlying DB.
+     *
+     * @param jobId job id
+     */
+    void stopClusterWriteDB(String jobId);
+    
+    /**
+     * List all data consistency check algorithms from SPI.
+     *
+     * @return data consistency check algorithms
+     */
+    Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms();
+    
+    /**
+     * Is data consistency check needed.
+     *
+     * @param jobId job id
+     * @return data consistency check needed or not
+     */
+    boolean isDataConsistencyCheckNeeded(String jobId);
+    
+    /**
+     * Do data consistency check.
+     *
+     * @param jobId job id
+     * @return each logic table check result
+     */
+    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(String jobId);
+    
+    /**
+     * Do data consistency check.
+     *
+     * @param jobId job id
+     * @param algorithmType algorithm type
+     * @return each logic table check result
+     */
+    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(String jobId, String algorithmType);
+    
+    /**
+     * Aggregate data consistency check results.
+     *
+     * @param jobId job id
+     * @param checkResultMap check result map
+     * @return check success or not
+     */
+    boolean aggregateDataConsistencyCheckResults(String jobId, Map<String, DataConsistencyCheckResult> checkResultMap);
+    
+    /**
+     * Switch job source schema's configuration to job target configuration.
+     *
+     * @param jobId job id
+     */
+    void switchClusterConfiguration(String jobId);
+    
+    /**
+     * Reset scaling job.
+     *
+     * @param jobId job id
+     */
+    void reset(String jobId);
+    
+    /**
+     * Get job progress.
+     *
+     * @param jobId job id
+     * @return each sharding item progress
+     */
+    Map<Integer, JobProgress> getProgress(String jobId);
+    
+    /**
+     * Get job configuration.
+     *
+     * @param jobId job id
+     * @return job configuration
+     */
+    JobConfiguration getJobConfig(String jobId);
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/check/consistency/DataConsistencyCheckAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/spi/check/consistency/DataConsistencyCheckAlgorithm.java
@@ -19,13 +19,14 @@ package org.apache.shardingsphere.data.pipeline.spi.check.consistency;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmPostProcessor;
+import org.apache.shardingsphere.spi.singleton.SingletonSPI;
 
 import java.util.Collection;
 
 /**
  * Data consistency check algorithm, SPI.
  */
-public interface DataConsistencyCheckAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor {
+public interface DataConsistencyCheckAlgorithm extends ShardingSphereAlgorithm, ShardingSphereAlgorithmPostProcessor, SingletonSPI {
     
     /**
      * Get algorithm description.

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/PipelineJobAPIImplTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/PipelineJobAPIImplTest.java
@@ -93,7 +93,7 @@ public final class PipelineJobAPIImplTest {
         assertTrue(getNonNullJobInfo(jobId.get()).isActive());
         pipelineJobAPI.stop(jobId.get());
         assertFalse(getNonNullJobInfo(jobId.get()).isActive());
-        pipelineJobAPI.start(jobId.get());
+        pipelineJobAPI.startDisabledJob(jobId.get());
         assertTrue(getNonNullJobInfo(jobId.get()).isActive());
     }
     

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/RuleAlteredJobAPIImplTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/impl/RuleAlteredJobAPIImplTest.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.data.pipeline.api.impl;
 
 import com.google.common.collect.ImmutableMap;
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.data.pipeline.api.PipelineJobAPI;
 import org.apache.shardingsphere.data.pipeline.api.PipelineJobAPIFactory;
+import org.apache.shardingsphere.data.pipeline.api.RuleAlteredJobAPI;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.JobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.config.rulealtered.PipelineConfiguration;
@@ -53,31 +53,31 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public final class PipelineJobAPIImplTest {
+public final class RuleAlteredJobAPIImplTest {
     
-    private static PipelineJobAPI pipelineJobAPI;
+    private static RuleAlteredJobAPI ruleAlteredJobAPI;
     
     @BeforeClass
     public static void beforeClass() {
         EmbedTestingServer.start();
         PipelineContextUtil.mockModeConfig();
-        pipelineJobAPI = PipelineJobAPIFactory.getPipelineJobAPI();
+        ruleAlteredJobAPI = PipelineJobAPIFactory.getRuleAlteredJobAPI();
     }
     
     @Test
     public void assertStartAndList() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
         JobInfo jobInfo = getNonNullJobInfo(jobId.get());
         assertTrue(jobInfo.isActive());
         assertThat(jobInfo.getTables(), is("t_order"));
         assertThat(jobInfo.getShardingTotalCount(), is(1));
-        List<Long> uncompletedJobIds = pipelineJobAPI.getUncompletedJobIds("logic_db");
+        List<Long> uncompletedJobIds = ruleAlteredJobAPI.getUncompletedJobIds("logic_db");
         assertTrue(uncompletedJobIds.size() > 0);
     }
     
     private Optional<JobInfo> getJobInfo(final String jobId) {
-        return pipelineJobAPI.list().stream().filter(each -> Objects.equals(each.getJobId(), jobId)).reduce((a, b) -> a);
+        return ruleAlteredJobAPI.list().stream().filter(each -> Objects.equals(each.getJobId(), jobId)).reduce((a, b) -> a);
     }
     
     private JobInfo getNonNullJobInfo(final String jobId) {
@@ -88,35 +88,35 @@ public final class PipelineJobAPIImplTest {
     
     @Test
     public void assertStartOrStopById() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
         assertTrue(getNonNullJobInfo(jobId.get()).isActive());
-        pipelineJobAPI.stop(jobId.get());
+        ruleAlteredJobAPI.stop(jobId.get());
         assertFalse(getNonNullJobInfo(jobId.get()).isActive());
-        pipelineJobAPI.startDisabledJob(jobId.get());
+        ruleAlteredJobAPI.startDisabledJob(jobId.get());
         assertTrue(getNonNullJobInfo(jobId.get()).isActive());
     }
     
     @Test
     public void assertRemove() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
         assertTrue(getJobInfo(jobId.get()).isPresent());
-        pipelineJobAPI.remove(jobId.get());
+        ruleAlteredJobAPI.remove(jobId.get());
         assertFalse(getJobInfo(jobId.get()).isPresent());
     }
     
     @Test
     public void assertGetProgress() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        Map<Integer, JobProgress> jobProgressMap = pipelineJobAPI.getProgress(jobId.get());
+        Map<Integer, JobProgress> jobProgressMap = ruleAlteredJobAPI.getProgress(jobId.get());
         assertThat(jobProgressMap.size(), is(1));
     }
     
     @Test
     public void assertListDataConsistencyCheckAlgorithms() {
-        Collection<DataConsistencyCheckAlgorithmInfo> algorithmInfos = pipelineJobAPI.listDataConsistencyCheckAlgorithms();
+        Collection<DataConsistencyCheckAlgorithmInfo> algorithmInfos = ruleAlteredJobAPI.listDataConsistencyCheckAlgorithms();
         assertTrue(algorithmInfos.size() > 0);
         Optional<DataConsistencyCheckAlgorithmInfo> algorithmInfoOptional = algorithmInfos.stream().filter(each -> each.getType().equals(FixtureDataConsistencyCheckAlgorithm.TYPE)).findFirst();
         assertTrue(algorithmInfoOptional.isPresent());
@@ -130,30 +130,30 @@ public final class PipelineJobAPIImplTest {
     
     @Test
     public void assertIsDataConsistencyCheckNeeded() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        assertThat(pipelineJobAPI.isDataConsistencyCheckNeeded(jobId.get()), is(true));
+        assertThat(ruleAlteredJobAPI.isDataConsistencyCheckNeeded(jobId.get()), is(true));
     }
     
     @Test
     public void assertDataConsistencyCheck() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        JobConfiguration jobConfig = pipelineJobAPI.getJobConfig(jobId.get());
+        JobConfiguration jobConfig = ruleAlteredJobAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getPipelineConfig());
         PipelineContextUtil.mockContextManager();
-        Map<String, DataConsistencyCheckResult> checkResultMap = pipelineJobAPI.dataConsistencyCheck(jobId.get());
+        Map<String, DataConsistencyCheckResult> checkResultMap = ruleAlteredJobAPI.dataConsistencyCheck(jobId.get());
         assertThat(checkResultMap.size(), is(1));
     }
     
     @Test
     public void assertDataConsistencyCheckWithAlgorithm() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        JobConfiguration jobConfig = pipelineJobAPI.getJobConfig(jobId.get());
+        JobConfiguration jobConfig = ruleAlteredJobAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getPipelineConfig());
         PipelineContextUtil.mockContextManager();
-        Map<String, DataConsistencyCheckResult> checkResultMap = pipelineJobAPI.dataConsistencyCheck(jobId.get(), FixtureDataConsistencyCheckAlgorithm.TYPE);
+        Map<String, DataConsistencyCheckResult> checkResultMap = ruleAlteredJobAPI.dataConsistencyCheck(jobId.get(), FixtureDataConsistencyCheckAlgorithm.TYPE);
         assertThat(checkResultMap.size(), is(1));
         assertTrue(checkResultMap.get("t_order").isRecordsCountMatched());
         assertTrue(checkResultMap.get("t_order").isRecordsContentMatched());
@@ -165,31 +165,31 @@ public final class PipelineJobAPIImplTest {
         String jobId = "1";
         Map<String, DataConsistencyCheckResult> checkResultMap;
         checkResultMap = Collections.emptyMap();
-        assertThat(pipelineJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
+        assertThat(ruleAlteredJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
         DataConsistencyCheckResult trueResult = new DataConsistencyCheckResult(1, 1);
         trueResult.setRecordsContentMatched(true);
         DataConsistencyCheckResult checkResult;
         checkResult = new DataConsistencyCheckResult(100, 95);
         checkResultMap = ImmutableMap.<String, DataConsistencyCheckResult>builder().put("t", trueResult).put("t_order", checkResult).build();
-        assertThat(pipelineJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
+        assertThat(ruleAlteredJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
         checkResult = new DataConsistencyCheckResult(100, 100);
         checkResult.setRecordsContentMatched(false);
         checkResultMap = ImmutableMap.<String, DataConsistencyCheckResult>builder().put("t", trueResult).put("t_order", checkResult).build();
-        assertThat(pipelineJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
+        assertThat(ruleAlteredJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(false));
         checkResult = new DataConsistencyCheckResult(100, 100);
         checkResult.setRecordsContentMatched(true);
         checkResultMap = ImmutableMap.<String, DataConsistencyCheckResult>builder().put("t", trueResult).put("t_order", checkResult).build();
-        assertThat(pipelineJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(true));
+        assertThat(ruleAlteredJobAPI.aggregateDataConsistencyCheckResults(jobId, checkResultMap), is(true));
     }
     
     @Test
     public void assertResetTargetTable() {
-        Optional<String> jobId = pipelineJobAPI.start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = ruleAlteredJobAPI.start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        JobConfiguration jobConfig = pipelineJobAPI.getJobConfig(jobId.get());
+        JobConfiguration jobConfig = ruleAlteredJobAPI.getJobConfig(jobId.get());
         initTableData(jobConfig.getPipelineConfig());
-        pipelineJobAPI.reset(jobId.get());
-        Map<String, DataConsistencyCheckResult> checkResultMap = pipelineJobAPI.dataConsistencyCheck(jobId.get(), FixtureDataConsistencyCheckAlgorithm.TYPE);
+        ruleAlteredJobAPI.reset(jobId.get());
+        Map<String, DataConsistencyCheckResult> checkResultMap = ruleAlteredJobAPI.dataConsistencyCheck(jobId.get(), FixtureDataConsistencyCheckAlgorithm.TYPE);
         assertThat(checkResultMap.get("t_order").getTargetRecordsCount(), is(0L));
     }
     

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJobTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJobTest.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.data.pipeline.core.job;
 
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.data.pipeline.api.PipelineJobAPI;
 import org.apache.shardingsphere.data.pipeline.api.PipelineJobAPIFactory;
+import org.apache.shardingsphere.data.pipeline.api.RuleAlteredJobAPI;
 import org.apache.shardingsphere.data.pipeline.api.pojo.JobInfo;
 import org.apache.shardingsphere.data.pipeline.core.fixture.EmbedTestingServer;
 import org.apache.shardingsphere.data.pipeline.core.util.PipelineContextUtil;
@@ -44,7 +44,7 @@ public final class FinishedCheckJobTest {
     private static FinishedCheckJob finishedCheckJob;
     
     @Mock
-    private PipelineJobAPI pipelineJobAPI;
+    private RuleAlteredJobAPI ruleAlteredJobAPI;
     
     @BeforeClass
     public static void beforeClass() {
@@ -56,26 +56,26 @@ public final class FinishedCheckJobTest {
     @Before
     @SneakyThrows(ReflectiveOperationException.class)
     public void setUp() {
-        ReflectionUtil.setFieldValue(finishedCheckJob, "pipelineJobAPI", pipelineJobAPI);
+        ReflectionUtil.setFieldValue(finishedCheckJob, "RULE_ALTERED_JOB_API", ruleAlteredJobAPI);
     }
     
     @Test
     public void assertExecuteAllDisabledJob() {
-        Optional<String> jobId = PipelineJobAPIFactory.getPipelineJobAPI().start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = PipelineJobAPIFactory.getRuleAlteredJobAPI().start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        List<JobInfo> jobInfos = PipelineJobAPIFactory.getPipelineJobAPI().list();
+        List<JobInfo> jobInfos = PipelineJobAPIFactory.getRuleAlteredJobAPI().list();
         jobInfos.forEach(each -> each.setActive(false));
-        when(pipelineJobAPI.list()).thenReturn(jobInfos);
+        when(ruleAlteredJobAPI.list()).thenReturn(jobInfos);
         finishedCheckJob.execute(null);
     }
     
     @Test
     public void assertExecuteActiveJob() {
-        Optional<String> jobId = PipelineJobAPIFactory.getPipelineJobAPI().start(ResourceUtil.mockJobConfig());
+        Optional<String> jobId = PipelineJobAPIFactory.getRuleAlteredJobAPI().start(ResourceUtil.mockJobConfig());
         assertTrue(jobId.isPresent());
-        List<JobInfo> jobInfos = PipelineJobAPIFactory.getPipelineJobAPI().list();
+        List<JobInfo> jobInfos = PipelineJobAPIFactory.getRuleAlteredJobAPI().list();
         jobInfos.forEach(each -> each.setActive(true));
-        when(pipelineJobAPI.list()).thenReturn(jobInfos);
+        when(ruleAlteredJobAPI.list()).thenReturn(jobInfos);
         finishedCheckJob.execute(null);
     }
 }

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJobTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/job/FinishedCheckJobTest.java
@@ -56,7 +56,7 @@ public final class FinishedCheckJobTest {
     @Before
     @SneakyThrows(ReflectiveOperationException.class)
     public void setUp() {
-        ReflectionUtil.setFieldValue(finishedCheckJob, "RULE_ALTERED_JOB_API", ruleAlteredJobAPI);
+        ReflectionUtil.setFieldValue(finishedCheckJob, "ruleAlteredJobAPI", ruleAlteredJobAPI);
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
- Separate `RuleAlteredJobAPI` from `PipelineJobAPI`. `PipelineJobAPI` will just keep some common methods.
- Rename job api `start` method to `startDisabledJob`
- Simplify SPI loading
