### PR TITLE
Set charset simple query supported for PostgreSQL in proxy

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLCharacterSet.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLCharacterSet.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.constant;
+
+import lombok.Getter;
+
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * Character set of PostgreSQL.
+ */
+@Getter
+public enum PostgreSQLCharacterSet {
+    
+    UNICODE("UNICODE", () -> StandardCharsets.UTF_8),
+    UNICODE_APOSTROPHE("'UNICODE'", () -> StandardCharsets.UTF_8),
+    UTF8("UTF8", () -> StandardCharsets.UTF_8),
+    UTF8_APOSTROPHE("'UTF8'", () -> StandardCharsets.UTF_8);
+    
+    private static final Map<String, PostgreSQLCharacterSet> CHARACTER_SET_MAP = Collections.unmodifiableMap(Arrays.stream(values()).collect(Collectors.toMap(each -> each.name, Function.identity())));
+    
+    private final String name;
+    
+    private final Charset charset;
+    
+    PostgreSQLCharacterSet(final String name, final Supplier<Charset> charsetSupplier) {
+        this.name = name;
+        Charset result = null;
+        try {
+            result = charsetSupplier.get();
+        } catch (UnsupportedCharsetException ignored) {
+        }
+        charset = result;
+    }
+    
+    /**
+     * Get character set by name.
+     *
+     * @param name name
+     * @return character set for PostgreSQL
+     */
+    public static Optional<Charset> findByName(final String name) {
+        PostgreSQLCharacterSet result = CHARACTER_SET_MAP.get(name);
+        if (null == result) {
+            return charsetForName(name);
+        }
+        if (null == result.getCharset()) {
+            return charsetForName(name);
+        }
+        return Optional.of(result.getCharset());
+    }
+    
+    private static Optional<Charset> charsetForName(final String name) {
+        Charset result = null;
+        try {
+            result = Charset.forName(name);
+        } catch (final IllegalCharsetNameException ignored) {
+        }
+        return null == result ? Optional.empty() : Optional.of(result);
+    }
+}

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLErrorCode.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/constant/PostgreSQLErrorCode.java
@@ -47,6 +47,7 @@ public enum PostgreSQLErrorCode {
     PROTOCOL_VIOLATION("08P01", "protocol_violation"),
     FEATURE_NOT_SUPPORTED("0A000", "feature_not_supported"),
     INVALID_AUTHORIZATION_SPECIFICATION("28000", "invalid_authorization_specification"),
+    INVALID_PARAMETER_VALUE("22023", "invalid_parameter_value"),
     INVALID_PASSWORD("28P01", "invalid_password"),
     INVALID_CATALOG_NAME("3D000", "invalid_catalog_name"),
     INVALID_SCHEMA_NAME("3F000", "invalid_schema_name"),

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/update/ClientEncodingResponseHeader.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/update/ClientEncodingResponseHeader.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.response.header.update;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+
+@RequiredArgsConstructor
+@Getter
+public class ClientEncodingResponseHeader implements ResponseHeader {
+    
+    private final String name = "client_encoding";
+    
+    private final String clientEncoding;
+    
+    private final SQLStatement sqlStatement;
+    
+    private final ConnectionSession connectionSession;
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/TextProtocolBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/TextProtocolBackendHandlerFactory.java
@@ -37,12 +37,14 @@ import org.apache.shardingsphere.proxy.backend.text.admin.DatabaseAdminBackendHa
 import org.apache.shardingsphere.proxy.backend.text.data.DatabaseBackendHandlerFactory;
 import org.apache.shardingsphere.proxy.backend.text.database.DatabaseOperateBackendHandlerFactory;
 import org.apache.shardingsphere.proxy.backend.text.distsql.DistSQLBackendHandlerFactory;
+import org.apache.shardingsphere.proxy.backend.text.encoding.SetClientEncodingBackendHandler;
 import org.apache.shardingsphere.proxy.backend.text.extra.ExtraTextProtocolBackendHandler;
 import org.apache.shardingsphere.proxy.backend.text.skip.SkipBackendHandler;
 import org.apache.shardingsphere.proxy.backend.text.transaction.TransactionBackendHandlerFactory;
 import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.FlushStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SetStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateDatabaseStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropDatabaseStatement;
@@ -117,6 +119,9 @@ public final class TextProtocolBackendHandlerFactory {
                 getRules(schemaName), schemaName, ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaDataMap(), connectionSession.getGrantee());
         if (sqlStatement instanceof TCLStatement) {
             return TransactionBackendHandlerFactory.newInstance((SQLStatementContext<TCLStatement>) sqlStatementContext, sql, connectionSession);
+        }
+        if (sqlStatement instanceof SetStatement && SetClientEncodingBackendHandler.isSetClientEncoding((SetStatement) sqlStatement)) {
+            return new SetClientEncodingBackendHandler((SetStatement) sqlStatement, connectionSession);
         }
         backendHandler = DatabaseAdminBackendHandlerFactory.newInstance(databaseType, sqlStatement, connectionSession);
         return backendHandler.orElseGet(() -> DatabaseBackendHandlerFactory.newInstance(sqlStatementContext, sql, connectionSession));

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/encoding/SetClientEncodingBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/encoding/SetClientEncodingBackendHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.text.encoding;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
+import org.apache.shardingsphere.proxy.backend.response.header.update.ClientEncodingResponseHeader;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.text.TextProtocolBackendHandler;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.SetStatement;
+
+import java.sql.SQLException;
+
+/**
+ * Set client encoding backend handler.
+ */
+@RequiredArgsConstructor
+public class SetClientEncodingBackendHandler implements TextProtocolBackendHandler {
+    
+    private static final String CLIENT_ENCODING = "client_encoding";
+    
+    private final SetStatement setStatement;
+    
+    private final ConnectionSession connectionSession;
+    
+    @Override
+    public ResponseHeader execute() throws SQLException {
+        String clientEncoding = setStatement.getVariableAssigns().iterator().next().getAssignValue();
+        return new ClientEncodingResponseHeader(clientEncoding.trim().toUpperCase(), setStatement, connectionSession);
+    }
+    
+    /**
+     * Is set client encoding.
+     *
+     * @param setStatement set statement
+     * @return is set client encoding or not
+     */
+    public static boolean isSetClientEncoding(final SetStatement setStatement) {
+        return CLIENT_ENCODING.equalsIgnoreCase(setStatement.getVariableAssigns().iterator().next().getVariable().getVariable());
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/exception/InvalidParameterValueException.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/exception/InvalidParameterValueException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.postgresql.command.query.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.proxy.frontend.exception.FrontendException;
+
+/**
+ * Invalid parameter value exception.
+ */
+@RequiredArgsConstructor
+@Getter
+public class InvalidParameterValueException extends FrontendException {
+    
+    private static final long serialVersionUID = -6561119208409452172L;
+    
+    private final String message;
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.proxy.frontend.postgresql.command.query.simple;
 
 import lombok.Getter;
+import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.packet.DatabasePacket;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLCharacterSet;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.PostgreSQLPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLColumnDescription;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLDataRowPacket;
@@ -26,10 +28,12 @@ import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.Pos
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLRowDescriptionPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.simple.PostgreSQLComQueryPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.generic.PostgreSQLCommandCompletePacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLParameterStatusPacket;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.impl.QueryHeader;
+import org.apache.shardingsphere.proxy.backend.response.header.update.ClientEncodingResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.text.TextProtocolBackendHandler;
@@ -38,11 +42,13 @@ import org.apache.shardingsphere.proxy.frontend.command.executor.QueryCommandExe
 import org.apache.shardingsphere.proxy.frontend.command.executor.ResponseType;
 import org.apache.shardingsphere.proxy.frontend.postgresql.command.PostgreSQLConnectionContext;
 import org.apache.shardingsphere.proxy.frontend.postgresql.command.query.PostgreSQLCommand;
+import org.apache.shardingsphere.proxy.frontend.postgresql.command.query.exception.InvalidParameterValueException;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.EmptyStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.tcl.CommitStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.tcl.RollbackStatement;
 
+import java.nio.charset.Charset;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
@@ -75,7 +81,8 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
             return Collections.singleton(createRowDescriptionPacket((QueryResponseHeader) responseHeader));
         }
         responseType = ResponseType.UPDATE;
-        return Collections.singleton(createUpdatePacket((UpdateResponseHeader) responseHeader));
+        return responseHeader instanceof UpdateResponseHeader ? Collections.singleton(createUpdatePacket((UpdateResponseHeader) responseHeader))
+                : createUpdatePackets((ClientEncodingResponseHeader) responseHeader);
     }
     
     private PostgreSQLRowDescriptionPacket createRowDescriptionPacket(final QueryResponseHeader queryResponseHeader) {
@@ -93,13 +100,26 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor {
         return result;
     }
     
-    private PostgreSQLPacket createUpdatePacket(final UpdateResponseHeader updateResponseHeader) throws SQLException {
+    private PostgreSQLPacket createUpdatePacket(final UpdateResponseHeader updateResponseHeader) {
         SQLStatement sqlStatement = updateResponseHeader.getSqlStatement();
         if (sqlStatement instanceof CommitStatement || sqlStatement instanceof RollbackStatement) {
             connectionContext.closeAllPortals();
         }
         return sqlStatement instanceof EmptyStatement ? new PostgreSQLEmptyQueryResponsePacket()
                 : new PostgreSQLCommandCompletePacket(PostgreSQLCommand.valueOf(sqlStatement.getClass()).map(PostgreSQLCommand::getTag).orElse(""), updateResponseHeader.getUpdateCount());
+    }
+    
+    private Collection<DatabasePacket<?>> createUpdatePackets(final ClientEncodingResponseHeader clientEncodingResponseHeader) {
+        Collection<DatabasePacket<?>> result = new LinkedList<>();
+        result.add(new PostgreSQLCommandCompletePacket(PostgreSQLCommand.valueOf(clientEncodingResponseHeader.getSqlStatement().getClass()).map(PostgreSQLCommand::getTag).orElse(""), 0));
+        String name = clientEncodingResponseHeader.getClientEncoding();
+        final Optional<Charset> charset = PostgreSQLCharacterSet.findByName(name);
+        if (charset.isPresent()) {
+            clientEncodingResponseHeader.getConnectionSession().getAttributeMap().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).set(charset.get());
+            result.add(new PostgreSQLParameterStatusPacket(clientEncodingResponseHeader.getName(), clientEncodingResponseHeader.getClientEncoding()));
+            return result;
+        }
+        throw new InvalidParameterValueException(String.format("invalid value for parameter \"clientEncoding\": \"%s\"", name));
     }
     
     @Override

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/err/PostgreSQLErrPacketFactory.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.packet.generic.PostgreSQ
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.InvalidAuthorizationSpecificationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLAuthenticationException;
 import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.exception.PostgreSQLProtocolViolationException;
+import org.apache.shardingsphere.proxy.frontend.postgresql.command.query.exception.InvalidParameterValueException;
 import org.postgresql.util.PSQLException;
 import org.postgresql.util.ServerErrorMessage;
 
@@ -49,6 +50,9 @@ public final class PostgreSQLErrPacketFactory {
         }
         if (cause instanceof SQLException) {
             return createErrorResponsePacket((SQLException) cause);
+        }
+        if (cause instanceof InvalidParameterValueException) {
+            return PostgreSQLErrorResponsePacket.newBuilder(PostgreSQLMessageSeverityLevel.ERROR, PostgreSQLErrorCode.INVALID_PARAMETER_VALUE, cause.getMessage()).build();
         }
         if (cause instanceof InvalidAuthorizationSpecificationException) {
             return PostgreSQLErrorResponsePacket.newBuilder(PostgreSQLMessageSeverityLevel.FATAL, PostgreSQLErrorCode.INVALID_AUTHORIZATION_SPECIFICATION, cause.getMessage()).build();


### PR DESCRIPTION
##  Set charset simple query supported for PostgreSQL in proxy

Related to #13317.

Changes proposed in this pull request:
- Set charset simple query supported for PostgreSQL in proxy.
