### PR TITLE
Refactor PipelineDataSourceManager for common usage; Simplify job preparer

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/PipelineDataSourceManager.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/PipelineDataSourceManager.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.data.pipeline.core.datasource;
 
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceWrapper;
@@ -31,45 +30,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * Pipeline data source manager.
  */
 @NoArgsConstructor
-@Getter
 @Slf4j
 public final class PipelineDataSourceManager implements AutoCloseable {
     
     private final PipelineDataSourceFactory dataSourceFactory = new PipelineDataSourceFactory();
     
     private final Map<PipelineDataSourceConfiguration, PipelineDataSourceWrapper> cachedDataSources = new ConcurrentHashMap<>();
-    
-    private final Map<PipelineDataSourceConfiguration, PipelineDataSourceWrapper> sourceDataSources = new ConcurrentHashMap<>();
-    
-    private final Map<PipelineDataSourceConfiguration, PipelineDataSourceWrapper> targetDataSources = new ConcurrentHashMap<>();
-    
-    /**
-     * Create source data source.
-     *
-     * @param pipelineDataSourceConfig pipeline data source configuration
-     */
-    public void createSourceDataSource(final PipelineDataSourceConfiguration pipelineDataSourceConfig) {
-        if (cachedDataSources.containsKey(pipelineDataSourceConfig)) {
-            return;
-        }
-        PipelineDataSourceWrapper dataSource = getDataSource(pipelineDataSourceConfig);
-        cachedDataSources.put(pipelineDataSourceConfig, dataSource);
-        sourceDataSources.put(pipelineDataSourceConfig, dataSource);
-    }
-    
-    /**
-     * Create target data source.
-     *
-     * @param pipelineDataSourceConfig pipeline data source configuration
-     */
-    public void createTargetDataSource(final PipelineDataSourceConfiguration pipelineDataSourceConfig) {
-        if (cachedDataSources.containsKey(pipelineDataSourceConfig)) {
-            return;
-        }
-        PipelineDataSourceWrapper dataSource = getDataSource(pipelineDataSourceConfig);
-        cachedDataSources.put(pipelineDataSourceConfig, dataSource);
-        targetDataSources.put(pipelineDataSourceConfig, dataSource);
-    }
     
     /**
      * Get cached data source.
@@ -106,7 +72,5 @@ public final class PipelineDataSourceManager implements AutoCloseable {
             }
         }
         cachedDataSources.clear();
-        sourceDataSources.clear();
-        targetDataSources.clear();
     }
 }

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/datasource/PipelineDataSourceManagerTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/datasource/PipelineDataSourceManagerTest.java
@@ -54,9 +54,9 @@ public final class PipelineDataSourceManagerTest {
     @Test
     public void assertClose() throws NoSuchFieldException, IllegalAccessException {
         try (PipelineDataSourceManager dataSourceManager = new PipelineDataSourceManager()) {
-            dataSourceManager.createSourceDataSource(
+            dataSourceManager.getDataSource(
                     PipelineDataSourceConfigurationFactory.newInstance(jobConfig.getPipelineConfig().getSource().getType(), jobConfig.getPipelineConfig().getSource().getParameter()));
-            dataSourceManager.createTargetDataSource(
+            dataSourceManager.getDataSource(
                     PipelineDataSourceConfigurationFactory.newInstance(jobConfig.getPipelineConfig().getTarget().getType(), jobConfig.getPipelineConfig().getTarget().getParameter()));
             Map<?, ?> cachedDataSources = ReflectionUtil.getFieldValue(dataSourceManager, "cachedDataSources", Map.class);
             assertNotNull(cachedDataSources);


### PR DESCRIPTION
Changes proposed in this pull request:
- Refactor PipelineDataSourceManager for common usage. For single responsibility.
- Refactor job preparer. Cache data source in local; Separate source and target data source connection check.
