### PR TITLE
[Example] Upgrade the version of spring-boot and related dependencies.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -42,8 +42,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.locale>zh_CN</project.build.locale>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
-        <spring-framework.version>5.2.19.RELEASE</spring-framework.version>
-        <spring-boot.version>2.0.9.RELEASE</spring-boot.version>
+        <spring-framework.version>5.2.15.RELEASE</spring-framework.version>
+        <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <postgresql.version>42.2.5</postgresql.version>
@@ -51,8 +51,9 @@
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.0</logback.version>
         <lombok.version>1.18.20</lombok.version>
-        <mybatis.version>3.5.1</mybatis.version>
-        <mybatis-spring.version>2.0.1</mybatis-spring.version>
+        <mybatis.version>3.5.5</mybatis.version>
+        <mybatis-spring.version>2.0.5</mybatis-spring.version>
+        <mybatis-spring-boot.version>2.1.3</mybatis-spring-boot.version>
 
         <jpa.version>1.0.0.Final</jpa.version>
         <hibernate.version>5.2.18.Final</hibernate.version>
@@ -260,7 +261,7 @@
             <dependency>
                 <groupId>org.mybatis.spring.boot</groupId>
                 <artifactId>mybatis-spring-boot-starter</artifactId>
-                <version>${mybatis-spring.version}</version>
+                <version>${mybatis-spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.btm</groupId>


### PR DESCRIPTION
Fixes #15400.

Changes proposed in this pull request:
- upgrade `spring-boot`: 2.0.9.RELEASE -> 2.3.12.RELEASE
- upgrade `spring-framework`: 5.2.19.RELEASE -> 5.2.15.RELEASE
- upgrade `mybatis-spring-boot`: 2.0.1 -> 2.1.3
- upgrade `mybatis`: 3.5.1 -> 3.5.5

#### Background
- spring-boot 2.3.12.RELEASE is the last GA release that depends on spring-framework 5.2.x. ([link](https://github.com/spring-projects/spring-boot/releases))
- spring-boot 2.3.12.RELEASE depends on spring-framework 5.2.15.RELEASE ([link](https://docs.spring.io/spring-boot/docs/2.3.12.RELEASE/reference/html/appendix-dependency-versions.html#dependency-versions))
- mybatis-spring-boot-starter needs to be upgraded to match the version of spring-boot ([link](http://mybatis.org/spring-boot-starter/mybatis-spring-boot-autoconfigure/))
- mybatis-spring-boot-starter 2.1.3 depends on mybatis 3.5.5 ([link](https://github.com/mybatis/spring-boot-starter/releases/tag/mybatis-spring-boot-2.1.3))