### PR TITLE
`DROP DEFAULT SINGLE TABLE RULE` syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
@@ -251,7 +251,7 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     
     @Override
     public ASTNode visitDropDefaultSingleTableRule(final DropDefaultSingleTableRuleContext ctx) {
-        return new DropDefaultSingleTableRuleStatement();
+        return new DropDefaultSingleTableRuleStatement(null != ctx.existClause());
     }
     
     private Properties getProperties(final PropertiesDefinitionContext ctx) {
@@ -269,7 +269,7 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     @Override
     public ASTNode visitDropResource(final DropResourceContext ctx) {
         boolean ignoreSingleTables = null != ctx.ignoreSingleTables();
-        return new DropResourceStatement(ctx.existClause() != null, 
+        return new DropResourceStatement(ctx.existClause() != null,
                 ctx.IDENTIFIER().stream().map(ParseTree::getText).map(each -> new IdentifierValue(each).getValue()).collect(Collectors.toList()), ignoreSingleTables);
     }
     

--- a/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/rdl/drop/DropDefaultSingleTableRuleStatement.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/rdl/drop/DropDefaultSingleTableRuleStatement.java
@@ -18,12 +18,16 @@
 package org.apache.shardingsphere.distsql.parser.statement.rdl.drop;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * Drop default single table rule statement.
  */
-@RequiredArgsConstructor
 @Getter
+@NoArgsConstructor
 public final class DropDefaultSingleTableRuleStatement extends DropRuleStatement {
+    
+    public DropDefaultSingleTableRuleStatement(final boolean containsExistClause) {
+        setContainsExistClause(containsExistClause);
+    }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/DropDefaultSingleTableRuleStatementUpdater.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/DropDefaultSingleTableRuleStatementUpdater.java
@@ -33,17 +33,25 @@ public final class DropDefaultSingleTableRuleStatementUpdater implements RuleDef
     public void checkSQLStatement(final ShardingSphereMetaData shardingSphereMetaData, final DropDefaultSingleTableRuleStatement sqlStatement,
                                   final SingleTableRuleConfiguration currentRuleConfig) throws DistSQLException {
         String schemaName = shardingSphereMetaData.getName();
-        checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
+        checkCurrentRuleConfiguration(schemaName, sqlStatement, currentRuleConfig);
     }
     
-    private void checkCurrentRuleConfiguration(final String schemaName, final SingleTableRuleConfiguration currentRuleConfig) throws DistSQLException {
-        DistSQLException.predictionThrow(null != currentRuleConfig && currentRuleConfig.getDefaultDataSource().isPresent(), new RequiredRuleMissedException("single table", schemaName));
+    private void checkCurrentRuleConfiguration(final String schemaName, final DropDefaultSingleTableRuleStatement sqlStatement,
+                                               final SingleTableRuleConfiguration currentRuleConfig) throws DistSQLException {
+        if (!sqlStatement.isContainsExistClause()) {
+            DistSQLException.predictionThrow(null != currentRuleConfig && currentRuleConfig.getDefaultDataSource().isPresent(), new RequiredRuleMissedException("single table", schemaName));
+        }
     }
     
     @Override
     public boolean updateCurrentRuleConfiguration(final DropDefaultSingleTableRuleStatement sqlStatement, final SingleTableRuleConfiguration currentRuleConfig) {
         currentRuleConfig.setDefaultDataSource(null);
         return false;
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropDefaultSingleTableRuleStatement sqlStatement, final SingleTableRuleConfiguration currentRuleConfig) {
+        return null != currentRuleConfig && currentRuleConfig.getDefaultDataSource().isPresent();
     }
     
     @Override

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/DropDefaultSingleTableRuleUpdaterTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/DropDefaultSingleTableRuleUpdaterTest.java
@@ -63,6 +63,14 @@ public final class DropDefaultSingleTableRuleUpdaterTest {
     }
     
     @Test
+    public void assertCheckWithIfExists() throws Exception {
+        DropDefaultSingleTableRuleStatement statement = new DropDefaultSingleTableRuleStatement(true);
+        SingleTableRuleConfiguration currentConfiguration = new SingleTableRuleConfiguration();
+        updater.checkSQLStatement(shardingSphereMetaData, statement, currentConfiguration);
+        updater.checkSQLStatement(shardingSphereMetaData, statement, null);
+    }
+    
+    @Test
     public void assertUpdate() {
         DropDefaultSingleTableRuleStatement statement = new DropDefaultSingleTableRuleStatement();
         SingleTableRuleConfiguration currentConfiguration = new SingleTableRuleConfiguration();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropDefaultSingleTableRuleAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropDefaultSingleTableRuleAssert.java
@@ -23,8 +23,10 @@ import org.apache.shardingsphere.distsql.parser.statement.rdl.drop.DropDefaultSi
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.rdl.drop.DropDefaultSingleTableRuleStatementTestCase;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * Drop default single table rule statement assert.
@@ -39,12 +41,13 @@ public final class DropDefaultSingleTableRuleAssert {
      * @param actual actual drop default single table rule statement
      * @param expected expected drop default single table rule statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final DropDefaultSingleTableRuleStatement actual, 
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DropDefaultSingleTableRuleStatement actual,
                                 final DropDefaultSingleTableRuleStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
+            assertThat(assertContext.getText("Actual statement should exist."), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropDefaultSingleTableRuleStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropDefaultSingleTableRuleStatementTestCase.java
@@ -21,10 +21,16 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
+import javax.xml.bind.annotation.XmlAttribute;
+
 /**
  * Drop default single table rule statement test case.
  */
 @Getter
 @Setter
 public final class DropDefaultSingleTableRuleStatementTestCase extends SQLParserTestCase {
+   
+    @XmlAttribute(name = "contains-exist-clause")
+    private boolean containsExistClause;
+    
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -105,6 +105,8 @@
     </drop-shadow-algorithm>
 
     <drop-default-single-table sql-case-id="drop-default-single-table" />
+    
+    <drop-default-single-table sql-case-id="drop-default-single-table-if-exists" contains-exist-clause="true"/>
 
     <drop-sharding-key-generator sql-case-id="drop-sharding-key-generator" >
         <key-generator>uuid_key_generator</key-generator>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -37,6 +37,7 @@
     <distsql-case id="drop-shadow-algorithm" value="DROP SHADOW algorithm shadow_algorithm_1,shadow_algorithm_2" />
     <distsql-case id="drop-shadow-algorithm-if-exists" value="DROP SHADOW ALGORITHM IF EXISTS shadow_algorithm_1,shadow_algorithm_2" />
     <distsql-case id="drop-default-single-table" value="DROP DEFAULT SINGLE TABLE RULE" />
+    <distsql-case id="drop-default-single-table-if-exists" value="DROP DEFAULT SINGLE TABLE RULE IF EXISTS" />
     <distsql-case id="drop-sharding-key-generator" value="DROP SHARDING KEY GENERATOR uuid_key_generator" />
     <distsql-case id="drop-default-sharding-strategy" value="DROP DEFAULT SHARDING TABLE STRATEGY" />
     <distsql-case id="drop-sharding-scaling-rule" value="DROP SHARDING SCALING RULE default_scaling" />


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/15623.

Changes proposed in this pull request:
- `DROP DEFAULT SINGLE TABLE RULE` syntax adds `IF EXISTS` keyword.

**Test**

<img width="414" alt="image" src="https://user-images.githubusercontent.com/52209337/156741962-4083ab00-e7de-4bcd-b84b-5b44d10df8d2.png">
