### PR TITLE
Show detailed error message to end user when scaling job does not exist

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -338,10 +338,10 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     }
     
     private JobConfigurationPOJO getElasticJobConfigPOJO(final String jobId) {
-        try {
-            return PipelineAPIFactory.getJobConfigurationAPI().getJobConfiguration(jobId);
-        } catch (final NullPointerException ex) {
+        JobConfigurationPOJO result = PipelineAPIFactory.getJobConfigurationAPI().getJobConfiguration(jobId);
+        if (null == result) {
             throw new PipelineJobNotFoundException(String.format("Can not find scaling job %s", jobId), jobId);
         }
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #15179.

Changes proposed in this pull request:
- Show detailed error message to end user when job does not exist
