### PR TITLE
Fix ModShardingAlgorithm wrong route result when exist same suffix table

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/common/DataNodeInfo.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/common/DataNodeInfo.java
@@ -15,28 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.api.sharding.standard;
+package org.apache.shardingsphere.sharding.api.sharding.common;
 
-import com.google.common.collect.Range;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import org.apache.shardingsphere.sharding.api.sharding.ShardingValue;
-import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 
 /**
- * Sharding value for range.
+ * Data node info.
  */
 @RequiredArgsConstructor
 @Getter
-@ToString
-public final class RangeShardingValue<T extends Comparable<?>> implements ShardingValue {
+public final class DataNodeInfo {
     
-    private final String logicTableName;
+    private final String prefix;
     
-    private final String columnName;
-    
-    private final DataNodeInfo dataNodeInfo;
-    
-    private final Range<T> valueRange;
+    private final int suffixMinLength;
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
@@ -34,5 +34,7 @@ public final class PreciseShardingValue<T extends Comparable<?>> implements Shar
     
     private final String columnName;
     
+    private final String dataNodePrefix;
+    
     private final T value;
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apache.shardingsphere.sharding.api.sharding.ShardingValue;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 
 /**
  * Sharding value for precise.
@@ -34,7 +35,7 @@ public final class PreciseShardingValue<T extends Comparable<?>> implements Shar
     
     private final String columnName;
     
-    private final String dataNodePrefix;
+    private final DataNodeInfo dataNodeInfo;
     
     private final T value;
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/RangeShardingValue.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/RangeShardingValue.java
@@ -35,5 +35,7 @@ public final class RangeShardingValue<T extends Comparable<?>> implements Shardi
     
     private final String columnName;
     
+    private final String dataNodePrefix;
+    
     private final Range<T> valueRange;
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmStrategyType.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmStrategyType.java
@@ -36,5 +36,4 @@ public enum ClassBasedShardingAlgorithmStrategyType {
      * The sharding strategy is hint.
      */
     HINT
-
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithm.java
@@ -73,7 +73,7 @@ public final class ModShardingAlgorithm implements StandardShardingAlgorithm<Com
     }
     
     private Optional<String> findMatchedActualTableName(final String actualTableName, final String dataNodePrefix, final long suffix) {
-        Long actualTableNameSuffix = Longs.tryParse(actualTableName.replace(dataNodePrefix, ""));
+        Long actualTableNameSuffix = Longs.tryParse(actualTableName.substring(dataNodePrefix.length()));
         if (null != actualTableNameSuffix && actualTableNameSuffix.equals(suffix)) {
             return Optional.of(actualTableName);
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
@@ -203,7 +203,7 @@ public final class ShardingStandardRoutingEngine implements ShardingRouteEngine 
         if (databaseShardingValues.isEmpty()) {
             return tableRule.getActualDatasourceNames();
         }
-        Collection<String> result = databaseShardingStrategy.doSharding(tableRule.getActualDatasourceNames(), databaseShardingValues, tableRule.getDataSourcePrefix(), properties);
+        Collection<String> result = databaseShardingStrategy.doSharding(tableRule.getActualDatasourceNames(), databaseShardingValues, tableRule.getDataSourceDataNode(), properties);
         Preconditions.checkState(!result.isEmpty(), "No database route info");
         Preconditions.checkState(tableRule.getActualDatasourceNames().containsAll(result), 
                 "Some routed data sources do not belong to configured data sources. routed data sources: `%s`, configured data sources: `%s`", result, tableRule.getActualDatasourceNames());
@@ -214,7 +214,7 @@ public final class ShardingStandardRoutingEngine implements ShardingRouteEngine 
                                              final ShardingStrategy tableShardingStrategy, final List<ShardingConditionValue> tableShardingValues) {
         Collection<String> availableTargetTables = tableRule.getActualTableNames(routedDataSource);
         Collection<String> routedTables = tableShardingValues.isEmpty() 
-                ? availableTargetTables : tableShardingStrategy.doSharding(availableTargetTables, tableShardingValues, tableRule.getTablePrefix(), properties);
+                ? availableTargetTables : tableShardingStrategy.doSharding(availableTargetTables, tableShardingValues, tableRule.getTableDataNode(), properties);
         Collection<DataNode> result = new LinkedList<>();
         for (String each : routedTables) {
             result.add(new DataNode(routedDataSource, each));

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/standard/ShardingStandardRoutingEngine.java
@@ -203,7 +203,7 @@ public final class ShardingStandardRoutingEngine implements ShardingRouteEngine 
         if (databaseShardingValues.isEmpty()) {
             return tableRule.getActualDatasourceNames();
         }
-        Collection<String> result = databaseShardingStrategy.doSharding(tableRule.getActualDatasourceNames(), databaseShardingValues, properties);
+        Collection<String> result = databaseShardingStrategy.doSharding(tableRule.getActualDatasourceNames(), databaseShardingValues, tableRule.getDataSourcePrefix(), properties);
         Preconditions.checkState(!result.isEmpty(), "No database route info");
         Preconditions.checkState(tableRule.getActualDatasourceNames().containsAll(result), 
                 "Some routed data sources do not belong to configured data sources. routed data sources: `%s`, configured data sources: `%s`", result, tableRule.getActualDatasourceNames());
@@ -213,7 +213,8 @@ public final class ShardingStandardRoutingEngine implements ShardingRouteEngine 
     private Collection<DataNode> routeTables(final TableRule tableRule, final String routedDataSource, 
                                              final ShardingStrategy tableShardingStrategy, final List<ShardingConditionValue> tableShardingValues) {
         Collection<String> availableTargetTables = tableRule.getActualTableNames(routedDataSource);
-        Collection<String> routedTables = tableShardingValues.isEmpty() ? availableTargetTables : tableShardingStrategy.doSharding(availableTargetTables, tableShardingValues, properties);
+        Collection<String> routedTables = tableShardingValues.isEmpty() 
+                ? availableTargetTables : tableShardingStrategy.doSharding(availableTargetTables, tableShardingValues, tableRule.getTablePrefix(), properties);
         Collection<DataNode> result = new LinkedList<>();
         for (String each : routedTables) {
             result.add(new DataNode(routedDataSource, each));

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategy.java
@@ -47,8 +47,9 @@ public interface ShardingStrategy {
      *
      * @param availableTargetNames available data source or table names
      * @param shardingConditionValues sharding condition values
+     * @param dataNodePrefix data node prefix
      * @param props configuration properties
      * @return sharding results for data source or table names
      */
-    Collection<String> doSharding(Collection<String> availableTargetNames, Collection<ShardingConditionValue> shardingConditionValues, ConfigurationProperties props);
+    Collection<String> doSharding(Collection<String> availableTargetNames, Collection<ShardingConditionValue> shardingConditionValues, String dataNodePrefix, ConfigurationProperties props);
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategy.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.route.strategy;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
 import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
 
@@ -47,9 +48,9 @@ public interface ShardingStrategy {
      *
      * @param availableTargetNames available data source or table names
      * @param shardingConditionValues sharding condition values
-     * @param dataNodePrefix data node prefix
+     * @param dataNodeInfo data node info
      * @param props configuration properties
      * @return sharding results for data source or table names
      */
-    Collection<String> doSharding(Collection<String> availableTargetNames, Collection<ShardingConditionValue> shardingConditionValues, String dataNodePrefix, ConfigurationProperties props);
+    Collection<String> doSharding(Collection<String> availableTargetNames, Collection<ShardingConditionValue> shardingConditionValues, DataNodeInfo dataNodeInfo, ConfigurationProperties props);
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
@@ -24,10 +24,10 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingValue;
-import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
+import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -54,7 +54,8 @@ public final class ComplexShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
+                                         final String dataNodePrefix, final ConfigurationProperties props) {
         Map<String, Collection<Comparable<?>>> columnShardingValues = new HashMap<>(shardingConditionValues.size(), 1);
         Map<String, Range<Comparable<?>>> columnRangeValues = new HashMap<>(shardingConditionValues.size(), 1);
         String logicTableName = "";

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategy.java
@@ -22,6 +22,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Range;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
@@ -54,8 +55,8 @@ public final class ComplexShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
-                                         final String dataNodePrefix, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues,
+                                         final DataNodeInfo dataNodeInfo, final ConfigurationProperties props) {
         Map<String, Collection<Comparable<?>>> columnShardingValues = new HashMap<>(shardingConditionValues.size(), 1);
         Map<String, Range<Comparable<?>>> columnRangeValues = new HashMap<>(shardingConditionValues.size(), 1);
         String logicTableName = "";

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
@@ -22,9 +22,9 @@ import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingValue;
-import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
+import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 
 import java.util.Collection;
 import java.util.TreeSet;
@@ -47,7 +47,8 @@ public final class HintShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
+                                         final String dataNodePrefix, final ConfigurationProperties props) {
         ListShardingConditionValue<?> shardingValue = (ListShardingConditionValue) shardingConditionValues.iterator().next();
         Collection<String> shardingResult = shardingAlgorithm.doSharding(availableTargetNames, 
                 new HintShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), shardingValue.getValues()));

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategy.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.strategy.type.hint;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
@@ -47,8 +48,8 @@ public final class HintShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
-                                         final String dataNodePrefix, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues,
+                                         final DataNodeInfo dataNodeInfo, final ConfigurationProperties props) {
         ListShardingConditionValue<?> shardingValue = (ListShardingConditionValue) shardingConditionValues.iterator().next();
         Collection<String> shardingResult = shardingAlgorithm.doSharding(availableTargetNames, 
                 new HintShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), shardingValue.getValues()));

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategy.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.strategy.type.none;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
 import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
@@ -40,8 +41,8 @@ public final class NoneShardingStrategy implements ShardingStrategy {
     }
     
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
-                                         final String dataNodePrefix, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues,
+                                         final DataNodeInfo dataNodeInfo, final ConfigurationProperties props) {
         return availableTargetNames;
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategy.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.sharding.route.strategy.type.none;
 
 import lombok.Getter;
-import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
-import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
-import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
+import org.apache.shardingsphere.sharding.route.strategy.ShardingStrategy;
+import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -40,7 +40,8 @@ public final class NoneShardingStrategy implements ShardingStrategy {
     }
     
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
+                                         final String dataNodePrefix, final ConfigurationProperties props) {
         return availableTargetNames;
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -55,21 +55,23 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings("rawtypes")
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
+                                         final String dataNodePrefix, final ConfigurationProperties props) {
         ShardingConditionValue shardingConditionValue = shardingConditionValues.iterator().next();
         Collection<String> shardingResult = shardingConditionValue instanceof ListShardingConditionValue
-                ? doSharding(availableTargetNames, (ListShardingConditionValue) shardingConditionValue) : doSharding(availableTargetNames, (RangeShardingConditionValue) shardingConditionValue);
+                ? doSharding(availableTargetNames, (ListShardingConditionValue) shardingConditionValue, dataNodePrefix) 
+                : doSharding(availableTargetNames, (RangeShardingConditionValue) shardingConditionValue, dataNodePrefix);
         Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         result.addAll(shardingResult);
         return result;
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Collection<String> doSharding(final Collection<String> availableTargetNames, final ListShardingConditionValue<?> shardingValue) {
+    private Collection<String> doSharding(final Collection<String> availableTargetNames, final ListShardingConditionValue<?> shardingValue, final String dataNodePrefix) {
         Collection<String> result = new LinkedList<>();
         for (Comparable<?> each : shardingValue.getValues()) {
-            String target;
-            target = shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), each));
+            String target = shardingAlgorithm.doSharding(availableTargetNames, 
+                    new PreciseShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodePrefix, each));
             if (null != target && availableTargetNames.contains(target)) {
                 result.add(target);
             } else if (null != target && !availableTargetNames.contains(target)) {
@@ -80,8 +82,8 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingConditionValue<?> shardingValue) {
+    private Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingConditionValue<?> shardingValue, final String dataNodePrefix) {
         return shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), shardingValue.getValueRange()));
+                new RangeShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodePrefix, shardingValue.getValueRange()));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
@@ -55,23 +56,23 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     
     @SuppressWarnings("rawtypes")
     @Override
-    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues, 
-                                         final String dataNodePrefix, final ConfigurationProperties props) {
+    public Collection<String> doSharding(final Collection<String> availableTargetNames, final Collection<ShardingConditionValue> shardingConditionValues,
+                                         final DataNodeInfo dataNodeInfo, final ConfigurationProperties props) {
         ShardingConditionValue shardingConditionValue = shardingConditionValues.iterator().next();
         Collection<String> shardingResult = shardingConditionValue instanceof ListShardingConditionValue
-                ? doSharding(availableTargetNames, (ListShardingConditionValue) shardingConditionValue, dataNodePrefix) 
-                : doSharding(availableTargetNames, (RangeShardingConditionValue) shardingConditionValue, dataNodePrefix);
+                ? doSharding(availableTargetNames, (ListShardingConditionValue) shardingConditionValue, dataNodeInfo) 
+                : doSharding(availableTargetNames, (RangeShardingConditionValue) shardingConditionValue, dataNodeInfo);
         Collection<String> result = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         result.addAll(shardingResult);
         return result;
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Collection<String> doSharding(final Collection<String> availableTargetNames, final ListShardingConditionValue<?> shardingValue, final String dataNodePrefix) {
+    private Collection<String> doSharding(final Collection<String> availableTargetNames, final ListShardingConditionValue<?> shardingValue, final DataNodeInfo dataNodeInfo) {
         Collection<String> result = new LinkedList<>();
         for (Comparable<?> each : shardingValue.getValues()) {
             String target = shardingAlgorithm.doSharding(availableTargetNames, 
-                    new PreciseShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodePrefix, each));
+                    new PreciseShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodeInfo, each));
             if (null != target && availableTargetNames.contains(target)) {
                 result.add(target);
             } else if (null != target && !availableTargetNames.contains(target)) {
@@ -82,8 +83,8 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingConditionValue<?> shardingValue, final String dataNodePrefix) {
+    private Collection<String> doSharding(final Collection<String> availableTargetNames, final RangeShardingConditionValue<?> shardingValue, final DataNodeInfo dataNodeInfo) {
         return shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodePrefix, shardingValue.getValueRange()));
+                new RangeShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodeInfo, shardingValue.getValueRange()));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/TableRule.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/TableRule.java
@@ -107,8 +107,8 @@ public final class TableRule {
         KeyGenerateStrategyConfiguration keyGeneratorConfig = tableRuleConfig.getKeyGenerateStrategy();
         generateKeyColumn = null != keyGeneratorConfig && !Strings.isNullOrEmpty(keyGeneratorConfig.getColumn()) ? keyGeneratorConfig.getColumn() : defaultGenerateKeyColumn;
         keyGeneratorName = null == keyGeneratorConfig ? null : keyGeneratorConfig.getKeyGeneratorName();
-        dataSourcePrefix = actualDataNodes.isEmpty() ? null : getDataNodePrefix(actualDataNodes.iterator().next().getDataSourceName());
-        tablePrefix = actualDataNodes.isEmpty() ? null : getDataNodePrefix(actualDataNodes.iterator().next().getTableName());
+        dataSourcePrefix = actualDataNodes.isEmpty() ? "" : getDataNodePrefix(actualDataNodes.iterator().next().getDataSourceName());
+        tablePrefix = actualDataNodes.isEmpty() ? "" : getDataNodePrefix(actualDataNodes.iterator().next().getTableName());
         checkRule(dataNodes);
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmTest.java
@@ -37,6 +37,8 @@ import static org.junit.Assert.assertThat;
 
 public final class ClassBasedShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     @Test
     public void assertStandardStrategyInit() {
         ClassBasedShardingAlgorithm shardingAlgorithm = getStandardShardingAlgorithm();
@@ -86,14 +88,16 @@ public final class ClassBasedShardingAlgorithmTest {
     public void assertPreciseDoSharding() {
         ClassBasedShardingAlgorithm shardingAlgorithm = getStandardShardingAlgorithm();
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        assertThat(shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", 0)), is("t_order_0"));
+        assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
     }
     
     @Test
     public void assertRangeDoSharding() {
         ClassBasedShardingAlgorithm shardingAlgorithm = getStandardShardingAlgorithm();
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "order_id", Range.closed(2, 15)));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2, 15)));
         assertThat(actual.size(), is(4));
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/classbased/ClassBasedShardingAlgorithmTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.algorithm.sharding.classbased;
 
 import com.google.common.collect.Range;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.complex.ComplexKeysShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertThat;
 
 public final class ClassBasedShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     @Test
     public void assertStandardStrategyInit() {
@@ -89,7 +90,7 @@ public final class ClassBasedShardingAlgorithmTest {
         ClassBasedShardingAlgorithm shardingAlgorithm = getStandardShardingAlgorithm();
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0)), is("t_order_0"));
     }
     
     @Test
@@ -97,7 +98,7 @@ public final class ClassBasedShardingAlgorithmTest {
         ClassBasedShardingAlgorithm shardingAlgorithm = getStandardShardingAlgorithm();
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2, 15)));
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(2, 15)));
         assertThat(actual.size(), is(4));
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdIntervalShardingAlgorithmTest.java
@@ -183,7 +183,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, dateTime);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, dateTime);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -215,7 +215,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -247,7 +247,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -279,7 +279,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -311,7 +311,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -343,7 +343,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -375,7 +375,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -407,7 +407,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdIntervalShardingAlgorithmTest.java
@@ -17,6 +17,7 @@ package org.apache.shardingsphere.sharding.algorithm.sharding.cosid;
 
 import com.google.common.collect.Range;
 import me.ahoo.cosid.sharding.ExactCollection;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -183,7 +184,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, dateTime);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), dateTime);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -215,7 +216,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -247,7 +248,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -279,7 +280,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -311,7 +312,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -343,7 +344,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -375,7 +376,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, value);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), value);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -407,7 +408,7 @@ public final class CosIdIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, LOGIC_NAME_PREFIX, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 6), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdModShardingAlgorithmTest.java
@@ -17,6 +17,7 @@ package org.apache.shardingsphere.sharding.algorithm.sharding.cosid;
 
 import com.google.common.collect.Range;
 import me.ahoo.cosid.sharding.ExactCollection;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public final class CosIdModShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue<Long> shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, "t_mod_", id);
+            PreciseShardingValue<Long> shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 1), id);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             String expected = LOGIC_NAME_PREFIX + (id % DIVISOR);
             assertThat(actual, is(expected));
@@ -104,66 +105,42 @@ public final class CosIdModShardingAlgorithmTest {
         @Parameterized.Parameters
         public static Iterable<Object[]> argsProvider() {
             return Arguments.ofArrayElement(Arguments.of(Range.all(), ALL_NODES),
-                    /**
-                     * Range.closed
-                     */
                     Arguments.of(Range.closed(1L, 3L), new ExactCollection<>("t_mod_1", "t_mod_2", "t_mod_3")),
                     Arguments.of(Range.closed(0L, 3L), ALL_NODES), Arguments.of(Range.closed(0L, 4L), ALL_NODES),
                     Arguments.of(Range.closed(0L, 1L), new ExactCollection<>("t_mod_0", "t_mod_1")),
                     Arguments.of(Range.closed(3L, 4L), new ExactCollection<>("t_mod_0", "t_mod_3")),
-                    /**
-                     * Range.closedOpen
-                     */
                     Arguments.of(Range.closedOpen(1L, 3L), new ExactCollection<>("t_mod_1", "t_mod_2")),
                     Arguments.of(Range.closedOpen(0L, 3L), new ExactCollection<>("t_mod_0", "t_mod_1", "t_mod_2")),
                     Arguments.of(Range.closedOpen(0L, 4L), ALL_NODES),
                     Arguments.of(Range.closedOpen(0L, 1L), new ExactCollection<>("t_mod_0")),
                     Arguments.of(Range.closedOpen(3L, 4L), new ExactCollection<>("t_mod_3")),
-                    /**
-                     * Range.openClosed
-                     */
                     Arguments.of(Range.openClosed(1L, 3L), new ExactCollection<>("t_mod_2", "t_mod_3")),
                     Arguments.of(Range.openClosed(0L, 3L), new ExactCollection<>("t_mod_1", "t_mod_2", "t_mod_3")),
                     Arguments.of(Range.openClosed(0L, 4L), ALL_NODES),
                     Arguments.of(Range.openClosed(0L, 1L), new ExactCollection<>("t_mod_1")),
                     Arguments.of(Range.openClosed(3L, 4L), new ExactCollection<>("t_mod_0")),
-                    /**
-                     * Range.open
-                     */
                     Arguments.of(Range.open(1L, 3L), new ExactCollection<>("t_mod_2")),
                     Arguments.of(Range.open(0L, 3L), new ExactCollection<>("t_mod_1", "t_mod_2")),
                     Arguments.of(Range.open(0L, 4L), new ExactCollection<>("t_mod_1", "t_mod_2", "t_mod_3")),
                     Arguments.of(Range.open(0L, 1L), ExactCollection.empty()),
                     Arguments.of(Range.open(3L, 4L), ExactCollection.empty()),
-                    /**
-                     * Range.greaterThan
-                     */
                     Arguments.of(Range.greaterThan(0L), ALL_NODES),
                     Arguments.of(Range.greaterThan(1L), ALL_NODES),
                     Arguments.of(Range.greaterThan(2L), ALL_NODES),
                     Arguments.of(Range.greaterThan(3L), ALL_NODES),
                     Arguments.of(Range.greaterThan(4L), ALL_NODES),
                     Arguments.of(Range.greaterThan(5L), ALL_NODES),
-                    /**
-                     * Range.atLeast
-                     */
                     Arguments.of(Range.atLeast(0L), ALL_NODES),
                     Arguments.of(Range.atLeast(1L), ALL_NODES),
                     Arguments.of(Range.atLeast(2L), ALL_NODES),
                     Arguments.of(Range.atLeast(3L), ALL_NODES),
                     Arguments.of(Range.atLeast(4L), ALL_NODES),
                     Arguments.of(Range.atLeast(5L), ALL_NODES),
-                    /**
-                     * Range.lessThan
-                     */
                     Arguments.of(Range.lessThan(0L), ExactCollection.empty()),
                     Arguments.of(Range.lessThan(1L), new ExactCollection<>("t_mod_0")),
                     Arguments.of(Range.lessThan(2L), new ExactCollection<>("t_mod_0", "t_mod_1")),
                     Arguments.of(Range.lessThan(3L), new ExactCollection<>("t_mod_0", "t_mod_1", "t_mod_2")),
                     Arguments.of(Range.lessThan(4L), ALL_NODES), Arguments.of(Range.lessThan(5L), ALL_NODES),
-                    /**
-                     * Range.atMost
-                     */
                     Arguments.of(Range.atMost(0L), new ExactCollection<>("t_mod_0")),
                     Arguments.of(Range.atMost(1L), new ExactCollection<>("t_mod_0", "t_mod_1")),
                     Arguments.of(Range.atMost(2L), new ExactCollection<>("t_mod_0", "t_mod_1", "t_mod_2")),
@@ -173,7 +150,7 @@ public final class CosIdModShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue<Long> shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, "t_mod_", rangeValue);
+            RangeShardingValue<Long> shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, new DataNodeInfo(LOGIC_NAME_PREFIX, 1), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdModShardingAlgorithmTest.java
@@ -75,7 +75,7 @@ public final class CosIdModShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue<Long> shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, id);
+            PreciseShardingValue<Long> shardingValue = new PreciseShardingValue<>(LOGIC_NAME, COLUMN_NAME, "t_mod_", id);
             String actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             String expected = LOGIC_NAME_PREFIX + (id % DIVISOR);
             assertThat(actual, is(expected));
@@ -173,7 +173,7 @@ public final class CosIdModShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue<Long> shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, rangeValue);
+            RangeShardingValue<Long> shardingValue = new RangeShardingValue<>(LOGIC_NAME, COLUMN_NAME, "t_mod_", rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdSnowflakeIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdSnowflakeIntervalShardingAlgorithmTest.java
@@ -91,7 +91,8 @@ public final class CosIdSnowflakeIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            PreciseShardingValue shardingValue = new PreciseShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, snowflakeId);
+            PreciseShardingValue shardingValue = new PreciseShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, 
+                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, snowflakeId);
             String actual = shardingAlgorithm.doSharding(CosIdIntervalShardingAlgorithmTest.ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -123,7 +124,8 @@ public final class CosIdSnowflakeIntervalShardingAlgorithmTest {
         
         @Test
         public void assertDoSharding() {
-            RangeShardingValue shardingValue = new RangeShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, rangeValue);
+            RangeShardingValue shardingValue = new RangeShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, 
+                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(CosIdIntervalShardingAlgorithmTest.ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdSnowflakeIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/cosid/CosIdSnowflakeIntervalShardingAlgorithmTest.java
@@ -18,6 +18,7 @@ package org.apache.shardingsphere.sharding.algorithm.sharding.cosid;
 import com.google.common.collect.Range;
 import me.ahoo.cosid.snowflake.MillisecondSnowflakeId;
 import org.apache.shardingsphere.sharding.algorithm.keygen.CosIdSnowflakeKeyGenerateAlgorithm;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -92,7 +93,7 @@ public final class CosIdSnowflakeIntervalShardingAlgorithmTest {
         @Test
         public void assertDoSharding() {
             PreciseShardingValue shardingValue = new PreciseShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, 
-                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, snowflakeId);
+                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, new DataNodeInfo(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, 6), snowflakeId);
             String actual = shardingAlgorithm.doSharding(CosIdIntervalShardingAlgorithmTest.ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }
@@ -125,7 +126,7 @@ public final class CosIdSnowflakeIntervalShardingAlgorithmTest {
         @Test
         public void assertDoSharding() {
             RangeShardingValue shardingValue = new RangeShardingValue<>(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME, 
-                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, rangeValue);
+                    CosIdIntervalShardingAlgorithmTest.COLUMN_NAME, new DataNodeInfo(CosIdIntervalShardingAlgorithmTest.LOGIC_NAME_PREFIX, 6), rangeValue);
             Collection<String> actual = shardingAlgorithm.doSharding(CosIdIntervalShardingAlgorithmTest.ALL_NODES, shardingValue);
             assertThat(actual, is(expected));
         }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.assertTrue;
 
 public final class AutoIntervalShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private AutoIntervalShardingAlgorithm shardingAlgorithm;
     
     @Before
@@ -48,26 +50,30 @@ public final class AutoIntervalShardingAlgorithmTest {
     @Test
     public void assertPreciseDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        assertThat(shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "create_time", "2020-01-01 00:00:01")), is("t_order_1"));
+        assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_1"));
     }
     
     @Test
     public void assertPreciseDoShardingBeyondTheLastOne() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5");
-        assertThat(shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "create_time", "2021-01-01 00:00:02")), is("t_order_5"));
+        assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-01-01 00:00:02")), is("t_order_5"));
     }
     
     @Test
     public void assertRangeDoShardingWithAllRange() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.closed("2019-01-01 00:00:00", "2020-01-01 00:00:15")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-01-01 00:00:00", "2020-01-01 00:00:15")));
         assertThat(actual.size(), is(5));
     }
     
     @Test
     public void assertRangeDoShardingWithPartRange() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:04", "2020-01-01 00:00:10")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:04", "2020-01-01 00:00:10")));
         assertThat(actual.size(), is(3));
         assertTrue(actual.contains("t_order_1"));
         assertTrue(actual.contains("t_order_2"));
@@ -77,7 +83,8 @@ public final class AutoIntervalShardingAlgorithmTest {
     @Test
     public void assertRangeDoShardingWithoutLowerBound() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.lessThan("2020-01-01 00:00:11")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.lessThan("2020-01-01 00:00:11")));
         assertThat(actual.size(), is(4));
         assertTrue(actual.contains("t_order_0"));
         assertTrue(actual.contains("t_order_1"));
@@ -88,7 +95,8 @@ public final class AutoIntervalShardingAlgorithmTest {
     @Test
     public void assertRangeDoShardingWithoutUpperBound() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.greaterThan("2020-01-01 00:00:09")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.greaterThan("2020-01-01 00:00:09")));
         assertThat(actual.size(), is(3));
         assertTrue(actual.contains("t_order_3"));
         assertTrue(actual.contains("t_order_4"));
@@ -116,7 +124,8 @@ public final class AutoIntervalShardingAlgorithmTest {
         for (int i = 0; i < 32; i++) {
             availableTargetNames.add("t_order_" + i);
         }
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:00", "2020-01-01 00:00:10")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:00", "2020-01-01 00:00:10")));
         assertThat(actual.size(), is(11));
     }
 
@@ -132,16 +141,16 @@ public final class AutoIntervalShardingAlgorithmTest {
             availableTargetNames.add("t_order_" + i);
         }
         Collection<String> actualWithoutMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:11", "2020-01-01 00:00:21")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11", "2020-01-01 00:00:21")));
         assertThat(actualWithoutMilliseconds.size(), is(11));
         Collection<String> actualWithOneMillisecond = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:11.1", "2020-01-01 00:00:21.1")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.1", "2020-01-01 00:00:21.1")));
         assertThat(actualWithOneMillisecond.size(), is(11));
         Collection<String> actualWithTwoMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:11.12", "2020-01-01 00:00:21.12")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.12", "2020-01-01 00:00:21.12")));
         assertThat(actualWithTwoMilliseconds.size(), is(11));
         Collection<String> actualWithThreeMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", Range.closed("2020-01-01 00:00:11.123", "2020-01-01 00:00:21.123")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.123", "2020-01-01 00:00:21.123")));
         assertThat(actualWithThreeMilliseconds.size(), is(11));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/AutoIntervalShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.datetime;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class AutoIntervalShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private AutoIntervalShardingAlgorithm shardingAlgorithm;
     
@@ -51,21 +52,21 @@ public final class AutoIntervalShardingAlgorithmTest {
     public void assertPreciseDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_1"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2020-01-01 00:00:01")), is("t_order_1"));
     }
     
     @Test
     public void assertPreciseDoShardingBeyondTheLastOne() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5");
         assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-01-01 00:00:02")), is("t_order_5"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2021-01-01 00:00:02")), is("t_order_5"));
     }
     
     @Test
     public void assertRangeDoShardingWithAllRange() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-01-01 00:00:00", "2020-01-01 00:00:15")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2019-01-01 00:00:00", "2020-01-01 00:00:15")));
         assertThat(actual.size(), is(5));
     }
     
@@ -73,7 +74,7 @@ public final class AutoIntervalShardingAlgorithmTest {
     public void assertRangeDoShardingWithPartRange() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:04", "2020-01-01 00:00:10")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:04", "2020-01-01 00:00:10")));
         assertThat(actual.size(), is(3));
         assertTrue(actual.contains("t_order_1"));
         assertTrue(actual.contains("t_order_2"));
@@ -84,7 +85,7 @@ public final class AutoIntervalShardingAlgorithmTest {
     public void assertRangeDoShardingWithoutLowerBound() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.lessThan("2020-01-01 00:00:11")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.lessThan("2020-01-01 00:00:11")));
         assertThat(actual.size(), is(4));
         assertTrue(actual.contains("t_order_0"));
         assertTrue(actual.contains("t_order_1"));
@@ -96,7 +97,7 @@ public final class AutoIntervalShardingAlgorithmTest {
     public void assertRangeDoShardingWithoutUpperBound() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.greaterThan("2020-01-01 00:00:09")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.greaterThan("2020-01-01 00:00:09")));
         assertThat(actual.size(), is(3));
         assertTrue(actual.contains("t_order_3"));
         assertTrue(actual.contains("t_order_4"));
@@ -125,7 +126,7 @@ public final class AutoIntervalShardingAlgorithmTest {
             availableTargetNames.add("t_order_" + i);
         }
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:00", "2020-01-01 00:00:10")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:00", "2020-01-01 00:00:10")));
         assertThat(actual.size(), is(11));
     }
 
@@ -141,16 +142,16 @@ public final class AutoIntervalShardingAlgorithmTest {
             availableTargetNames.add("t_order_" + i);
         }
         Collection<String> actualWithoutMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11", "2020-01-01 00:00:21")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:11", "2020-01-01 00:00:21")));
         assertThat(actualWithoutMilliseconds.size(), is(11));
         Collection<String> actualWithOneMillisecond = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.1", "2020-01-01 00:00:21.1")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:11.1", "2020-01-01 00:00:21.1")));
         assertThat(actualWithOneMillisecond.size(), is(11));
         Collection<String> actualWithTwoMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.12", "2020-01-01 00:00:21.12")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:11.12", "2020-01-01 00:00:21.12")));
         assertThat(actualWithTwoMilliseconds.size(), is(11));
         Collection<String> actualWithThreeMilliseconds = shardingAlgorithm.doSharding(availableTargetNames,
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2020-01-01 00:00:11.123", "2020-01-01 00:00:21.123")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2020-01-01 00:00:11.123", "2020-01-01 00:00:21.123")));
         assertThat(actualWithThreeMilliseconds.size(), is(11));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.datetime;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertThat;
 
 public final class IntervalShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    public static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 6);
     
     private final Collection<String> availableTablesForQuarterDataSources = new LinkedList<>();
     
@@ -106,73 +107,73 @@ public final class IntervalShardingAlgorithmTest {
     @Test
     public void assertPreciseDoShardingByQuarter() {
         assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_202001"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2020-01-01 00:00:01")), is("t_order_202001"));
         assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-02-01 00:00:01")), is("t_order_202001"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2020-02-01 00:00:01")), is("t_order_202001"));
     }
     
     @Test
     public void assertRangeDoShardingByQuarter() {
         Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
         assertThat(actual.size(), is(3));
     }
     
     @Test
     public void assertPreciseDoShardingByMonth() {
         assertThat(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_202001"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2020-01-01 00:00:01")), is("t_order_202001"));
         assertNull(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2030-01-01 00:00:01")));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2030-01-01 00:00:01")));
     }
     
     @Test
     public void assertRangeDoShardingByMonth() {
         Collection<String> actual = shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
         assertThat(actual.size(), is(7));
     }
     
     @Test
     public void assertLowerHalfRangeDoSharding() {
         Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atLeast("2018-10-15 10:59:08")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.atLeast("2018-10-15 10:59:08")));
         assertThat(actual.size(), is(9));
     }
     
     @Test
     public void assertUpperHalfRangeDoSharding() {
         Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atMost("2019-09-01 00:00:00")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.atMost("2019-09-01 00:00:00")));
         assertThat(actual.size(), is(15));
     }
     
     @Test
     public void assertLowerHalfRangeDoShardingByDay() {
         Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atLeast("2021-01-01 00:00:00")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.atLeast("2021-01-01 00:00:00")));
         assertThat(actual.size(), is(31));
     }
     
     @Test
     public void assertUpperHalfRangeDoShardingByDay() {
         Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atMost("2021-07-31 01:00:00")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.atMost("2021-07-31 01:00:00")));
         assertThat(actual.size(), is(31));
     }
     
     @Test
     public void assertPreciseDoShardingByDay() {
         assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-07-01 00:00:01")), is("t_order_20210701"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2021-07-01 00:00:01")), is("t_order_20210701"));
         assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
-                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-07-02 00:00:01")), is("t_order_20210701"));
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_INFO, "2021-07-02 00:00:01")), is("t_order_20210701"));
     }
     
     @Test
     public void assertRangeDoShardingByDay() {
         Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2021-06-15 00:00:00", "2021-07-31 01:00:00")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("2021-06-15 00:00:00", "2021-07-31 01:00:00")));
         assertThat(actual.size(), is(24));
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -34,6 +34,8 @@ import static org.junit.Assert.assertThat;
 
 public final class IntervalShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private final Collection<String> availableTablesForQuarterDataSources = new LinkedList<>();
     
     private final Collection<String> availableTablesForMonthDataSources = new LinkedList<>();
@@ -103,68 +105,74 @@ public final class IntervalShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoShardingByQuarter() {
-        assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, new PreciseShardingValue<>("t_order", "create_time", "2020-01-01 00:00:01")), is("t_order_202001"));
-        assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, new PreciseShardingValue<>("t_order", "create_time", "2020-02-01 00:00:01")), is("t_order_202001"));
+        assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_202001"));
+        assertThat(shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-02-01 00:00:01")), is("t_order_202001"));
     }
     
     @Test
     public void assertRangeDoShardingByQuarter() {
-        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(
-                availableTablesForQuarterDataSources, new RangeShardingValue<>("t_order", "create_time", Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
+        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
         assertThat(actual.size(), is(3));
     }
     
     @Test
     public void assertPreciseDoShardingByMonth() {
-        assertThat(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, new PreciseShardingValue<>("t_order", "create_time", "2020-01-01 00:00:01")), is("t_order_202001"));
-        assertNull(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, new PreciseShardingValue<>("t_order", "create_time", "2030-01-01 00:00:01")));
+        assertThat(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2020-01-01 00:00:01")), is("t_order_202001"));
+        assertNull(shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2030-01-01 00:00:01")));
     }
     
     @Test
     public void assertRangeDoShardingByMonth() {
-        Collection<String> actual = shardingAlgorithmByMonth.doSharding(
-                availableTablesForMonthDataSources, new RangeShardingValue<>("t_order", "create_time", Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
+        Collection<String> actual = shardingAlgorithmByMonth.doSharding(availableTablesForMonthDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2019-10-15 10:59:08", "2020-04-08 10:59:08")));
         assertThat(actual.size(), is(7));
     }
     
     @Test
     public void assertLowerHalfRangeDoSharding() {
-        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(
-                availableTablesForQuarterDataSources, new RangeShardingValue<>("t_order", "create_time", Range.atLeast("2018-10-15 10:59:08")));
+        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atLeast("2018-10-15 10:59:08")));
         assertThat(actual.size(), is(9));
     }
     
     @Test
     public void assertUpperHalfRangeDoSharding() {
-        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(
-                availableTablesForQuarterDataSources, new RangeShardingValue<>("t_order", "create_time", Range.atMost("2019-09-01 00:00:00")));
+        Collection<String> actual = shardingAlgorithmByQuarter.doSharding(availableTablesForQuarterDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atMost("2019-09-01 00:00:00")));
         assertThat(actual.size(), is(15));
     }
     
     @Test
     public void assertLowerHalfRangeDoShardingByDay() {
-        Collection<String> actual = shardingAlgorithmByDay.doSharding(
-                availableTablesForDayDataSources, new RangeShardingValue<>("t_order", "create_time", Range.atLeast("2021-01-01 00:00:00")));
+        Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atLeast("2021-01-01 00:00:00")));
         assertThat(actual.size(), is(31));
     }
     
     @Test
     public void assertUpperHalfRangeDoShardingByDay() {
-        Collection<String> actual = shardingAlgorithmByDay.doSharding(
-                availableTablesForDayDataSources, new RangeShardingValue<>("t_order", "create_time", Range.atMost("2021-07-31 01:00:00")));
+        Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.atMost("2021-07-31 01:00:00")));
         assertThat(actual.size(), is(31));
     }
     
     @Test
     public void assertPreciseDoShardingByDay() {
-        assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, new PreciseShardingValue<>("t_order", "create_time", "2021-07-01 00:00:01")), is("t_order_20210701"));
-        assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, new PreciseShardingValue<>("t_order", "create_time", "2021-07-02 00:00:01")), is("t_order_20210701"));
+        assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-07-01 00:00:01")), is("t_order_20210701"));
+        assertThat(shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
+                new PreciseShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, "2021-07-02 00:00:01")), is("t_order_20210701"));
     }
     
     @Test
     public void assertRangeDoShardingByDay() {
-        Collection<String> actual = shardingAlgorithmByDay.doSharding(
-                availableTablesForDayDataSources, new RangeShardingValue<>("t_order", "create_time", Range.closed("2021-06-15 00:00:00", "2021-07-31 01:00:00")));
+        Collection<String> actual = shardingAlgorithmByDay.doSharding(availableTablesForDayDataSources, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("2021-06-15 00:00:00", "2021-07-31 01:00:00")));
         assertThat(actual.size(), is(24));
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/InlineShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/InlineShardingAlgorithmTest.java
@@ -35,6 +35,8 @@ import static org.mockito.Mockito.mock;
 
 public final class InlineShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private InlineShardingAlgorithm inlineShardingAlgorithm;
     
     private InlineShardingAlgorithm inlineShardingAlgorithmWithSimplified;
@@ -61,21 +63,26 @@ public final class InlineShardingAlgorithmTest {
     @Test(expected = ShardingSphereException.class)
     public void assertDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", 0)), is("t_order_0"));
-        inlineShardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "non_existent_column1", 0));
+        assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+        inlineShardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "non_existent_column1", DATA_NODE_PREFIX, 0));
     }
     
     @Test
     public void assertDoShardingWithRangeShardingConditionValue() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = inlineShardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "order_id", mock(Range.class)));
+        Collection<String> actual = inlineShardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, mock(Range.class)));
         assertTrue(actual.containsAll(availableTargetNames));
     }
     
     @Test
     public void assertDoShardingWithNonExistNodes() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1");
-        assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", 0)), is("t_order_0"));
-        assertThat(inlineShardingAlgorithmWithSimplified.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", 0)), is("t_order_0"));
+        assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+        assertThat(inlineShardingAlgorithmWithSimplified.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/InlineShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/inline/InlineShardingAlgorithmTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.algorithm.sharding.inline;
 
 import com.google.common.collect.Range;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 
 public final class InlineShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private InlineShardingAlgorithm inlineShardingAlgorithm;
     
@@ -64,16 +65,16 @@ public final class InlineShardingAlgorithmTest {
     public void assertDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0)), is("t_order_0"));
         inlineShardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "non_existent_column1", DATA_NODE_PREFIX, 0));
+                new PreciseShardingValue<>("t_order", "non_existent_column1", DATA_NODE_INFO, 0));
     }
     
     @Test
     public void assertDoShardingWithRangeShardingConditionValue() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         Collection<String> actual = inlineShardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, mock(Range.class)));
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, mock(Range.class)));
         assertTrue(actual.containsAll(availableTargetNames));
     }
     
@@ -81,8 +82,8 @@ public final class InlineShardingAlgorithmTest {
     public void assertDoShardingWithNonExistNodes() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1");
         assertThat(inlineShardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0)), is("t_order_0"));
         assertThat(inlineShardingAlgorithmWithSimplified.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0)), is("t_order_0"));
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0)), is("t_order_0"));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.mod;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertThat;
 
 public final class HashModShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private HashModShardingAlgorithm shardingAlgorithm;
     
@@ -47,14 +48,14 @@ public final class HashModShardingAlgorithmTest {
     public void assertPreciseDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
-                new PreciseShardingValue<>("t_order", "order_type", DATA_NODE_PREFIX, "a")), is("t_order_1"));
+                new PreciseShardingValue<>("t_order", "order_type", DATA_NODE_INFO, "a")), is("t_order_1"));
     }
     
     @Test
     public void assertRangeDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
         Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("a", "f")));
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("a", "f")));
         assertThat(actual.size(), is(4));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithmTest.java
@@ -32,6 +32,8 @@ import static org.junit.Assert.assertThat;
 
 public final class HashModShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private HashModShardingAlgorithm shardingAlgorithm;
     
     @Before
@@ -44,13 +46,15 @@ public final class HashModShardingAlgorithmTest {
     @Test
     public void assertPreciseDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        assertThat(shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_type", "a")), is("t_order_1"));
+        assertThat(shardingAlgorithm.doSharding(availableTargetNames, 
+                new PreciseShardingValue<>("t_order", "order_type", DATA_NODE_PREFIX, "a")), is("t_order_1"));
     }
     
     @Test
     public void assertRangeDoSharding() {
         List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "create_time", Range.closed("a", "f")));
+        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, 
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_PREFIX, Range.closed("a", "f")));
         assertThat(actual.size(), is(4));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -33,34 +32,41 @@ import static org.junit.Assert.assertTrue;
 
 public final class ModShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private ModShardingAlgorithm shardingAlgorithm;
     
     @Before
     public void setup() {
         shardingAlgorithm = new ModShardingAlgorithm();
-        shardingAlgorithm.getProps().setProperty("sharding-count", "4");
+        shardingAlgorithm.getProps().setProperty("sharding-count", "16");
         shardingAlgorithm.init();
     }
     
     @Test
     public void assertPreciseDoSharding() {
-        List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        assertThat(shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", 13L)), is("t_order_1"));
+        assertThat(shardingAlgorithm.doSharding(createAvailableTargetNames(), 
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 17)), is("t_order_1"));
     }
     
     @Test
     public void assertRangeDoShardingWithAllTargets() {
-        List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "order_id", Range.closed(11L, 14L)));
-        assertThat(actual.size(), is(4));
+        Collection<String> actual = shardingAlgorithm.doSharding(createAvailableTargetNames(), 
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(1L, 16L)));
+        assertThat(actual.size(), is(16));
+    }
+    
+    private Collection<String> createAvailableTargetNames() {
+        return Arrays.asList("t_order_8", "t_order_9", "t_order_10", "t_order_11", "t_order_12", "t_order_13", "t_order_14", "t_order_15", 
+                "t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5", "t_order_6", "t_order_7");
     }
     
     @Test
     public void assertRangeDoShardingWithPartTargets() {
-        List<String> availableTargetNames = Arrays.asList("t_order_0", "t_order_1", "t_order_2", "t_order_3");
-        Collection<String> actual = shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "order_id", Range.closed(11L, 12L)));
+        Collection<String> actual = shardingAlgorithm.doSharding(createAvailableTargetNames(), 
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(1L, 2L)));
         assertThat(actual.size(), is(2));
-        assertTrue(actual.contains("t_order_3"));
-        assertTrue(actual.contains("t_order_0"));
+        assertTrue(actual.contains("t_order_1"));
+        assertTrue(actual.contains("t_order_2"));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class ModShardingAlgorithmTest {
     
-    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 6);
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private ModShardingAlgorithm shardingAlgorithm;
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/ModShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.mod;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -32,7 +33,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class ModShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 6);
     
     private ModShardingAlgorithm shardingAlgorithm;
     
@@ -46,13 +47,13 @@ public final class ModShardingAlgorithmTest {
     @Test
     public void assertPreciseDoSharding() {
         assertThat(shardingAlgorithm.doSharding(createAvailableTargetNames(), 
-                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 17)), is("t_order_1"));
+                new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 17)), is("t_order_1"));
     }
     
     @Test
     public void assertRangeDoShardingWithAllTargets() {
         Collection<String> actual = shardingAlgorithm.doSharding(createAvailableTargetNames(), 
-                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(1L, 16L)));
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(1L, 16L)));
         assertThat(actual.size(), is(16));
     }
     
@@ -64,7 +65,7 @@ public final class ModShardingAlgorithmTest {
     @Test
     public void assertRangeDoShardingWithPartTargets() {
         Collection<String> actual = shardingAlgorithm.doSharding(createAvailableTargetNames(), 
-                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(1L, 2L)));
+                new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(1L, 2L)));
         assertThat(actual.size(), is(2));
         assertTrue(actual.contains("t_order_1"));
         assertTrue(actual.contains("t_order_2"));

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/BoundaryBasedRangeShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/BoundaryBasedRangeShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.range;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class BoundaryBasedRangeShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private BoundaryBasedRangeShardingAlgorithm shardingAlgorithm;
     
@@ -46,7 +47,7 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoSharding() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0L));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0L));
     }
     
     private void assertPreciseDoSharding(final PreciseShardingValue<Comparable<?>> shardingValue) {
@@ -56,12 +57,12 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoShardingWithIntShardingValue() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0));
     }
     
     @Test
     public void assertRangeDoSharding() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2L, 15L)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(2L, 15L)));
     }
     
     private void assertRangeDoSharding(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -75,7 +76,7 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithIntShardingValue() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2, 15)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(2, 15)));
     }
     
     @Test

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/BoundaryBasedRangeShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/BoundaryBasedRangeShardingAlgorithmTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertTrue;
 
 public final class BoundaryBasedRangeShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private BoundaryBasedRangeShardingAlgorithm shardingAlgorithm;
     
     @Before
@@ -44,7 +46,7 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoSharding() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", 0L));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0L));
     }
     
     private void assertPreciseDoSharding(final PreciseShardingValue<Comparable<?>> shardingValue) {
@@ -54,12 +56,12 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoShardingWithIntShardingValue() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", 0));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0));
     }
     
     @Test
     public void assertRangeDoSharding() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", Range.closed(2L, 15L)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2L, 15L)));
     }
     
     private void assertRangeDoSharding(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -73,7 +75,7 @@ public final class BoundaryBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithIntShardingValue() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", Range.closed(2, 15)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(2, 15)));
     }
     
     @Test

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/VolumeBasedRangeShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/VolumeBasedRangeShardingAlgorithmTest.java
@@ -33,6 +33,8 @@ import static org.junit.Assert.assertTrue;
 
 public final class VolumeBasedRangeShardingAlgorithmTest {
     
+    private static final String DATA_NODE_PREFIX = "t_order_";
+    
     private VolumeBasedRangeShardingAlgorithm shardingAlgorithm;
     
     @Before
@@ -46,7 +48,7 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoSharding() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", 0L));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0L));
     }
     
     private void assertPreciseDoSharding(final PreciseShardingValue<Comparable<?>> shardingValue) {
@@ -56,12 +58,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoShardingWithIntShardingValue() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", 0));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0));
     }
     
     @Test
     public void assertRangeDoShardingWithoutLowerBound() {
-        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", Range.lessThan(12L)));
+        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.lessThan(12L)));
     }
     
     private void assertRangeDoShardingWithoutLowerBound(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -74,12 +76,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithoutLowerBoundWithIntShardingValue() {
-        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", Range.lessThan(12)));
+        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.lessThan(12)));
     }
     
     @Test
     public void assertRangeDoShardingWithoutUpperBound() {
-        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", Range.greaterThan(40L)));
+        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.greaterThan(40L)));
     }
     
     private void assertRangeDoShardingWithoutUpperBound(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -92,12 +94,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithoutUpperBoundWithIntShardingValue() {
-        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", Range.greaterThan(40)));
+        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.greaterThan(40)));
     }
     
     @Test
     public void assertRangeDoSharding() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", Range.closed(12L, 55L)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(12L, 55L)));
     }
     
     private void assertRangeDoSharding(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -113,7 +115,7 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithIntegerShardingValue() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", Range.closed(12, 55)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(12, 55)));
     }
     
     @Test

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/VolumeBasedRangeShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/range/VolumeBasedRangeShardingAlgorithmTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.algorithm.sharding.range;
 
 import com.google.common.collect.Range;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.junit.Before;
@@ -33,7 +34,7 @@ import static org.junit.Assert.assertTrue;
 
 public final class VolumeBasedRangeShardingAlgorithmTest {
     
-    private static final String DATA_NODE_PREFIX = "t_order_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("t_order_", 1);
     
     private VolumeBasedRangeShardingAlgorithm shardingAlgorithm;
     
@@ -48,7 +49,7 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoSharding() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0L));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0L));
     }
     
     private void assertPreciseDoSharding(final PreciseShardingValue<Comparable<?>> shardingValue) {
@@ -58,12 +59,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertPreciseDoShardingWithIntShardingValue() {
-        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 0));
+        assertPreciseDoSharding(new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_INFO, 0));
     }
     
     @Test
     public void assertRangeDoShardingWithoutLowerBound() {
-        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.lessThan(12L)));
+        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.lessThan(12L)));
     }
     
     private void assertRangeDoShardingWithoutLowerBound(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -76,12 +77,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithoutLowerBoundWithIntShardingValue() {
-        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.lessThan(12)));
+        assertRangeDoShardingWithoutLowerBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.lessThan(12)));
     }
     
     @Test
     public void assertRangeDoShardingWithoutUpperBound() {
-        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.greaterThan(40L)));
+        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.greaterThan(40L)));
     }
     
     private void assertRangeDoShardingWithoutUpperBound(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -94,12 +95,12 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithoutUpperBoundWithIntShardingValue() {
-        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.greaterThan(40)));
+        assertRangeDoShardingWithoutUpperBound(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.greaterThan(40)));
     }
     
     @Test
     public void assertRangeDoSharding() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(12L, 55L)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(12L, 55L)));
     }
     
     private void assertRangeDoSharding(final RangeShardingValue<Comparable<?>> shardingValue) {
@@ -115,7 +116,7 @@ public final class VolumeBasedRangeShardingAlgorithmTest {
     
     @Test
     public void assertRangeDoShardingWithIntegerShardingValue() {
-        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(12, 55)));
+        assertRangeDoSharding(new RangeShardingValue<>("t_order", "order_id", DATA_NODE_INFO, Range.closed(12, 55)));
     }
     
     @Test

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategyTest.java
@@ -40,20 +40,21 @@ import static org.junit.Assert.assertThat;
 
 public final class ShardingStrategyTest {
     
+    private static final String DATA_NODE_PREFIX = "logicTable_";
+    
     private final Collection<String> targets = Arrays.asList("1", "2", "3");
     
     @Test
     public void assertDoShardingWithoutShardingColumns() {
         NoneShardingStrategy strategy = new NoneShardingStrategy();
-        assertThat(strategy.doSharding(targets, Collections.emptySet(), new ConfigurationProperties(new Properties())), is(targets));
+        assertThat(strategy.doSharding(targets, Collections.emptySet(), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(targets));
     }
     
     @Test
     public void assertDoShardingForBetweenSingleKey() {
         StandardShardingStrategy strategy = new StandardShardingStrategy("column", new StandardShardingAlgorithmFixture());
-        assertThat(strategy.doSharding(targets, 
-                Collections.singleton(new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3))), new ConfigurationProperties(new Properties())),
-                is(Collections.singleton("1")));
+        Collection<ShardingConditionValue> shardingConditionValues = Collections.singleton(new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3)));
+        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(Collections.singleton("1")));
     }
     
     @Test
@@ -66,6 +67,6 @@ public final class ShardingStrategyTest {
         Collection<ShardingConditionValue> shardingConditionValues = Arrays.asList(
                 new ListShardingConditionValue<>("column1", "logicTable", Collections.singletonList(1)),
                 new RangeShardingConditionValue<>("column2", "logicTable", Range.open(1, 3)));
-        assertThat(strategy.doSharding(targets, shardingConditionValues, new ConfigurationProperties(new Properties())), is(expected));
+        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(expected));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/ShardingStrategyTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.strategy;
 
 import com.google.common.collect.Range;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
@@ -40,21 +41,21 @@ import static org.junit.Assert.assertThat;
 
 public final class ShardingStrategyTest {
     
-    private static final String DATA_NODE_PREFIX = "logicTable_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("logicTable_", 1);
     
     private final Collection<String> targets = Arrays.asList("1", "2", "3");
     
     @Test
     public void assertDoShardingWithoutShardingColumns() {
         NoneShardingStrategy strategy = new NoneShardingStrategy();
-        assertThat(strategy.doSharding(targets, Collections.emptySet(), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(targets));
+        assertThat(strategy.doSharding(targets, Collections.emptySet(), DATA_NODE_INFO, new ConfigurationProperties(new Properties())), is(targets));
     }
     
     @Test
     public void assertDoShardingForBetweenSingleKey() {
         StandardShardingStrategy strategy = new StandardShardingStrategy("column", new StandardShardingAlgorithmFixture());
         Collection<ShardingConditionValue> shardingConditionValues = Collections.singleton(new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3)));
-        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(Collections.singleton("1")));
+        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_INFO, new ConfigurationProperties(new Properties())), is(Collections.singleton("1")));
     }
     
     @Test
@@ -67,6 +68,6 @@ public final class ShardingStrategyTest {
         Collection<ShardingConditionValue> shardingConditionValues = Arrays.asList(
                 new ListShardingConditionValue<>("column1", "logicTable", Collections.singletonList(1)),
                 new RangeShardingConditionValue<>("column2", "logicTable", Range.open(1, 3)));
-        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties())), is(expected));
+        assertThat(strategy.doSharding(targets, shardingConditionValues, DATA_NODE_INFO, new ConfigurationProperties(new Properties())), is(expected));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategyTest.java
@@ -37,13 +37,15 @@ import static org.junit.Assert.assertThat;
 
 public final class ComplexShardingStrategyTest {
     
+    private static final String DATA_NODE_PREFIX = "logicTable_";
+    
     @Test
     public void assertDoSharding() {
         Collection<String> targets = Sets.newHashSet("1", "2", "3");
         ComplexShardingStrategy complexShardingStrategy = new ComplexShardingStrategy("column1, column2", new ComplexKeysShardingAlgorithmFixture());
         List<ShardingConditionValue> shardingConditionValues =
             Arrays.asList(new ListShardingConditionValue<>("column1", "logicTable", Collections.singletonList(1)), new RangeShardingConditionValue<>("column2", "logicTable", Range.open(1, 3)));
-        Collection<String> actualSharding = complexShardingStrategy.doSharding(targets, shardingConditionValues, new ConfigurationProperties(new Properties()));
+        Collection<String> actualSharding = complexShardingStrategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(3));
         assertThat(actualSharding, is(targets));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/complex/ComplexShardingStrategyTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.strategy.type.complex;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ShardingConditionValue;
@@ -37,7 +38,7 @@ import static org.junit.Assert.assertThat;
 
 public final class ComplexShardingStrategyTest {
     
-    private static final String DATA_NODE_PREFIX = "logicTable_";
+    private static final DataNodeInfo DATA_NODE_INFO = new DataNodeInfo("logicTable_", 1);
     
     @Test
     public void assertDoSharding() {
@@ -45,7 +46,7 @@ public final class ComplexShardingStrategyTest {
         ComplexShardingStrategy complexShardingStrategy = new ComplexShardingStrategy("column1, column2", new ComplexKeysShardingAlgorithmFixture());
         List<ShardingConditionValue> shardingConditionValues =
             Arrays.asList(new ListShardingConditionValue<>("column1", "logicTable", Collections.singletonList(1)), new RangeShardingConditionValue<>("column2", "logicTable", Range.open(1, 3)));
-        Collection<String> actualSharding = complexShardingStrategy.doSharding(targets, shardingConditionValues, DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
+        Collection<String> actualSharding = complexShardingStrategy.doSharding(targets, shardingConditionValues, DATA_NODE_INFO, new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(3));
         assertThat(actualSharding, is(targets));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategyTest.java
@@ -18,25 +18,28 @@
 package org.apache.shardingsphere.sharding.route.strategy.type.hint;
 
 import com.google.common.collect.Sets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Properties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.strategy.fixture.HintShardingAlgorithmFixture;
 import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class HintShardingStrategyTest {
     
+    private static final String DATA_NODE_PREFIX = "logicTable_";
+    
     @Test
     public void assertDoSharding() {
         Collection<String> targets = Sets.newHashSet("1", "2", "3");
         HintShardingStrategy hintShardingStrategy = new HintShardingStrategy(new HintShardingAlgorithmFixture());
-        Collection<String> actualSharding = hintShardingStrategy
-            .doSharding(targets, Collections.singletonList(new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), new ConfigurationProperties(new Properties()));
+        Collection<String> actualSharding = hintShardingStrategy.doSharding(targets, Collections.singletonList(
+                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(1));
         assertThat(actualSharding.iterator().next(), is("1"));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/hint/HintShardingStrategyTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sharding.route.strategy.type.hint;
 
 import com.google.common.collect.Sets;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.strategy.fixture.HintShardingAlgorithmFixture;
 import org.junit.Test;
@@ -32,14 +33,13 @@ import static org.junit.Assert.assertThat;
 
 public final class HintShardingStrategyTest {
     
-    private static final String DATA_NODE_PREFIX = "logicTable_";
-    
     @Test
     public void assertDoSharding() {
         Collection<String> targets = Sets.newHashSet("1", "2", "3");
         HintShardingStrategy hintShardingStrategy = new HintShardingStrategy(new HintShardingAlgorithmFixture());
+        DataNodeInfo dataNodeInfo = new DataNodeInfo("logicTable_", 1);
         Collection<String> actualSharding = hintShardingStrategy.doSharding(targets, Collections.singletonList(
-                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
+                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), dataNodeInfo, new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(1));
         assertThat(actualSharding.iterator().next(), is("1"));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategyTest.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +42,8 @@ public final class NoneShardingStrategyTest {
     @Test
     public void assertGetShardingAlgorithm() {
         Collection<String> targets = Sets.newHashSet("1", "2", "3");
-        Collection<String> actualSharding = noneShardingStrategy.doSharding(targets, Collections.emptySet(), "", new ConfigurationProperties(new Properties()));
+        DataNodeInfo dataNodeInfo = new DataNodeInfo("logicTable_", 1);
+        Collection<String> actualSharding = noneShardingStrategy.doSharding(targets, Collections.emptySet(), dataNodeInfo, new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(3));
         assertThat(actualSharding, is(targets));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/none/NoneShardingStrategyTest.java
@@ -41,7 +41,7 @@ public final class NoneShardingStrategyTest {
     @Test
     public void assertGetShardingAlgorithm() {
         Collection<String> targets = Sets.newHashSet("1", "2", "3");
-        Collection<String> actualSharding = noneShardingStrategy.doSharding(targets, Collections.emptySet(), new ConfigurationProperties(new Properties()));
+        Collection<String> actualSharding = noneShardingStrategy.doSharding(targets, Collections.emptySet(), "", new ConfigurationProperties(new Properties()));
         assertThat(actualSharding.size(), is(3));
         assertThat(actualSharding, is(targets));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategyTest.java
@@ -19,9 +19,6 @@ package org.apache.shardingsphere.sharding.route.strategy.type.standard;
 
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Properties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
@@ -29,10 +26,16 @@ import org.apache.shardingsphere.sharding.route.strategy.fixture.StandardShardin
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class StandardShardingStrategyTest {
+    
+    private static final String DATA_NODE_PREFIX = "logicTable_";
     
     private final Collection<String> targets = Sets.newHashSet("1", "2", "3");
     
@@ -45,16 +48,16 @@ public final class StandardShardingStrategyTest {
     
     @Test
     public void assertDoShardingForRangeSharding() {
-        Collection<String> actualRangeSharding = standardShardingStrategy
-            .doSharding(targets, Collections.singletonList(new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3))), new ConfigurationProperties(new Properties()));
+        Collection<String> actualRangeSharding = standardShardingStrategy.doSharding(targets, Collections.singletonList(
+                new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
         assertThat(actualRangeSharding.size(), is(1));
         assertThat(actualRangeSharding.iterator().next(), is("1"));
     }
     
     @Test
     public void assertDoShardingForListSharding() {
-        Collection<String> actualListSharding = standardShardingStrategy
-            .doSharding(targets, Collections.singletonList(new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), new ConfigurationProperties(new Properties()));
+        Collection<String> actualListSharding = standardShardingStrategy.doSharding(targets, Collections.singletonList(
+                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
         assertThat(actualListSharding.size(), is(1));
         assertThat(actualListSharding.iterator().next(), is("1"));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategyTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategyTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sharding.route.strategy.type.standard;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.sharding.api.sharding.common.DataNodeInfo;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.ListShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.engine.condition.value.RangeShardingConditionValue;
 import org.apache.shardingsphere.sharding.route.strategy.fixture.StandardShardingAlgorithmFixture;
@@ -35,21 +36,22 @@ import static org.junit.Assert.assertThat;
 
 public final class StandardShardingStrategyTest {
     
-    private static final String DATA_NODE_PREFIX = "logicTable_";
-    
     private final Collection<String> targets = Sets.newHashSet("1", "2", "3");
     
     private StandardShardingStrategy standardShardingStrategy;
     
+    private DataNodeInfo dataNodeSegment;
+    
     @Before
     public void setUp() {
         standardShardingStrategy = new StandardShardingStrategy("column", new StandardShardingAlgorithmFixture());
+        dataNodeSegment = new DataNodeInfo("logicTable_", 1);
     }
     
     @Test
     public void assertDoShardingForRangeSharding() {
         Collection<String> actualRangeSharding = standardShardingStrategy.doSharding(targets, Collections.singletonList(
-                new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
+                new RangeShardingConditionValue<>("column", "logicTable", Range.open(1, 3))), dataNodeSegment, new ConfigurationProperties(new Properties()));
         assertThat(actualRangeSharding.size(), is(1));
         assertThat(actualRangeSharding.iterator().next(), is("1"));
     }
@@ -57,7 +59,7 @@ public final class StandardShardingStrategyTest {
     @Test
     public void assertDoShardingForListSharding() {
         Collection<String> actualListSharding = standardShardingStrategy.doSharding(targets, Collections.singletonList(
-                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), DATA_NODE_PREFIX, new ConfigurationProperties(new Properties()));
+                new ListShardingConditionValue<>("column", "logicTable", Collections.singletonList(1))), dataNodeSegment, new ConfigurationProperties(new Properties()));
         assertThat(actualListSharding.size(), is(1));
         assertThat(actualListSharding.iterator().next(), is("1"));
     }


### PR DESCRIPTION
Fixes #15506.

Changes proposed in this pull request:
- fix ModShardingAlgorithm wrong route result when exist same suffix table
- add unit test for ModShardingAlgorithm

JMH test result:

```
Before

Benchmark                                               Mode  Cnt      Score      Error   Units
ModShardingAlgorithmBenchmark.assertPreciseDoSharding  thrpt    5  61544.908 ± 9351.080  ops/ms
ModShardingAlgorithmBenchmark.assertRangeDoSharding    thrpt    5  14702.253 ± 4314.774  ops/ms


After

Benchmark                                               Mode  Cnt      Score      Error   Units
ModShardingAlgorithmBenchmark.assertPreciseDoSharding  thrpt    5  72314.197 ± 3708.266  ops/ms
ModShardingAlgorithmBenchmark.assertRangeDoSharding    thrpt    5  21055.536 ± 5386.631  ops/ms
```

Code is as following:

```java
/**
 * Mod sharding algorithm benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(5)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class ModShardingAlgorithmBenchmark {
    
    private static final DataNodeInfo DATA_NODE_PREFIX = new DataNodeInfo("t_order_", 1);
    
    private ModShardingAlgorithm shardingAlgorithm;
    
    private Collection<String> availableTargetNames;
    
    @Setup(Level.Trial)
    public void setUp() {
        shardingAlgorithm = new ModShardingAlgorithm();
        shardingAlgorithm.getProps().setProperty("sharding-count", "16");
        shardingAlgorithm.init();
        availableTargetNames = createAvailableTargetNames();
    }
    
    @Benchmark
    public void assertPreciseDoSharding() {
        shardingAlgorithm.doSharding(availableTargetNames, new PreciseShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, 15));
    }
    
    @Benchmark
    public void assertRangeDoSharding() {
        shardingAlgorithm.doSharding(availableTargetNames, new RangeShardingValue<>("t_order", "order_id", DATA_NODE_PREFIX, Range.closed(11L, 12L)));
    }
    
    private Collection<String> createAvailableTargetNames() {
        return new LinkedHashSet<>(Arrays.asList("t_order_8", "t_order_9", "t_order_10", "t_order_11", "t_order_12", "t_order_13", "t_order_14", "t_order_15",
                "t_order_0", "t_order_1", "t_order_2", "t_order_3", "t_order_4", "t_order_5", "t_order_6", "t_order_7"));
    }
}
```