### PR TITLE
g4 files refactor and resolve load order problems

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DALStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DALStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 use
     : USE schemaName

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import BaseRule, DMLStatement, DALStatement;
+import DMLStatement, DALStatement;
 
 alterStatement
     : alterTable
@@ -178,10 +178,6 @@ restrict
 fulltextIndexOption
     : commonIndexOption
     | WITH PARSER identifier
-    ;
-
-partitionNames
-    : partitionName (COMMA_ partitionName)*
     ;
 
 dropTable

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/MySQLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/MySQLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar MySQLStatement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, DALStatement, RLStatement;
+import Comments, DDLStatement, TCLStatement, DCLStatement, RLStatement;
 
 execute
     : (select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DALStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DALStatement;
 
-import BaseRule, DDLStatement;
+import DDLStatement;
 
 show
     : SHOW (varName | TIME ZONE | TRANSACTION ISOLATION LEVEL | SESSION AUTHORIZATION | ALL) EOF

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DCLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DCLStatement;
 
-import BaseRule, DDLStatement;
+import DDLStatement;
 
 grant
     : GRANT (privilegeClause | roleClause)

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 createTable
     : CREATE createTableSpecification TABLE notExistClause? tableName

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/TCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/TCLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar TCLStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 setTransaction
     : SET (SESSION CHARACTERISTICS AS)? TRANSACTION transactionModeList

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OpenGaussStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OpenGaussStatement.g4
@@ -17,7 +17,7 @@
 
 grammar OpenGaussStatement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, DALStatement, StoreProcedure;
+import Comments, TCLStatement, DCLStatement, DALStatement, StoreProcedure;
 
 execute
     : (select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DMLStatement;
 
-import BaseRule, Comments, DDLStatement;
+import Comments, DDLStatement;
 
 insert
     : INSERT hint? (insertSingleTable | insertMultiTable)

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/OracleStatement.g4
@@ -17,7 +17,7 @@
 
 grammar OracleStatement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, StoreProcedure;
+import DMLStatement, TCLStatement, DCLStatement, StoreProcedure;
 
 execute
     : (select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DALStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DALStatement;
 
-import BaseRule, DDLStatement;
+import DDLStatement;
 
 show
     : SHOW (varName | TIME ZONE | TRANSACTION ISOLATION LEVEL | SESSION AUTHORIZATION | ALL) EOF

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DCLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DCLStatement;
 
-import BaseRule, DDLStatement;
+import DDLStatement;
 
 grant
     : GRANT (privilegeClause | roleClause)

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 createTable
     : CREATE createTableSpecification TABLE notExistClause? tableName

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/TCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/TCLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar TCLStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 setTransaction
     : SET (SESSION CHARACTERISTICS AS)? TRANSACTION transactionModeList

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar PostgreSQLStatement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, DALStatement, StoreProcedure;
+import Comments, TCLStatement, DCLStatement, DALStatement, StoreProcedure;
 
 execute
     : (select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/antlr4/imports/sql92/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/antlr4/imports/sql92/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import BaseRule, DMLStatement;
+import DMLStatement;
 
 createTable
     : CREATE createTableSpecification? TABLE tableName (createDefinitionClause | createLikeClause)

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQL92Statement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sql92/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQL92Statement.g4
@@ -17,7 +17,7 @@
 
 grammar SQL92Statement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement;
+import Comments, DDLStatement, TCLStatement, DCLStatement;
 
 execute
     : (select

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -194,7 +194,7 @@ collationName
     ;
 
 alias
-    : IDENTIFIER_
+    : identifier | STRING_
     ;
 
 dataTypeLength

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -193,10 +193,6 @@ collationName
     : STRING_ | IDENTIFIER_
     ;
 
-alias
-    : identifier | STRING_
-    ;
-
 dataTypeLength
     : LP_ (NUMBER_ (COMMA_ NUMBER_)?)? RP_
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -193,6 +193,10 @@ collationName
     : STRING_ | IDENTIFIER_
     ;
 
+alias
+    : identifier | STRING_
+    ;
+
 dataTypeLength
     : LP_ (NUMBER_ (COMMA_ NUMBER_)?)? RP_
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/BaseRule.g4
@@ -327,10 +327,6 @@ privateExprOfDb
     : windowedFunction | atTimeZoneExpr | castExpr | convertExpr
     ;
 
-subquery
-    : matchNone
-    ;
-
 orderByClause
     : ORDER BY orderByItem (COMMA_ orderByItem)*
     (OFFSET expr (ROW | ROWS) (FETCH (FIRST | NEXT) expr (ROW | ROWS) ONLY)?)?

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DALStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DALStatement;
 
-import SQLServerKeyword, DMLStatement, DDLStatement;
+import SQLServerKeyword, DDLStatement;
 
 explain
     : EXPLAIN WITH_RECOMMENDATIONS? explainableStatement

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import BaseRule, DMLStatement, DCLStatement;
+import DMLStatement, DCLStatement;
 
 createTable
     : createTableClause | createTableAsSelectClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DMLStatement.g4
@@ -104,10 +104,6 @@ topNum
     : numberLiterals | parameterMarker
     ;
 
-alias
-    : identifier | STRING_
-    ;
-
 unqualifiedShorthand
     : ASTERISK_
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/SQLServerStatement.g4
@@ -17,7 +17,7 @@
 
 grammar SQLServerStatement;
 
-import Symbol, Comments, DMLStatement, DDLStatement, TCLStatement, DCLStatement, StoreProcedure, DALStatement;
+import Comments, TCLStatement, StoreProcedure, DALStatement;
 
 execute
     : (select


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/35389145/155123822-d8124c3f-9351-4d6d-91fc-2e24461036e5.png)
![image](https://user-images.githubusercontent.com/35389145/155123977-1bc049cb-915b-4f02-92fb-fdf8c2bef3f7.png)

`DMLStatement `already import `BaseRule`, I think it is not necessary import `BaseRule `again. so I refactor some files. 

And `MySQLStatement.g4` will load g4 file in the order of import, load `Symbol `first, load `Comments `second. 

If there are two files contains `alias `grammar, `MySQLStatement` can only find it in the first load file, and I resolve some problems caused by it.

![image](https://user-images.githubusercontent.com/35389145/155124495-b2c95265-aa71-4c6c-8fa4-aaa39ade0c13.png)

Changes proposed in this pull request:
-
-
-
