### PR TITLE
Use unified spring version in example modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target/
 *.tar
 *.tar.gz
 dependency-reduced-pom.xml
+.flattened-pom.xml
 
 # maven plugin ignore
 release.properties

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -203,6 +203,11 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring-framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${spring-framework.version}</version>
             </dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -41,7 +41,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.locale>zh_CN</project.build.locale>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
-        <spring-framework.version>5.0.13.RELEASE</spring-framework.version>
+        <spring-framework.version>5.2.19.RELEASE</spring-framework.version>
         <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-db-discovery-example/shardingsphere-jdbc-memory-local-db-discovery-spring-boot-starter-jpa-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-db-discovery-example/shardingsphere-jdbc-memory-local-db-discovery-spring-boot-starter-jpa-example/pom.xml
@@ -46,7 +46,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <version>5.2.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-db-discovery-example/shardingsphere-jdbc-memory-local-db-discovery-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-db-discovery-example/shardingsphere-jdbc-memory-local-db-discovery-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
     

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-boot-starter-jpa-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-boot-starter-jpa-example/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
-            <version>5.2.0.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-encrypt-example/shardingsphere-jdbc-memory-local-encrypt-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
     

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-mixed-example/shardingsphere-jdbc-memory-local-mixed-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-mixed-example/shardingsphere-jdbc-memory-local-mixed-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
     

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-readwrite-splitting-example/shardingsphere-jdbc-memory-local-readwrite-splitting-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-readwrite-splitting-example/shardingsphere-jdbc-memory-local-readwrite-splitting-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
     

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-shadow-example/shardingsphere-jdbc-memory-local-shadow-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-shadow-example/shardingsphere-jdbc-memory-local-shadow-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
     

--- a/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-sharding-example/shardingsphere-jdbc-memory-local-sharding-spring-namespace-jdbc-example/pom.xml
+++ b/examples/shardingsphere-sample/shardingsphere-jdbc-sample/shardingsphere-jdbc-memory-example/shardingsphere-jdbc-memory-local-example/shardingsphere-jdbc-memory-local-sharding-example/shardingsphere-jdbc-memory-local-sharding-spring-namespace-jdbc-example/pom.xml
@@ -36,7 +36,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <version>5.1.5.RELEASE</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Purpose:
- Use unified spring version in example modules for code conduct
- Prepare for issue 14878, use unified spring version in all ShardingSphere modules

Changes proposed in this pull request:
- Clean hard coded spring version in example modules
- Upgrade spring version in example. From `5.0.13.RELEASE` to `5.2.19.RELEASE` for better security.
- Add spring-context in maven dependency management. Solve mvn build error.
