### PR TITLE
Add RuleAlteredJobAPI new methods for internal invocation, different with API for DistSQL

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -159,7 +159,15 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     
     @Override
     public Map<Integer, JobProgress> getProgress(final String jobId) {
-        return IntStream.range(0, getJobConfig(jobId).getHandleConfig().getJobShardingCount()).boxed().collect(LinkedHashMap::new, (map, each) -> {
+        log.info("getProgress for job {}", jobId);
+        JobConfiguration jobConfig = getJobConfig(jobId);
+        return getProgress(jobConfig);
+    }
+    
+    @Override
+    public Map<Integer, JobProgress> getProgress(final JobConfiguration jobConfig) {
+        String jobId = jobConfig.getHandleConfig().getJobId();
+        return IntStream.range(0, jobConfig.getHandleConfig().getJobShardingCount()).boxed().collect(LinkedHashMap::new, (map, each) -> {
             JobProgress jobProgress = PipelineAPIFactory.getGovernanceRepositoryAPI().getJobProgress(jobId, each);
             JobConfigurationPOJO jobConfigPOJO = getElasticJobConfigPOJO(jobId);
             if (null != jobProgress) {
@@ -189,7 +197,13 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     
     @Override
     public boolean isDataConsistencyCheckNeeded(final String jobId) {
+        log.info("isDataConsistencyCheckNeeded for job {}", jobId);
         JobConfiguration jobConfig = getJobConfig(jobId);
+        return isDataConsistencyCheckNeeded(jobConfig);
+    }
+    
+    @Override
+    public boolean isDataConsistencyCheckNeeded(final JobConfiguration jobConfig) {
         RuleAlteredContext ruleAlteredContext = RuleAlteredJobWorker.createRuleAlteredContext(jobConfig);
         return isDataConsistencyCheckNeeded(ruleAlteredContext);
     }
@@ -202,6 +216,11 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     public Map<String, DataConsistencyCheckResult> dataConsistencyCheck(final String jobId) {
         log.info("Data consistency check for job {}", jobId);
         JobConfiguration jobConfig = getJobConfig(jobId);
+        return dataConsistencyCheck(jobConfig);
+    }
+    
+    @Override
+    public Map<String, DataConsistencyCheckResult> dataConsistencyCheck(final JobConfiguration jobConfig) {
         RuleAlteredJobContext jobContext = new RuleAlteredJobContext(jobConfig);
         if (!isDataConsistencyCheckNeeded(jobContext.getRuleAlteredContext())) {
             log.info("dataConsistencyCheckAlgorithm is not configured, data consistency check is ignored.");
@@ -254,6 +273,12 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     public void switchClusterConfiguration(final String jobId) {
         log.info("Switch cluster configuration for job {}", jobId);
         JobConfiguration jobConfig = getJobConfig(jobId);
+        switchClusterConfiguration(jobConfig);
+    }
+    
+    @Override
+    public void switchClusterConfiguration(final JobConfiguration jobConfig) {
+        String jobId = jobConfig.getHandleConfig().getJobId();
         RuleAlteredContext ruleAlteredContext = RuleAlteredJobWorker.createRuleAlteredContext(jobConfig);
         if (isDataConsistencyCheckNeeded(ruleAlteredContext)) {
             Optional<Boolean> checkResultOptional = PipelineAPIFactory.getGovernanceRepositoryAPI().getJobCheckResult(jobId);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
@@ -67,6 +67,14 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
     Map<Integer, JobProgress> getProgress(String jobId);
     
     /**
+     * Get job progress.
+     *
+     * @param jobConfig job configuration
+     * @return each sharding item progress
+     */
+    Map<Integer, JobProgress> getProgress(JobConfiguration jobConfig);
+    
+    /**
      * Stop cluster write to job source schema's underlying DB.
      *
      * @param jobId job id
@@ -89,12 +97,28 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
     boolean isDataConsistencyCheckNeeded(String jobId);
     
     /**
+     * Is data consistency check needed.
+     *
+     * @param jobConfig job configuration
+     * @return data consistency check needed or not
+     */
+    boolean isDataConsistencyCheckNeeded(JobConfiguration jobConfig);
+    
+    /**
      * Do data consistency check.
      *
      * @param jobId job id
      * @return each logic table check result
      */
     Map<String, DataConsistencyCheckResult> dataConsistencyCheck(String jobId);
+    
+    /**
+     * Do data consistency check.
+     *
+     * @param jobConfig job configuration
+     * @return each logic table check result
+     */
+    Map<String, DataConsistencyCheckResult> dataConsistencyCheck(JobConfiguration jobConfig);
     
     /**
      * Do data consistency check.
@@ -120,6 +144,13 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
      * @param jobId job id
      */
     void switchClusterConfiguration(String jobId);
+    
+    /**
+     * Switch job source schema's configuration to job target configuration.
+     *
+     * @param jobConfig job configuration
+     */
+    void switchClusterConfiguration(JobConfiguration jobConfig);
     
     /**
      * Reset scaling job.


### PR DESCRIPTION
Purpose:
- Isolate `RuleAlteredJobAPI` methods for internal usage and DistSQL usage, clean code and better performance.

Changes proposed in this pull request:
- Add `RuleAlteredJobAPI` new methods for internal invocation, different with API for DistSQL
