### PR TITLE
Avoid get unused service in InsertClauseShardingConditionEngine

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/impl/InsertClauseShardingConditionEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/impl/InsertClauseShardingConditionEngine.java
@@ -89,17 +89,18 @@ public final class InsertClauseShardingConditionEngine implements ShardingCondit
         DatetimeService datetimeService = null;
         for (ExpressionSegment each : insertValueContext.getValueExpressions()) {
             Optional<String> shardingColumn = shardingRule.findShardingColumn(columnNames.next(), tableName);
-            if (shardingColumn.isPresent()) {
-                if (each instanceof SimpleExpressionSegment) {
-                    result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(getShardingValue((SimpleExpressionSegment) each, parameters))));
-                } else if (ExpressionConditionUtils.isNowExpression(each)) {
-                    if (null == datetimeService) {
-                        datetimeService = RequiredSPIRegistry.getRegisteredService(DatetimeService.class);
-                    }
-                    result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(datetimeService.getDatetime())));
-                } else if (ExpressionConditionUtils.isNullExpression(each)) {
-                    throw new ShardingSphereException("Insert clause sharding column can't be null.");
+            if (!shardingColumn.isPresent()) {
+                continue;
+            }
+            if (each instanceof SimpleExpressionSegment) {
+                result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(getShardingValue((SimpleExpressionSegment) each, parameters))));
+            } else if (ExpressionConditionUtils.isNowExpression(each)) {
+                if (null == datetimeService) {
+                    datetimeService = RequiredSPIRegistry.getRegisteredService(DatetimeService.class);
                 }
+                result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(datetimeService.getDatetime())));
+            } else if (ExpressionConditionUtils.isNullExpression(each)) {
+                throw new ShardingSphereException("Insert clause sharding column can't be null.");
             }
         }
         return result;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/impl/InsertClauseShardingConditionEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/impl/InsertClauseShardingConditionEngine.java
@@ -86,13 +86,16 @@ public final class InsertClauseShardingConditionEngine implements ShardingCondit
     
     private ShardingCondition createShardingCondition(final String tableName, final Iterator<String> columnNames, final InsertValueContext insertValueContext, final List<Object> parameters) {
         ShardingCondition result = new ShardingCondition();
-        DatetimeService datetimeService = RequiredSPIRegistry.getRegisteredService(DatetimeService.class);
+        DatetimeService datetimeService = null;
         for (ExpressionSegment each : insertValueContext.getValueExpressions()) {
             Optional<String> shardingColumn = shardingRule.findShardingColumn(columnNames.next(), tableName);
             if (shardingColumn.isPresent()) {
                 if (each instanceof SimpleExpressionSegment) {
                     result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(getShardingValue((SimpleExpressionSegment) each, parameters))));
                 } else if (ExpressionConditionUtils.isNowExpression(each)) {
+                    if (null == datetimeService) {
+                        datetimeService = RequiredSPIRegistry.getRegisteredService(DatetimeService.class);
+                    }
                     result.getValues().add(new ListShardingConditionValue<>(shardingColumn.get(), tableName, Collections.singletonList(datetimeService.getDatetime())));
                 } else if (ExpressionConditionUtils.isNullExpression(each)) {
                     throw new ShardingSphereException("Insert clause sharding column can't be null.");


### PR DESCRIPTION
Related to #10626.

The overhead of getting `DatetimeService` is always present even if we never use `now()` in insertions.

https://github.com/apache/shardingsphere/blob/af1c0fc750a8a1ef57d843d0bfbed5dde673bba7/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/impl/InsertClauseShardingConditionEngine.java#L87-L103

![image](https://user-images.githubusercontent.com/20503072/155299634-fd8d46d7-1649-429b-a77b-2c189f27d4d5.png)
