### PR TITLE
Fix actionConfig variable name conflict in RuleAlteredContext

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -83,8 +83,9 @@ public final class RuleAlteredContext {
     
     private final ExecuteEngine importerExecuteEngine;
     
-    public RuleAlteredContext(final OnRuleAlteredActionConfiguration onRuleAlteredActionConfig) {
-        this.onRuleAlteredActionConfig = convertActionConfig(onRuleAlteredActionConfig);
+    public RuleAlteredContext(final OnRuleAlteredActionConfiguration actionConfig) {
+        OnRuleAlteredActionConfiguration onRuleAlteredActionConfig = convertActionConfig(actionConfig);
+        this.onRuleAlteredActionConfig = onRuleAlteredActionConfig;
         InputConfiguration inputConfig = onRuleAlteredActionConfig.getInput();
         ShardingSphereAlgorithmConfiguration inputRateLimiter = inputConfig.getRateLimiter();
         inputRateLimitAlgorithm = null != inputRateLimiter ? ShardingSphereAlgorithmFactory.createAlgorithm(inputRateLimiter, JobRateLimitAlgorithm.class) : null;


### PR DESCRIPTION

Changes proposed in this pull request:
- Fix actionConfig variable name conflict in RuleAlteredContext. When `input` is not available, it'll cause issue. It's changed by mistake in diff ui before commit of #15105.
