### PR TITLE
Avoid new TreeSet every time in StandardShardingStrategy

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -32,7 +32,6 @@ import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Set;
 import java.util.TreeSet;
 
 /**
@@ -48,9 +47,9 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     public StandardShardingStrategy(final String shardingColumn, final StandardShardingAlgorithm<?> shardingAlgorithm) {
         Preconditions.checkNotNull(shardingColumn, "Sharding column cannot be null.");
         Preconditions.checkNotNull(shardingAlgorithm, "sharding algorithm cannot be null.");
-        Set<String> shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        Collection<String> shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         shardingColumns.add(shardingColumn);
-        this.shardingColumns = Collections.unmodifiableSet(shardingColumns);
+        this.shardingColumns = Collections.unmodifiableCollection(shardingColumns);
         this.shardingAlgorithm = shardingAlgorithm;
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -24,29 +24,33 @@ import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
-import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
+import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Set;
 import java.util.TreeSet;
 
 /**
  * Standard sharding strategy.
  */
+@Getter
 public final class StandardShardingStrategy implements ShardingStrategy {
     
-    private final String shardingColumn;
+    private final Collection<String> shardingColumns;
     
-    @Getter
     private final StandardShardingAlgorithm<?> shardingAlgorithm;
     
     public StandardShardingStrategy(final String shardingColumn, final StandardShardingAlgorithm<?> shardingAlgorithm) {
         Preconditions.checkNotNull(shardingColumn, "Sharding column cannot be null.");
         Preconditions.checkNotNull(shardingAlgorithm, "sharding algorithm cannot be null.");
-        this.shardingColumn = shardingColumn;
+        Set<String> shardingColumns = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+        shardingColumns.add(shardingColumn);
+        this.shardingColumns = Collections.unmodifiableSet(shardingColumns);
         this.shardingAlgorithm = shardingAlgorithm;
     }
     
@@ -79,12 +83,5 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     private Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingConditionValue<?> shardingValue) {
         return shardingAlgorithm.doSharding(availableTargetNames,
                 new RangeShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), shardingValue.getValueRange()));
-    }
-    
-    @Override
-    public Collection<String> getShardingColumns() {
-        Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-        result.add(shardingColumn);
-        return result;
     }
 }


### PR DESCRIPTION
Related to #10626.

The `shardingColumn` is unmodifiable.

![image](https://user-images.githubusercontent.com/20503072/153817506-d88c51c1-65b3-4053-beac-858da627db04.png)
