### PR TITLE
Proofread SET TRANSACTION, and SET IMPLICIT_TRANSACTIONS

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/SQLServerKeyword.g4
@@ -1782,3 +1782,11 @@ PROVIDER
 SID
     : S I D
     ;
+
+UNCOMMITTED
+    : U N C O M M I T T E D
+    ;
+
+COMMITTED
+    : C O M M I T T E D
+    ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/TCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/TCLStatement.g4
@@ -20,11 +20,15 @@ grammar TCLStatement;
 import Symbol, Keyword, SQLServerKeyword, Literals, BaseRule;
 
 setTransaction
-    : SET TRANSACTION
+    : SET TRANSACTION ISOLATION LEVEL isolationLevel
+    ;
+
+isolationLevel
+    : READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ | SNAPSHOT | SERIALIZABLE
     ;
 
 setImplicitTransactions
-    : (IF AT_ AT_ TRANCOUNT GT_ NUMBER_ COMMIT TRAN)? SET IMPLICIT_TRANSACTIONS implicitTransactionsValue
+    : SET IMPLICIT_TRANSACTIONS implicitTransactionsValue
     ;
 
 implicitTransactionsValue

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerTCLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerTCLStatementSQLVisitor.java
@@ -25,11 +25,13 @@ import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.Beg
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.BeginTransactionContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.CommitContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.CommitWorkContext;
+import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.IsolationLevelContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.RollbackContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.RollbackWorkContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.SavepointContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.SetImplicitTransactionsContext;
 import org.apache.shardingsphere.sql.parser.autogen.SQLServerStatementParser.SetTransactionContext;
+import org.apache.shardingsphere.sql.parser.sql.common.constant.TransactionIsolationLevel;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.tcl.SQLServerBeginDistributedTransactionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.tcl.SQLServerBeginTransactionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.tcl.SQLServerCommitStatement;
@@ -52,7 +54,25 @@ public final class SQLServerTCLStatementSQLVisitor extends SQLServerStatementSQL
     
     @Override
     public ASTNode visitSetTransaction(final SetTransactionContext ctx) {
-        return new SQLServerSetTransactionStatement();
+        SQLServerSetTransactionStatement result = new SQLServerSetTransactionStatement();
+        result.setIsolationLevel(getTransactionIsolationLevel(ctx.isolationLevel()));
+        return result;
+    }
+    
+    private TransactionIsolationLevel getTransactionIsolationLevel(final IsolationLevelContext ctx) {
+        TransactionIsolationLevel result;
+        if (null != ctx.UNCOMMITTED()) {
+            result = TransactionIsolationLevel.READ_UNCOMMITTED;
+        } else if (null != ctx.COMMITTED()) {
+            result = TransactionIsolationLevel.READ_COMMITTED;
+        } else if (null != ctx.REPEATABLE()) {
+            result = TransactionIsolationLevel.REPEATABLE_READ;
+        } else if (null != ctx.SNAPSHOT()) {
+            result = TransactionIsolationLevel.SNAPSHOT;
+        } else {
+            result = TransactionIsolationLevel.SERIALIZABLE;
+        }
+        return result;
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/constant/TransactionIsolationLevel.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/constant/TransactionIsolationLevel.java
@@ -31,6 +31,7 @@ public enum TransactionIsolationLevel {
     READ_UNCOMMITTED("READ_UNCOMMITTED"),
     READ_COMMITTED("READ_COMMITTED"),
     REPEATABLE_READ("REPEATABLE_READ"),
+    SNAPSHOT("SNAPSHOT"),
     SERIALIZABLE("SERIALIZABLE");
 
     private final String isolationLevel;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/tcl/set-transaction.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/tcl/set-transaction.xml
@@ -24,6 +24,7 @@
     <set-transaction sql-case-id="set_transaction_read_write_with_name" />
     <set-transaction sql-case-id="set_transaction_isolation_level_serializable" />
     <set-transaction sql-case-id="set_transaction_isolation_level_read_committed" />
+    <set-transaction sql-case-id="set_transaction_isolation_level_snapshot" />
     <set-transaction sql-case-id="set_transaction_use_rollback_segment" />
     <set-transaction sql-case-id="set_transaction_with_name" />
     <set-transaction sql-case-id="set_transaction_snapshot" />

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/tcl/set-auto-commit.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/tcl/set-auto-commit.xml
@@ -22,5 +22,5 @@
     <sql-case id="set_auto_commit_off" value="SET AUTOCOMMIT = 0" db-types="MySQL" />
     <sql-case id="set_auto_commit_off_with_scope" value="SET SESSION AUTOCOMMIT = OFF" db-types="MySQL" />
     <sql-case id="set_implicit_transactions_on" value="SET IMPLICIT_TRANSACTIONS ON" db-types="SQLServer" />
-    <sql-case id="set_implicit_transactions_off" value="IF @@TRANCOUNT > 0 COMMIT TRAN SET IMPLICIT_TRANSACTIONS OFF" db-types="SQLServer" />
+    <sql-case id="set_implicit_transactions_off" value="SET IMPLICIT_TRANSACTIONS OFF" db-types="SQLServer" />
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/tcl/set-transaction.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/tcl/set-transaction.xml
@@ -22,10 +22,11 @@
     <sql-case id="set_session_transaction" value="SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ COMMITTED" db-types="PostgreSQL,openGauss" />
     <sql-case id="set_transaction_read_only" value="SET TRANSACTION READ ONLY" db-types="MySQL,Oracle" />
     <sql-case id="set_transaction_read_write_with_name" value="SET TRANSACTION READ WRITE NAME 'Toronto'" db-types="Oracle" />
-    <sql-case id="set_transaction_isolation_level_serializable" value="SET TRANSACTION ISOLATION LEVEL SERIALIZABLE" db-types="Oracle" />
-    <sql-case id="set_transaction_isolation_level_read_committed" value="SET TRANSACTION ISOLATION LEVEL READ COMMITTED" db-types="Oracle" />
+    <sql-case id="set_transaction_isolation_level_serializable" value="SET TRANSACTION ISOLATION LEVEL SERIALIZABLE" db-types="Oracle, SQLServer" />
+    <sql-case id="set_transaction_isolation_level_read_committed" value="SET TRANSACTION ISOLATION LEVEL READ COMMITTED" db-types="Oracle, SQLServer" />
+    <sql-case id="set_transaction_isolation_level_snapshot" value="SET TRANSACTION ISOLATION LEVEL SNAPSHOT" db-types="SQLServer" />
     <sql-case id="set_transaction_use_rollback_segment" value="SET TRANSACTION USE ROLLBACK SEGMENT rbs_ts" db-types="Oracle" />
-    <sql-case id="set_transaction_with_name" value="SET TRANSACTION NAME 'comment1'" db-types="Oracle,SQLServer" />
+    <sql-case id="set_transaction_with_name" value="SET TRANSACTION NAME 'comment1'" db-types="Oracle" />
     <sql-case id="set_transaction_snapshot" value="SET TRANSACTION SNAPSHOT 'snapshot1'" db-types="PostgreSQL,openGauss" />
     <sql-case id="xa_recover" value="XA RECOVER" db-types="MySQL" />
     <sql-case id="xa_start" value="XA start 'abcdef7' join" db-types="MySQL" />


### PR DESCRIPTION
For #6478 

Changes proposed in this pull request:
- I've proofread[ SET TRANSACTION ISOLATION LEVEL](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-transaction-isolation-level-transact-sql?view=sql-server-ver15) and [SET IMPLICIT_TRANSACTIONS](https://docs.microsoft.com/en-us/sql/t-sql/statements/set-implicit-transactions-transact-sql?view=sql-server-ver15)
- I couldn't able to find `SQLServer` definition for the statement `SET TRANSACTION NAME 'comment1'` in the documentation. Therefore, I've removed `SQLServer` from the `db-types`.
