### PR TITLE
Fix wrong metadata when config single dataSource for ReadwriteSplitting

### DIFF
--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
@@ -48,8 +48,8 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
         RouteContext result = new RouteContext();
         if (1 == metaData.getResource().getDataSources().size()) {
             String logicDataSource = rule.getDataSourceNames().iterator().next();
-            String actualDataSourceName = metaData.getResource().getDataSources().keySet().iterator().next();
-            result.getRouteUnits().add(new RouteUnit(new RouteMapper(logicDataSource, actualDataSourceName), Collections.emptyList()));
+            String actualDataSource = metaData.getResource().getDataSources().keySet().iterator().next();
+            result.getRouteUnits().add(new RouteUnit(new RouteMapper(logicDataSource, actualDataSource), Collections.emptyList()));
         } else {
             route(logicSQL.getSqlStatementContext(), rule, result, props);
         }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
@@ -47,8 +47,9 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
     public RouteContext createRouteContext(final LogicSQL logicSQL, final ShardingSphereMetaData metaData, final SingleTableRule rule, final ConfigurationProperties props) {
         RouteContext result = new RouteContext();
         if (1 == metaData.getResource().getDataSources().size()) {
-            String singleDataSourceName = metaData.getResource().getDataSources().keySet().iterator().next();
-            result.getRouteUnits().add(new RouteUnit(new RouteMapper(singleDataSourceName, singleDataSourceName), Collections.emptyList()));
+            String logicDataSource = rule.getDataSourceNames().iterator().next();
+            String actualDataSourceName = metaData.getResource().getDataSources().keySet().iterator().next();
+            result.getRouteUnits().add(new RouteUnit(new RouteMapper(logicDataSource, actualDataSourceName), Collections.emptyList()));
         } else {
             route(logicSQL.getSqlStatementContext(), rule, result, props);
         }


### PR DESCRIPTION
Fixes #15799.

Changes proposed in this pull request:
- fix wrong metadata when config single dataSource for ReadwriteSplitting
- add unit test for SingleTableSQLRouter
