### PR TITLE
Optimize SingleTableSQLRouter single data source route logic

### DIFF
--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
@@ -27,12 +27,15 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.route.SQLRouter;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
+import org.apache.shardingsphere.infra.route.context.RouteMapper;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.singletable.constant.SingleTableOrder;
 import org.apache.shardingsphere.singletable.rule.SingleTableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 
 /**
@@ -43,7 +46,12 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
     @Override
     public RouteContext createRouteContext(final LogicSQL logicSQL, final ShardingSphereMetaData metaData, final SingleTableRule rule, final ConfigurationProperties props) {
         RouteContext result = new RouteContext();
-        route(logicSQL.getSqlStatementContext(), rule, result, props);
+        if (1 == metaData.getResource().getDataSources().size()) {
+            String singleDataSourceName = metaData.getResource().getDataSources().keySet().iterator().next();
+            result.getRouteUnits().add(new RouteUnit(new RouteMapper(singleDataSourceName, singleDataSourceName), Collections.emptyList()));
+        } else {
+            route(logicSQL.getSqlStatementContext(), rule, result, props);
+        }
         return result;
     }
     

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
@@ -37,7 +37,6 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.ddl.MySQ
 import org.junit.Test;
 
 import javax.sql.DataSource;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -51,12 +50,59 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class SingleTableSQLRouterTest {
-
+    
     @Test
-    public void assertCreateTableSuccessfully() {
-        SingleTableSQLRouter singleTableSQLRouter = new SingleTableSQLRouter();
+    public void assertCreateRouteContextWithSingleDataSource() {
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+                createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("ds_0", "t_order")));
+        ShardingSphereMetaData metaData = mockSingleDataSourceMetaData();
+        RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
+        List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
+        assertThat(actual.getRouteUnits().size(), is(1));
+        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
+        assertThat(routeUnits.get(0).getTableMappers().size(), is(0));
+        assertFalse(actual.isFederated());
+    }
+    
+    @Test
+    public void assertCreateRouteContextWithMultiDataSource() {
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+                createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("ds_0", "t_order")));
+        ShardingSphereMetaData metaData = mockMultiDataSourceMetaData();
+        RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
+        List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
+        assertThat(actual.getRouteUnits().size(), is(1));
+        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
+        assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
+        RouteMapper tableMapper = routeUnits.get(0).getTableMappers().iterator().next();
+        assertThat(tableMapper.getActualName(), is("t_order"));
+        assertThat(tableMapper.getLogicName(), is("t_order"));
+        assertFalse(actual.isFederated());
+    }
+    
+    private ShardingSphereMetaData mockSingleDataSourceMetaData() {
+        ShardingSphereMetaData result = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        Map<String, DataSource> dataSourceMap = new HashMap<>(2, 1);
+        dataSourceMap.put("ds_0", mock(DataSource.class, RETURNS_DEEP_STUBS));
+        when(result.getResource().getDataSources()).thenReturn(dataSourceMap);
+        return result;
+    }
+    
+    private ShardingSphereMetaData mockMultiDataSourceMetaData() {
+        ShardingSphereMetaData result = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
+        Map<String, DataSource> dataSourceMap = new HashMap<>(2, 1);
+        dataSourceMap.put("ds_0", mock(DataSource.class, RETURNS_DEEP_STUBS));
+        dataSourceMap.put("ds_1", mock(DataSource.class, RETURNS_DEEP_STUBS));
+        when(result.getResource().getDataSources()).thenReturn(dataSourceMap);
+        return result;
+    }
+    
+    private LogicSQL createLogicSQL() {
         IdentifierValue identifierValue = new IdentifierValue("t_order");
         TableNameSegment tableNameSegment = new TableNameSegment(1, 2, identifierValue);
         SimpleTableSegment simpleTableSegment = new SimpleTableSegment(tableNameSegment);
@@ -64,21 +110,9 @@ public final class SingleTableSQLRouterTest {
         createTableStatement.setTable(simpleTableSegment);
         List<Object> parametersList = new LinkedList<>();
         SQLStatementContext<CreateTableStatement> sqlStatementContext = new CreateTableStatementContext(createTableStatement);
-        LogicSQL logicSQL = new LogicSQL(sqlStatementContext, "create table", parametersList);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
-                createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("ds_0", "t_order")));
-        RouteContext routeContext = singleTableSQLRouter.createRouteContext(logicSQL, mock(ShardingSphereMetaData.class), singleTableRule, new ConfigurationProperties(new Properties()));
-        List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
-        assertThat(routeContext.getRouteUnits().size(), is(1));
-        assertThat(routeUnits.get(0).getDataSourceMapper().getActualName(), is("ds_0"));
-        assertThat(routeUnits.get(0).getTableMappers().size(), is(1));
-        RouteMapper tableMapper0 = routeUnits.get(0).getTableMappers().iterator().next();
-        assertThat(tableMapper0.getActualName(), is("t_order"));
-        assertThat(tableMapper0.getLogicName(), is("t_order"));
-        assertFalse(routeContext.isFederated());
+        return new LogicSQL(sqlStatementContext, "create table", parametersList);
     }
-
+    
     private Map<String, DataSource> createDataSourceMap() {
         Map<String, DataSource> result = new HashMap<>(2, 1);
         result.put("ds_0", mock(DataSource.class, RETURNS_DEEP_STUBS));


### PR DESCRIPTION
Ref #15686.

Changes proposed in this pull request:
- optimize SingleTableSQLRouter single data source route logic
- add unit test for SingleTableSQLRouter

Performance test result:

```
Benchmark                                                                  Mode  Cnt      Score      Error   Units
SingleTableSQLRouterBenchmark.testCreateRouteContextWithMultiDataSource   thrpt    5  10594.418 ± 1257.918  ops/ms
SingleTableSQLRouterBenchmark.testCreateRouteContextWithSingleDataSource  thrpt    5  33895.990 ± 3634.950  ops/ms
```
JMH source code.

```java
/**
 * Single table sql router benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(5)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class SingleTableSQLRouterBenchmark {
    
    private SingleTableSQLRouter singleTableSQLRouter;
    
    private LogicSQL logicSQL;
    
    private ShardingSphereMetaData singleDataSourceMetaData;
    
    private ShardingSphereMetaData multiDataSourceMetaData;
    
    private SingleTableRule rule;
    
    private ConfigurationProperties props;
    
    @Setup(Level.Trial)
    public void setUp() {
        singleTableSQLRouter = new SingleTableSQLRouter();
        Map<String, ShardingSphereMetaData> metaDataMap = new HashMap<>(1, 1);
        DatabaseType databaseType = DatabaseTypeRegistry.getTrunkDatabaseType("MySQL");
        ShardingSphereSchema schema = new ShardingSphereSchema();
        ColumnMetaData columnMetaData = new ColumnMetaData("single_id", Types.INTEGER, false, false, false);
        schema.put("t_single", new TableMetaData("t_single", Collections.singletonList(columnMetaData), Collections.emptyList()));
        singleDataSourceMetaData = new ShardingSphereMetaData("sharding_db", 
                new ShardingSphereResource(createSingleDataSource(), null, null, databaseType), null, schema);
        multiDataSourceMetaData = new ShardingSphereMetaData("sharding_db", 
                new ShardingSphereResource(createMultiDataSource(), null, null, databaseType), null, schema);
        metaDataMap.put("sharding_db", singleDataSourceMetaData);
        CacheOption cacheOption = new CacheOption(65535, 2000, 4);
        Optional<SQLParserRule> sqlParserRule = Optional.of(new SQLParserRule(new SQLParserRuleConfiguration(false, cacheOption, cacheOption)));
        ShardingSphereSQLParserEngine sqlParserEngine = new ShardingSphereSQLParserEngine("MySQL", sqlParserRule.get());
        String sql = "SELECT * FROM t_single";
        SQLStatement sqlStatement = sqlParserEngine.parse(sql, true);
        logicSQL = new LogicSQL(SQLStatementContextFactory.newInstance(metaDataMap, sqlStatement, "sharding_db"), sql, Collections.emptyList());
        props = new ConfigurationProperties(new Properties());
        rule = new SingleTableRule(new SingleTableRuleConfiguration(), databaseType, Collections.emptyMap(), Collections.emptyList(), props);
        rule.getSingleTableDataNodes().put("t_single", Collections.singletonList(new DataNode("ds_0", "t_single")));
    }
    
    private Map<String, DataSource> createMultiDataSource() {
        Map<String, DataSource> result = new HashMap<>(2, 1);
        result.put("ds_0", null);
        result.put("ds_1", null);
        return result;
    }
    
    private Map<String, DataSource> createSingleDataSource() {
        Map<String, DataSource> result = new HashMap<>(1, 1);
        result.put("ds_0", null);
        return result;
    }
    
    @Benchmark
    public void testCreateRouteContextWithSingleDataSource() {
        singleTableSQLRouter.createRouteContext(logicSQL, singleDataSourceMetaData, rule, props);
    }
    
    @Benchmark
    public void testCreateRouteContextWithMultiDataSource() {
        singleTableSQLRouter.createRouteContext(logicSQL, multiDataSourceMetaData, rule, props);
    }
}
```