### PR TITLE
Fixes #15083, support more types in `getObject` method.

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -83,9 +84,8 @@ public final class ResultSetUtil {
         }
         if (String.class.equals(convertType)) {
             return value.toString();
-        } else {
-            return value;
         }
+        throw new SQLFeatureNotSupportedException("getObject with type");
     }
     
     private static Object convertURL(final Object value) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtil.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -47,8 +48,12 @@ public final class ResultSetUtil {
      * @param value original value
      * @param convertType expected class type
      * @return converted value
+     * @throws SQLException SQL exception
      */
-    public static Object convertValue(final Object value, final Class<?> convertType) {
+    public static Object convertValue(final Object value, final Class<?> convertType) throws SQLException {
+        if (null == convertType) {
+            throw new SQLException("Type cannot be null");
+        }
         if (null == value) {
             return convertNullValue(convertType);
         }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -369,9 +369,6 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getObject(final int columnIndex, final Class<T> type) throws SQLException {
-        if (null == type) {
-            throw new SQLException("Type cannot be null");
-        }
         if (String.class.equals(type)) {
             return (T) getString(columnIndex);
         } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -31,7 +31,6 @@ import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
-import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -369,46 +368,17 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getObject(final int columnIndex, final Class<T> type) throws SQLException {
-        if (String.class.equals(type)) {
-            return (T) getString(columnIndex);
-        } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
-            return (T) Boolean.valueOf(getBoolean(columnIndex));
-        } else if (Byte.class.equals(type) || Byte.TYPE.equals(type)) {
-            return (T) Byte.valueOf(getByte(columnIndex));
-        } else if (byte[].class.equals(type)) {
-            return (T) getBytes(columnIndex);
-        } else if (BigDecimal.class.equals(type)) {
-            return (T) getBigDecimal(columnIndex);
-        } else if (BigInteger.class.equals(type)) {
+        if (BigInteger.class.equals(type)) {
             return (T) BigInteger.valueOf(getLong(columnIndex));
-        } else if (Double.class.equals(type) || Double.TYPE.equals(type)) {
-            return (T) Double.valueOf(getDouble(columnIndex));
-        } else if (Float.class.equals(type) || Float.TYPE.equals(type)) {
-            return (T) Float.valueOf(getFloat(columnIndex));
-        } else if (Integer.class.equals(type) || Integer.TYPE.equals(type)) {
-            return (T) Integer.valueOf(getInt(columnIndex));
-        } else if (Long.class.equals(type) || Long.TYPE.equals(type)) {
-            return (T) Long.valueOf(getLong(columnIndex));
-        } else if (Short.class.equals(type) || Short.TYPE.equals(type)) {
-            return (T) Short.valueOf(getShort(columnIndex));
-        } else if (Date.class.equals(type)) {
-            return (T) getDate(columnIndex);
-        } else if (Time.class.equals(type)) {
-            return (T) getTime(columnIndex);
-        } else if (Timestamp.class.equals(type)) {
-            return (T) getTimestamp(columnIndex);
-        } else if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type)) {
-            return (T) ResultSetUtil.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type);
         } else if (Blob.class.equals(type)) {
             return (T) getBlob(columnIndex);
         } else if (Clob.class.equals(type)) {
             return (T) getClob(columnIndex);
-        } else if (Ref.class.equals(type)) {
-            return (T) getRef(columnIndex);
-        } else if (URL.class.equals(type)) {
-            return (T) getURL(columnIndex);
+        } else if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type)) {
+            return (T) ResultSetUtil.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type);
+        } else {
+            return (T) ResultSetUtil.convertValue(mergeResultSet.getValue(columnIndex, type), type);
         }
-        throw new SQLFeatureNotSupportedException("getObject with type");
     }
     
     @Override

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSet.java
@@ -25,11 +25,13 @@ import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -367,8 +369,47 @@ public final class ShardingSphereResultSet extends AbstractResultSetAdapter {
     @SuppressWarnings("unchecked")
     @Override
     public <T> T getObject(final int columnIndex, final Class<T> type) throws SQLException {
-        if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type)) {
+        if (null == type) {
+            throw new SQLException("Type cannot be null");
+        }
+        if (String.class.equals(type)) {
+            return (T) getString(columnIndex);
+        } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
+            return (T) Boolean.valueOf(getBoolean(columnIndex));
+        } else if (Byte.class.equals(type) || Byte.TYPE.equals(type)) {
+            return (T) Byte.valueOf(getByte(columnIndex));
+        } else if (byte[].class.equals(type)) {
+            return (T) getBytes(columnIndex);
+        } else if (BigDecimal.class.equals(type)) {
+            return (T) getBigDecimal(columnIndex);
+        } else if (BigInteger.class.equals(type)) {
+            return (T) BigInteger.valueOf(getLong(columnIndex));
+        } else if (Double.class.equals(type) || Double.TYPE.equals(type)) {
+            return (T) Double.valueOf(getDouble(columnIndex));
+        } else if (Float.class.equals(type) || Float.TYPE.equals(type)) {
+            return (T) Float.valueOf(getFloat(columnIndex));
+        } else if (Integer.class.equals(type) || Integer.TYPE.equals(type)) {
+            return (T) Integer.valueOf(getInt(columnIndex));
+        } else if (Long.class.equals(type) || Long.TYPE.equals(type)) {
+            return (T) Long.valueOf(getLong(columnIndex));
+        } else if (Short.class.equals(type) || Short.TYPE.equals(type)) {
+            return (T) Short.valueOf(getShort(columnIndex));
+        } else if (Date.class.equals(type)) {
+            return (T) getDate(columnIndex);
+        } else if (Time.class.equals(type)) {
+            return (T) getTime(columnIndex);
+        } else if (Timestamp.class.equals(type)) {
+            return (T) getTimestamp(columnIndex);
+        } else if (LocalDateTime.class.equals(type) || LocalDate.class.equals(type) || LocalTime.class.equals(type)) {
             return (T) ResultSetUtil.convertValue(mergeResultSet.getValue(columnIndex, Timestamp.class), type);
+        } else if (Blob.class.equals(type)) {
+            return (T) getBlob(columnIndex);
+        } else if (Clob.class.equals(type)) {
+            return (T) getClob(columnIndex);
+        } else if (Ref.class.equals(type)) {
+            return (T) getRef(columnIndex);
+        } else if (URL.class.equals(type)) {
+            return (T) getURL(columnIndex);
         }
         throw new SQLFeatureNotSupportedException("getObject with type");
     }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
@@ -43,21 +44,22 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class ResultSetUtilTest {
+    
     @Test
-    public void assertConvertValue() {
+    public void assertConvertValue() throws SQLException {
         Object object = new Object();
         assertThat(ResultSetUtil.convertValue(object, String.class), is(object.toString()));
         assertThat(ResultSetUtil.convertValue("1", int.class), is("1"));
     }
     
     @Test
-    public void assertConvertLocalDateTimeValue() {
+    public void assertConvertLocalDateTimeValue() throws SQLException {
         LocalDateTime localDateTime = LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30);
         assertThat(ResultSetUtil.convertValue(localDateTime, Timestamp.class), is(Timestamp.valueOf(localDateTime)));
     }
     
     @Test
-    public void assertConvertTimestampValue() {
+    public void assertConvertTimestampValue() throws SQLException {
         LocalDateTime localDateTime = LocalDateTime.of(2021, Month.DECEMBER, 23, 19, 30);
         Timestamp timestamp = Timestamp.valueOf(localDateTime);
         assertThat(ResultSetUtil.convertValue(timestamp, LocalDateTime.class), is(localDateTime));
@@ -66,7 +68,7 @@ public final class ResultSetUtilTest {
     }
 
     @Test
-    public void assertConvertBooleanValue() {
+    public void assertConvertBooleanValue() throws SQLException {
         String dbFalse = "-2";
         String dbTrue = "1";
         assertThat(ResultSetUtil.convertValue(dbFalse, boolean.class), is(false));
@@ -74,7 +76,7 @@ public final class ResultSetUtilTest {
     }
     
     @Test
-    public void assertConvertNumberValueSuccess() {
+    public void assertConvertNumberValueSuccess() throws SQLException {
         assertThat(ResultSetUtil.convertValue("1", String.class), is("1"));
         assertTrue((boolean) ResultSetUtil.convertValue(1, boolean.class));
         assertThat(ResultSetUtil.convertValue((byte) 1, byte.class), is((byte) 1));
@@ -91,12 +93,12 @@ public final class ResultSetUtilTest {
     }
     
     @Test(expected = ShardingSphereException.class)
-    public void assertConvertNumberValueError() {
+    public void assertConvertNumberValueError() throws SQLException {
         ResultSetUtil.convertValue(1, Date.class);
     }
     
     @Test
-    public void assertConvertNullValue() {
+    public void assertConvertNullValue() throws SQLException {
         assertFalse((boolean) ResultSetUtil.convertValue(null, boolean.class));
         assertThat(ResultSetUtil.convertValue(null, byte.class), is((byte) 0));
         assertThat(ResultSetUtil.convertValue(null, short.class), is((short) 0));
@@ -110,8 +112,13 @@ public final class ResultSetUtilTest {
         assertThat(ResultSetUtil.convertValue(null, Date.class), is((Object) null));
     }
     
+    @Test(expected = SQLException.class)
+    public void assertConvertNullType() throws SQLException {
+        ResultSetUtil.convertValue(null, null);
+    }
+    
     @Test
-    public void assertConvertDateValueSuccess() {
+    public void assertConvertDateValueSuccess() throws SQLException {
         Date now = new Date();
         assertThat(ResultSetUtil.convertValue(now, Date.class), is(now));
         assertThat(ResultSetUtil.convertValue(now, java.sql.Date.class), is(now));
@@ -121,7 +128,7 @@ public final class ResultSetUtilTest {
     }
     
     @Test
-    public void assertConvertByteArrayValueSuccess() {
+    public void assertConvertByteArrayValueSuccess() throws SQLException {
         byte[] bytesValue = {};
         assertThat(ResultSetUtil.convertValue(bytesValue, byte.class), is(bytesValue));
         assertThat(ResultSetUtil.convertValue(new byte[]{1}, byte.class), is((byte) 1));
@@ -135,7 +142,7 @@ public final class ResultSetUtilTest {
     
     @SneakyThrows(MalformedURLException.class)
     @Test
-    public void assertConvertURLValue() {
+    public void assertConvertURLValue() throws SQLException {
         String urlString = "http://apache.org";
         URL url = (URL) ResultSetUtil.convertValue(urlString, URL.class);
         assertNotNull(url);
@@ -143,7 +150,7 @@ public final class ResultSetUtilTest {
     }
     
     @Test(expected = ShardingSphereException.class)
-    public void assertConvertURLValueError() {
+    public void assertConvertURLValueError() throws SQLException {
         String urlString = "no-exist:apache.org";
         ResultSetUtil.convertValue(urlString, URL.class);
     }
@@ -172,7 +179,7 @@ public final class ResultSetUtilTest {
     }
     
     @Test(expected = ShardingSphereException.class)
-    public void assertConvertDateValueError() {
+    public void assertConvertDateValueError() throws SQLException {
         ResultSetUtil.convertValue(new Date(), int.class);
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ResultSetUtilTest.java
@@ -49,7 +49,6 @@ public final class ResultSetUtilTest {
     public void assertConvertValue() throws SQLException {
         Object object = new Object();
         assertThat(ResultSetUtil.convertValue(object, String.class), is(object.toString()));
-        assertThat(ResultSetUtil.convertValue("1", int.class), is("1"));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -486,7 +486,10 @@ public final class ShardingSphereResultSetTest {
     
     @Test
     public void assertGetObjectWithBoolean() throws SQLException {
-        when(mergeResultSet.getValue(1, boolean.class)).thenReturn(true);
+        boolean result = true;
+        when(mergeResultSet.getValue(1, boolean.class)).thenReturn(result);
+        assertTrue(shardingSphereResultSet.getObject(1, boolean.class));
+        when(mergeResultSet.getValue(1, Boolean.class)).thenReturn(result);
         assertTrue(shardingSphereResultSet.getObject(1, Boolean.class));
     }
     
@@ -520,36 +523,46 @@ public final class ShardingSphereResultSetTest {
     
     @Test
     public void assertGetObjectWithDouble() throws SQLException {
-        Double result = Double.valueOf(0.0);
+        double result = 0.0;
         when(mergeResultSet.getValue(1, double.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, double.class), is(result));
+        when(mergeResultSet.getValue(1, Double.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Double.class), is(result));
     }
     
     @Test
     public void assertGetObjectWithFloat() throws SQLException {
-        Float result = Float.valueOf(0.0f);
+        float result = 0.0f;
         when(mergeResultSet.getValue(1, float.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, float.class), is(result));
+        when(mergeResultSet.getValue(1, Float.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Float.class), is(result));
     }
     
     @Test
     public void assertGetObjectWithInteger() throws SQLException {
-        Integer result = Integer.valueOf(0);
+        int result = 0;
         when(mergeResultSet.getValue(1, int.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, int.class), is(result));
+        when(mergeResultSet.getValue(1, Integer.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(result));
     }
     
     @Test
     public void assertGetObjectWithLong() throws SQLException {
-        Long result = Long.valueOf(0L);
+        long result = 0L;
         when(mergeResultSet.getValue(1, long.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, long.class), is(result));
+        when(mergeResultSet.getValue(1, Long.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Long.class), is(result));
     }
     
     @Test
     public void assertGetObjectWithShort() throws SQLException {
-        Short result = Short.valueOf((short) 0);
+        short result = (short) 0;
         when(mergeResultSet.getValue(1, short.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, short.class), is(result));
+        when(mergeResultSet.getValue(1, Short.class)).thenReturn(result);
         assertThat(shardingSphereResultSet.getObject(1, Short.class), is(result));
     }
     
@@ -597,6 +610,8 @@ public final class ShardingSphereResultSetTest {
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetObjectWithRef() throws SQLException {
+        Ref result = mock(Ref.class);
+        when(mergeResultSet.getValue(1, Ref.class)).thenReturn(result);
         shardingSphereResultSet.getObject(1, Ref.class);
     }
     

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -22,24 +22,27 @@ import org.apache.shardingsphere.driver.jdbc.core.statement.ShardingSphereStatem
 import org.apache.shardingsphere.infra.binder.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
+import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.InputStream;
 import java.io.Reader;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.sql.Array;
 import java.sql.Blob;
 import java.sql.Clob;
 import java.sql.Date;
+import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -473,12 +476,134 @@ public final class ShardingSphereResultSetTest {
         when(mergeResultSet.getValue(1, Object.class)).thenReturn("object_value");
         assertThat(shardingSphereResultSet.getObject("label"), is("object_value"));
     }
-
+    
     @Test
-    public void assertGetObjectWithLocalDateColumnLabel() throws SQLException {
-        LocalDateTime now = LocalDateTime.now();
-        when(mergeResultSet.getValue(1, Timestamp.class)).thenReturn(Timestamp.valueOf(now));
-        LocalDateTime timestamp = shardingSphereResultSet.getObject(1, LocalDateTime.class);
-        assertThat(shardingSphereResultSet.getObject(1, LocalDateTime.class), is(now));
+    public void assertGetObjectWithString() throws SQLException {
+        String result = "foo";
+        when(mergeResultSet.getValue(1, String.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, String.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithBoolean() throws SQLException {
+        when(mergeResultSet.getValue(1, boolean.class)).thenReturn(true);
+        assertTrue(shardingSphereResultSet.getObject(1, Boolean.class));
+    }
+    
+    @Test
+    public void assertGetObjectWithByte() throws SQLException {
+        Byte result = new Byte((byte) 1);
+        when(mergeResultSet.getValue(1, byte.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, byte.class), is(result));
+    }  
+    
+    @Test
+    public void assertGetObjectWithByteArray() throws SQLException {
+        byte[] result = new byte[0];
+        when(mergeResultSet.getValue(1, byte[].class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, byte[].class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithBigDecimal() throws SQLException {
+        BigDecimal result = new BigDecimal("0");
+        when(mergeResultSet.getValue(1, BigDecimal.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, BigDecimal.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithBigInteger() throws SQLException {
+        BigInteger result = BigInteger.valueOf(0L);
+        when(mergeResultSet.getValue(1, BigInteger.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, BigInteger.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithDouble() throws SQLException {
+        Double result = Double.valueOf(0.0);
+        when(mergeResultSet.getValue(1, double.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Double.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithFloat() throws SQLException {
+        Float result = Float.valueOf(0.0f);
+        when(mergeResultSet.getValue(1, float.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Float.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithInteger() throws SQLException {
+        Integer result = Integer.valueOf(0);
+        when(mergeResultSet.getValue(1, int.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Integer.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithLong() throws SQLException {
+        Long result = Long.valueOf(0L);
+        when(mergeResultSet.getValue(1, long.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Long.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithShort() throws SQLException {
+        Short result = Short.valueOf((short) 0);
+        when(mergeResultSet.getValue(1, short.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Short.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithDate() throws SQLException {
+        Date result = mock(Date.class);
+        when(mergeResultSet.getValue(1, Date.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Date.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithTime() throws SQLException {
+        Time result = mock(Time.class);
+        when(mergeResultSet.getValue(1, Time.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Time.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithTimestamp() throws SQLException {
+        Timestamp result = mock(Timestamp.class);
+        when(mergeResultSet.getValue(1, Timestamp.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Timestamp.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithLocalDateTime() throws SQLException {
+        LocalDateTime result = LocalDateTime.now();
+        when(mergeResultSet.getValue(1, Timestamp.class)).thenReturn(Timestamp.valueOf(result));
+        assertThat(shardingSphereResultSet.getObject(1, LocalDateTime.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithBlob() throws SQLException {
+        Blob result = mock(Blob.class);
+        when(mergeResultSet.getValue(1, Blob.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Blob.class), is(result));
+    }
+    
+    @Test
+    public void assertGetObjectWithClob() throws SQLException {
+        Clob result = mock(Clob.class);
+        when(mergeResultSet.getValue(1, Clob.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, Clob.class), is(result));
+    }
+    
+    @Test(expected = SQLFeatureNotSupportedException.class)
+    public void assertGetObjectWithRef() throws SQLException {
+        shardingSphereResultSet.getObject(1, Ref.class);
+    }
+    
+    @Test
+    public void assertGetObjectWithURL() throws SQLException {
+        URL result = mock(URL.class);
+        when(mergeResultSet.getValue(1, URL.class)).thenReturn(result);
+        assertThat(shardingSphereResultSet.getObject(1, URL.class), is(result));
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationResultSetTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationResultSetTest.java
@@ -204,16 +204,6 @@ public final class UnsupportedOperationResultSetTest {
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertObjectForColumnIndexWithType() throws SQLException {
-        shardingSphereResultSet.getObject(1, String.class);
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
-    public void assertObjectForColumnLabelWithType() throws SQLException {
-        shardingSphereResultSet.getObject("label", String.class);
-    }
-    
-    @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertObjectForColumnIndexWithMap() throws SQLException {
         shardingSphereResultSet.getObject(1, Collections.emptyMap());
     }


### PR DESCRIPTION
Fixes #15083.

## Referemce
### MySQL
- mysql-connector-java:8.0
https://github.com/mysql/mysql-connector-j/blob/release/8.0/src/main/user-impl/java/com/mysql/cj/jdbc/result/ResultSetImpl.java

- mysql-connector-java:5.1
https://github.com/mysql/mysql-connector-j/blob/release/5.1/src/com/mysql/jdbc/ResultSetImpl.java

### Postgres
https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/jdbc/PgResultSet.java

