### PR TITLE
Add props to the result set of `SHOW TRANSACTION RULE`

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowTransactionRuleExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowTransactionRuleExecutor.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.show.executor;
 
+import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -39,11 +40,14 @@ public final class ShowTransactionRuleExecutor extends AbstractShowExecutor {
     
     private static final String PROVIDER_TYPE = "provider_type";
     
+    private static final String PROPS = "props";
+    
     @Override
     protected List<QueryHeader> createQueryHeaders() {
         return Arrays.asList(
                 new QueryHeader("", "", DEFAULT_TYPE, DEFAULT_TYPE, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false),
-                new QueryHeader("", "", PROVIDER_TYPE, PROVIDER_TYPE, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false));
+                new QueryHeader("", "", PROVIDER_TYPE, PROVIDER_TYPE, Types.VARCHAR, "VARCHAR", 64, 0, false, false, false, false),
+                new QueryHeader("", "", PROPS, PROPS, Types.VARCHAR, "VARCHAR", 128, 0, false, false, false, false));
     }
     
     @Override
@@ -57,6 +61,7 @@ public final class ShowTransactionRuleExecutor extends AbstractShowExecutor {
         List<Object> row = new LinkedList<>();
         row.add(transactionRuleConfiguration.getDefaultType());
         row.add(null == transactionRuleConfiguration.getProviderType() ? "" : transactionRuleConfiguration.getProviderType());
+        row.add(null == transactionRuleConfiguration.getProps() ? "" : new Gson().toJson(transactionRuleConfiguration.getProps()));
         Collection<List<Object>> rows = new LinkedList<>();
         rows.add(row);
         return new MultipleLocalDataMergedResult(rows);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/ShowTransactionRuleExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/ShowTransactionRuleExecutorTest.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Properties;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -56,7 +57,9 @@ public final class ShowTransactionRuleExecutorTest {
         assertThat(data.size(), is(3));
         assertThat(data.get(0), is("XA"));
         assertThat(data.get(1), is("Atomikos"));
-        assertThat(data.get(2), is("{\"host\":\"127.0.0.1\",\"databaseName\":\"jbossts\"}"));
+        String props = String.valueOf(data.get(2));
+        assertThat(props, containsString("\"host\":\"127.0.0.1\""));
+        assertThat(props, containsString("\"databaseName\":\"jbossts\""));
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/ShowTransactionRuleExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/ShowTransactionRuleExecutorTest.java
@@ -47,33 +47,42 @@ public final class ShowTransactionRuleExecutorTest {
     @Test
     public void assertExecutorWithXA() throws SQLException {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        when(contextManager.getMetaDataContexts().getGlobalRuleMetaData()).thenReturn(getGlobalRuleMetaData("XA", "Atomikos"));
+        when(contextManager.getMetaDataContexts().getGlobalRuleMetaData()).thenReturn(getGlobalRuleMetaData("XA", "Atomikos", getProperties()));
         ProxyContext.getInstance().init(contextManager);
         executor.execute();
         executor.next();
         QueryResponseRow queryResponseRow = executor.getQueryResponseRow();
         ArrayList<Object> data = new ArrayList<>(queryResponseRow.getData());
-        assertThat(data.size(), is(2));
+        assertThat(data.size(), is(3));
         assertThat(data.get(0), is("XA"));
         assertThat(data.get(1), is("Atomikos"));
+        assertThat(data.get(2), is("{\"host\":\"127.0.0.1\",\"databaseName\":\"jbossts\"}"));
     }
     
     @Test
     public void assertExecutorWithLocal() throws SQLException {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
-        when(contextManager.getMetaDataContexts().getGlobalRuleMetaData()).thenReturn(getGlobalRuleMetaData("LOCAL", null));
+        when(contextManager.getMetaDataContexts().getGlobalRuleMetaData()).thenReturn(getGlobalRuleMetaData("LOCAL", null, null));
         ProxyContext.getInstance().init(contextManager);
         executor.execute();
         executor.next();
         QueryResponseRow queryResponseRow = executor.getQueryResponseRow();
         ArrayList<Object> data = new ArrayList<>(queryResponseRow.getData());
-        assertThat(data.size(), is(2));
+        assertThat(data.size(), is(3));
         assertThat(data.get(0), is("LOCAL"));
         assertThat(data.get(1), is(""));
+        assertThat(data.get(2), is(""));
     }
     
-    private ShardingSphereRuleMetaData getGlobalRuleMetaData(final String defaultType, final String providerType) {
-        RuleConfiguration transactionRuleConfiguration = new TransactionRuleConfiguration(defaultType, providerType, new Properties());
+    private ShardingSphereRuleMetaData getGlobalRuleMetaData(final String defaultType, final String providerType, final Properties props) {
+        RuleConfiguration transactionRuleConfiguration = new TransactionRuleConfiguration(defaultType, providerType, props);
         return new ShardingSphereRuleMetaData(Collections.singleton(transactionRuleConfiguration), Collections.emptyList());
+    }
+    
+    private Properties getProperties() {
+        Properties result = new Properties();
+        result.setProperty("host", "127.0.0.1");
+        result.setProperty("databaseName", "jbossts");
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #14770.
After adding props to `TransactionRuleConfiguration`, update the result set of `SHOW TRANSACTION RULE` to match it.

Changes proposed in this pull request:
- update ShowTransactionRuleExecutor
- update ShowTransactionRuleExecutorTest
