### PR TITLE
add java version adapt for linux shell

### DIFF
--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
@@ -58,9 +58,29 @@ set CLASS_PATH=../conf;%CLASS_PATH%
     echo The classpath is %CLASS_PATH%
 )
 
+for /f "tokens=3" %%a in ('java -version 2^>^&1 ^| findstr /i "version"') do set total_version=%%a
+for /f "tokens=1,2 delims=." %%a in (%total_version%) do (
+    if %%a == 1 (
+        set int_version=%%b
+    ) else (
+        set int_version=%%a
+    )
+)
+echo we find java version: java%int_version%, full_version=%total_version:~1,9%
+set VERSION_OPTS=
+if %int_version% == 8 (
+    set VERSION_OPTS=-XX:+UseFastAccessorMethods -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70
+) else if %int_version% == 11 (
+    set VERSION_OPTS=-XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70
+) else if %int_version% == 17 (
+    set VERSION_OPTS=
+) else (
+    echo unadapted java version, please notice...
+)
+
 echo Starting the %SERVER_NAME% ...
 
-java -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
+java -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
 
 goto exit
 

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
@@ -32,9 +32,28 @@ EXT_LIB=${DEPLOY_DIR}/ext-lib
 
 CLASS_PATH=.:${DEPLOY_DIR}/lib/*:${EXT_LIB}/*
 
+total_version=`java -version 2>&1 | grep version | sed '1!d' | sed -e 's/"//g' | awk '{print $3}'`
+int_version=${total_version%%.*}
+if [ $int_version = '1' ] ; then
+    int_version=${total_version%.*}
+    int_version=${int_version:2}
+fi
+echo "we find java version: java${int_version}, full_version=${total_version}"
+
+VERSION_OPTS=""
+if [ $int_version = '8' ] ; then
+    VERSION_OPTS=" -XX:+UseFastAccessorMethods -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70"
+elif [ $int_version = '11' ] ; then
+    VERSION_OPTS=" -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70"
+elif [ $int_version = '17' ] ; then
+    VERSION_OPTS=""
+else
+    echo "unadapted java version, please notice..."
+fi
+
 JAVA_OPTS=" -Djava.awt.headless=true "
 
-JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:+DisableExplicitGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:LargePageSizeInBytes=128m -XX:+UseFastAccessorMethods -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70 -Dio.netty.leakDetection.level=DISABLED "
+JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m ${VERSION_OPTS} -Dio.netty.leakDetection.level=DISABLED "
 
 MAIN_CLASS=org.apache.shardingsphere.proxy.Bootstrap
 


### PR DESCRIPTION
Fixes #14941.

Changes proposed in this pull request:
- cur java options support java8、java11 and java17
- the java version format must be: `1.x.x_x`  or `1x.xx.xx`
- both support linux shell and windows bat
