### PR TITLE
Decouple PostgreSQLAuthenticationEngine and PostgreSQLAuthenticationMethod.

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLAuthenticationMethod.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLAuthenticationMethod.java
@@ -15,29 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.db.protocol.mysql.constant;
+package org.apache.shardingsphere.db.protocol.postgresql.constant;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * MySQL client/server protocol authentication method.
+ * PostgreSQL password authentication method.
  *
- * @see <a href="https://dev.mysql.com/doc/internals/en/authentication-method.html">Authentication Method</a>
+ * @see <a href="https://www.postgresql.org/docs/14/auth-password.html">Password Authentication</a>
  */
 @RequiredArgsConstructor
 @Getter
-public enum MySQLAuthenticationMethod {
+public enum PostgreSQLAuthenticationMethod {
     
-    OLD_PASSWORD_AUTHENTICATION("mysql_old_password"),
+    MD5("md5"),
     
-    SECURE_PASSWORD_AUTHENTICATION("mysql_native_password"),
-    
-    CLEAR_TEXT_AUTHENTICATION("mysql_clear_password"),
-    
-    WINDOWS_NATIVE_AUTHENTICATION("authentication_windows_client"),
-    
-    SHA256("sha256_password");
+    PASSWORD("password"),
+
+    SCRAM_SHA256("scram-sha-256");
     
     private final String methodName;
 }

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLMD5PasswordAuthenticationPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLMD5PasswordAuthenticationPacket.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.db.protocol.postgresql.packet.handshake;
+package org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
@@ -24,10 +24,10 @@ import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.Postgr
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 
 /**
- * AuthenticationMD5Password (backend) packet for PostgreSQL.
+ * MD5Password authentication (backend) packet for PostgreSQL.
  */
 @RequiredArgsConstructor
-public final class PostgreSQLAuthenticationMD5PasswordPacket implements PostgreSQLIdentifierPacket {
+public final class PostgreSQLMD5PasswordAuthenticationPacket implements PostgreSQLIdentifierPacket {
     
     private static final int AUTH_REQ_MD5 = 5;
     

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLPasswordAuthenticationPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLPasswordAuthenticationPacket.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+
+/**
+ * Password authentication (backend) packet for PostgreSQL.
+ *
+ */
+@RequiredArgsConstructor
+public final class PostgreSQLPasswordAuthenticationPacket implements PostgreSQLIdentifierPacket {
+    
+    private static final int AUTH_REQ_PASSWORD = 3;
+    
+    @Override
+    public void write(final PostgreSQLPacketPayload payload) {
+        payload.writeInt4(AUTH_REQ_PASSWORD);
+    }
+    
+    @Override
+    public PostgreSQLIdentifierTag getIdentifier() {
+        return PostgreSQLMessagePacketType.AUTHENTICATION_REQUEST;
+    }
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLMD5PasswordAuthenticationPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLMD5PasswordAuthenticationPacketTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 import io.netty.buffer.ByteBuf;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.ByteBufTestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;
-import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationMD5PasswordPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication.PostgreSQLMD5PasswordAuthenticationPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
 
@@ -29,7 +29,7 @@ import java.nio.charset.StandardCharsets;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public final class PostgreSQLAuthenticationMD5PasswordPacketTest {
+public final class PostgreSQLMD5PasswordAuthenticationPacketTest {
     
     @Test
     public void assertReadWrite() {
@@ -37,7 +37,7 @@ public final class PostgreSQLAuthenticationMD5PasswordPacketTest {
         int expectedLength = 4 + md5Salt.length;
         ByteBuf byteBuf = ByteBufTestUtils.createByteBuf(expectedLength);
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        PostgreSQLAuthenticationMD5PasswordPacket packet = new PostgreSQLAuthenticationMD5PasswordPacket(md5Salt);
+        PostgreSQLMD5PasswordAuthenticationPacket packet = new PostgreSQLMD5PasswordAuthenticationPacket(md5Salt);
         assertThat(packet.getIdentifier(), is(PostgreSQLMessagePacketType.AUTHENTICATION_REQUEST));
         packet.write(payload);
         assertThat(byteBuf.writerIndex(), is(expectedLength));

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -21,23 +21,27 @@ import com.google.common.base.Strings;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLErrorCode;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLServerInfo;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLPreparedStatementRegistry;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.generic.PostgreSQLReadyForQueryPacket;
-import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationMD5PasswordPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationOKPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLComStartupPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLPasswordMessagePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLRandomGenerator;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLSSLNegativePacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication.PostgreSQLMD5PasswordAuthenticationPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication.PostgreSQLPasswordAuthenticationPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLMessagePacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.apache.shardingsphere.proxy.frontend.authentication.AuthenticationEngine;
 import org.apache.shardingsphere.proxy.frontend.authentication.AuthenticationResult;
 import org.apache.shardingsphere.proxy.frontend.authentication.AuthenticationResultBuilder;
 import org.apache.shardingsphere.proxy.frontend.connection.ConnectionIdGenerator;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLAuthenticator;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.InvalidAuthorizationSpecificationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLAuthenticationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLProtocolViolationException;
@@ -60,6 +64,8 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
     private byte[] md5Salt;
     
     private AuthenticationResult currentAuthResult;
+    
+    private final PostgreSQLAuthenticationHandler authenticationHandler = new PostgreSQLAuthenticationHandler();
     
     @Override
     public int handshake(final ChannelHandlerContext context) {
@@ -87,8 +93,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         if (Strings.isNullOrEmpty(user)) {
             throw new InvalidAuthorizationSpecificationException("no PostgreSQL user name specified in startup packet");
         }
-        md5Salt = PostgreSQLRandomGenerator.getInstance().generateRandomBytes(4);
-        context.writeAndFlush(new PostgreSQLAuthenticationMD5PasswordPacket(md5Salt));
+        context.writeAndFlush(getIdentifierPacket(user));
         currentAuthResult = AuthenticationResultBuilder.continued(user, "", comStartupPacket.getDatabase());
         return currentAuthResult;
     }
@@ -99,7 +104,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
             throw new PostgreSQLProtocolViolationException("password", Character.toString(messageType));
         }
         PostgreSQLPasswordMessagePacket passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
-        PostgreSQLLoginResult loginResult = PostgreSQLAuthenticationHandler.loginWithMd5Password(currentAuthResult.getUsername(), currentAuthResult.getDatabase(), md5Salt, passwordMessagePacket);
+        PostgreSQLLoginResult loginResult = authenticationHandler.login(currentAuthResult.getUsername(), currentAuthResult.getDatabase(), md5Salt, passwordMessagePacket);
         if (PostgreSQLErrorCode.SUCCESSFUL_COMPLETION != loginResult.getErrorCode()) {
             throw new PostgreSQLAuthenticationException(loginResult.getErrorCode(), loginResult.getErrorMessage());
         }
@@ -111,5 +116,14 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         context.write(new PostgreSQLParameterStatusPacket("integer_datetimes", "on"));
         context.writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         return AuthenticationResultBuilder.finished(currentAuthResult.getUsername(), "", currentAuthResult.getDatabase());
+    }
+    
+    private PostgreSQLIdentifierPacket getIdentifierPacket(final String username) {
+        PostgreSQLAuthenticator authenticator = authenticationHandler.getAuthenticator(username, "");
+        if (PostgreSQLAuthenticationMethod.PASSWORD.getMethodName().equals(authenticator.getAuthenticationMethodName())) {
+            return new PostgreSQLPasswordAuthenticationPacket();
+        }
+        md5Salt = PostgreSQLRandomGenerator.getInstance().generateRandomBytes(4);
+        return new PostgreSQLMD5PasswordAuthenticationPacket(md5Salt);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandler.java
@@ -18,10 +18,6 @@
 package org.apache.shardingsphere.proxy.frontend.postgresql.authentication;
 
 import com.google.common.base.Strings;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLErrorCode;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLPasswordMessagePacket;
 import org.apache.shardingsphere.infra.executor.check.SQLCheckEngine;
@@ -29,15 +25,15 @@ import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLAuthenticator;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLMD5PasswordAuthenticator;
 
-import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.LinkedList;
 
 /**
  * Authentication handler for PostgreSQL.
  */
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PostgreSQLAuthenticationHandler {
     
     /**
@@ -49,7 +45,7 @@ public final class PostgreSQLAuthenticationHandler {
      * @param passwordMessagePacket password message packet
      * @return PostgreSQL login result
      */
-    public static PostgreSQLLoginResult loginWithMd5Password(final String username, final String databaseName, final byte[] md5Salt, final PostgreSQLPasswordMessagePacket passwordMessagePacket) {
+    public PostgreSQLLoginResult login(final String username, final String databaseName, final byte[] md5Salt, final PostgreSQLPasswordMessagePacket passwordMessagePacket) {
         String md5Digest = passwordMessagePacket.getDigest();
         Grantee grantee = new Grantee(username, "%");
         if (!Strings.isNullOrEmpty(databaseName) && !ProxyContext.getInstance().schemaExists(databaseName)) {
@@ -58,35 +54,33 @@ public final class PostgreSQLAuthenticationHandler {
         if (!SQLCheckEngine.check(grantee, getRules(databaseName))) {
             return new PostgreSQLLoginResult(PostgreSQLErrorCode.INVALID_AUTHORIZATION_SPECIFICATION, String.format("unknown username: %s", username));
         }
-        if (!SQLCheckEngine.check(grantee, (a, b) -> isPasswordRight((ShardingSphereUser) a, (Object[]) b), new Object[] {md5Digest, md5Salt}, getRules(databaseName))) {
+        PostgreSQLAuthenticator authenticator = getAuthenticator(username, grantee.getHostname());
+        if (!SQLCheckEngine.check(grantee, (a, b) -> authenticator.authenticate((ShardingSphereUser) a, (Object[]) b), new Object[] {md5Digest, md5Salt}, getRules(databaseName))) {
             return new PostgreSQLLoginResult(PostgreSQLErrorCode.INVALID_PASSWORD, String.format("password authentication failed for user \"%s\"", username));
         }
         return null == databaseName || SQLCheckEngine.check(databaseName, getRules(databaseName), grantee)
                 ? new PostgreSQLLoginResult(PostgreSQLErrorCode.SUCCESSFUL_COMPLETION, null)
                 : new PostgreSQLLoginResult(PostgreSQLErrorCode.PRIVILEGE_NOT_GRANTED, String.format("Access denied for user '%s' to database '%s'", username, databaseName));
     }
-
-    private static boolean isPasswordRight(final ShardingSphereUser user, final Object[] args) {
-        String md5Digest = (String) args[0];
-        byte[] md5Salt = (byte[]) args[1];
-        String expectedMd5Digest = md5Encode(user.getGrantee().getUsername(), user.getPassword(), md5Salt);
-        return expectedMd5Digest.equals(md5Digest);
-    }
-
-    private static String md5Encode(final String username, final String password, final byte[] md5Salt) {
-        String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
-        MessageDigest messageDigest = DigestUtils.getMd5Digest();
-        messageDigest.update(passwordHash.getBytes());
-        messageDigest.update(md5Salt);
-        return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
-    }
     
-    private static Collection<ShardingSphereRule> getRules(final String databaseName) {
+    private Collection<ShardingSphereRule> getRules(final String databaseName) {
         Collection<ShardingSphereRule> result = new LinkedList<>();
         if (!Strings.isNullOrEmpty(databaseName) && ProxyContext.getInstance().schemaExists(databaseName)) {
             result.addAll(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(databaseName).getRuleMetaData().getRules());
         }
         result.addAll(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getGlobalRuleMetaData().getRules());
         return result;
+    }
+    
+    /**
+     * Get authenticator.
+     *
+     * @param username username
+     * @param hostname hostname
+     * @return authenticator
+     */
+    public PostgreSQLAuthenticator getAuthenticator(final String username, final String hostname) {
+        // TODO get authenticator by username and hostname
+        return new PostgreSQLMD5PasswordAuthenticator();
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLAuthenticator.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLAuthenticator.java
@@ -15,29 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.db.protocol.mysql.constant;
+package org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.apache.shardingsphere.proxy.frontend.authentication.Authenticator;
 
 /**
- * MySQL client/server protocol authentication method.
- *
- * @see <a href="https://dev.mysql.com/doc/internals/en/authentication-method.html">Authentication Method</a>
+ * PostgreSQL authenticator.
+ * 
+ * @see <a href="https://www.postgresql.org/docs/14/auth-password.html">Password Authentication</a>
  */
-@RequiredArgsConstructor
-@Getter
-public enum MySQLAuthenticationMethod {
+public interface PostgreSQLAuthenticator extends Authenticator {
     
-    OLD_PASSWORD_AUTHENTICATION("mysql_old_password"),
-    
-    SECURE_PASSWORD_AUTHENTICATION("mysql_native_password"),
-    
-    CLEAR_TEXT_AUTHENTICATION("mysql_clear_password"),
-    
-    WINDOWS_NATIVE_AUTHENTICATION("authentication_windows_client"),
-    
-    SHA256("sha256_password");
-    
-    private final String methodName;
+    /**
+     * Authenticate.
+     *
+     * @param user ShardingSphere user
+     * @param args arguments for user authentication
+     * @return authentication success or not
+     */
+    boolean authenticate(ShardingSphereUser user, Object[] args);
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLMD5PasswordAuthenticator.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLMD5PasswordAuthenticator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+
+import java.security.MessageDigest;
+
+/**
+ * MD5 password authenticator for PostgreSQL.
+ */
+@RequiredArgsConstructor
+public final class PostgreSQLMD5PasswordAuthenticator implements PostgreSQLAuthenticator {
+    
+    @Override
+    public boolean authenticate(final ShardingSphereUser user, final Object[] args) {
+        String md5Digest = (String) args[0];
+        byte[] md5Salt = (byte[]) args[1];
+        String expectedMd5Digest = md5Encode(user.getGrantee().getUsername(), user.getPassword(), md5Salt);
+        return expectedMd5Digest.equals(md5Digest);
+    }
+    
+    private String md5Encode(final String username, final String password, final byte[] md5Salt) {
+        String passwordHash = new String(Hex.encodeHex(DigestUtils.md5(password + username), true));
+        MessageDigest messageDigest = DigestUtils.getMd5Digest();
+        messageDigest.update(passwordHash.getBytes());
+        messageDigest.update(md5Salt);
+        return "md5" + new String(Hex.encodeHex(messageDigest.digest(), true));
+    }
+    
+    @Override
+    public String getAuthenticationMethodName() {
+        return PostgreSQLAuthenticationMethod.MD5.getMethodName();
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -65,7 +65,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -137,8 +136,6 @@ public final class PostgreSQLAuthenticationEngineTest {
     @Test
     @SneakyThrows(ReflectiveOperationException.class)
     public void assertGetIdentifierPacket() {
-        PostgreSQLAuthenticationHandler authenticationHandler = mock(PostgreSQLAuthenticationHandler.class);
-        when(authenticationHandler.getAuthenticator(anyString(), anyString())).thenReturn(new PostgreSQLMD5PasswordAuthenticator());
         Method method = PostgreSQLAuthenticationEngine.class.getDeclaredMethod("getIdentifierPacket", String.class);
         method.setAccessible(true);
         PostgreSQLIdentifierPacket packet = (PostgreSQLIdentifierPacket) method.invoke(new PostgreSQLAuthenticationEngine(), username);

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.authority.rule.builder.AuthorityRuleBuilder;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
-import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLAuthenticationMD5PasswordPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication.PostgreSQLMD5PasswordAuthenticationPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.frontend.authentication.AuthenticationResult;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLMD5PasswordAuthenticator;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.InvalidAuthorizationSpecificationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLAuthenticationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLProtocolViolationException;
@@ -142,9 +143,9 @@ public final class PostgreSQLAuthenticationEngineTest {
         AuthenticationResult actual = engine.authenticate(channelHandlerContext, payload);
         assertFalse(actual.isFinished());
         assertThat(actual.getUsername(), is(username));
-        ArgumentCaptor<PostgreSQLAuthenticationMD5PasswordPacket> argumentCaptor = ArgumentCaptor.forClass(PostgreSQLAuthenticationMD5PasswordPacket.class);
+        ArgumentCaptor<PostgreSQLMD5PasswordAuthenticationPacket> argumentCaptor = ArgumentCaptor.forClass(PostgreSQLMD5PasswordAuthenticationPacket.class);
         verify(channelHandlerContext).writeAndFlush(argumentCaptor.capture());
-        PostgreSQLAuthenticationMD5PasswordPacket md5PasswordPacket = argumentCaptor.getValue();
+        PostgreSQLMD5PasswordAuthenticationPacket md5PasswordPacket = argumentCaptor.getValue();
         byte[] md5Salt = getMd5Salt(md5PasswordPacket);
         payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
         String md5Digest = md5Encode(username, inputPassword, md5Salt);
@@ -175,16 +176,16 @@ public final class PostgreSQLAuthenticationEngineTest {
     }
     
     @SneakyThrows(ReflectiveOperationException.class)
-    private byte[] getMd5Salt(final PostgreSQLAuthenticationMD5PasswordPacket md5PasswordPacket) {
-        Field field = PostgreSQLAuthenticationMD5PasswordPacket.class.getDeclaredField("md5Salt");
+    private byte[] getMd5Salt(final PostgreSQLMD5PasswordAuthenticationPacket md5PasswordPacket) {
+        Field field = PostgreSQLMD5PasswordAuthenticationPacket.class.getDeclaredField("md5Salt");
         field.setAccessible(true);
         return (byte[]) field.get(md5PasswordPacket);
     }
     
     @SneakyThrows(ReflectiveOperationException.class)
     private String md5Encode(final String username, final String password, final byte[] md5Salt) {
-        Method method = PostgreSQLAuthenticationHandler.class.getDeclaredMethod("md5Encode", String.class, String.class, byte[].class);
+        Method method = PostgreSQLMD5PasswordAuthenticator.class.getDeclaredMethod("md5Encode", String.class, String.class, byte[].class);
         method.setAccessible(true);
-        return (String) method.invoke(PostgreSQLAuthenticationHandler.class, username, password, md5Salt);
+        return (String) method.invoke(new PostgreSQLMD5PasswordAuthenticator(), username, password, md5Salt);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngineTest.java
@@ -138,7 +138,7 @@ public final class PostgreSQLAuthenticationEngineTest {
     @SneakyThrows(ReflectiveOperationException.class)
     public void assertGetIdentifierPacket() {
         PostgreSQLAuthenticationHandler authenticationHandler = mock(PostgreSQLAuthenticationHandler.class);
-        when(authenticationHandler.getAuthenticator(anyString(),anyString())).thenReturn(new PostgreSQLMD5PasswordAuthenticator());
+        when(authenticationHandler.getAuthenticator(anyString(), anyString())).thenReturn(new PostgreSQLMD5PasswordAuthenticator());
         Method method = PostgreSQLAuthenticationEngine.class.getDeclaredMethod("getIdentifierPacket", String.class);
         method.setAccessible(true);
         PostgreSQLIdentifierPacket packet = (PostgreSQLIdentifierPacket) method.invoke(new PostgreSQLAuthenticationEngine(), username);

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandlerTest.java
@@ -127,7 +127,7 @@ public final class PostgreSQLAuthenticationHandlerTest {
     
     @Test
     public void assertGetAuthenticator() {
-        PostgreSQLAuthenticator authenticator = authenticationHandler.getAuthenticator("root", "");
+        PostgreSQLAuthenticator authenticator = authenticationHandler.getAuthenticator(username, "");
         assertThat(authenticator, instanceOf(PostgreSQLMD5PasswordAuthenticator.class));
         assertThat(authenticator.getAuthenticationMethodName(), is(PostgreSQLAuthenticationMethod.MD5.getMethodName()));
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandlerTest.java
@@ -24,6 +24,7 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.authority.config.AuthorityRuleConfiguration;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.authority.rule.builder.AuthorityRuleBuilder;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLErrorCode;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLPasswordMessagePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
@@ -41,6 +42,7 @@ import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLAuthenticator;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLMD5PasswordAuthenticator;
 import org.junit.Before;
 import org.junit.Test;
@@ -53,6 +55,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -120,6 +123,13 @@ public final class PostgreSQLAuthenticationHandlerTest {
         String database = "non_exist_database";
         PostgreSQLLoginResult postgreSQLLoginResult = authenticationHandler.login(username, database, md5Salt.getBytes(StandardCharsets.UTF_8), passwordMessagePacket);
         assertThat(postgreSQLLoginResult.getErrorCode(), is(PostgreSQLErrorCode.INVALID_CATALOG_NAME));
+    }
+    
+    @Test
+    public void assertGetAuthenticator() {
+        PostgreSQLAuthenticator authenticator = authenticationHandler.getAuthenticator("root", "");
+        assertThat(authenticator, instanceOf(PostgreSQLMD5PasswordAuthenticator.class));
+        assertThat(authenticator.getAuthenticationMethodName(), is(PostgreSQLAuthenticationMethod.MD5.getMethodName()));
     }
     
     @SneakyThrows(ReflectiveOperationException.class)


### PR DESCRIPTION
Related to  #15444.
Decouple PostgreSQLAuthenticationEngine and PostgreSQLAuthenticationMethod to support more authentication methods. 