### PR TITLE
Use raw connection to handle traffic sql statement in xa transaction

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManager.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManager.java
@@ -302,8 +302,12 @@ public final class ConnectionManager implements ExecutorJDBCManager, AutoCloseab
     }
     
     private Connection createConnection(final String dataSourceName, final DataSource dataSource) throws SQLException {
-        Optional<Connection> connectionInTransaction = connectionTransaction.getConnection(dataSourceName);
+        Optional<Connection> connectionInTransaction = isRawJdbcDataSource(dataSourceName) ? connectionTransaction.getConnection(dataSourceName) : Optional.empty();
         return connectionInTransaction.isPresent() ? connectionInTransaction.get() : dataSource.getConnection();
+    }
+    
+    private boolean isRawJdbcDataSource(final String dataSourceName) {
+        return physicalDataSourceMap.containsKey(dataSourceName);
     }
     
     @SuppressWarnings("MagicConstant")

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
@@ -91,7 +91,7 @@ public final class ConnectionManagerTest {
     
     private Map<String, DataSource> mockTrafficDataSourceMap() {
         Map<String, DataSource> result = new LinkedHashMap<>();
-        result.put("127.0.0.1@3307", new MockedDataSource());
+        result.put("127.0.0.1@3307", new MockedDataSource("jdbc:mysql://127.0.0.1:3307/logic_db?serverTimezone=UTC&useSSL=false", "root", "123456"));
         return result;
     }
     
@@ -163,7 +163,16 @@ public final class ConnectionManagerTest {
         List<Connection> actual = connectionManager.getConnections("127.0.0.1@3307", 1, ConnectionMode.MEMORY_STRICTLY);
         assertThat(actual, is(connectionManager.getConnections("127.0.0.1@3307", 1, ConnectionMode.MEMORY_STRICTLY)));
         assertThat(actual.size(), is(1));
-        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mock://127.0.0.1/foo_ds"));
+        assertThat(actual.get(0).getMetaData().getUserName(), is("root"));
+        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mysql://127.0.0.1:3307/logic_db?serverTimezone=UTC&useSSL=false"));
+    }
+    
+    @Test
+    public void assertGetConnectionWhenConfigTrafficRuleInXaTransaction() throws SQLException {
+        List<Connection> actual = connectionManagerInXaTransaction.getConnections("127.0.0.1@3307", 1, ConnectionMode.MEMORY_STRICTLY);
+        assertThat(actual.size(), is(1));
+        assertThat(actual.get(0).getMetaData().getUserName(), is("root"));
+        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mysql://127.0.0.1:3307/logic_db?serverTimezone=UTC&useSSL=false"));
     }
     
     @Test
@@ -180,7 +189,8 @@ public final class ConnectionManagerTest {
         List<Connection> actual = connectionManager.getConnections("127.0.0.1@3307", 1, ConnectionMode.CONNECTION_STRICTLY);
         assertThat(actual.size(), is(1));
         assertThat(actual.get(0), is(expected));
-        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mock://127.0.0.1/foo_ds"));
+        assertThat(actual.get(0).getMetaData().getUserName(), is("root"));
+        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mysql://127.0.0.1:3307/logic_db?serverTimezone=UTC&useSSL=false"));
     }
     
     @Test
@@ -193,7 +203,8 @@ public final class ConnectionManagerTest {
     public void assertGetConnectionsWhenConfigTrafficRuleAndEmptyCache() throws SQLException {
         List<Connection> actual = connectionManager.getConnections("127.0.0.1@3307", 1, ConnectionMode.MEMORY_STRICTLY);
         assertThat(actual.size(), is(1));
-        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mock://127.0.0.1/foo_ds"));
+        assertThat(actual.get(0).getMetaData().getUserName(), is("root"));
+        assertThat(actual.get(0).getMetaData().getURL(), is("jdbc:mysql://127.0.0.1:3307/logic_db?serverTimezone=UTC&useSSL=false"));
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
@@ -31,6 +31,8 @@ import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.test.mock.MockedDataSource;
 import org.apache.shardingsphere.traffic.rule.TrafficRule;
+import org.apache.shardingsphere.transaction.core.TransactionType;
+import org.apache.shardingsphere.transaction.core.TransactionTypeHolder;
 import org.apache.shardingsphere.transaction.rule.TransactionRule;
 import org.junit.After;
 import org.junit.Before;
@@ -61,11 +63,16 @@ public final class ConnectionManagerTest {
     
     private ConnectionManager connectionManager;
     
+    private ConnectionManager connectionManagerInXaTransaction;
+    
     private MockedStatic<DataSourcePoolCreator> dataSourcePoolCreator;
     
     @Before
     public void setUp() throws SQLException {
-        connectionManager = new ConnectionManager(DefaultSchema.LOGIC_NAME, mockContextManager());
+        ContextManager contextManager = mockContextManager();
+        connectionManager = new ConnectionManager(DefaultSchema.LOGIC_NAME, contextManager);
+        TransactionTypeHolder.set(TransactionType.XA);
+        connectionManagerInXaTransaction = new ConnectionManager(DefaultSchema.LOGIC_NAME, contextManager);
     }
     
     @After

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
@@ -78,6 +78,7 @@ public final class ConnectionManagerTest {
     @After
     public void cleanUp() {
         dataSourcePoolCreator.close();
+        TransactionTypeHolder.clear();
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/shardingsphere-test/shardingsphere-test-common/src/main/java/org/apache/shardingsphere/test/mock/MockedDataSource.java
+++ b/shardingsphere-test/shardingsphere-test-common/src/main/java/org/apache/shardingsphere/test/mock/MockedDataSource.java
@@ -43,9 +43,9 @@ import static org.mockito.Mockito.when;
 @Setter
 public final class MockedDataSource implements DataSource {
     
-    private String driverClassName;
-    
     private String url = "jdbc:mock://127.0.0.1/foo_ds";
+    
+    private String driverClassName;
     
     private String username = "root";
     
@@ -63,6 +63,12 @@ public final class MockedDataSource implements DataSource {
     @Setter(AccessLevel.NONE)
     private Connection connection;
     
+    public MockedDataSource(final String url, final String username, final String password) {
+        this.url = url;
+        this.username = username;
+        this.password = password;
+    }
+    
     public MockedDataSource(final Connection connection) {
         this.connection = connection;
     }
@@ -75,6 +81,7 @@ public final class MockedDataSource implements DataSource {
         }
         Connection result = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(result.getMetaData().getURL()).thenReturn(url);
+        when(result.getMetaData().getUserName()).thenReturn(username);
         when(result.createStatement(anyInt(), anyInt(), anyInt()).getConnection()).thenReturn(result);
         return result;
     }


### PR DESCRIPTION
Fixes #15580.

Changes proposed in this pull request:
- use raw connection to handle traffic sql statement in xa transaction
- add unit test for traffic sql statement in xa transaction
