### PR TITLE
Fix set character sql parser

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/constant/MySQLCharacterSet.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/constant/MySQLCharacterSet.java
@@ -370,7 +370,11 @@ public enum MySQLCharacterSet {
      * @return MySQL character set
      */
     public static Optional<Charset> findByValue(final String charsetName) {
-        MySQLCharacterSet result = CHARACTER_NAME_SET_MAP.get(charsetName.toLowerCase(Locale.ROOT));
+        String key = charsetName.toLowerCase(Locale.ROOT);
+        if ("default".equals(key)) {
+            return Optional.of(MySQLServerInfo.DEFAULT_CHARSET.getCharset());
+        }
+        MySQLCharacterSet result = CHARACTER_NAME_SET_MAP.get(key);
         return null == result || null == result.getCharset() ? Optional.empty() : Optional.of(result.getCharset());
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
@@ -974,13 +974,15 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
     
     @Override
     public ASTNode visitSetCharacter(final SetCharacterContext ctx) {
-        MySQLSetStatement result = new MySQLSetStatement();
+        final MySQLSetStatement result = new MySQLSetStatement();
         VariableAssignSegment characterSet = new VariableAssignSegment();
         VariableSegment variable = new VariableSegment();
         String variableName = (null != ctx.CHARSET()) ? ctx.CHARSET().getText() : "charset";
         variable.setVariable(variableName);
+        characterSet.setVariable(variable);
         String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.charsetName().getText();
         characterSet.setAssignValue(assignValue);
+        result.getVariableAssigns().add(characterSet);
         return result;
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDALStatementSQLVisitor.java
@@ -974,7 +974,6 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
     
     @Override
     public ASTNode visitSetCharacter(final SetCharacterContext ctx) {
-        final MySQLSetStatement result = new MySQLSetStatement();
         VariableAssignSegment characterSet = new VariableAssignSegment();
         VariableSegment variable = new VariableSegment();
         String variableName = (null != ctx.CHARSET()) ? ctx.CHARSET().getText() : "charset";
@@ -982,6 +981,7 @@ public final class MySQLDALStatementSQLVisitor extends MySQLStatementSQLVisitor 
         characterSet.setVariable(variable);
         String assignValue = (null != ctx.DEFAULT()) ? ctx.DEFAULT().getText() : ctx.charsetName().getText();
         characterSet.setAssignValue(assignValue);
+        MySQLSetStatement result = new MySQLSetStatement();
         result.getVariableAssigns().add(characterSet);
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDALStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDALStatementSQLVisitor.java
@@ -77,8 +77,17 @@ public final class PostgreSQLDALStatementSQLVisitor extends PostgreSQLStatementS
                 variableAssignSegment.getVariable().setScope(ctx.runtimeScope().getText());
             }
             variableAssigns.add(variableAssignSegment);
-            result.getVariableAssigns().addAll(variableAssigns);
         }
+        if (null != ctx.encoding()) {
+            VariableAssignSegment variableAssignSegment = new VariableAssignSegment();
+            VariableSegment variableSegment = new VariableSegment();
+            variableSegment.setVariable("charset");
+            variableAssignSegment.setVariable(variableSegment);
+            String value = ctx.encoding().getText();
+            variableAssignSegment.setAssignValue(value);
+            variableAssigns.add(variableAssignSegment);
+        }
+        result.getVariableAssigns().addAll(variableAssigns);
         return result;
     }
     

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/set.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dal/set.xml
@@ -83,4 +83,14 @@
     <set-resource-group sql-case-id="set_resource_group">
         <group name="rg" />
     </set-resource-group>
+    <set-parameter sql-case-id="set_charset" >
+        <parameter-assign value="'UTF8'" >
+            <parameter name="charset" />
+        </parameter-assign>
+    </set-parameter>
+    <set-parameter sql-case-id="set_client_encoding" >
+        <parameter-assign value="'UTF8'" >
+            <parameter name="CLIENT_ENCODING" />
+        </parameter-assign>
+    </set-parameter>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/set.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dal/set.xml
@@ -37,4 +37,6 @@
     <sql-case id="set_parameter_equal_number_with_signal" value="SET extra_float_digits = -10.5" db-types="PostgreSQL,openGauss" />
     <sql-case id="set_names" value="SET NAMES 'utf8' COLLATE 'utf8_general_ci'" db-types="MySQL" />
     <sql-case id="set_resource_group" value="SET RESOURCE GROUP rg" db-types="MySQL"/>
+    <sql-case id="set_charset" value="SET NAMES 'UTF8'" db-types="MySQL,PostgreSQL" />
+    <sql-case id="set_client_encoding" value="SET CLIENT_ENCODING TO 'UTF8'" db-types="PostgreSQL" />
 </sql-cases>


### PR DESCRIPTION
## Fix set character sql parser

Related to #13317.

Changes proposed in this pull request:
-  Set charset sql parser supported for MySQL by `SET {CHARACTER SET | CHARSET} {'charsetName' | DEFAULT};`.
-  Set charset sql parser supported for PostgreSQL by `SET NAMES 'charsetName';`.
