### PR TITLE
[CI] Refactor integration test scenario jobs to dependent jobs

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -32,7 +32,7 @@ env:
 
 jobs:
   it-empty-rule:
-    name: Integration Test - empty rule
+    name: IT empty rule
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -72,7 +72,7 @@ jobs:
         run: ./mvnw -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dit.adapters=${{ matrix.adapter }} -Dit.databases=${{ matrix.database }} -Dit.scenarios=${{ matrix.scenario }} -Dit.env.type=DOCKER
 
   it-single-rule:
-    name: Integration Test - single rule
+    name: IT single rule
     needs: it-empty-rule
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -113,7 +113,7 @@ jobs:
         run: ./mvnw -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dit.adapters=${{ matrix.adapter }} -Dit.databases=${{ matrix.database }} -Dit.scenarios=${{ matrix.scenario }} -Dit.env.type=DOCKER
 
   it-mixture-rule:
-    name: Integration Test - mixture rule
+    name: IT mixture rule
     needs: [ it-empty-rule, it-single-rule ]
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -31,17 +31,99 @@ env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 
 jobs:
-  integration-test-docker:
-    name: Integration Test in Docker
+  it-empty-rule:
+    name: Integration Test - empty rule
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         env: [ docker ]
         adapter: [ proxy, jdbc ]
         database: [ MySQL, PostgreSQL ]
-        scenario: [ db,tbl,dbtbl_with_readwrite_splitting,encrypt,dbtbl_with_readwrite_splitting_and_encrypt,readwrite_splitting,empty_rules ]
+        scenario: [ empty_rules ]
+        exclude:
+          - adapter: jdbc
+            database: PostgreSQL
+          - adapter: proxy
+            database: PostgreSQL
+            scenario: tbl
+          - adapter: proxy
+            database: PostgreSQL
+            scenario: empty_rules
+    steps:
+      - name: Cache Maven Repos
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: set environment
+        run: export MAVEN_OPTS=' -Dmaven.javadoc.skip=true -Drat.skip=true -Djacoco.skip=true ${MAVEN_OPTS}'
+      - name: Build Project
+        run: ./mvnw -B clean install -am -pl shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite -Pit.env.docker -DskipTests
+      - name: Run Integration Test
+        run: ./mvnw -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dit.adapters=${{ matrix.adapter }} -Dit.databases=${{ matrix.database }} -Dit.scenarios=${{ matrix.scenario }} -Dit.env.type=DOCKER
+
+  it-single-rule:
+    name: Integration Test - single rule
+    needs: it-empty-rule
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [ docker ]
+        adapter: [ proxy, jdbc ]
+        database: [ MySQL, PostgreSQL ]
+        scenario: [ db, tbl, encrypt, readwrite_splitting ]
+        exclude:
+          - adapter: jdbc
+            database: PostgreSQL
+          - adapter: proxy
+            database: PostgreSQL
+            scenario: tbl
+          - adapter: proxy
+            database: PostgreSQL
+            scenario: empty_rules
+    steps:
+      - name: Cache Maven Repos
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: set environment
+        run: export MAVEN_OPTS=' -Dmaven.javadoc.skip=true -Drat.skip=true -Djacoco.skip=true ${MAVEN_OPTS}'
+      - name: Build Project
+        run: ./mvnw -B clean install -am -pl shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite -Pit.env.docker -DskipTests
+      - name: Run Integration Test
+        run: ./mvnw -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dit.adapters=${{ matrix.adapter }} -Dit.databases=${{ matrix.database }} -Dit.scenarios=${{ matrix.scenario }} -Dit.env.type=DOCKER
+
+  it-mixture-rule:
+    name: Integration Test - mixture rule
+    needs: [ it-empty-rule, it-single-rule ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        env: [ docker ]
+        adapter: [ proxy, jdbc ]
+        database: [ MySQL, PostgreSQL ]
+        scenario: [ dbtbl_with_readwrite_splitting, dbtbl_with_readwrite_splitting_and_encrypt ]
         exclude:
           - adapter: jdbc
             database: PostgreSQL


### PR DESCRIPTION
Purpose:
- Eliminate unnecessary GitHub CI runs to optimize GitHub CI resource consumption

Changes proposed in this pull request:
- Refactor integration test scenario jobs to dependent jobs.

Three layers jobs:
1. empty rule
2. single rule : db, tbl, encrypt, readwrite_splitting
3. mixture rule : dbtbl_with_readwrite_splitting, dbtbl_with_readwrite_splitting_and_encrypt

Next layer jobs will start to run after current layer jobs are successful.
