### PR TITLE
Support mysql JSON_VALUE return type syntax

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -874,9 +874,18 @@ simpleExpr
     | EXISTS? subquery
     | LBE_ identifier expr RBE_
     | identifier (JSON_SEPARATOR | JSON_UNQUOTED_SEPARATOR) string_
+    | path (RETURNING dataType)? onEmptyError? 
     | matchExpression
     | caseExpression
     | intervalExpression
+    ;
+    
+path
+    : string_
+    ;
+
+onEmptyError
+    : (NULL | ERROR | DEFAULT literals) ON (EMPTY | ERROR)
     ;
     
 columnRef

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select.xml
@@ -2989,6 +2989,35 @@
         </where>
     </select>
 
+    <select sql-case-id="select_with_json_value_return_type">
+        <from>
+            <simple-table name="t_order" start-index="14" stop-index="20" />
+        </from>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <where start-index="22" stop-index="86">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="86">
+                    <left>
+                        <function start-index="28" stop-index="77" function-name="JSON_VALUE" text="JSON_VALUE(items, '$.name' RETURNING VARCHAR(100))">
+                            <parameter>
+                                <column name="items" start-index="39" stop-index="43"/>
+                            </parameter>
+                            <parameter>
+                                <common-expression text="'$.name' RETURNING VARCHAR(100)" start-index="46" stop-index="76" />
+                            </parameter>
+                        </function>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="jack" start-index="81" stop-index="86" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
     <select sql-case-id="select_with_convert_function">
         <from>
             <simple-table name="t_order" start-index="70" stop-index="76" />

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select.xml
@@ -66,6 +66,7 @@
     <sql-case id="select_current_user" value="SELECT CURRENT_USER" db-types="PostgreSQL,openGauss"/>
     <sql-case id="select_with_match_against" value="SELECT * FROM t_order_item WHERE MATCH(t_order_item.description) AGAINST (? IN NATURAL LANGUAGE MODE) AND user_id = ?" db-types="MySQL" />
     <sql-case id="select_with_json_separator" value="select content_json->>'$.nation' as nation,content_json->>'$.title' as title from tb_content_json b where b.content_id=1" db-types="MySQL" />
+    <sql-case id="select_with_json_value_return_type" value="SELECT * FROM t_order WHERE JSON_VALUE(items, '$.name' RETURNING VARCHAR(100)) = 'jack'" db-types="MySQL" />
     <sql-case id="select_with_convert_function" value="SELECT CONVERT(SUBSTRING(content, 5) , SIGNED) AS signed_content FROM t_order WHERE order_id = 1" db-types="MySQL" />
     <sql-case id="select_with_json_extract" value="SELECT content_json::json->'title', content_json::json->'nation' FROM tb_content_json WHERE content_id = 1" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_with_json_extract_text" value="SELECT * FROM tb_content_json WHERE content_json::json->>'nation'='CHINA'" db-types="PostgreSQL,openGauss" />


### PR DESCRIPTION
Fixes #15311.

Changes proposed in this pull request:
- support mysql JSON_VALUE return type syntax
- add sql parse test case
