### PR TITLE
Optimize EncryptProjectionTokenGenerator logic to improve performance

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
@@ -67,47 +67,46 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
     public Collection<SubstitutableColumnNameToken> generateSQLTokens(final SQLStatementContext<?> sqlStatementContext) {
         Preconditions.checkState(sqlStatementContext instanceof SelectStatementContext);
         Collection<SubstitutableColumnNameToken> result = new LinkedHashSet<>();
-        for (SelectStatementContext each : getSelectStatementContexts((SelectStatementContext) sqlStatementContext)) {
-            Map<String, String> columnTableNames = getColumnTableNames(each);
-            for (ProjectionSegment projection : each.getSqlStatement().getProjections().getProjections()) {
-                result.addAll(generateSQLTokens(each, projection, columnTableNames));
-            }
+        SelectStatementContext selectStatementContext = (SelectStatementContext) sqlStatementContext;
+        addGenerateSQLTokens(result, selectStatementContext);
+        for (SelectStatementContext each : selectStatementContext.getSubqueryContexts().values()) {
+            addGenerateSQLTokens(result, each);
         }
         return result;
     }
     
-    private Collection<SubstitutableColumnNameToken> generateSQLTokens(final SelectStatementContext selectStatementContext, 
-                                                                       final ProjectionSegment projection, final Map<String, String> columnTableNames) {
-        Collection<SubstitutableColumnNameToken> result = new LinkedList<>();
-        SubqueryType subqueryType = selectStatementContext.getSubqueryType();
-        if (projection instanceof ColumnProjectionSegment) {
-            ColumnProjectionSegment columnSegment = (ColumnProjectionSegment) projection;
-            ColumnProjection columnProjection = buildColumnProjection(columnSegment);
-            String tableName = columnTableNames.get(columnProjection.getExpression());
-            if (null != tableName && encryptRule.findEncryptor(tableName, columnProjection.getName()).isPresent()) {
-                result.add(generateSQLTokens(tableName, columnSegment, columnProjection, subqueryType));
+    private void addGenerateSQLTokens(final Collection<SubstitutableColumnNameToken> result, final SelectStatementContext selectStatementContext) {
+        Map<String, String> columnTableNames = getColumnTableNames(selectStatementContext);
+        for (ProjectionSegment projection : selectStatementContext.getSqlStatement().getProjections().getProjections()) {
+            SubqueryType subqueryType = selectStatementContext.getSubqueryType();
+            if (projection instanceof ColumnProjectionSegment) {
+                ColumnProjectionSegment columnSegment = (ColumnProjectionSegment) projection;
+                ColumnProjection columnProjection = buildColumnProjection(columnSegment);
+                String tableName = columnTableNames.get(columnProjection.getExpression());
+                if (null != tableName && encryptRule.findEncryptColumn(tableName, columnProjection.getName()).isPresent()) {
+                    result.add(generateSQLToken(tableName, columnSegment, columnProjection, subqueryType));
+                }
+            }
+            if (projection instanceof ShorthandProjectionSegment) {
+                ShorthandProjectionSegment shorthandSegment = (ShorthandProjectionSegment) projection;
+                Collection<ColumnProjection> actualColumns = getShorthandProjection(shorthandSegment, selectStatementContext.getProjectionsContext()).getActualColumns().values();
+                if (!actualColumns.isEmpty()) {
+                    result.add(generateSQLToken(shorthandSegment, actualColumns, selectStatementContext.getDatabaseType(), subqueryType, columnTableNames));
+                }
             }
         }
-        if (projection instanceof ShorthandProjectionSegment) {
-            ShorthandProjectionSegment shorthandSegment = (ShorthandProjectionSegment) projection;
-            Collection<ColumnProjection> actualColumns = getShorthandProjection(shorthandSegment, selectStatementContext.getProjectionsContext()).getActualColumns().values();
-            if (!actualColumns.isEmpty()) {
-                result.add(generateSQLTokens(shorthandSegment, actualColumns, selectStatementContext.getDatabaseType(), subqueryType, columnTableNames));
-            }
-        }
-        return result;
     }
     
-    private SubstitutableColumnNameToken generateSQLTokens(final String tableName, final ColumnProjectionSegment columnSegment, 
-                                                           final ColumnProjection columnProjection, final SubqueryType subqueryType) {
+    private SubstitutableColumnNameToken generateSQLToken(final String tableName, final ColumnProjectionSegment columnSegment,
+                                                          final ColumnProjection columnProjection, final SubqueryType subqueryType) {
         Collection<ColumnProjection> projections = generateProjections(tableName, columnProjection, subqueryType, false, null);
         int startIndex = columnSegment.getColumn().getOwner().isPresent() ? columnSegment.getColumn().getOwner().get().getStopIndex() + 2 : columnSegment.getColumn().getStartIndex();
         int stopIndex = columnSegment.getStopIndex();
         return new SubstitutableColumnNameToken(startIndex, stopIndex, projections);
     }
     
-    private SubstitutableColumnNameToken generateSQLTokens(final ShorthandProjectionSegment segment, final Collection<ColumnProjection> actualColumns, 
-                                                           final DatabaseType databaseType, final SubqueryType subqueryType, final Map<String, String> columnTableNames) {
+    private SubstitutableColumnNameToken generateSQLToken(final ShorthandProjectionSegment segment, final Collection<ColumnProjection> actualColumns,
+                                                          final DatabaseType databaseType, final SubqueryType subqueryType, final Map<String, String> columnTableNames) {
         List<ColumnProjection> projections = new LinkedList<>();
         for (ColumnProjection each : actualColumns) {
             String tableName = columnTableNames.get(each.getExpression());
@@ -138,13 +137,6 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
             }
         }
         return selectStatementContext.getTablesContext().findTableNamesByColumnProjection(columns, schema);
-    }
-    
-    private Collection<SelectStatementContext> getSelectStatementContexts(final SelectStatementContext selectStatementContext) {
-        Collection<SelectStatementContext> result = new LinkedList<>();
-        result.add(selectStatementContext);
-        result.addAll(selectStatementContext.getSubqueryContexts().values());
-        return result;
     }
     
     private Collection<ColumnProjection> generateProjections(final String tableName, final ColumnProjection column, final SubqueryType subqueryType, final boolean shorthand, 
@@ -203,15 +195,14 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
     
     private ColumnProjection generateCommonProjection(final String tableName, final ColumnProjection column, final ShorthandProjectionSegment segment) {
         String encryptColumnName = getEncryptColumnName(tableName, column.getName());
-        String owner = (segment != null && segment.getOwner().isPresent()) ? segment.getOwner().get().getIdentifier().getValue() : column.getOwner();
+        String owner = (null != segment && segment.getOwner().isPresent()) ? segment.getOwner().get().getIdentifier().getValue() : column.getOwner();
         return new ColumnProjection(owner, encryptColumnName, column.getAlias().orElse(column.getName()));
     }
     
     private String getEncryptColumnName(final String tableName, final String logicEncryptColumnName) {
-        Optional<String> plainColumn = encryptRule.findPlainColumn(tableName, logicEncryptColumnName);
         boolean queryWithCipherColumn = encryptRule.isQueryWithCipherColumn(tableName);
         if (!queryWithCipherColumn) {
-            return plainColumn.orElseGet(() -> encryptRule.getCipherColumn(tableName, logicEncryptColumnName));
+            return encryptRule.findPlainColumn(tableName, logicEncryptColumnName).orElseGet(() -> encryptRule.getCipherColumn(tableName, logicEncryptColumnName));
         }
         return encryptRule.getCipherColumn(tableName, logicEncryptColumnName);
     }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptProjectionTokenGeneratorTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.impl;
 
-import org.apache.shardingsphere.encrypt.fixture.TestEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptProjectionTokenGenerator;
+import org.apache.shardingsphere.encrypt.rule.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
@@ -120,7 +120,8 @@ public final class EncryptProjectionTokenGeneratorTest {
         when(encryptRule.findPlainColumn("doctor1", "mobile")).thenReturn(Optional.of("Mobile"));
         when(encryptRule.findEncryptTable("doctor")).thenReturn(Optional.of(encryptTable1));
         when(encryptRule.findEncryptTable("doctor1")).thenReturn(Optional.of(encryptTable2));
-        when(encryptRule.findEncryptor("doctor", "mobile")).thenReturn(Optional.of(new TestEncryptAlgorithm()));
+        EncryptColumn column = new EncryptColumn(null, "mobile", null, null, null, "mobile", null, null);
+        when(encryptRule.findEncryptColumn("doctor", "mobile")).thenReturn(Optional.of(column));
         return encryptRule;
     }
 }


### PR DESCRIPTION
Ref #15686.

Changes proposed in this pull request:
- optimize EncryptProjectionTokenGenerator logic to improve performance

Performance test result:

```java
Before

Benchmark                                                        Mode  Cnt     Score      Error   Units
EncryptProjectionTokenGeneratorBenchmark.testGenerateSQLTokens  thrpt    5  6602.248 ± 1211.224  ops/ms


After

Benchmark                                                        Mode  Cnt      Score      Error   Units
EncryptProjectionTokenGeneratorBenchmark.testGenerateSQLTokens  thrpt    5  20716.001 ± 2366.933  ops/ms
```

JMH source code:

```java
package com.strongduanmu.performance.encrypt.rewrite.token;

import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptPredicateColumnTokenGenerator;
import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptProjectionTokenGenerator;
import org.apache.shardingsphere.encrypt.rule.EncryptRule;
import org.apache.shardingsphere.infra.binder.SQLStatementContextFactory;
import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
import org.apache.shardingsphere.infra.parser.ShardingSphereSQLParserEngine;
import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
import org.apache.shardingsphere.parser.rule.SQLParserRule;
import org.apache.shardingsphere.sql.parser.api.CacheOption;
import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Threads;
import org.openjdk.jmh.annotations.Warmup;

import java.sql.Types;
import java.util.Collection;
import java.util.Collections;
import java.util.HashMap;
import java.util.Map;
import java.util.Optional;
import java.util.Properties;
import java.util.concurrent.TimeUnit;

import static java.util.Collections.emptyList;

/**
 * Encrypt predicate column token generator benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(5)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class EncryptProjectionTokenGeneratorBenchmark {
    
    private EncryptProjectionTokenGenerator tokenGenerator;
    
    private SQLStatementContext<?> sqlStatementContext;
    
    @Setup(Level.Trial)
    public void setUp() {
        EncryptRule encryptRule = createEncryptRule();
        ShardingSphereSchema schema = new ShardingSphereSchema();
        ColumnMetaData columnMetaData = new ColumnMetaData("encrypt_id", Types.INTEGER, false, false, false);
        schema.put("t_encrypt", new TableMetaData("t_encrypt", Collections.singletonList(columnMetaData), emptyList()));
        SQLStatement sqlStatement = createSqlStatement();
        Map<String, ShardingSphereMetaData> metaDataMap = new HashMap<>(1, 1);
        ShardingSphereResource resource = new ShardingSphereResource(Collections.emptyMap(), null, null, DatabaseTypeRegistry.getTrunkDatabaseType("MySQL"));
        ShardingSphereMetaData metaData = new ShardingSphereMetaData("sharding_db", resource, null, schema);
        metaDataMap.put("sharding_db", metaData);
        sqlStatementContext = SQLStatementContextFactory.newInstance(metaDataMap, Collections.emptyList(), sqlStatement, "sharding_db");
        tokenGenerator = new EncryptProjectionTokenGenerator();
        tokenGenerator.setEncryptRule(encryptRule);
        tokenGenerator.setSchema(schema);
    }
    
    private SQLStatement createSqlStatement() {
        CacheOption cacheOption = new CacheOption(65535, 2000, 4);
        Optional<SQLParserRule> sqlParserRule = Optional.of(new SQLParserRule(new SQLParserRuleConfiguration(false, cacheOption, cacheOption)));
        ShardingSphereSQLParserEngine sqlParserEngine = new ShardingSphereSQLParserEngine("MySQL", sqlParserRule.get());
        String sql = "SELECT password FROM t_encrypt WHERE encrypt_id = ?";
        return sqlParserEngine.parse(sql, true);
    }
    
    private EncryptRule createEncryptRule() {
        Collection<EncryptColumnRuleConfiguration> columns = Collections.singletonList(new EncryptColumnRuleConfiguration("password", "password", null, null, "TEST"));
        Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("t_encrypt", columns, true));
        Properties props = new Properties();
        props.setProperty("aes-key-value", "test13123");
        return new EncryptRule(new EncryptRuleConfiguration(tables, Collections.singletonMap("TEST", new ShardingSphereAlgorithmConfiguration("AES", props))), Collections.emptyMap());
    }
    
    @Benchmark
    public void testGenerateSQLTokens() {
        tokenGenerator.generateSQLTokens(sqlStatementContext);
    }
}

```