### PR TITLE
Minor refactor PostgreSQLPreparedStatementRegistry

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLPreparedStatementRegistry.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLPreparedStatementRegistry.java
@@ -21,9 +21,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.EmptyStatement;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -77,7 +75,7 @@ public final class PostgreSQLPreparedStatementRegistry {
      * @return prepared statement
      */
     public PostgreSQLPreparedStatement get(final int connectionId, final String statementId) {
-        return connectionPreparedStatements.get(connectionId).preparedStatements.getOrDefault(statementId, new PostgreSQLPreparedStatement("", new EmptyStatement(), Collections.emptyList()));
+        return connectionPreparedStatements.get(connectionId).preparedStatements.get(statementId);
     }
     
     /**
@@ -90,19 +88,19 @@ public final class PostgreSQLPreparedStatementRegistry {
     }
     
     /**
-     * Unregister.
+     * Close statement.
      *
      * @param connectionId connection ID
      * @param statementId statement ID
      */
-    public void unregister(final int connectionId, final String statementId) {
+    public void closeStatement(final int connectionId, final String statementId) {
         if (connectionPreparedStatements.containsKey(connectionId)) {
             connectionPreparedStatements.get(connectionId).getPreparedStatements().remove(statementId);
         }
     }
     
     @Getter
-    private final class PostgreSQLConnectionPreparedStatementRegistry {
+    private static class PostgreSQLConnectionPreparedStatementRegistry {
         
         private final ConcurrentMap<String, PostgreSQLPreparedStatement> preparedStatements = new ConcurrentHashMap<>(65535, 1);
     }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLPreparedStatementRegistryTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLPreparedStatementRegistryTest.java
@@ -18,15 +18,13 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended;
 
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.EmptyStatement;
-
 import org.junit.Test;
 
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -45,21 +43,23 @@ public final class PostgreSQLPreparedStatementRegistryTest {
     }
     
     @Test
-    public void assertGetNotExists() {
-        PostgreSQLPreparedStatement preparedStatement = PostgreSQLPreparedStatementRegistry.getInstance().get(1, "stat-no-exists");
-        assertThat(preparedStatement.getSqlStatement(), instanceOf(EmptyStatement.class));
-    
+    public void assertCloseStatement() {
+        final int connectionId = 2;
+        final String statementId = "S_2";
+        PostgreSQLPreparedStatementRegistry.getInstance().register(connectionId);
+        PostgreSQLPreparedStatementRegistry.getInstance().register(connectionId, statementId, "", mock(SQLStatement.class), Collections.emptyList());
+        assertNotNull(PostgreSQLPreparedStatementRegistry.getInstance().get(connectionId, statementId));
+        PostgreSQLPreparedStatementRegistry.getInstance().closeStatement(connectionId, statementId);
+        assertNull(PostgreSQLPreparedStatementRegistry.getInstance().get(connectionId, statementId));
     }
     
-    @Test
+    @Test(expected = NullPointerException.class)
     public void assertUnregister() {
-        String statementId = "stat-id";
-        String sql = "select * from t_order";
-        PostgreSQLPreparedStatementRegistry.getInstance().register(1, statementId, sql, mock(SQLStatement.class), Collections.emptyList());
-        PostgreSQLPreparedStatement preparedStatement = PostgreSQLPreparedStatementRegistry.getInstance().get(1, statementId);
-        assertNotNull(preparedStatement);
-        PostgreSQLPreparedStatementRegistry.getInstance().unregister(1, statementId);
-        preparedStatement = PostgreSQLPreparedStatementRegistry.getInstance().get(1, "stat-no-exists");
-        assertThat(preparedStatement.getSqlStatement(), instanceOf(EmptyStatement.class));
+        final int connectionId = 3;
+        final String statementId = "";
+        PostgreSQLPreparedStatementRegistry.getInstance().register(connectionId);
+        PostgreSQLPreparedStatementRegistry.getInstance().get(connectionId, statementId);
+        PostgreSQLPreparedStatementRegistry.getInstance().unregister(connectionId);
+        PostgreSQLPreparedStatementRegistry.getInstance().get(connectionId, statementId);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/close/PostgreSQLComCloseExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/close/PostgreSQLComCloseExecutor.java
@@ -46,7 +46,7 @@ public final class PostgreSQLComCloseExecutor implements CommandExecutor {
     public Collection<DatabasePacket<?>> execute() throws SQLException {
         switch (packet.getType()) {
             case PREPARED_STATEMENT:
-                PostgreSQLPreparedStatementRegistry.getInstance().unregister(connectionSession.getConnectionId(), packet.getName());
+                PostgreSQLPreparedStatementRegistry.getInstance().closeStatement(connectionSession.getConnectionId(), packet.getName());
                 break;
             case PORTAL:
                 closePortal();

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/bind/PostgreSQLComBindExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/bind/PostgreSQLComBindExecutorTest.java
@@ -64,7 +64,7 @@ public final class PostgreSQLComBindExecutorTest {
     @Before
     public void setup() {
         PostgreSQLPreparedStatementRegistry.getInstance().register(1);
-        PostgreSQLPreparedStatementRegistry.getInstance().register(1, "2", "", new EmptyStatement(), Collections.emptyList());
+        PostgreSQLPreparedStatementRegistry.getInstance().register(1, "1", "", new EmptyStatement(), Collections.emptyList());
         when(bindPacket.getStatementId()).thenReturn("1");
         when(bindPacket.getPortal()).thenReturn("C_1");
         when(bindPacket.readParameters(anyList())).thenReturn(Collections.emptyList());


### PR DESCRIPTION
Related to #10626.

Statement must exists, so there is no need to new a default value.