### PR TITLE
Upgrade Groovy to 4.0.0 to support new features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <cosid.version>1.8.6</cosid.version>
         <antlr4.version>4.9.2</antlr4.version>
         
-        <groovy.version>2.5.15</groovy.version>
+        <groovy.version>4.0.0</groovy.version>
         <snakeyaml.version>1.16</snakeyaml.version>
         
         <netty.version>4.1.73.Final</netty.version>
@@ -197,10 +197,9 @@
             </dependency>
             
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy</artifactId>
                 <version>${groovy.version}</version>
-                <classifier>indy</classifier>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -299,7 +299,7 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    groovy 2.4.19-indy: https://github.com/apache/groovy, Apache 2.0
+    groovy 4.0.0: https://github.com/apache/groovy, Apache 2.0
     atomikos-util 5.0.8: https://www.atomikos.com, Apache 2.0
     transactions 5.0.8: https://www.atomikos.com, Apache 2.0
     transactions-api 5.0.8: https://www.atomikos.com, Apache 2.0

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/pom.xml
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/pom.xml
@@ -116,9 +116,8 @@
         </dependency>
         
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <classifier>indy</classifier>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/shardingsphere-infra/shardingsphere-infra-common/pom.xml
+++ b/shardingsphere-infra/shardingsphere-infra-common/pom.xml
@@ -49,9 +49,8 @@
         </dependency>
         
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <classifier>indy</classifier>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/shardingsphere-test/shardingsphere-rewrite-test/pom.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/pom.xml
@@ -84,9 +84,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
-            <classifier>indy</classifier>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>


### PR DESCRIPTION
Fixes #15277 ,#13080 .

Changes proposed in this pull request:
- Upgrade `org.codehaus.groovy:groovy:2.5.15` to `org.apache.groovy:groovy:4.0.0`, to provide low-level support for using `Lambda` in row expressions ( Features introduced in Groovy 3.0 , refer to http://groovy-lang.org/releasenotes/groovy-3.0.html ), and handle the `JPMS` issue mentioned in #13080 ( One of the main issues to be resolved in Groovy 4.0 ).
- Update LICENSE .
- Influenced by the `Classic bytecode generation removal` section of http://groovy-lang.org/releasenotes/groovy-4.0.html , `groovy-indy` is no longer specified.
- I have noticed some potential issues with Groovy namespace changes, not sure if it will affect future usage, including but not limited to https://github.com/gradle/gradle/pull/18552 , https://github.com/grails/grails-core/issues/12373 , https://github.com/spring-projects/spring-framework/issues/27985 , I have no experience with Gradle and Grails. So it would be great if a friend could provide experience and examples of Gradle and Grails, so that we can determine whether we should limit the Groovy version to `3.0.9`.
