### PR TITLE
Add plain password authenticator for PostgreSQL.

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLMD5PasswordAuthenticationPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/handshake/authentication/PostgreSQLMD5PasswordAuthenticationPacket.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.Postgr
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 
 /**
- * MD5Password authentication (backend) packet for PostgreSQL.
+ * MD5 password authentication (backend) packet for PostgreSQL.
  */
 @RequiredArgsConstructor
 public final class PostgreSQLMD5PasswordAuthenticationPacket implements PostgreSQLIdentifierPacket {

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationHandler.java
@@ -46,7 +46,7 @@ public final class PostgreSQLAuthenticationHandler {
      * @return PostgreSQL login result
      */
     public PostgreSQLLoginResult login(final String username, final String databaseName, final byte[] md5Salt, final PostgreSQLPasswordMessagePacket passwordMessagePacket) {
-        String md5Digest = passwordMessagePacket.getDigest();
+        String digest = passwordMessagePacket.getDigest();
         Grantee grantee = new Grantee(username, "%");
         if (!Strings.isNullOrEmpty(databaseName) && !ProxyContext.getInstance().schemaExists(databaseName)) {
             return new PostgreSQLLoginResult(PostgreSQLErrorCode.INVALID_CATALOG_NAME, String.format("database \"%s\" does not exist", databaseName));
@@ -55,7 +55,7 @@ public final class PostgreSQLAuthenticationHandler {
             return new PostgreSQLLoginResult(PostgreSQLErrorCode.INVALID_AUTHORIZATION_SPECIFICATION, String.format("unknown username: %s", username));
         }
         PostgreSQLAuthenticator authenticator = getAuthenticator(username, grantee.getHostname());
-        if (!SQLCheckEngine.check(grantee, (a, b) -> authenticator.authenticate((ShardingSphereUser) a, (Object[]) b), new Object[] {md5Digest, md5Salt}, getRules(databaseName))) {
+        if (!SQLCheckEngine.check(grantee, (a, b) -> authenticator.authenticate((ShardingSphereUser) a, (Object[]) b), new Object[] {digest, md5Salt}, getRules(databaseName))) {
             return new PostgreSQLLoginResult(PostgreSQLErrorCode.INVALID_PASSWORD, String.format("password authentication failed for user \"%s\"", username));
         }
         return null == databaseName || SQLCheckEngine.check(databaseName, getRules(databaseName), grantee)

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLPasswordAuthenticator.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLPasswordAuthenticator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator;
+
+import com.google.common.base.Strings;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+
+/**
+ * Password authenticator for PostgreSQL.
+ */
+@RequiredArgsConstructor
+public final class PostgreSQLPasswordAuthenticator implements PostgreSQLAuthenticator {
+    
+    @Override
+    public boolean authenticate(final ShardingSphereUser user, final Object[] args) {
+        String password = (String) args[0];
+        return Strings.isNullOrEmpty(user.getPassword()) || user.getPassword().equals(password);
+    }
+    
+    @Override
+    public String getAuthenticationMethodName() {
+        return PostgreSQLAuthenticationMethod.PASSWORD.getMethodName();
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLMD5PasswordAuthenticatorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLMD5PasswordAuthenticatorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLRandomGenerator;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class PostgreSQLMD5PasswordAuthenticatorTest {
+    
+    private final PostgreSQLMD5PasswordAuthenticator authenticator = new PostgreSQLMD5PasswordAuthenticator();
+    
+    private final String username = "root";
+    
+    private final String password = "password";
+    
+    @Test
+    public void assertGetAuthenticationMethodName() {
+        assertThat(authenticator.getAuthenticationMethodName(), is(PostgreSQLAuthenticationMethod.MD5.getMethodName()));
+    }
+    
+    @Test
+    public void assertAuthenticate() {
+        ShardingSphereUser user = new ShardingSphereUser(username, password, "");
+        byte[] md5Salt = PostgreSQLRandomGenerator.getInstance().generateRandomBytes(4);
+        String md5Digest = md5Encode(username, password, md5Salt);
+        assertTrue(authenticator.authenticate(user, new Object[] {md5Digest, md5Salt}));
+        assertFalse(authenticator.authenticate(user, new Object[] {"wrong", md5Salt}));
+    }
+    
+    @SneakyThrows(ReflectiveOperationException.class)
+    private String md5Encode(final String username, final String password, final byte[] md5Salt) {
+        Method method = PostgreSQLMD5PasswordAuthenticator.class.getDeclaredMethod("md5Encode", String.class, String.class, byte[].class);
+        method.setAccessible(true);
+        return (String) method.invoke(new PostgreSQLMD5PasswordAuthenticator(), username, password, md5Salt);
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLPasswordAuthenticatorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/authenticator/PostgreSQLPasswordAuthenticatorTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator;
+
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLAuthenticationMethod;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class PostgreSQLPasswordAuthenticatorTest {
+    
+    private final PostgreSQLPasswordAuthenticator authenticator = new PostgreSQLPasswordAuthenticator();
+    
+    private final String username = "root";
+    
+    private final String password = "password";
+    
+    @Test
+    public void assertGetAuthenticationMethodName() {
+        assertThat(authenticator.getAuthenticationMethodName(), is(PostgreSQLAuthenticationMethod.PASSWORD.getMethodName()));
+    }
+    
+    @Test
+    public void assertAuthenticate() {
+        ShardingSphereUser user = new ShardingSphereUser(username, password, "");
+        assertTrue(authenticator.authenticate(user, new Object[] {password, null}));
+        assertFalse(authenticator.authenticate(user, new Object[] {"wrong", null}));
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- add password authenticator for PostgreSQL
- add unit test for PostgreSQLMD5PasswordAuthenticator & PostgreSQLPasswordAuthenticator
