### PR TITLE
Optimize EncryptParameterRewriterBuilder and EncryptPredicateColumnTokenGenerator logic

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilder.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilder.java
@@ -35,7 +35,6 @@ import org.apache.shardingsphere.infra.rewrite.parameter.rewriter.ParameterRewri
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.SchemaMetaDataAware;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -54,14 +53,9 @@ public final class EncryptParameterRewriterBuilder implements ParameterRewriterB
     
     private final Collection<EncryptCondition> encryptConditions;
     
-    private final boolean containsEncryptTable;
-    
     @SuppressWarnings("rawtypes")
     @Override
     public Collection<ParameterRewriter> getParameterRewriters() {
-        if (!containsEncryptTable) {
-            return Collections.emptyList();
-        }
         Collection<ParameterRewriter> result = new LinkedList<>();
         addParameterRewriter(result, new EncryptAssignmentParameterRewriter());
         addParameterRewriter(result, new EncryptPredicateParameterRewriter());
@@ -70,8 +64,15 @@ public final class EncryptParameterRewriterBuilder implements ParameterRewriterB
         return result;
     }
     
+    private void addParameterRewriter(final Collection<ParameterRewriter> parameterRewriters, final ParameterRewriter<?> toBeAddedParameterRewriter) {
+        if (toBeAddedParameterRewriter.isNeedRewrite(sqlStatementContext)) {
+            setUpParameterRewriter(toBeAddedParameterRewriter);
+            parameterRewriters.add(toBeAddedParameterRewriter);
+        }
+    }
+    
     @SuppressWarnings("rawtypes")
-    private void addParameterRewriter(final Collection<ParameterRewriter> parameterRewriters, final ParameterRewriter toBeAddedParameterRewriter) {
+    private void setUpParameterRewriter(final ParameterRewriter toBeAddedParameterRewriter) {
         if (toBeAddedParameterRewriter instanceof SchemaMetaDataAware) {
             ((SchemaMetaDataAware) toBeAddedParameterRewriter).setSchema(schema);
         }
@@ -86,9 +87,6 @@ public final class EncryptParameterRewriterBuilder implements ParameterRewriterB
         }
         if (toBeAddedParameterRewriter instanceof SchemaNameAware) {
             ((SchemaNameAware) toBeAddedParameterRewriter).setSchemaName(schemaName);
-        }
-        if (toBeAddedParameterRewriter.isNeedRewrite(sqlStatementContext)) {
-            parameterRewriters.add(toBeAddedParameterRewriter);
         }
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilder.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilder.java
@@ -41,7 +41,6 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.generator.SQLTokenGener
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.builder.SQLTokenGeneratorBuilder;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 
 /**
@@ -56,15 +55,10 @@ public final class EncryptTokenGenerateBuilder implements SQLTokenGeneratorBuild
     
     private final Collection<EncryptCondition> encryptConditions;
     
-    private final boolean containsEncryptTable;
-    
     private final String schemaName;
     
     @Override
     public Collection<SQLTokenGenerator> getSQLTokenGenerators() {
-        if (!containsEncryptTable) {
-            return Collections.emptyList();
-        }
         Collection<SQLTokenGenerator> result = new LinkedList<>();
         addSQLTokenGenerator(result, new EncryptProjectionTokenGenerator());
         addSQLTokenGenerator(result, new EncryptAssignmentTokenGenerator());
@@ -82,6 +76,13 @@ public final class EncryptTokenGenerateBuilder implements SQLTokenGeneratorBuild
     }
     
     private void addSQLTokenGenerator(final Collection<SQLTokenGenerator> sqlTokenGenerators, final SQLTokenGenerator toBeAddedSQLTokenGenerator) {
+        if (toBeAddedSQLTokenGenerator.isGenerateSQLToken(sqlStatementContext)) {
+            setUpSQLTokenGenerator(toBeAddedSQLTokenGenerator);
+            sqlTokenGenerators.add(toBeAddedSQLTokenGenerator);
+        }
+    }
+    
+    private void setUpSQLTokenGenerator(final SQLTokenGenerator toBeAddedSQLTokenGenerator) {
         if (toBeAddedSQLTokenGenerator instanceof EncryptRuleAware) {
             ((EncryptRuleAware) toBeAddedSQLTokenGenerator).setEncryptRule(encryptRule);
         }
@@ -93,9 +94,6 @@ public final class EncryptTokenGenerateBuilder implements SQLTokenGeneratorBuild
         }
         if (toBeAddedSQLTokenGenerator instanceof SchemaNameAware) {
             ((SchemaNameAware) toBeAddedSQLTokenGenerator).setSchemaName(schemaName);
-        }
-        if (toBeAddedSQLTokenGenerator.isGenerateSQLToken(sqlStatementContext)) {
-            sqlTokenGenerators.add(toBeAddedSQLTokenGenerator);
         }
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptPredicateColumnTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptPredicateColumnTokenGenerator.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.encrypt.rule.aware.EncryptRuleAware;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
-import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.binder.type.WhereAvailable;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.CollectionSQLTokenGenerator;
@@ -56,9 +55,7 @@ public final class EncryptPredicateColumnTokenGenerator implements CollectionSQL
     @SuppressWarnings("rawtypes")
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
-        boolean containsJoinQuery = sqlStatementContext instanceof SelectStatementContext && ((SelectStatementContext) sqlStatementContext).isContainsJoinQuery();
-        boolean containsSubquery = sqlStatementContext instanceof SelectStatementContext && ((SelectStatementContext) sqlStatementContext).isContainsSubquery();
-        return containsJoinQuery || containsSubquery || (sqlStatementContext instanceof WhereAvailable && !((WhereAvailable) sqlStatementContext).getWhereSegments().isEmpty());
+        return sqlStatementContext instanceof WhereAvailable && !((WhereAvailable) sqlStatementContext).getWhereSegments().isEmpty();
     }
     
     @SuppressWarnings("rawtypes")

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilderTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/parameter/EncryptParameterRewriterBuilderTest.java
@@ -48,7 +48,7 @@ public final class EncryptParameterRewriterBuilderTest {
         SQLStatementContext<?> sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
         Collection<ParameterRewriter> actual = new EncryptParameterRewriterBuilder(
-                encryptRule, DefaultSchema.LOGIC_NAME, shardingSphereSchema, sqlStatementContext, Collections.emptyList(), true).getParameterRewriters();
+                encryptRule, DefaultSchema.LOGIC_NAME, shardingSphereSchema, sqlStatementContext, Collections.emptyList()).getParameterRewriters();
         assertThat(actual.size(), is(1));
         ParameterRewriter parameterRewriter = actual.iterator().next();
         assertThat(parameterRewriter, instanceOf(EncryptPredicateParameterRewriter.class));
@@ -64,7 +64,7 @@ public final class EncryptParameterRewriterBuilderTest {
         when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
         when(sqlStatementContext.getWhereSegments()).thenReturn(Collections.emptyList());
         Collection<ParameterRewriter> actual = new EncryptParameterRewriterBuilder(
-                encryptRule, DefaultSchema.LOGIC_NAME, shardingSphereSchema, sqlStatementContext, Collections.emptyList(), true).getParameterRewriters();
+                encryptRule, DefaultSchema.LOGIC_NAME, shardingSphereSchema, sqlStatementContext, Collections.emptyList()).getParameterRewriters();
         assertThat(actual.size(), is(0));
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilderTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptTokenGenerateBuilderTest.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.encrypt.rewrite.token;
 
 import org.apache.shardingsphere.encrypt.rewrite.aware.QueryWithCipherColumnAware;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptOrderByItemTokenGenerator;
-import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptPredicateColumnTokenGenerator;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptProjectionTokenGenerator;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.aware.EncryptRuleAware;
@@ -66,22 +65,18 @@ public final class EncryptTokenGenerateBuilderTest {
         when(selectStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("table"));
         when(selectStatementContext.getOrderByContext().getItems()).thenReturn(Collections.singletonList(mock(OrderByItem.class)));
         when(selectStatementContext.getGroupByContext().getItems()).thenReturn(Collections.emptyList());
-        when(selectStatementContext.isContainsJoinQuery()).thenReturn(true);
         when(selectStatementContext.getWhereSegments()).thenReturn(Collections.emptyList());
         EncryptTokenGenerateBuilder encryptTokenGenerateBuilder = new EncryptTokenGenerateBuilder(
-                encryptRule, selectStatementContext, Collections.emptyList(), true, DefaultSchema.LOGIC_NAME);
+                encryptRule, selectStatementContext, Collections.emptyList(), DefaultSchema.LOGIC_NAME);
         Collection<SQLTokenGenerator> sqlTokenGenerators = encryptTokenGenerateBuilder.getSQLTokenGenerators();
-        assertThat(sqlTokenGenerators.size(), is(3));
+        assertThat(sqlTokenGenerators.size(), is(2));
         Iterator<SQLTokenGenerator> iterator = sqlTokenGenerators.iterator();
         SQLTokenGenerator item1 = iterator.next();
         assertThat(item1, instanceOf(EncryptProjectionTokenGenerator.class));
         assertSqlTokenGenerator(item1);
         SQLTokenGenerator item2 = iterator.next();
-        assertThat(item2, instanceOf(EncryptPredicateColumnTokenGenerator.class));
+        assertThat(item2, instanceOf(EncryptOrderByItemTokenGenerator.class));
         assertSqlTokenGenerator(item2);
-        SQLTokenGenerator item3 = iterator.next();
-        assertThat(item3, instanceOf(EncryptOrderByItemTokenGenerator.class));
-        assertSqlTokenGenerator(item3);
     }
     
     private void assertSqlTokenGenerator(final SQLTokenGenerator sqlTokenGenerator) throws IllegalAccessException {


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/15686.

Changes proposed in this pull request:
- optimize EncryptParameterRewriterBuilder and EncryptPredicateColumnTokenGenerator logic

Performance test result:

```
Before

Benchmark                                                            Mode  Cnt      Score     Error   Units
EncryptParameterRewriterBuilderBenchmark.testGetParameterRewriters  thrpt    5  26733.191 ± 203.123  ops/ms
EncryptParameterRewriterBuilderBenchmark.testGetSQLTokenGenerators  thrpt    5   8842.210 ± 136.072  ops/ms

After

Benchmark                                                            Mode  Cnt       Score      Error   Units
EncryptParameterRewriterBuilderBenchmark.testGetParameterRewriters  thrpt    5  125362.945 ±  227.434  ops/ms
EncryptParameterRewriterBuilderBenchmark.testGetSQLTokenGenerators  thrpt    5   33337.342 ± 3024.904  ops/ms
```

JMH source code.

```java
package com.strongduanmu.performance.encrypt.rewrite.parameter;

import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptCondition;
import org.apache.shardingsphere.encrypt.rewrite.condition.EncryptConditionEngine;
import org.apache.shardingsphere.encrypt.rewrite.parameter.EncryptParameterRewriterBuilder;
import org.apache.shardingsphere.encrypt.rewrite.token.EncryptTokenGenerateBuilder;
import org.apache.shardingsphere.encrypt.rule.EncryptRule;
import org.apache.shardingsphere.infra.binder.SQLStatementContextFactory;
import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
import org.apache.shardingsphere.infra.binder.type.WhereAvailable;
import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
import org.apache.shardingsphere.infra.parser.ShardingSphereSQLParserEngine;
import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
import org.apache.shardingsphere.parser.rule.SQLParserRule;
import org.apache.shardingsphere.sql.parser.api.CacheOption;
import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.WhereSegment;
import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Threads;
import org.openjdk.jmh.annotations.Warmup;

import java.sql.Types;
import java.util.Collection;
import java.util.Collections;
import java.util.HashMap;
import java.util.Map;
import java.util.Optional;
import java.util.Properties;
import java.util.concurrent.TimeUnit;

import static java.util.Collections.emptyList;

/**
 * Encrypt parameter rewriter builder benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(5)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class EncryptParameterRewriterBuilderBenchmark {
    
    private EncryptParameterRewriterBuilder parameterRewriterBuilder;
    
    private EncryptTokenGenerateBuilder encryptTokenGenerateBuilder;
    
    @Setup(Level.Trial)
    public void setUp() {
        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(new EncryptColumnRuleConfiguration("password", "password", null, null, "TEST"));
        Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns, true));
        Properties props = new Properties();
        props.setProperty("aes-key-value", "test13123");
        EncryptRule encryptRule = new EncryptRule(new EncryptRuleConfiguration(tables, Collections.singletonMap("TEST", new ShardingSphereAlgorithmConfiguration("AES", props))), Collections.emptyMap());
        ShardingSphereSchema schema = new ShardingSphereSchema();
        ColumnMetaData columnMetaData = new ColumnMetaData("encrypt_id", Types.INTEGER, false, false, false);
        schema.put("t_encrypt", new TableMetaData("t_encrypt", Collections.singletonList(columnMetaData), emptyList()));
        EncryptConditionEngine encryptConditionEngine = new EncryptConditionEngine(encryptRule, schema);
        CacheOption cacheOption = new CacheOption(65535, 2000, 4);
        Optional<SQLParserRule> sqlParserRule = Optional.of(new SQLParserRule(new SQLParserRuleConfiguration(false, cacheOption, cacheOption)));
        ShardingSphereSQLParserEngine sqlParserEngine = new ShardingSphereSQLParserEngine("MySQL", sqlParserRule.get());
        String sql = "SELECT password FROM t_encrypt WHERE encrypt_id = ?";
        SQLStatement sqlStatement = sqlParserEngine.parse(sql, true);
        Map<String, ShardingSphereMetaData> metaDataMap = new HashMap<>(1, 1);
        ShardingSphereResource resource = new ShardingSphereResource(Collections.emptyMap(), null, null, DatabaseTypeRegistry.getTrunkDatabaseType("MySQL"));
        ShardingSphereMetaData metaData = new ShardingSphereMetaData("sharding_db", resource, null, schema);
        metaDataMap.put("sharding_db", metaData);
        SQLStatementContext<?> sqlStatementContext = SQLStatementContextFactory.newInstance(metaDataMap, Collections.emptyList(), sqlStatement, "sharding_db");
        Collection<WhereSegment> whereSegments = sqlStatementContext instanceof WhereAvailable ? ((WhereAvailable) sqlStatementContext).getWhereSegments() : Collections.emptyList();
        Collection<EncryptCondition> encryptConditions = encryptConditionEngine.createEncryptConditions(whereSegments, sqlStatementContext.getTablesContext());
        parameterRewriterBuilder = new EncryptParameterRewriterBuilder(encryptRule, "sharding_db", schema, sqlStatementContext, encryptConditions);
        encryptTokenGenerateBuilder = new EncryptTokenGenerateBuilder(encryptRule, sqlStatementContext, encryptConditions, "sharding_db");
    }
    
    @Benchmark
    public void testGetParameterRewriters() {
        parameterRewriterBuilder.getParameterRewriters();
    }
    
    @Benchmark
    public void testGetSQLTokenGenerators() {
        encryptTokenGenerateBuilder.getSQLTokenGenerators();
    }
}
```