### PR TITLE
Refactor scaling input and output config fields type from int to Integer

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/config/rulealtered/OnRuleAlteredActionConfiguration.java
@@ -45,9 +45,9 @@ public final class OnRuleAlteredActionConfiguration {
     @ToString
     public static final class InputConfiguration {
         
-        private final int workerThread;
+        private final Integer workerThread;
         
-        private final int batchSize;
+        private final Integer batchSize;
         
         private final ShardingSphereAlgorithmConfiguration rateLimiter;
     }
@@ -57,9 +57,9 @@ public final class OnRuleAlteredActionConfiguration {
     @ToString
     public static final class OutputConfiguration {
         
-        private final int workerThread;
+        private final Integer workerThread;
         
-        private final int batchSize;
+        private final Integer batchSize;
         
         private final ShardingSphereAlgorithmConfiguration rateLimiter;
     }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/rulealtered/YamlOnRuleAlteredActionConfiguration.java
@@ -45,20 +45,44 @@ public final class YamlOnRuleAlteredActionConfiguration implements YamlConfigura
     @Data
     public static final class YamlInputConfiguration implements YamlConfiguration {
         
-        private int workerThread = 40;
+        private Integer workerThread;
         
-        private int batchSize = 1000;
+        private Integer batchSize;
         
         private YamlShardingSphereAlgorithmConfiguration rateLimiter;
+    
+        /**
+         * Build with default value.
+         *
+         * @return input configuration
+         */
+        public static YamlInputConfiguration buildWithDefaultValue() {
+            YamlInputConfiguration result = new YamlInputConfiguration();
+            result.setWorkerThread(40);
+            result.setBatchSize(1000);
+            return result;
+        }
     }
     
     @Data
     public static final class YamlOutputConfiguration implements YamlConfiguration {
         
-        private int workerThread = 40;
+        private Integer workerThread;
         
-        private int batchSize = 1000;
+        private Integer batchSize;
         
         private YamlShardingSphereAlgorithmConfiguration rateLimiter;
+    
+        /**
+         * Build with default value.
+         *
+         * @return output configuration
+         */
+        public static YamlOutputConfiguration buildWithDefaultValue() {
+            YamlOutputConfiguration result = new YamlOutputConfiguration();
+            result.setWorkerThread(40);
+            result.setBatchSize(1000);
+            return result;
+        }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredContext.java
@@ -108,10 +108,10 @@ public final class RuleAlteredContext {
     private OnRuleAlteredActionConfiguration convertActionConfig(final OnRuleAlteredActionConfiguration actionConfig) {
         YamlOnRuleAlteredActionConfiguration yamlActionConfig = ACTION_CONFIG_YAML_SWAPPER.swapToYamlConfiguration(actionConfig);
         if (null == yamlActionConfig.getInput()) {
-            yamlActionConfig.setInput(new YamlInputConfiguration());
+            yamlActionConfig.setInput(YamlInputConfiguration.buildWithDefaultValue());
         }
         if (null == yamlActionConfig.getOutput()) {
-            yamlActionConfig.setOutput(new YamlOutputConfiguration());
+            yamlActionConfig.setOutput(YamlOutputConfiguration.buildWithDefaultValue());
         }
         if (null == yamlActionConfig.getStreamChannel()) {
             yamlActionConfig.setStreamChannel(new YamlShardingSphereAlgorithmConfiguration(MemoryPipelineChannelFactory.TYPE, new Properties()));

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/prepare/InventoryTaskSplitter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/prepare/InventoryTaskSplitter.java
@@ -107,7 +107,7 @@ public final class InventoryTaskSplitter {
         RuleAlteredContext ruleAlteredContext = jobContext.getRuleAlteredContext();
         InputConfiguration inputConfig = ruleAlteredContext.getOnRuleAlteredActionConfig().getInput();
         if (null == inputConfig) {
-            inputConfig = new InputConfigurationSwapper().swapToObject(new YamlInputConfiguration());
+            inputConfig = new InputConfigurationSwapper().swapToObject(YamlInputConfiguration.buildWithDefaultValue());
         }
         int batchSize = inputConfig.getBatchSize();
         JobRateLimitAlgorithm rateLimitAlgorithm = ruleAlteredContext.getInputRateLimitAlgorithm();


### PR DESCRIPTION

Changes proposed in this pull request:
- Refactor scaling input and output config fields type from int to Integer. Used for DistSQL `CreateShardingScalingRuleStatementUpdater`, `workerThread` and `batchSize` might be not configured, keep empty in marshalled yaml if they're not configured.
