### PR TITLE
Add restoreClusterWriteDB method in scaling API

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -195,6 +195,19 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     }
     
     @Override
+    public void restoreClusterWriteDB(final String jobId) {
+        checkModeConfig();
+        log.info("restoreClusterWriteDB for job {}", jobId);
+        JobConfiguration jobConfig = getJobConfig(jobId);
+        restoreClusterWriteDB(jobConfig);
+    }
+    
+    @Override
+    public void restoreClusterWriteDB(final JobConfiguration jobConfig) {
+        // TODO restoreClusterWriteDB
+    }
+    
+    @Override
     public Collection<DataConsistencyCheckAlgorithmInfo> listDataConsistencyCheckAlgorithms() {
         checkModeConfig();
         return DATA_CONSISTENCY_CHECK_ALGORITHM_MAP.values()

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/RuleAlteredJobAPI.java
@@ -82,6 +82,20 @@ public interface RuleAlteredJobAPI extends PipelineJobAPI, RequiredSPI, Singleto
     void stopClusterWriteDB(String jobId);
     
     /**
+     * Restore cluster write to job source schema's underlying DB.
+     *
+     * @param jobId job id
+     */
+    void restoreClusterWriteDB(String jobId);
+    
+    /**
+     * Restore cluster write to job source schema's underlying DB.
+     *
+     * @param jobConfig job configuration
+     */
+    void restoreClusterWriteDB(JobConfiguration jobConfig);
+    
+    /**
      * List all data consistency check algorithms from SPI.
      *
      * @return data consistency check algorithms


### PR DESCRIPTION

Changes proposed in this pull request:
- Add restoreClusterWriteDB method in scaling API. Used for DistSQL.
