### PR TITLE
Upgrade Netty to 4.1.73

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <btm.version>2.1.3</btm.version>
         
         <curator.version>5.1.0</curator.version>
+        <zookeeper.version>3.6.0</zookeeper.version>
         <jetcd.version>0.5.0</jetcd.version>
         
         <lombok.version>1.18.20</lombok.version>
@@ -268,7 +269,7 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-transport-native-epoll</artifactId>
+                <artifactId>netty-transport-classes-epoll</artifactId>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
@@ -386,6 +387,17 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-recipes</artifactId>
                 <version>${curator.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport-native-epoll</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.etcd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <groovy.version>2.4.19</groovy.version>
         <snakeyaml.version>1.16</snakeyaml.version>
         
-        <netty.version>4.1.70.Final</netty.version>
+        <netty.version>4.1.73.Final</netty.version>
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-codec.version>1.10</commons-codec.version>
         <commons-cli.version>1.4</commons-cli.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -264,22 +264,23 @@ The text of each license is the standard Apache 2.0 license.
     listenablefuture 9999.0-empty-to-avoid-conflict-with-guava:https://github.com/google/guava, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-codec-dns 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-resolver-dns 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.69.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.69.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.69.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.69.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-codec-dns 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-resolver-dns 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-tcnative-classes 2.0.46.Final: https://github.com/netty/netty-tcnative, Apache 2.0
+    netty-transport 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.73.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.73.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.73.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.73.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.19.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 1.17.0: https://github.com/googleapis/common-protos-java, Apache 2.0
     quartz 2.3.2: https://github.com/quartz-scheduler/quartz, Apache 2.0

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/NOTICE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/NOTICE
@@ -15,7 +15,7 @@ netty NOTICE
 
 Please visit the Netty web site for more information:
 
-  * http://netty.io/
+  * https://netty.io/
 
 Copyright 2014 The Netty Project
 
@@ -23,7 +23,7 @@ The Netty Project licenses this file to you under the Apache License,
 version 2.0 (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at:
 
-  http://www.apache.org/licenses/LICENSE-2.0
+  https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -67,7 +67,7 @@ facade for Java, which can be obtained at:
   * LICENSE:
     * license/LICENSE.slf4j.txt (MIT License)
   * HOMEPAGE:
-    * http://www.slf4j.org/
+    * https://www.slf4j.org/
 
 This product contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
@@ -77,7 +77,7 @@ Java SE, which can be obtained at:
   * LICENSE:
     * license/LICENSE.harmony.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://archive.apache.org/dist/harmony/
+    * https://archive.apache.org/dist/harmony/
 
 This product contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
@@ -136,6 +136,14 @@ and decompression library, which can be obtained at:
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
+This product optionally depends on 'zstd-jni', a zstd-jni Java compression
+and decompression library, which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.zstd-jni.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/luben/zstd-jni
+
 This product contains a modified portion of 'jfastlz', a Java port of FastLZ compression
 and decompression library written by William Kinney. It can be obtained at:
 
@@ -159,7 +167,7 @@ equivalent functionality.  It can be obtained at:
   * LICENSE:
     * license/LICENSE.bouncycastle.txt (MIT License)
   * HOMEPAGE:
-    * http://www.bouncycastle.org/
+    * https://www.bouncycastle.org/
 
 This product optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
@@ -173,9 +181,9 @@ This product optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jboss-marshalling.txt (GNU LGPL 2.1)
+    * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://www.jboss.org/jbossmarshalling
+    * https://github.com/jboss-remoting/jboss-marshalling
 
 This product optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
@@ -191,7 +199,7 @@ framework, which can be obtained at:
   * LICENSE:
     * license/LICENSE.commons-logging.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://commons.apache.org/logging/
+    * https://commons.apache.org/logging/
 
 This product optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
@@ -199,7 +207,7 @@ can be obtained at:
   * LICENSE:
     * license/LICENSE.log4j.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://logging.apache.org/log4j/
+    * https://logging.apache.org/log4j/
 
 This product optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
@@ -207,7 +215,7 @@ non-blocking XML processor, which can be obtained at:
   * LICENSE:
     * license/LICENSE.aalto-xml.txt (Apache License 2.0)
   * HOMEPAGE:
-    * http://wiki.fasterxml.com/AaltoHome
+    * https://wiki.fasterxml.com/AaltoHome
 
 This product contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
@@ -216,6 +224,22 @@ the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
     * license/LICENSE.hpack.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/twitter/hpack
+    
+This product contains a modified version of 'HPACK', a Java implementation of
+the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.hyper-hpack.txt (MIT License)
+  * HOMEPAGE:
+    * https://github.com/python-hyper/hpack/
+
+This product contains a modified version of 'HPACK', a Java implementation of
+the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.nghttp2-hpack.txt (MIT License)
+  * HOMEPAGE:
+    * https://github.com/nghttp2/nghttp2/
 
 This product contains a modified portion of 'Apache Commons Lang', a Java library
 provides utilities for the java.lang API, which can be obtained at:
@@ -233,6 +257,23 @@ This product contains the Maven wrapper scripts from 'Maven Wrapper', that provi
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
+This product contains the dnsinfo.h header file, that provides a way to retrieve the system DNS configuration on MacOS.
+This private header is also used by Apple's open source
+ mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
+
+ * LICENSE:
+    * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+  * HOMEPAGE:
+    * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
+
+This product optionally depends on 'Brotli4j', Brotli compression and
+decompression for Java., which can be obtained at:
+
+  * LICENSE:
+    * license/LICENSE.brotli4j.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/hyperxpro/Brotli4j
+    
 ========================================================================
 
 Apache groovy NOTICE

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
+            <artifactId>netty-transport-classes-epoll</artifactId>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
Related to #10626.

Refer to https://netty.io/news/2022/01/12/4-1-73-Final.html
> We are happy to announce the release of netty 4.1.73.Final, which is the first netty release for this year (late Happy New Year!). Because this release fixes a few bugs in "core parts" of netty we highly recommend everyone to upgrade.

And I found there is a little increasement in performance.

### BenchmarkSQL Before

![middle_img_v2_d8284cf3-4651-4152-b549-fe85880b86bg](https://user-images.githubusercontent.com/20503072/151644829-a548e0b5-a700-4d95-8168-065af52de552.png)

### BenchmarkSQL After

![middle_img_v2_a2589b96-99c3-43d9-b960-f35c63a9cf1g](https://user-images.githubusercontent.com/20503072/151644832-a2361bff-5c82-41b6-ba84-4d64ea592978.png)
