### PR TITLE
Cancel previous GitHub CI runs in the PR when pushing new commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ on:
   repository_dispatch:
     types: [rerun-ci]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
@@ -52,6 +56,10 @@ jobs:
       - name: Support longpaths
         run: git config --system core.longpaths true
       - uses: actions/checkout@v2
+      - name: Dump concurrency group
+        env:
+          CON_GROUP: ${{ github.workflow }}-${{ github.ref }}
+        run: echo "$CON_GROUP"
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -23,6 +23,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
@@ -79,6 +83,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - uses: actions/checkout@v2
+      - name: Dump concurrency group
+        env:
+          CON_GROUP: ${{ github.workflow }}-${{ github.ref }}
+        run: echo "$CON_GROUP"
       - name: Set up JDK 8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION

Changes proposed in this pull request:
- Cancel previous GitHub CI runs in the PR when pushing new commits, and also when merging PR into master branch


Currently, every commit in any PR will trigger new GitHub CI workflow, but previous workflows won't be cancelled.
e.g. PR 14821, there're 5 times of `Continuous Integration` and 5 times of `Integration Test`. `Continuous Integration` details:
- When PR opened, it triggered [1706584203]( https://github.com/apache/shardingsphere/actions/runs/1706584203 )
- When commited pushed, it triggered 3 pull_request `synchronize` type workflows: [1706599853]( https://github.com/apache/shardingsphere/actions/runs/1706599853 ), [1706621209]( https://github.com/apache/shardingsphere/actions/runs/1706621209 ), [1706629362]( https://github.com/apache/shardingsphere/actions/runs/1706629362 )
- When PR merged, it triggered [1706896237]( https://github.com/apache/shardingsphere/actions/runs/1706896237 )

Purpose:
- Eliminate unnecessary GitHub CI runs to optimize GitHub CI resource consumption

References:
- [Workflow syntax#concurrency]( https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency )
- [Contexts]( https://docs.github.com/en/actions/learn-github-actions/contexts#github-context )

For concurrency group `${{ github.workflow }}-${{ github.ref }}`, test result on [my demo project]( https://github.com/sandynz/shardingsphere-test/actions ), [test ci.yml]( https://github.com/sandynz/shardingsphere-test/blob/master/.github/workflows/ci.yml ):
- On PR open and commit, group is `Test CI-refs/pull/2/merge` (`2` is the PR number)
- On PR merged, group is `Test CI-refs/heads/master`
