### PR TITLE
Update VM options for ShardingSphere-Proxy

### DIFF
--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
@@ -80,7 +80,7 @@ if %int_version% == 8 (
 
 echo Starting the %SERVER_NAME% ...
 
-java -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
+java -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
 
 goto exit
 

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
@@ -69,7 +69,7 @@ for /f "tokens=1,2 delims=." %%a in (%total_version%) do (
 echo we find java version: java%int_version%, full_version=%total_version:~1,9%
 set VERSION_OPTS=
 if %int_version% == 8 (
-    set VERSION_OPTS=-XX:+UseFastAccessorMethods -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70
+    set VERSION_OPTS=-XX:+UseConcMarkSweepGC -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70
 ) else if %int_version% == 11 (
     set VERSION_OPTS=-XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler
 ) else if %int_version% == 17 (

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
@@ -80,7 +80,7 @@ if %int_version% == 8 (
 
 echo Starting the %SERVER_NAME% ...
 
-java -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
+java -server -Xmx2g -Xms2g -Xmn1g -Xss256k -XX:AutoBoxCacheMax=4096 -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m %VERSION_OPTS% -Dfile.encoding=UTF-8 -Dio.netty.leakDetection.level=DISABLED -classpath %CLASS_PATH% %MAIN_CLASS%
 
 goto exit
 

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.bat
@@ -71,9 +71,9 @@ set VERSION_OPTS=
 if %int_version% == 8 (
     set VERSION_OPTS=-XX:+UseConcMarkSweepGC -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70
 ) else if %int_version% == 11 (
-    set VERSION_OPTS=-XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler
+    set VERSION_OPTS=-XX:+SegmentedCodeCache -XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler
 ) else if %int_version% == 17 (
-    set VERSION_OPTS=-XX:+AggressiveHeap
+    set VERSION_OPTS=-XX:+SegmentedCodeCache -XX:+AggressiveHeap
 ) else (
     echo unadapted java version, please notice...
 )

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
@@ -53,7 +53,7 @@ fi
 
 JAVA_OPTS=" -Djava.awt.headless=true "
 
-JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:+UseNUMA -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m ${VERSION_OPTS} -Dio.netty.leakDetection.level=DISABLED "
+JAVA_MEM_OPTS=" -server -Xmx2g -Xms2g -Xmn1g -Xss1m -XX:AutoBoxCacheMax=4096 -XX:+UseNUMA -XX:+DisableExplicitGC -XX:LargePageSizeInBytes=128m ${VERSION_OPTS} -Dio.netty.leakDetection.level=DISABLED "
 
 MAIN_CLASS=org.apache.shardingsphere.proxy.Bootstrap
 

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
@@ -44,9 +44,9 @@ VERSION_OPTS=""
 if [ $int_version = '8' ] ; then
     VERSION_OPTS="-XX:+UseConcMarkSweepGC -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70"
 elif [ $int_version = '11' ] ; then
-    VERSION_OPTS="-XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+    VERSION_OPTS="-XX:+SegmentedCodeCache -XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
 elif [ $int_version = '17' ] ; then
-    VERSION_OPTS="-XX:+AggressiveHeap"
+    VERSION_OPTS="-XX:+SegmentedCodeCache -XX:+AggressiveHeap"
 else
     echo "unadapted java version, please notice..."
 fi

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/resources/bin/start.sh
@@ -42,7 +42,7 @@ echo "we find java version: java${int_version}, full_version=${total_version}"
 
 VERSION_OPTS=""
 if [ $int_version = '8' ] ; then
-    VERSION_OPTS="-XX:+UseFastAccessorMethods -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70"
+    VERSION_OPTS="-XX:+UseConcMarkSweepGC -XX:+UseCMSInitiatingOccupancyOnly -XX:CMSInitiatingOccupancyFraction=70"
 elif [ $int_version = '11' ] ; then
     VERSION_OPTS="-XX:+AggressiveHeap -XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
 elif [ $int_version = '17' ] ; then


### PR DESCRIPTION
Related to #10626

The options are removed because they are enabled by default.
- UseFastAccessorMethods
- CMSParallelRemarkEnabled