### PR TITLE
Remove hard coded SO_BACKLOG

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/ShardingSphereProxy.java
@@ -96,7 +96,6 @@ public final class ShardingSphereProxy {
     private void initServerBootstrap(final ServerBootstrap bootstrap) {
         bootstrap.group(bossGroup, workerGroup)
                 .channel(Epoll.isAvailable() ? EpollServerSocketChannel.class : NioServerSocketChannel.class)
-                .option(ChannelOption.SO_BACKLOG, 128)
                 .option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024 * 1024, 16 * 1024 * 1024))
                 .option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)


### PR DESCRIPTION
`128` is the default value in Linux and macOS. Netty can detect this value from `/proc/sys/net/core/somaxconn` or `sysctl`.

https://github.com/netty/netty/blob/62ef8f96e3ff5c21f4ff122756d8a21e6e6d1c01/common/src/main/java/io/netty/util/NetUtil.java#L154-L159