### PR TITLE
Correct misplaced dependency bcprov in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
                 <version>${snakeyaml.version}</version>
             </dependency>
             
-        <dependency>
+            <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcprov-jdk15on</artifactId>
                 <version>${bcprov-jdk15on.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,9 @@
         
         <groovy.version>4.0.0</groovy.version>
         <snakeyaml.version>1.30</snakeyaml.version>
-
+        
+        <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
+        
         <netty.version>4.1.73.Final</netty.version>
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-codec.version>1.10</commons-codec.version>
@@ -148,7 +150,6 @@
         <checksum-maven-plugin.version>1.10</checksum-maven-plugin.version>
         <templating-maven-plugin.version>1.0.0</templating-maven-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
-        <bcprov-jdk15on.version>1.70</bcprov-jdk15on.version>
         <maven.deploy.skip>false</maven.deploy.skip>
     </properties>
     
@@ -205,6 +206,12 @@
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
                 <version>${snakeyaml.version}</version>
+            </dependency>
+            
+        <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk15on</artifactId>
+                <version>${bcprov-jdk15on.version}</version>
             </dependency>
             
             <dependency>
@@ -1083,11 +1090,6 @@
                     <groupId>javax.activation</groupId>
                     <artifactId>javax.activation-api</artifactId>
                     <version>${activation-api.version}</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.bouncycastle</groupId>
-                    <artifactId>bcprov-jdk15on</artifactId>
-                    <version>${bcprov-jdk15on.version}</version>
                 </dependency>
             </dependencies>
             <build>

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/pom.xml
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/pom.xml
@@ -57,15 +57,15 @@
         </dependency>
         
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+        </dependency>
+        
+        <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-single-table-core</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>${bcprov-jdk15on.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Revise #13894.
The dependency `bcprov` was misplaced into the profile `jdk11+`.