### PR TITLE
Complete SQL type in integration test

### DIFF
--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/dml/BatchDMLIT.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/dml/BatchDMLIT.java
@@ -61,9 +61,11 @@ public final class BatchDMLIT extends BatchITCase {
     
     @Test
     public void assertExecuteBatch() throws SQLException, ParseException {
+        if ("shadow".equals(getScenario()) && "PostgreSQL".equals(getDatabaseType().getName())) {
+            return;
+        }
         switch (getScenario()) {
             case "replica_query":
-            case "shadow":
             case "encrypt":
                 return;
             default:
@@ -94,9 +96,11 @@ public final class BatchDMLIT extends BatchITCase {
     @Test
     public void assertClearBatch() throws SQLException, ParseException {
         // TODO fix replica_query
+        if ("shadow".equals(getScenario()) && "PostgreSQL".equals(getDatabaseType().getName())) {
+            return;
+        }
         switch (getScenario()) {
             case "replica_query":
-            case "shadow":
             case "encrypt":
                 return;
             default:

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/dml/GeneralDMLIT.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/dml/GeneralDMLIT.java
@@ -61,7 +61,6 @@ public final class GeneralDMLIT extends BaseDMLIT {
     public void assertExecuteUpdate() throws SQLException, ParseException {
         switch (getScenario()) {
             case "replica_query":
-            case "shadow":
             case "encrypt":
                 return;
             default:
@@ -92,7 +91,6 @@ public final class GeneralDMLIT extends BaseDMLIT {
     public void assertExecute() throws SQLException, ParseException {
         switch (getScenario()) {
             case "replica_query":
-            case "shadow":
             case "encrypt":
                 return;
             default:

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_insert_order_batch_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_insert_order_batch_value.xml
@@ -16,7 +16,7 @@
   -->
 
 <dataset update-count="2">
-    <metadata data-nodes="shadow_db.t_order">
+    <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
@@ -29,7 +29,11 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="7, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="db.t_order" values="8, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_insert_order_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_insert_order_value.xml
@@ -15,8 +15,8 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="2">
-    <metadata data-nodes="shadow_db.t_order">
+<dataset update-count="1">
+    <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
@@ -29,7 +29,10 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="6, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_update_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/pro_update_order_by_user_id.xml
@@ -15,26 +15,23 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="3">
+<dataset update-count="2">
     <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="6, 1, pro_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
-    <row data-node="db.t_order" values="7, 1, pro_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
-    <row data-node="db.t_order" values="8, 1, pro_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order_update, F, false, 60, spring, 120.00, 2021-01-02, 13:30:30, 2021-01-02 13:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order_update, F, false, 60, spring, 120.00, 2021-01-02, 13:30:30, 2021-01-02 13:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_insert_order_batch_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_insert_order_batch_value.xml
@@ -20,21 +20,20 @@
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="6, 0, shadow_order, 100.00, S, 2021-01-01, summer, true, 6, 12:30:30, 2021-01-01 12:30:30.0" />
-    <row data-node="shadow_db.t_order" values="7, 0, shadow_order, 100.00, S, 2021-01-01, summer, true, 7, 12:30:30, 2021-01-01 12:30:30.0" />
-    <row data-node="shadow_db.t_order" values="8, 0, shadow_order, 100.00, S, 2021-01-01, summer, true, 7, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="7, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="shadow_db.t_order" values="8, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_insert_order_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_insert_order_value.xml
@@ -20,19 +20,19 @@
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="6, 0, shadow_order, 100.00, S, 2021-01-01, summer, true, 6, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="6, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_update_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/mysql/shadow_update_order_by_user_id.xml
@@ -29,7 +29,9 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order_update, F, false, 60, spring, 120.00, 2021-01-02, 13:30:30, 2021-01-02 13:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order_update, F, false, 60, spring, 120.00, 2021-01-02, 13:30:30, 2021-01-02 13:30:30.0" />
     <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_insert_order_batch_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_insert_order_batch_value.xml
@@ -16,7 +16,7 @@
   -->
 
 <dataset update-count="2">
-    <metadata data-nodes="shadow_db.t_order">
+    <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
@@ -29,7 +29,11 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="7, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="db.t_order" values="8, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_insert_order_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_insert_order_value.xml
@@ -15,26 +15,24 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="2">
+<dataset update-count="1">
     <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="6, 1, pro_order, 100.00, S, 2021-01-01, summer, true, 6, 12:30:30, 2021-01-01 12:30:30.0" />
-    <row data-node="db.t_order" values="7, 1, pro_order, 100.00, S, 2021-01-01, summer, true, 7, 12:30:30, 2021-01-01 12:30:30.0" />
-    <row data-node="db.t_order" values="8, 1, pro_order, 100.00, S, 2021-01-01, summer, true, 7, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0 " />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="6, 1, pro_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_update_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/pro_update_order_by_user_id.xml
@@ -15,26 +15,23 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="3">
+<dataset update-count="2">
     <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="1, 1, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="2, 1, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="3, 1, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="4, 1, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="5, 1, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="6, 1, shadow_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
-    <row data-node="db.t_order" values="7, 1, shadow_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
-    <row data-node="db.t_order" values="8, 1, shadow_order, 110.00, S, 2021-01-02, spring, false, 8, 13:30:30, 2021-01-02 13:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order_update, F, false, 60, spring, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order_update, F, false, 60, spring, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_insert_order_batch_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_insert_order_batch_value.xml
@@ -32,4 +32,8 @@
     <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="7, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="shadow_db.t_order" values="8, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_insert_order_value.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_insert_order_value.xml
@@ -16,23 +16,23 @@
   -->
 
 <dataset update-count="1">
-    <metadata data-nodes="db.t_order">
+    <metadata data-nodes="shadow_db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="6, 1, pro_order, 100.00, S, 2021-01-01, summer, true, 6, 12:30:30, 2021-01-01 12:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="6, 0, shadow_order, S, true, 50, summer, 100.00, 2021-01-01, 12:30:30, 2021-01-01 12:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_update_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/postgresql/shadow_update_order_by_user_id.xml
@@ -29,7 +29,9 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order_update, F, false, 60, spring, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order_update, F, false, 60, spring, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/pro_delete_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dataset/shadow/pro_delete_order_by_user_id.xml
@@ -15,23 +15,21 @@
   ~ limitations under the License.
   -->
 
-<dataset update-count="3" >
+<dataset update-count="2" >
     <metadata data-nodes="db.t_order">
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row data-node="db.t_order" values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
@@ -213,6 +213,10 @@
                             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="6:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="pro_insert_order_value.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="6:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="shadow_insert_order_value.xml" />
     </test-case>
@@ -221,20 +225,31 @@
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="7:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp, 8:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                 expected-data-file="pro_insert_order_batch_value.xml" />
+    </test-case>
+
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="7:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp, 8:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
-                expected-data-file="shadow_insert_order_batch_value.xml" />
+                   expected-data-file="shadow_insert_order_batch_value.xml" />
     </test-case>
 
     <test-case sql="UPDATE t_order SET order_name = ?, type_char = ?, type_boolean = ?, type_smallint = ?, type_enum = ?, type_decimal = ?, type_date = ?, type_time = ?, type_timestamp = ?
                     WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="pro_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 120.00:decimal, 2021-01-02:Date, 13:30:30:time, 2021-01-02 13:30:30:timestamp, 1:int, 1:long, 2:long"
                    expected-data-file="pro_update_order_by_user_id.xml" />
+    </test-case>
+
+    <test-case sql="UPDATE t_order SET order_name = ?, type_char = ?, type_boolean = ?, type_smallint = ?, type_enum = ?, type_decimal = ?, type_date = ?, type_time = ?, type_timestamp = ?
+                    WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="shadow_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 120.00:decimal, 2021-01-02:Date, 13:30:30:time, 2021-01-02 13:30:30:timestamp, 0:int, 1:long, 2:long"
                    expected-data-file="shadow_update_order_by_user_id.xml" />
     </test-case>
 
     <test-case sql="DELETE FROM t_order WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="1:int, 4:long, 5:long" expected-data-file="pro_delete_order_by_user_id.xml" />
+    </test-case>
+
+    <test-case sql="DELETE FROM t_order WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
         <assertion parameters="0:int, 4:long, 5:long" expected-data-file="shadow_delete_order_by_user_id.xml" />
     </test-case>
 

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
@@ -209,33 +209,56 @@
         <!--<assertion parameters="init:String" expected-data-file="delete_with_alias.xml" />-->
     <!--</test-case>-->
 
-    <!-- TODO complete test type -->
-    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_decimal, type_char, type_date, type_enum, type_boolean, type_smallint, type_time, type_timestamp)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL,PostgreSQL" scenario-types="shadow">
-        <assertion parameters="6:long, 1:int, pro_order:String, 100.00:decimal, S:char, 2021-01-01:Date, summer:enum#season, true:boolean, 6:smallint, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
+        <assertion parameters="6:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="pro_insert_order_value.xml" />
-        <assertion parameters="6:long, 0:int, shadow_order:String, 100.00:decimal, S:char, 2021-01-01:Date, summer:enum#season, true:boolean, 6:smallint, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+        <assertion parameters="6:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="shadow_insert_order_value.xml" />
     </test-case>
 
-    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_decimal, type_char, type_date, type_enum, type_boolean, type_smallint, type_time, type_timestamp) VALUES
-                    (7, 1, 'pro_order', 100.00, 'S', '2021-01-01', 'summer', true, 7, '12:30:30', '2021-01-01 12:30:30'), (8, 1, 'pro_order', 100.00, 'S', '2021-01-01', 'summer', true, 7, '12:30:30', '2021-01-01 12:30:30');"
-               db-types="MySQL,PostgreSQL" scenario-types="shadow">
-        <assertion expected-data-file="pro_insert_order_batch_value.xml" />
-        <assertion expected-data-file="shadow_insert_order_batch_value.xml" />
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="MySQL" scenario-types="shadow">
+        <assertion parameters="7:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp, 8:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+                expected-data-file="pro_insert_order_batch_value.xml" />
+        <assertion parameters="7:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp, 8:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+                expected-data-file="shadow_insert_order_batch_value.xml" />
     </test-case>
 
-    <test-case sql="UPDATE t_order SET order_name = ?, type_decimal = ?, type_char = ?, type_date = ?, type_enum = ?, type_boolean = ?, type_smallint = ?, type_time = ?, type_timestamp = ?
-                    WHERE user_id = ? and order_id in (?, ?, ?)" db-types="MySQL,PostgreSQL" scenario-types="shadow">
-        <assertion parameters="pro_order:String, 110.00:decimal, S:char, 2021-01-02:Date, spring:enum#season, false:boolean, 8:smallint, 13:30:30:time, '2021-01-02 13:30:30':timestamp, 1:int, 6:long, 7:long, 8:long"
+    <test-case sql="UPDATE t_order SET order_name = ?, type_char = ?, type_boolean = ?, type_smallint = ?, type_enum = ?, type_decimal = ?, type_date = ?, type_time = ?, type_timestamp = ?
+                    WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
+        <assertion parameters="pro_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 120.00:decimal, 2021-01-02:Date, 13:30:30:time, 2021-01-02 13:30:30:timestamp, 1:int, 1:long, 2:long"
                    expected-data-file="pro_update_order_by_user_id.xml" />
-        <assertion parameters="pro_order:String, 110.00:decimal, S:char, 2021-01-02:Date, spring:enum#season, false:boolean, 8:smallint, 13:30:30:time, '2021-01-02 13:30:30':timestamp, 0:int, 6:long, 7:long, 8:long"
+        <assertion parameters="shadow_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 120.00:decimal, 2021-01-02:Date, 13:30:30:time, 2021-01-02 13:30:30:timestamp, 0:int, 1:long, 2:long"
                    expected-data-file="shadow_update_order_by_user_id.xml" />
     </test-case>
 
-    <test-case sql="DELETE FROM t_order WHERE user_id = ? and order_id in (?, ?, ?)" db-types="MySQL,PostgreSQL" scenario-types="shadow">
-        <assertion parameters="1:int, 6:long, 7:long, 8:long" expected-data-file="pro_delete_order_by_user_id.xml" />
-        <assertion parameters="0:int, 6:long, 7:long, 8:long" expected-data-file="shadow_delete_order_by_user_id.xml" />
+    <test-case sql="DELETE FROM t_order WHERE user_id = ? and order_id in (?, ?)" db-types="MySQL" scenario-types="shadow">
+        <assertion parameters="1:int, 4:long, 5:long" expected-data-file="pro_delete_order_by_user_id.xml" />
+        <assertion parameters="0:int, 4:long, 5:long" expected-data-file="shadow_delete_order_by_user_id.xml" />
+    </test-case>
+
+    <!-- FIXME Support decimal, Date, time, timestamp types for PostgreSQL
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?, ?::season, ?, ?, ?, ?);" db-types="PostgreSQL" scenario-types="shadow">
+        <assertion parameters="6:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+                   expected-data-file="pro_insert_order_value.xml" />
+        <assertion parameters="6:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+                   expected-data-file="shadow_insert_order_value.xml" />
+    </test-case>
+    -->
+
+    <test-case sql="UPDATE t_order SET order_name = ?, type_char = ?, type_boolean = ?, type_smallint = ?, type_enum = ?::season
+                    WHERE user_id = ? and order_id in (?, ?)" db-types="PostgreSQL" scenario-types="shadow">
+        <assertion parameters="pro_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 1:int, 1:long, 2:long"
+                   expected-data-file="pro_update_order_by_user_id.xml" />
+        <assertion parameters="shadow_order_update:String, F:char, false:boolean, 60:smallint, spring:enum#season, 0:int, 1:long, 2:long"
+                   expected-data-file="shadow_update_order_by_user_id.xml" />
+    </test-case>
+
+    <test-case sql="DELETE FROM t_order WHERE user_id = ? and order_id in (?, ?)" db-types="PostgreSQL" scenario-types="shadow">
+        <assertion parameters="1:int, 4:long, 5:long" expected-data-file="pro_delete_order_by_user_id.xml" />
+        <assertion parameters="0:int, 4:long, 5:long" expected-data-file="shadow_delete_order_by_user_id.xml" />
     </test-case>
 
 </integration-test-cases>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dml/dml-integration-test-cases.xml
@@ -238,15 +238,14 @@
         <assertion parameters="0:int, 4:long, 5:long" expected-data-file="shadow_delete_order_by_user_id.xml" />
     </test-case>
 
-    <!-- FIXME Support decimal, Date, time, timestamp types for PostgreSQL
-    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp)
-                    VALUES (?, ?, ?, ?, ?, ?, ?::season, ?, ?, ?, ?);" db-types="PostgreSQL" scenario-types="shadow">
-        <assertion parameters="6:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+    <!-- FIXME Support decimal, enum types for PostgreSQL -->
+    <test-case sql="INSERT INTO t_order (order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_date, type_time, type_timestamp)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);" db-types="PostgreSQL" scenario-types="shadow">
+        <assertion parameters="6:long, 1:int, pro_order:String, S:char, true:boolean, 50:smallint, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="pro_insert_order_value.xml" />
-        <assertion parameters="6:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, summer:enum#season, 100.00:decimal, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
+        <assertion parameters="6:long, 0:int, shadow_order:String, S:char, true:boolean, 50:smallint, 2021-01-01:Date, 12:30:30:time, 2021-01-01 12:30:30:timestamp"
                    expected-data-file="shadow_insert_order_value.xml" />
     </test-case>
-    -->
 
     <test-case sql="UPDATE t_order SET order_name = ?, type_char = ?, type_boolean = ?, type_smallint = ?, type_enum = ?::season
                     WHERE user_id = ? and order_id in (?, ?)" db-types="PostgreSQL" scenario-types="shadow">

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dataset/shadow/pro_select_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dataset/shadow/pro_select_order_by_user_id.xml
@@ -20,18 +20,18 @@
         <column name="order_id" />
         <column name="user_id" />
         <column name="order_name" />
-        <column name="type_decimal" />
         <column name="type_char" />
-        <column name="type_date" />
-        <column name="type_enum" />
         <column name="type_boolean" />
         <column name="type_smallint" />
+        <column name="type_enum" />
+        <column name="type_decimal" />
+        <column name="type_date" />
         <column name="type_time" />
         <column name="type_timestamp" />
     </metadata>
-    <row values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dataset/shadow/shadow_select_order_by_user_id.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dataset/shadow/shadow_select_order_by_user_id.xml
@@ -20,18 +20,18 @@
         <column name="order_id" />
         <column name="user_id" />
         <column name="order_name" />
-        <column name="type_decimal" />
         <column name="type_char" />
-        <column name="type_date" />
-        <column name="type_enum" />
         <column name="type_boolean" />
         <column name="type_smallint" />
+        <column name="type_enum" />
+        <column name="type_decimal" />
+        <column name="type_date" />
         <column name="type_time" />
         <column name="type_timestamp" />
     </metadata>
-    <row values="1, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="2, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="3, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="4, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
-    <row values="5, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -627,7 +627,8 @@
     </test-case>
 
     <!-- TODO complete test type -->
-    <test-case sql="SELECT order_id, user_id, order_name, type_decimal, type_char, type_date, type_enum, type_boolean, type_smallint, type_time, type_timestamp FROM t_order WHERE user_id = ?"
+    <test-case
+            sql="SELECT order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp FROM t_order WHERE user_id = ?"
                db-types="MySQL,PostgreSQL" scenario-types="shadow">
         <assertion parameters="1:int" expected-data-file="pro_select_order_by_user_id.xml"/>
         <assertion parameters="0:int" expected-data-file="shadow_select_order_by_user_id.xml"/>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/dataset.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/dataset.xml
@@ -20,23 +20,23 @@
         <column name="order_id" type="long" />
         <column name="user_id" type="int" />
         <column name="order_name" type="varchar" />
-        <column name="type_decimal" type="decimal" />
         <column name="type_char" type="char" />
-        <column name="type_date" type="Date" />
-        <column name="type_enum" type="enum#season" />
         <column name="type_boolean" type="boolean" />
         <column name="type_smallint" type="smallint" />
+        <column name="type_enum" type="enum#season" />
+        <column name="type_decimal" type="decimal" />
+        <column name="type_date" type="Date" />
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp"/>
     </metadata>
-    <row data-node="db.t_order" values="1, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="db.t_order" values="2, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="db.t_order" values="3, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="db.t_order" values="4, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="db.t_order" values="5, 1, pro_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
-    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, 10.00, S, 2017-08-08, summer, true, 5, 18:30:30, 2017-08-08 18:30:30" />
+    <row data-node="db.t_order" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_order" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="shadow_db.t_order" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/mysql/init.sql
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/mysql/init.sql
@@ -25,14 +25,14 @@ DROP DATABASE IF EXISTS db;
 
 CREATE DATABASE db;
 
-CREATE TABLE db.t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_decimal DECIMAL(18,2) NOT NULL, type_char char(1) NOT NULL, type_date DATE NOT NULL,
-                        type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_time time NOT NULL,
-                        type_timestamp timestamp NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE db.t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
+                         type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL,
+                         PRIMARY KEY (order_id));
 
 DROP DATABASE IF EXISTS shadow_db;
 
 CREATE DATABASE shadow_db;
 
-CREATE TABLE shadow_db.t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_decimal DECIMAL(18,2) NOT NULL, type_char char(1) NOT NULL, type_date DATE NOT NULL,
-                                type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_time time NOT NULL,
-                                type_timestamp timestamp NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE shadow_db.t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
+                                type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL,
+                                PRIMARY KEY (order_id));

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/postgresql/init.sql
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/postgresql/init.sql
@@ -27,8 +27,8 @@ DROP TABLE IF EXISTS t_order;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
-CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_decimal DECIMAL(18,2) NOT NULL, type_char char(1) NOT NULL, type_date DATE NOT NULL,
-                      type_enum season NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_time time(0) NOT NULL, type_timestamp timestamp(0) without time zone,
+CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
+                      type_enum season NOT NULL, type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
                       PRIMARY KEY (order_id));
 
 \c shadow_db
@@ -37,6 +37,6 @@ DROP TABLE IF EXISTS t_order;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
-CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_decimal DECIMAL(18,2) NOT NULL, type_char char(1) NOT NULL, type_date DATE NOT NULL,
-                      type_enum season NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_time time(0) NOT NULL, type_timestamp timestamp(0) without time zone,
+CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
+                      type_enum season NOT NULL, type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
                       PRIMARY KEY (order_id));

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/postgresql/init.sql
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/shadow/init-sql/postgresql/init.sql
@@ -28,7 +28,7 @@ DROP TABLE IF EXISTS t_order;
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
-                      type_enum season NOT NULL, type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
+                      type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT '100.00', type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
                       PRIMARY KEY (order_id));
 
 \c shadow_db
@@ -38,5 +38,5 @@ DROP TABLE IF EXISTS t_order;
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_order (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL,
-                      type_enum season NOT NULL, type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
+                      type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT '100.00', type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL,
                       PRIMARY KEY (order_id));


### PR DESCRIPTION
## Complete SQL type in integration test

Related to #14899.

Changes proposed in this pull request:
-  MySQL data type  test case completed  DML and DQL.
-  PostgreSQL data type test case completed DQL.
-  PostgreSQL data type test case partially completed DML, except  decimal, Date, time, timestamp.
