### PR TITLE
Fixes #14881, allow users not to configure authority provider.

### DIFF
--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/rule/AuthorityRule.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/rule/AuthorityRule.java
@@ -44,10 +44,10 @@ public final class AuthorityRule implements GlobalRule {
     
     private final Collection<ShardingSphereUser> users;
     
-    public AuthorityRule(final AuthorityRuleConfiguration config, final Map<String, ShardingSphereMetaData> metaDataMap, final Collection<ShardingSphereUser> users) {
+    public AuthorityRule(final AuthorityRuleConfiguration config, final Map<String, ShardingSphereMetaData> metaDataMap) {
         provider = ShardingSphereAlgorithmFactory.createAlgorithm(config.getProvider(), AuthorityProvideAlgorithm.class);
-        provider.init(metaDataMap, users);
-        this.users = users;
+        provider.init(metaDataMap, config.getUsers());
+        users = config.getUsers();
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/rule/builder/AuthorityRuleBuilder.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/rule/builder/AuthorityRuleBuilder.java
@@ -32,7 +32,7 @@ public final class AuthorityRuleBuilder implements GlobalRuleBuilder<AuthorityRu
     
     @Override
     public AuthorityRule build(final AuthorityRuleConfiguration ruleConfig, final Map<String, ShardingSphereMetaData> metaDataMap) {
-        return new AuthorityRule(ruleConfig, metaDataMap, ruleConfig.getUsers());
+        return new AuthorityRule(ruleConfig, metaDataMap);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapper.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapper.java
@@ -19,7 +19,9 @@ package org.apache.shardingsphere.authority.yaml.swapper;
 
 import org.apache.shardingsphere.authority.config.AuthorityRuleConfiguration;
 import org.apache.shardingsphere.authority.constant.AuthorityOrder;
+import org.apache.shardingsphere.authority.rule.builder.DefaultAuthorityRuleConfigurationBuilder;
 import org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.infra.metadata.user.yaml.config.YamlUsersConfigurationConverter;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlRuleConfigurationSwapper;
@@ -45,7 +47,11 @@ public final class AuthorityRuleConfigurationYamlSwapper implements YamlRuleConf
     @Override
     public AuthorityRuleConfiguration swapToObject(final YamlAuthorityRuleConfiguration yamlConfig) {
         Collection<ShardingSphereUser> users = YamlUsersConfigurationConverter.convertShardingSphereUser(yamlConfig.getUsers());
-        return new AuthorityRuleConfiguration(users, algorithmSwapper.swapToObject(yamlConfig.getProvider()));
+        ShardingSphereAlgorithmConfiguration provider = algorithmSwapper.swapToObject(yamlConfig.getProvider());
+        if (null == provider) {
+            provider = new DefaultAuthorityRuleConfigurationBuilder().build().getProvider();
+        }
+        return new AuthorityRuleConfiguration(users, provider);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/checker/AuthorityCheckerTest.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/checker/AuthorityCheckerTest.java
@@ -68,8 +68,8 @@ public final class AuthorityCheckerTest {
         Collection<ShardingSphereUser> users = new LinkedList<>();
         ShardingSphereUser root = new ShardingSphereUser("root", "", "localhost");
         users.add(root);
-        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("ALL_PRIVILEGES_PERMITTED", new Properties()));
-        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap(), users);
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(users, new ShardingSphereAlgorithmConfiguration("ALL_PRIVILEGES_PERMITTED", new Properties()));
+        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap());
         SQLChecker<AuthorityRule> sqlChecker = OrderedSPIRegistry.getRegisteredServices(SQLChecker.class, Collections.singleton(rule)).get(rule);
         assertNotNull(sqlChecker);
         assertTrue(sqlChecker.check("db0", new Grantee("root", "localhost"), rule));
@@ -81,8 +81,8 @@ public final class AuthorityCheckerTest {
         Collection<ShardingSphereUser> users = new LinkedList<>();
         ShardingSphereUser root = new ShardingSphereUser("root", "", "localhost");
         users.add(root);
-        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
-        AuthorityRule rule = new AuthorityRule(ruleConfig, createMetaDataMap(users), users);
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(users, new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
+        AuthorityRule rule = new AuthorityRule(ruleConfig, createMetaDataMap(users));
         SQLChecker<AuthorityRule> sqlChecker = OrderedSPIRegistry.getRegisteredServices(SQLChecker.class, Collections.singleton(rule)).get(rule);
         assertNotNull(sqlChecker);
         assertTrue(sqlChecker.check("db0", new Grantee("root", "localhost"), rule));
@@ -96,8 +96,8 @@ public final class AuthorityCheckerTest {
         Collection<ShardingSphereUser> users = new LinkedList<>();
         ShardingSphereUser root = new ShardingSphereUser("root", "", "localhost");
         users.add(root);
-        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
-        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap(), users);
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(users, new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
+        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap());
         SQLChecker<AuthorityRule> sqlChecker = OrderedSPIRegistry.getRegisteredServices(SQLChecker.class, Collections.singleton(rule)).get(rule);
         assertNotNull(sqlChecker);
         assertTrue(sqlChecker.check(new Grantee("root", "localhost"), rule));
@@ -111,8 +111,8 @@ public final class AuthorityCheckerTest {
         Collection<ShardingSphereUser> users = new LinkedList<>();
         ShardingSphereUser root = new ShardingSphereUser("root", "", "localhost");
         users.add(root);
-        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
-        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap(), users);
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(users, new ShardingSphereAlgorithmConfiguration("NATIVE", new Properties()));
+        AuthorityRule rule = new AuthorityRule(ruleConfig, Collections.emptyMap());
         SQLChecker<AuthorityRule> sqlChecker = OrderedSPIRegistry.getRegisteredServices(SQLChecker.class, Collections.singleton(rule)).get(rule);
         assertNotNull(sqlChecker);
         SelectStatement selectStatement = mock(SelectStatement.class);

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/rule/AuthorityRuleTest.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/rule/AuthorityRuleTest.java
@@ -37,8 +37,8 @@ public final class AuthorityRuleTest {
         Collection<ShardingSphereUser> users = new LinkedList<>();
         ShardingSphereUser root = new ShardingSphereUser("root", "", "localhost");
         users.add(root);
-        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("ALL_PRIVILEGES_PERMITTED", new Properties()));
-        AuthorityRule authorityRule = new AuthorityRule(ruleConfig, Collections.emptyMap(), users);
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(users, new ShardingSphereAlgorithmConfiguration("ALL_PRIVILEGES_PERMITTED", new Properties()));
+        AuthorityRule authorityRule = new AuthorityRule(ruleConfig, Collections.emptyMap());
         assertThat(authorityRule.getType(), is(AuthorityRule.class.getSimpleName()));
     }
 }

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapperTest.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/yaml/swapper/AuthorityRuleConfigurationYamlSwapperTest.java
@@ -59,7 +59,6 @@ public final class AuthorityRuleConfigurationYamlSwapperTest {
         YamlShardingSphereAlgorithmConfiguration configuration = mock(YamlShardingSphereAlgorithmConfiguration.class);
         when(authorityRuleConfiguration.getUsers()).thenReturn(Collections.singletonList("root@localhost:pass"));
         when(authorityRuleConfiguration.getProvider()).thenReturn(configuration);
-        when(authorityRuleConfiguration.getProvider()).thenReturn(configuration);
         when(configuration.getType()).thenReturn("type");
         when(configuration.getProps()).thenReturn(new Properties());
         AuthorityRuleConfiguration resultConfig = swapper.swapToObject(authorityRuleConfiguration);
@@ -67,6 +66,19 @@ public final class AuthorityRuleConfigurationYamlSwapperTest {
         assertNotNull(resultConfig.getUsers());
         assertThat(resultConfig.getUsers().size(), is(1));
         assertNotNull(resultConfig.getProvider());
+    }
+    
+    @Test
+    public void assertSwapToObjectWithDefaultProvider() {
+        YamlAuthorityRuleConfiguration authorityRuleConfiguration = mock(YamlAuthorityRuleConfiguration.class);
+        when(authorityRuleConfiguration.getUsers()).thenReturn(Collections.singletonList("root@localhost:pass"));
+        when(authorityRuleConfiguration.getProvider()).thenReturn(null);
+        AuthorityRuleConfiguration resultConfig = swapper.swapToObject(authorityRuleConfiguration);
+        assertNotNull(resultConfig);
+        assertNotNull(resultConfig.getUsers());
+        assertThat(resultConfig.getUsers().size(), is(1));
+        assertNotNull(resultConfig.getProvider());
+        assertThat(resultConfig.getProvider().getType(), is("ALL_PRIVILEGES_PERMITTED"));
     }
     
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinatorTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinatorTest.java
@@ -231,7 +231,7 @@ public final class ClusterContextManagerCoordinatorTest {
     
     private Collection<ShardingSphereRule> createAuthorityRule() {
         AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.emptyList(), new ShardingSphereAlgorithmConfiguration("ALL_PRIVILEGES_PERMITTED", new Properties()));
-        AuthorityRule authorityRule = new AuthorityRule(ruleConfig, contextManager.getMetaDataContexts().getMetaDataMap(), Collections.emptyList());
+        AuthorityRule authorityRule = new AuthorityRule(ruleConfig, contextManager.getMetaDataContexts().getMetaDataMap());
         return Collections.singleton(authorityRule);
     }
     


### PR DESCRIPTION
Fixes #14881, 

- if no authority provider configured in server.yaml, use `DefaultAuthorityRuleConfigurationBuilder` to get a provider
- optimize the passing of the parameter `users`
- update test cases