### PR TITLE
Move ackCallback in channel impl; Improve performance of MemoryPipelineChannelFactory.createPipelineChannel

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/MultiplexMemoryPipelineChannel.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/MultiplexMemoryPipelineChannel.java
@@ -41,8 +41,6 @@ public final class MultiplexMemoryPipelineChannel implements PipelineChannel {
     
     private final Map<String, Integer> channelAssignment = new HashMap<>();
     
-    private final AckCallback ackCallback;
-    
     public MultiplexMemoryPipelineChannel(final AckCallback ackCallback) {
         this(10000, ackCallback);
     }
@@ -53,10 +51,9 @@ public final class MultiplexMemoryPipelineChannel implements PipelineChannel {
     
     public MultiplexMemoryPipelineChannel(final int channelNumber, final int blockQueueSize, final AckCallback ackCallback) {
         this.channelNumber = channelNumber;
-        this.ackCallback = ackCallback;
         channels = new PipelineChannel[channelNumber];
         for (int i = 0; i < channelNumber; i++) {
-            channels[i] = new SimpleMemoryPipelineChannel(blockQueueSize);
+            channels[i] = new SimpleMemoryPipelineChannel(blockQueueSize, ackCallback);
         }
     }
     
@@ -88,7 +85,6 @@ public final class MultiplexMemoryPipelineChannel implements PipelineChannel {
     @Override
     public void ack(final List<Record> records) {
         findChannel().ack(records);
-        ackCallback.onAck(records);
     }
     
     private PipelineChannel findChannel() {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/channel/memory/SimpleMemoryPipelineChannel.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory;
 
+import org.apache.shardingsphere.data.pipeline.api.ingest.channel.AckCallback;
 import org.apache.shardingsphere.data.pipeline.api.ingest.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.Record;
 import org.apache.shardingsphere.data.pipeline.core.util.ThreadUtil;
@@ -33,12 +34,11 @@ public final class SimpleMemoryPipelineChannel implements PipelineChannel {
     
     private final BlockingQueue<Record> queue;
     
-    public SimpleMemoryPipelineChannel() {
-        this(10000);
-    }
+    private final AckCallback ackCallback;
     
-    public SimpleMemoryPipelineChannel(final int blockQueueSize) {
+    public SimpleMemoryPipelineChannel(final int blockQueueSize, final AckCallback ackCallback) {
         this.queue = new ArrayBlockingQueue<>(blockQueueSize);
+        this.ackCallback = ackCallback;
     }
     
     @Override
@@ -67,6 +67,7 @@ public final class SimpleMemoryPipelineChannel implements PipelineChannel {
     
     @Override
     public void ack(final List<Record> records) {
+        ackCallback.onAck(records);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ingest/channel/MemoryPipelineChannelFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/spi/ingest/channel/MemoryPipelineChannelFactory.java
@@ -21,6 +21,7 @@ import com.google.common.base.Strings;
 import org.apache.shardingsphere.data.pipeline.api.ingest.channel.AckCallback;
 import org.apache.shardingsphere.data.pipeline.api.ingest.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory.MultiplexMemoryPipelineChannel;
+import org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory.SimpleMemoryPipelineChannel;
 import org.apache.shardingsphere.data.pipeline.spi.ingest.channel.PipelineChannelFactory;
 
 import java.util.Properties;
@@ -58,6 +59,9 @@ public final class MemoryPipelineChannelFactory implements PipelineChannelFactor
     
     @Override
     public PipelineChannel createPipelineChannel(final int outputConcurrency, final AckCallback ackCallback) {
+        if (1 == outputConcurrency) {
+            return new SimpleMemoryPipelineChannel(blockQueueSize, ackCallback);
+        }
         return new MultiplexMemoryPipelineChannel(outputConcurrency, blockQueueSize, ackCallback);
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:
- Move ackCallback from multiplex channel impl to simple channel impl. For cleaner responsibility.
- Use simple channel impl when output concurrency is 1 in channel factory. For better performance.
