### PR TITLE
[DistSQL] `CREATE/ALTER TRAFFIC RULE` syntax supports empty Labels and `LoadBalancer

### DIFF
--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
@@ -96,7 +96,7 @@ dropTrafficRule
     ;
 
 trafficRuleDefinition
-    : ruleName LP labelDefinition COMMA trafficAlgorithmDefinition COMMA loadBanlanceDefinition RP
+    : ruleName LP (labelDefinition COMMA)? trafficAlgorithmDefinition (COMMA loadBalanceDefinition)? RP
     ;
 
 labelDefinition
@@ -107,7 +107,7 @@ trafficAlgorithmDefinition
     : TRAFFIC_ALGORITHM LP algorithmDefinition RP 
     ;
 
-loadBanlanceDefinition
+loadBalanceDefinition
     : LOAD_BALANCER LP algorithmDefinition RP
     ;
 

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
@@ -43,6 +43,7 @@ import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementPa
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.InstanceDefinationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.InstanceIdContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.LabelDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.LoadBalanceDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.PasswordContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.PropertiesDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.PropertyContext;
@@ -107,6 +108,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSeg
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
@@ -373,8 +375,20 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     
     @Override
     public ASTNode visitTrafficRuleDefinition(final TrafficRuleDefinitionContext ctx) {
+        AlgorithmSegment loadBalancerSegment = null;
+        if (null != ctx.loadBalanceDefinition()) {
+            loadBalancerSegment = (AlgorithmSegment) visit(ctx.loadBalanceDefinition().algorithmDefinition());
+        }
         return new TrafficRuleSegment(getIdentifierValue(ctx.ruleName()), buildLabels(ctx.labelDefinition()),
-                (AlgorithmSegment) visit(ctx.trafficAlgorithmDefinition().algorithmDefinition()), (AlgorithmSegment) visit(ctx.loadBanlanceDefinition().algorithmDefinition()));
+                (AlgorithmSegment) visit(ctx.trafficAlgorithmDefinition().algorithmDefinition()), loadBalancerSegment);
+    }
+    
+    @Override
+    public ASTNode visitLoadBalanceDefinition(final LoadBalanceDefinitionContext ctx) {
+        if (null == ctx) {
+            return null;
+        }
+        return visit(ctx.algorithmDefinition());
     }
     
     @Override
@@ -394,6 +408,9 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     }
     
     private Collection<String> buildLabels(final LabelDefinitionContext labelDefinition) {
+        if (null == labelDefinition) {
+            return Collections.emptyList();
+        }
         return labelDefinition.label().stream().map(this::getIdentifierValue).collect(Collectors.toCollection(LinkedList::new));
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/convert/TrafficRuleConverter.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/convert/TrafficRuleConverter.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.traffic.api.config.TrafficRuleConfiguration;
 import org.apache.shardingsphere.traffic.api.config.TrafficStrategyConfiguration;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Traffic rule converter.
@@ -42,18 +43,21 @@ public final class TrafficRuleConverter {
         return result;
     }
     
-    private static void setConfigurationData(final TrafficRuleConfiguration result, final TrafficRuleSegment each) {
-        ShardingSphereAlgorithmConfiguration trafficAlgorithm = createAlgorithmConfiguration(each.getAlgorithm());
-        ShardingSphereAlgorithmConfiguration loadBalancer = createAlgorithmConfiguration(each.getLoadBalancer());
-        String trafficAlgorithmName = createAlgorithmName(each.getName(), trafficAlgorithm);
-        String loadBalancerName = createAlgorithmName(each.getName(), loadBalancer);
-        TrafficStrategyConfiguration trafficStrategy = createTrafficStrategy(each, trafficAlgorithmName, loadBalancerName);
+    private static void setConfigurationData(final TrafficRuleConfiguration result, final TrafficRuleSegment segment) {
+        ShardingSphereAlgorithmConfiguration trafficAlgorithm = createAlgorithmConfiguration(segment.getAlgorithm());
+        ShardingSphereAlgorithmConfiguration loadBalancer = createAlgorithmConfiguration(segment.getLoadBalancer());
+        String trafficAlgorithmName = createAlgorithmName(segment.getName(), trafficAlgorithm);
+        String loadBalancerName = createAlgorithmName(segment.getName(), loadBalancer);
+        TrafficStrategyConfiguration trafficStrategy = createTrafficStrategy(segment, trafficAlgorithmName, loadBalancerName);
         result.getTrafficStrategies().add(trafficStrategy);
         result.getTrafficAlgorithms().put(trafficAlgorithmName, trafficAlgorithm);
-        result.getLoadBalancers().put(loadBalancerName, loadBalancer);
+        Optional.ofNullable(loadBalancerName).ifPresent(op -> result.getLoadBalancers().put(loadBalancerName, loadBalancer));
     }
     
     private static ShardingSphereAlgorithmConfiguration createAlgorithmConfiguration(final AlgorithmSegment segment) {
+        if (null == segment) {
+            return null;
+        }
         return new ShardingSphereAlgorithmConfiguration(segment.getName(), segment.getProps());
     }
     
@@ -62,6 +66,9 @@ public final class TrafficRuleConverter {
     }
     
     private static String createAlgorithmName(final String ruleName, final ShardingSphereAlgorithmConfiguration algorithm) {
+        if (null == algorithm) {
+            return null;
+        }
         return String.format("%s_%s", ruleName, algorithm.getType()).toLowerCase();
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/create/CreateTrafficRuleHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/create/CreateTrafficRuleHandler.java
@@ -78,7 +78,8 @@ public final class CreateTrafficRuleHandler implements TextProtocolBackendHandle
             if (!TypedSPIRegistry.findRegisteredService(TrafficAlgorithm.class, each.getAlgorithm().getName(), new Properties()).isPresent()) {
                 result.add(each.getAlgorithm().getName());
             }
-            if (!TypedSPIRegistry.findRegisteredService(TrafficLoadBalanceAlgorithm.class, each.getLoadBalancer().getName(), new Properties()).isPresent()) {
+            if (null != each.getLoadBalancer()
+                    && !TypedSPIRegistry.findRegisteredService(TrafficLoadBalanceAlgorithm.class, each.getLoadBalancer().getName(), new Properties()).isPresent()) {
                 result.add(each.getLoadBalancer().getName());
             }
         });

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/drop/DropTrafficRuleHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/drop/DropTrafficRuleHandler.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.drop.DropTrafficRuleStatement;
 import org.apache.shardingsphere.infra.distsql.exception.DistSQLException;
 import org.apache.shardingsphere.infra.distsql.exception.rule.RequiredRuleMissedException;
+import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
+import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
@@ -50,6 +52,7 @@ public final class DropTrafficRuleHandler implements TextProtocolBackendHandler 
             configuration.get().getTrafficStrategies().removeIf(each -> sqlStatement.getRuleNames().contains(each.getName()));
             getUnusedAlgorithm(configuration.get()).forEach(each -> configuration.get().getTrafficAlgorithms().remove(each));
             getUnusedLoadBalancer(configuration.get()).forEach(each -> configuration.get().getLoadBalancers().remove(each));
+            updateToRepository(configuration.get());
         }
         return new UpdateResponseHeader(sqlStatement);
     }
@@ -71,5 +74,12 @@ public final class DropTrafficRuleHandler implements TextProtocolBackendHandler 
     private Collection<String> getUnusedLoadBalancer(final TrafficRuleConfiguration configuration) {
         Set<String> currentlyInUse = configuration.getTrafficStrategies().stream().map(TrafficStrategyConfiguration::getLoadBalancerName).collect(Collectors.toSet());
         return configuration.getLoadBalancers().keySet().stream().filter(each -> !currentlyInUse.contains(each)).collect(Collectors.toSet());
+    }
+    
+    private void updateToRepository(final TrafficRuleConfiguration currentConfiguration) {
+        MetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
+        Optional<MetaDataPersistService> metaDataPersistService = metaDataContexts.getMetaDataPersistService();
+        getUnusedLoadBalancer(currentConfiguration).forEach(each -> currentConfiguration.getLoadBalancers().remove(each));
+        metaDataPersistService.ifPresent(op -> op.getGlobalRuleService().persist(metaDataContexts.getGlobalRuleMetaData().getConfigurations(), true));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowVariableExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/show/executor/ShowVariableExecutor.java
@@ -63,7 +63,7 @@ public final class ShowVariableExecutor extends AbstractShowExecutor {
         VariableEnum variable = VariableEnum.getValueOf(sqlStatement.getName());
         switch (variable) {
             case AGENT_PLUGINS_ENABLED:
-                return new MultipleLocalDataMergedResult(Collections.singletonList(Collections.singletonList(SystemPropertyUtil.getSystemProperty(variable.name(), Boolean.FALSE.toString()))));
+                return new MultipleLocalDataMergedResult(Collections.singletonList(Collections.singletonList(SystemPropertyUtil.getSystemProperty(variable.name(), Boolean.TRUE.toString()))));
             case CACHED_CONNECTIONS:
                 if (connectionSession.getBackendConnection() instanceof JDBCBackendConnection) {
                     int connectionSize = ((JDBCBackendConnection) connectionSession.getBackendConnection()).getConnectionSize();

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/ShowVariableBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/ShowVariableBackendHandlerTest.java
@@ -99,7 +99,7 @@ public final class ShowVariableBackendHandlerTest {
         assertThat(((QueryResponseHeader) actual).getQueryHeaders().size(), is(1));
         backendHandler.next();
         Collection<Object> rowData = backendHandler.getRowData();
-        assertThat(rowData.iterator().next(), is(Boolean.FALSE.toString()));
+        assertThat(rowData.iterator().next(), is(Boolean.TRUE.toString()));
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/alter/AlterTrafficRuleHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/alter/AlterTrafficRuleHandlerTest.java
@@ -88,9 +88,11 @@ public class AlterTrafficRuleHandlerTest {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts().getGlobalRuleMetaData().findRuleConfiguration(any())).thenReturn(createTrafficRule());
         ProxyContext.getInstance().init(contextManager);
-        TrafficRuleSegment trafficRuleSegment = new TrafficRuleSegment("rule_name_1", Arrays.asList("olap", "order_by"),
+        TrafficRuleSegment trafficRuleSegment1 = new TrafficRuleSegment("rule_name_1", Arrays.asList("olap", "order_by"),
                 new AlgorithmSegment("TEST", new Properties()), new AlgorithmSegment("TEST", new Properties()));
-        new AlterTrafficRuleExecutor(getSQLStatement(trafficRuleSegment)).execute();
+        TrafficRuleSegment trafficRuleSegment2 = new TrafficRuleSegment("rule_name_2", Collections.emptyList(),
+                new AlgorithmSegment("TEST", new Properties()), null);
+        new AlterTrafficRuleExecutor(getSQLStatement(trafficRuleSegment1, trafficRuleSegment2)).execute();
     }
     
     private Collection<RuleConfiguration> createTrafficRule() {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/create/CreateTrafficRuleHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/create/CreateTrafficRuleHandlerTest.java
@@ -87,9 +87,11 @@ public class CreateTrafficRuleHandlerTest {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts().getGlobalRuleMetaData().findRuleConfiguration(any())).thenReturn(createTrafficRule());
         ProxyContext.getInstance().init(contextManager);
-        TrafficRuleSegment trafficRuleSegment = new TrafficRuleSegment("rule_name_3", Arrays.asList("olap", "order_by"),
+        TrafficRuleSegment trafficRuleSegment1 = new TrafficRuleSegment("rule_name_3", Arrays.asList("olap", "order_by"),
                 new AlgorithmSegment("TEST", new Properties()), new AlgorithmSegment("TEST", new Properties()));
-        new CreateTrafficRuleHandler(getSQLStatement(trafficRuleSegment)).execute();
+        TrafficRuleSegment trafficRuleSegment2 = new TrafficRuleSegment("rule_name_4", Collections.emptyList(),
+                new AlgorithmSegment("TEST", new Properties()), null);
+        new CreateTrafficRuleHandler(getSQLStatement(trafficRuleSegment1, trafficRuleSegment2)).execute();
     }
     
     private Collection<RuleConfiguration> createTrafficRule() {


### PR DESCRIPTION
Changes proposed in this pull request:
- `CREATE/ALTER TRAFFIC RULE` syntax supports empty Labels and `LoadBalancer
- Fix `DROP TRAFFIC RULE` syntax is not persisted
- Modify default value of AGENT_PLUGINS_ENABLED


<img width="1289" alt="image" src="https://user-images.githubusercontent.com/52209337/153386991-01c8e81a-3ccd-497c-83d8-ac79a6d6262a.png">
