### PR TITLE
Use JDBCMemoryQueryResult to avoid federation execution exception

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResult.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.stream;
 
+import lombok.Getter;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.metadata.JDBCQueryResultMetaData;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.type.stream.AbstractStreamQueryResult;
 
@@ -37,6 +38,7 @@ import java.util.Calendar;
  */
 public final class JDBCStreamQueryResult extends AbstractStreamQueryResult {
     
+    @Getter
     private final ResultSet resultSet;
     
     public JDBCStreamQueryResult(final ResultSet resultSet) throws SQLException {

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/stream/JDBCStreamQueryResultTest.java
@@ -32,6 +32,7 @@ import java.util.Calendar;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -242,6 +243,17 @@ public final class JDBCStreamQueryResultTest {
         assertFalse(queryResult.wasNull());
         queryResult.next();
         assertTrue(queryResult.wasNull());
+    }
+    
+    @Test
+    public void assertGetResultSet() throws SQLException {
+        JDBCStreamQueryResult queryResult = new JDBCStreamQueryResult(getResultSet());
+        ResultSet actual = queryResult.getResultSet();
+        assertNotNull(actual);
+        actual.next();
+        assertFalse(actual.wasNull());
+        actual.next();
+        assertTrue(actual.wasNull());
     }
     
     private ResultSet getResultSet() throws SQLException {

--- a/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-executor/src/main/java/org/apache/shardingsphere/infra/federation/executor/original/table/FilterableTableScanExecutor.java
+++ b/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-executor/src/main/java/org/apache/shardingsphere/infra/federation/executor/original/table/FilterableTableScanExecutor.java
@@ -38,7 +38,6 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.binder.SQLStatementContextFactory;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
-import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.context.kernel.KernelProcessor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
@@ -59,6 +58,8 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.J
 import org.apache.shardingsphere.infra.executor.sql.execute.result.ExecuteResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.memory.JDBCMemoryQueryResult;
+import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.stream.JDBCStreamQueryResult;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.DriverExecutionPrepareEngine;
 import org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine;
 import org.apache.shardingsphere.infra.federation.executor.FederationContext;
@@ -75,6 +76,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -136,26 +138,52 @@ public final class FilterableTableScanExecutor {
         FederationContext federationContext = executorContext.getFederationContext();
         LogicSQL logicSQL = createLogicSQL(federationContext.getMetaDataMap(), sqlString, databaseType);
         ShardingSphereMetaData metaData = federationContext.getMetaDataMap().get(schemaName);
-        ConfigurationProperties props = executorContext.getProps();
-        ExecutionContext context = new KernelProcessor().generateExecutionContext(logicSQL, metaData, props);
+        ExecutionContext context = new KernelProcessor().generateExecutionContext(logicSQL, metaData, executorContext.getProps());
         if (federationContext.isPreview()) {
             federationContext.getExecutionUnits().addAll(context.getExecutionUnits());
             return createEmptyEnumerable();
         }
+        return execute(schemaName, databaseType, logicSQL, metaData, context);
+    }
+    
+    private AbstractEnumerable<Object[]> execute(final String schemaName, final DatabaseType databaseType, final LogicSQL logicSQL, 
+                                                 final ShardingSphereMetaData metaData, final ExecutionContext context) {
         try {
             ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext = prepareEngine.prepare(context.getRouteContext(), context.getExecutionUnits());
             setParameters(executionGroupContext.getInputGroups());
-            ExecuteProcessEngine.initialize(context.getLogicSQL(), executionGroupContext, props);
-            List<QueryResult> result = jdbcExecutor.execute(executionGroupContext, callback).stream().map(each -> (QueryResult) each).collect(Collectors.toList());
+            ExecuteProcessEngine.initialize(context.getLogicSQL(), executionGroupContext, executorContext.getProps());
+            List<QueryResult> queryResults = execute(executionGroupContext);
             ExecuteProcessEngine.finish(executionGroupContext.getExecutionID());
-            MergeEngine mergeEngine = new MergeEngine(schemaName, databaseType, metaData.getSchema(), props, metaData.getRuleMetaData().getRules());
-            MergedResult mergedResult = mergeEngine.merge(result, logicSQL.getSqlStatementContext());
-            return createEnumerable(mergedResult, result.get(0).getMetaData());
+            MergeEngine mergeEngine = new MergeEngine(schemaName, databaseType, metaData.getSchema(), executorContext.getProps(), metaData.getRuleMetaData().getRules());
+            MergedResult mergedResult = mergeEngine.merge(queryResults, logicSQL.getSqlStatementContext());
+            Collection<Statement> statements = getStatements(executionGroupContext.getInputGroups());
+            return createEnumerable(mergedResult, queryResults.get(0).getMetaData(), statements);
         } catch (final SQLException ex) {
             throw new ShardingSphereException(ex);
         } finally {
             ExecuteProcessEngine.clean();
         }
+    }
+    
+    private List<QueryResult> execute(final ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext) throws SQLException {
+        Collection<QueryResult> queryResults = jdbcExecutor.execute(executionGroupContext, callback).stream().map(each -> (QueryResult) each).collect(Collectors.toList());
+        List<QueryResult> result = new LinkedList<>();
+        for (QueryResult each : queryResults) {
+            QueryResult queryResult = each instanceof JDBCStreamQueryResult 
+                    ? new JDBCMemoryQueryResult(((JDBCStreamQueryResult) each).getResultSet()) : each;
+            result.add(queryResult);
+        }
+        return result;
+    }
+    
+    private Collection<Statement> getStatements(final Collection<ExecutionGroup<JDBCExecutionUnit>> inputGroups) {
+        Collection<Statement> result = new LinkedList<>();
+        for (ExecutionGroup<JDBCExecutionUnit> each : inputGroups) {
+            for (JDBCExecutionUnit executionUnit : each.getInputs()) {
+                result.add(executionUnit.getStorageResource());
+            }
+        }
+        return result;
     }
     
     private SqlString createSQLString(final FederationTableMetaData tableMetaData, final FilterableTableScanContext scanContext, final DatabaseType databaseType) {
@@ -213,12 +241,12 @@ public final class FilterableTableScanExecutor {
         return result;
     }
     
-    private AbstractEnumerable<Object[]> createEnumerable(final MergedResult mergedResult, final QueryResultMetaData metaData) {
+    private AbstractEnumerable<Object[]> createEnumerable(final MergedResult mergedResult, final QueryResultMetaData metaData, final Collection<Statement> statements) {
         return new AbstractEnumerable<Object[]>() {
             
             @Override
             public Enumerator<Object[]> enumerator() {
-                return new FilterableRowEnumerator(mergedResult, metaData);
+                return new FilterableRowEnumerator(mergedResult, metaData, statements);
             }
         };
     }


### PR DESCRIPTION
Ref #14780.

Changes proposed in this pull request:
- Use JDBCMemoryQueryResult to avoid federation execution exception
