### PR TITLE
Fix show tables statement loses part of the single table

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilderTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptTableMetaDataBuilderTest.java
@@ -18,12 +18,11 @@
 package org.apache.shardingsphere.encrypt.metadata;
 
 import org.apache.shardingsphere.encrypt.rule.EncryptColumn;
-import org.apache.shardingsphere.encrypt.spi.context.EncryptColumnDataType;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
+import org.apache.shardingsphere.encrypt.spi.context.EncryptColumnDataType;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.schema.builder.SchemaBuilderMaterials;
 import org.apache.shardingsphere.infra.metadata.schema.builder.spi.DialectTableMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.schema.builder.spi.RuleBasedTableMetaDataBuilder;
@@ -372,9 +371,7 @@ public final class EncryptTableMetaDataBuilderTest {
     }
     
     private SingleTableRule createSingleTableRule() {
-        SingleTableRule result = mock(SingleTableRule.class);
-        when(result.getAllDataNodes()).thenReturn(Collections.singletonMap(TABLE_NAME, Collections.singletonList(new DataNode("logic_db", TABLE_NAME))));
-        return result;
+        return mock(SingleTableRule.class);
     }
     
     private EncryptTableMetaDataBuilder getEncryptMetaDataBuilder(final EncryptRule encryptRule, final Collection<ShardingSphereRule> rules) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -576,13 +577,13 @@ public final class ShardingRuleTest {
         String owner = segment.getOwner().map(optional -> optional.getIdentifier().getValue()).orElse(null);
         return new ColumnProjection(owner, segment.getIdentifier().getValue(), null);
     }
-
+    
     @Test
     public void assertGetLogicTablesByActualTable() {
         assertThat(createShardingRuleWithSameActualTablesButDifferentLogicTables().getLogicTablesByActualTable("table_0"),
                 is(new LinkedHashSet<>(Arrays.asList("ID_STRATEGY_LOGIC_TABLE", "HINT_STRATEGY_LOGIC_TABLE"))));
     }
-
+    
     private ShardingRule createShardingRuleWithSameActualTablesButDifferentLogicTables() {
         ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
         ShardingTableRuleConfiguration idTableRuleConfig = createTableRuleConfiguration("ID_STRATEGY_LOGIC_TABLE", "ds_${0..1}.table_${0..2}");
@@ -591,5 +592,30 @@ public final class ShardingRuleTest {
         shardingRuleConfig.getTables().add(hintTableRuleConfig);
         return new ShardingRule(shardingRuleConfig, createDataSourceNames());
     }
-
+    
+    @Test
+    public void assertGetDataNodesByTableName() {
+        ShardingRule shardingRule = createMinimumShardingRule();
+        Collection<DataNode> actual = shardingRule.getDataNodesByTableName("logic_table");
+        assertThat(actual.size(), is(6));
+        Iterator<DataNode> iterator = actual.iterator();
+        DataNode firstDataNode = iterator.next();
+        assertThat(firstDataNode.getDataSourceName(), is("ds_0"));
+        assertThat(firstDataNode.getTableName(), is("table_0"));
+        DataNode secondDataNode = iterator.next();
+        assertThat(secondDataNode.getDataSourceName(), is("ds_0"));
+        assertThat(secondDataNode.getTableName(), is("table_1"));
+        DataNode thirdDataNode = iterator.next();
+        assertThat(thirdDataNode.getDataSourceName(), is("ds_0"));
+        assertThat(thirdDataNode.getTableName(), is("table_2"));
+        DataNode fourthDataNode = iterator.next();
+        assertThat(fourthDataNode.getDataSourceName(), is("ds_1"));
+        assertThat(fourthDataNode.getTableName(), is("table_0"));
+        DataNode fifthDataNode = iterator.next();
+        assertThat(fifthDataNode.getDataSourceName(), is("ds_1"));
+        assertThat(fifthDataNode.getTableName(), is("table_1"));
+        DataNode sixthDataNode = iterator.next();
+        assertThat(sixthDataNode.getDataSourceName(), is("ds_1"));
+        assertThat(sixthDataNode.getTableName(), is("table_2"));
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNodes.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/datanode/DataNodes.java
@@ -62,7 +62,7 @@ public final class DataNodes {
         if (!dataNodeContainedRule.isPresent()) {
             return Collections.emptyList();
         }
-        Collection<DataNode> result = new LinkedList<>(dataNodeContainedRule.get().getAllDataNodes().get(tableName));
+        Collection<DataNode> result = new LinkedList<>(dataNodeContainedRule.get().getDataNodesByTableName(tableName));
         for (Entry<ShardingSphereRule, DataNodeBuilder> entry : decorators.entrySet()) {
             result = entry.getValue().build(result, entry.getKey());
         }
@@ -74,6 +74,6 @@ public final class DataNodes {
     }
     
     private boolean isDataNodeContainedRuleContainsTable(final ShardingSphereRule each, final String tableName) {
-        return each instanceof DataNodeContainedRule && ((DataNodeContainedRule) each).getAllDataNodes().containsKey(tableName);
+        return each instanceof DataNodeContainedRule && !((DataNodeContainedRule) each).getDataNodesByTableName(tableName).isEmpty();
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/DataNodeContainedRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/DataNodeContainedRule.java
@@ -37,6 +37,14 @@ public interface DataNodeContainedRule extends ShardingSphereRule {
     Map<String, Collection<DataNode>> getAllDataNodes();
     
     /**
+     * Get data nodes by table name.
+     * 
+     * @param tableName table name
+     * @return data nodes
+     */
+    Collection<DataNode> getDataNodesByTableName(String tableName);
+    
+    /**
      * Get all actual tables.
      * 
      * @return all actual tables

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodesTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datanode/DataNodesTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.datanode;
 
 import org.apache.shardingsphere.infra.fixture.ReadWriteSplittingRuleFixture;
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.junit.Test;
@@ -26,10 +27,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -40,90 +40,124 @@ public final class DataNodesTest {
     
     private static final Map<String, Collection<String>> READ_WRITE_SPLITTING_DATASOURCE_MAP = new HashMap<>();
     
-    private static final Map<String, List<String>> SHARDING_ACTUAL_TABLE_MAP = new HashMap<>();
-    
-    private static final Map<String, List<String>> DATASOURCE_SINGLE_TABLE_MAP = new HashMap<>();
-    
     static {
-        READ_WRITE_SPLITTING_DATASOURCE_MAP.putIfAbsent("node_0", Arrays.asList("primary_ds0", "replica_ds0_0", "replica_ds0_1"));
-        SHARDING_ACTUAL_TABLE_MAP.put("user", Arrays.asList("user_0", "user_1"));
-        DATASOURCE_SINGLE_TABLE_MAP.put("primary_ds0", Arrays.asList("primary_ds0_table_0", "primary_ds0_table_1"));
+        READ_WRITE_SPLITTING_DATASOURCE_MAP.putIfAbsent("readwrite_ds", Arrays.asList("primary_ds", "replica_ds_0", "replica_ds_1"));
     }
     
     @Test
-    public void assertGetDataNodesWithTablePresent() {
-        DataNodes dataNodes = new DataNodes(Arrays.asList(buildDataSourceContainedRule(), buildDataNodeContainedRule(true)));
-        Collection<DataNode> userDataNodes = dataNodes.getDataNodes("user");
-        assertThat(userDataNodes, is(getShardingActualDataNode().get("user")));
-        List<String> primaryDs0SingleTables = DATASOURCE_SINGLE_TABLE_MAP.get("primary_ds0");
-        for (String primaryDs0SingleTable : primaryDs0SingleTables) {
-            Collection<DataNode> primaryDs0SingleTableDataNodes = dataNodes.getDataNodes(primaryDs0SingleTable);
-            assertThat(primaryDs0SingleTableDataNodes, is(getSingleTableDataNode().get(primaryDs0SingleTable)));
-        }
+    public void assertGetDataNodesForShardingTableWithoutDataNodeContainedRule() {
+        DataNodes dataNodes = new DataNodes(Collections.singletonList(mockDataSourceContainedRule()));
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_order");
+        assertThat(actual, is(Collections.emptyList()));
     }
     
     @Test
-    public void assertGetDataNodesWithTableAbsent() {
-        DataNodes dataNodes = new DataNodes(Arrays.asList(buildDataSourceContainedRule(), buildDataNodeContainedRule(true)));
-        Collection<DataNode> userDataNodes = dataNodes.getDataNodes("order");
-        assertThat(userDataNodes, is(Collections.emptyList()));
+    public void assertGetDataNodesForSingleTableWithoutDataNodeContainedRule() {
+        DataNodes dataNodes = new DataNodes(Collections.singletonList(mockDataSourceContainedRule()));
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_single");
+        assertThat(actual, is(Collections.emptyList()));
     }
     
     @Test
-    public void assertGetDataNodesWithDataNodeContainedRuleAbsent() {
-        DataNodes dataNodes = new DataNodes(Collections.singletonList(buildDataSourceContainedRule()));
-        Collection<DataNode> userDataNodes = dataNodes.getDataNodes("user");
-        assertThat(userDataNodes, is(Collections.emptyList()));
+    public void assertGetDataNodesForShardingTableWithDataNodeContainedRuleWithoutDataSourceContainedRule() {
+        DataNodes dataNodes = new DataNodes(mockDataNodeContainedRules());
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_order");
+        assertThat(actual.size(), is(2));
+        Iterator<DataNode> iterator = actual.iterator();
+        DataNode firstDataNode = iterator.next();
+        assertThat(firstDataNode.getDataSourceName(), is("readwrite_ds"));
+        assertThat(firstDataNode.getTableName(), is("t_order_0"));
+        DataNode secondDataNode = iterator.next();
+        assertThat(secondDataNode.getDataSourceName(), is("readwrite_ds"));
+        assertThat(secondDataNode.getTableName(), is("t_order_1"));
     }
     
     @Test
-    public void assertGetDataNodesWithDataSourceContainedRuleAbsent() {
-        DataNodes dataNodes = new DataNodes(Collections.singletonList(buildDataNodeContainedRule(false)));
-        Collection<DataNode> userDataNodes = dataNodes.getDataNodes("user");
-        assertThat(userDataNodes, is(getShardingActualDataNode().get("user")));
+    public void assertGetDataNodesForSingleTableWithDataNodeContainedRuleWithoutDataSourceContainedRule() {
+        DataNodes dataNodes = new DataNodes(mockDataNodeContainedRules());
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_single");
+        assertThat(actual.size(), is(1));
+        Iterator<DataNode> iterator = actual.iterator();
+        DataNode firstDataNode = iterator.next();
+        assertThat(firstDataNode.getDataSourceName(), is("readwrite_ds"));
+        assertThat(firstDataNode.getTableName(), is("t_single"));
     }
     
-    private DataSourceContainedRule buildDataSourceContainedRule() {
+    @Test
+    public void assertGetDataNodesForShardingTableWithDataNodeContainedRuleAndDataSourceContainedRule() {
+        DataNodes dataNodes = new DataNodes(mockShardingSphereRules());
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_order");
+        assertThat(actual.size(), is(6));
+        Iterator<DataNode> iterator = actual.iterator();
+        DataNode firstDataNode = iterator.next();
+        assertThat(firstDataNode.getDataSourceName(), is("primary_ds"));
+        assertThat(firstDataNode.getTableName(), is("t_order_0"));
+        DataNode secondDataNode = iterator.next();
+        assertThat(secondDataNode.getDataSourceName(), is("replica_ds_0"));
+        assertThat(secondDataNode.getTableName(), is("t_order_0"));
+        DataNode thirdDataNode = iterator.next();
+        assertThat(thirdDataNode.getDataSourceName(), is("replica_ds_1"));
+        assertThat(thirdDataNode.getTableName(), is("t_order_0"));
+        DataNode fourthDataNode = iterator.next();
+        assertThat(fourthDataNode.getDataSourceName(), is("primary_ds"));
+        assertThat(fourthDataNode.getTableName(), is("t_order_1"));
+        DataNode fifthDataNode = iterator.next();
+        assertThat(fifthDataNode.getDataSourceName(), is("replica_ds_0"));
+        assertThat(fifthDataNode.getTableName(), is("t_order_1"));
+        DataNode sixthDataNode = iterator.next();
+        assertThat(sixthDataNode.getDataSourceName(), is("replica_ds_1"));
+        assertThat(sixthDataNode.getTableName(), is("t_order_1"));
+    }
+    
+    @Test
+    public void assertGetDataNodesForSingleTableWithDataNodeContainedRuleAndDataSourceContainedRule() {
+        DataNodes dataNodes = new DataNodes(mockShardingSphereRules());
+        Collection<DataNode> actual = dataNodes.getDataNodes("t_single");
+        assertThat(actual.size(), is(3));
+        Iterator<DataNode> iterator = actual.iterator();
+        DataNode firstDataNode = iterator.next();
+        assertThat(firstDataNode.getDataSourceName(), is("primary_ds"));
+        assertThat(firstDataNode.getTableName(), is("t_single"));
+        DataNode secondDataNode = iterator.next();
+        assertThat(secondDataNode.getDataSourceName(), is("replica_ds_0"));
+        assertThat(secondDataNode.getTableName(), is("t_single"));
+        DataNode thirdDataNode = iterator.next();
+        assertThat(thirdDataNode.getDataSourceName(), is("replica_ds_1"));
+        assertThat(thirdDataNode.getTableName(), is("t_single"));
+    }
+    
+    private Collection<ShardingSphereRule> mockShardingSphereRules() {
+        Collection<ShardingSphereRule> result = new LinkedList<>();
+        result.add(mockDataSourceContainedRule());
+        result.addAll(mockDataNodeContainedRules());
+        return result;
+    }
+    
+    private ShardingSphereRule mockDataSourceContainedRule() {
         DataSourceContainedRule result = mock(ReadWriteSplittingRuleFixture.class);
         when(result.getDataSourceMapper()).thenReturn(READ_WRITE_SPLITTING_DATASOURCE_MAP);
         return result;
     }
     
-    private DataNodeContainedRule buildDataNodeContainedRule(final boolean replicaQuery) {
+    private Collection<ShardingSphereRule> mockDataNodeContainedRules() {
+        Collection<ShardingSphereRule> result = new LinkedList<>();
+        result.add(mockSingleTableRule());
+        result.add(mockShardingRule());
+        return result;
+    }
+    
+    private ShardingSphereRule mockSingleTableRule() {
         DataNodeContainedRule result = mock(DataNodeContainedRule.class);
-        Map<String, Collection<DataNode>> dataNodes = new HashMap<>();
-        dataNodes.putAll(getSingleTableDataNode());
-        dataNodes.putAll(replicaQuery ? getReplicaShardingDataNode() : getShardingActualDataNode());
-        when(result.getAllDataNodes()).thenReturn(dataNodes);
+        when(result.getDataNodesByTableName("t_single")).thenReturn(Collections.singletonList(new DataNode("readwrite_ds", "t_single")));
         return result;
     }
     
-    private Map<String, Collection<DataNode>> getSingleTableDataNode() {
-        Map<String, Collection<DataNode>> result = new HashMap<>();
-        for (Entry<String, List<String>> entry : DATASOURCE_SINGLE_TABLE_MAP.entrySet()) {
-            Map<String, Collection<DataNode>> map = entry.getValue().stream().collect(Collectors.toMap(singleTable -> singleTable,
-                singleTable -> Collections.singletonList(new DataNode(entry.getKey(), singleTable)), (Collection<DataNode> oldList, Collection<DataNode> newList) -> {
-                    oldList.addAll(newList);
-                    return oldList;
-                })
-            );
-            result.putAll(map);
-        }
+    private ShardingSphereRule mockShardingRule() {
+        DataNodeContainedRule result = mock(DataNodeContainedRule.class);
+        Collection<DataNode> dataNodes = new LinkedList<>();
+        dataNodes.add(new DataNode("readwrite_ds", "t_order_0"));
+        dataNodes.add(new DataNode("readwrite_ds", "t_order_1"));
+        when(result.getDataNodesByTableName("t_order")).thenReturn(dataNodes);
         return result;
-    }
-    
-    private Map<String, Collection<DataNode>> getReplicaShardingDataNode() {
-        return SHARDING_ACTUAL_TABLE_MAP.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().stream().map(
-            shardingTable -> getActualDataNode(READ_WRITE_SPLITTING_DATASOURCE_MAP.keySet(), shardingTable)).flatMap(Collection::stream).collect(Collectors.toList())));
-    }
-    
-    private Map<String, Collection<DataNode>> getShardingActualDataNode() {
-        List<String> allDataSources = READ_WRITE_SPLITTING_DATASOURCE_MAP.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
-        return SHARDING_ACTUAL_TABLE_MAP.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().stream()
-                .map(shardingTable -> getActualDataNode(allDataSources, shardingTable)).flatMap(Collection::stream).collect(Collectors.toList())));
-    }
-    
-    private List<DataNode> getActualDataNode(final Collection<String> dataSources, final String tableName) {
-        return dataSources.stream().map(each -> new DataNode(each, tableName)).collect(Collectors.toList());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/util/TableMetaDataUtilTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/builder/util/TableMetaDataUtilTest.java
@@ -62,8 +62,6 @@ public final class TableMetaDataUtilTest {
         Map<String, Collection<DataNode>> dataNodes = new HashMap<>();
         dataNodes.put("t_user", Collections.singletonList(new DataNode("ds0.t_user")));
         dataNodes.put("t_order", Collections.singletonList(new DataNode("ds1.t_order")));
-        when(dataNodeContainedRule.getAllDataNodes()).thenReturn(dataNodes);
-        Map<String, Collection<String>> dataSourceMapper = new HashMap<>();
         Collection<ShardingSphereRule> rules = new LinkedList<>();
         rules.add(dataNodeContainedRule);
         rules.add(dataSourceContainedRule);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/fixture/rule/DataNodeContainedFixtureRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/fixture/rule/DataNodeContainedFixtureRule.java
@@ -41,7 +41,12 @@ public final class DataNodeContainedFixtureRule implements DataNodeContainedRule
     
     @Override
     public Map<String, Collection<DataNode>> getAllDataNodes() {
-        return null;
+        return Collections.emptyMap();
+    }
+    
+    @Override
+    public Collection<DataNode> getDataNodesByTableName(final String tableName) {
+        return Collections.emptyList();
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -198,6 +198,11 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     }
     
     @Override
+    public Collection<DataNode> getDataNodesByTableName(final String tableName) {
+        return singleTableDataNodes.getOrDefault(tableName.toLowerCase(), Collections.emptyList());
+    }
+    
+    @Override
     public Collection<String> getAllActualTables() {
         return Collections.emptyList();
     }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
@@ -228,6 +228,18 @@ public final class SingleTableRuleTest {
     }
     
     @Test
+    public void assertGetDataNodesByTableName() {
+        DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+                Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
+        Collection<DataNode> actual = singleTableRule.getDataNodesByTableName("EMPLOYEE");
+        assertThat(actual.size(), is(1));
+        DataNode dataNode = actual.iterator().next();
+        assertThat(dataNode.getDataSourceName(), is("ds_0"));
+        assertThat(dataNode.getTableName(), is("employee"));
+    }
+    
+    @Test
     public void assertGetAllActualTables() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap, 


### PR DESCRIPTION
Fixes #15539.

Changes proposed in this pull request:
- fix show tables statement loses part of the single table
- add unit test for getDataNodesByTableName method
- refactor DataNodesTest
