### PR TITLE
Fix precision match for timestamp

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValue.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValue.java
@@ -42,7 +42,7 @@ public final class MySQLDateBinaryProtocolValue implements MySQLBinaryProtocolVa
                 return getTimestampForDatetime(payload);
             case 11:
                 Timestamp result = getTimestampForDatetime(payload);
-                result.setNanos(payload.readInt4());
+                result.setNanos(payload.readInt4() * 1000);
                 return result;
             default:
                 throw new IllegalArgumentException(String.format("Wrong length '%d' of MYSQL_TYPE_TIME", length));

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
@@ -73,15 +73,17 @@ public final class MySQLDateBinaryProtocolValueTest {
     public void assertReadWithElevenBytes() throws SQLException {
         when(payload.readInt1()).thenReturn(11, 12, 31, 10, 59, 0);
         when(payload.readInt2()).thenReturn(2018);
-        when(payload.readInt4()).thenReturn(500);
+        when(payload.readInt4()).thenReturn(232323);
         Calendar actual = Calendar.getInstance();
-        actual.setTimeInMillis(((Timestamp) new MySQLDateBinaryProtocolValue().read(payload)).getTime());
+        Timestamp actualTimestamp = (Timestamp) new MySQLDateBinaryProtocolValue().read(payload);
+        actual.setTimeInMillis(actualTimestamp.getTime());
         assertThat(actual.get(Calendar.YEAR), is(2018));
         assertThat(actual.get(Calendar.MONTH), is(Calendar.DECEMBER));
         assertThat(actual.get(Calendar.DAY_OF_MONTH), is(31));
         assertThat(actual.get(Calendar.HOUR_OF_DAY), is(10));
         assertThat(actual.get(Calendar.MINUTE), is(59));
         assertThat(actual.get(Calendar.SECOND), is(0));
+        assertThat(actualTimestamp.getNanos(), is(232323000));
     }
     
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
## Fix precision match for timestamp

Fix  #11953.

Changes proposed in this pull request:
- Precision adaptation forMySQL.
