### PR TITLE
`DROP READWRITE_SPLITTING RULE` syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/DropReadwriteSplittingRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/DropReadwriteSplittingRuleStatementUpdater.java
@@ -92,7 +92,6 @@ public final class DropReadwriteSplittingRuleStatementUpdater implements RuleDef
     public boolean hasAnyOneToBeDropped(final DropReadwriteSplittingRuleStatement sqlStatement, final ReadwriteSplittingRuleConfiguration currentRuleConfig) {
         return null != currentRuleConfig
                 && !getIdenticalData(currentRuleConfig.getDataSources().stream().map(each -> each.getName()).collect(Collectors.toSet()), sqlStatement.getRuleNames()).isEmpty();
-        
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/imports/readwrite-splitting/Keyword.g4
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/imports/readwrite-splitting/Keyword.g4
@@ -114,3 +114,11 @@ DISABLE
 READ
    : R E A D
    ;
+
+IF
+    : I F
+    ;
+    
+EXISTS
+    : E X I S T S
+    ;  

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/imports/readwrite-splitting/RDLStatement.g4
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/antlr4/imports/readwrite-splitting/RDLStatement.g4
@@ -28,7 +28,7 @@ alterReadwriteSplittingRule
     ;
 
 dropReadwriteSplittingRule
-    : DROP READWRITE_SPLITTING RULE ruleName (COMMA ruleName)*
+    : DROP READWRITE_SPLITTING RULE existClause? ruleName (COMMA ruleName)*
     ;
 
 readwriteSplittingRuleDefinition
@@ -69,4 +69,8 @@ algorithmProperties
 
 algorithmProperty
     : key=(IDENTIFIER | STRING) EQ value=(NUMBER | INT | STRING)
+    ;
+
+existClause
+    : IF EXISTS
     ;

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
@@ -71,7 +71,7 @@ public final class ReadwriteSplittingDistSQLStatementVisitor extends ReadwriteSp
     
     @Override
     public ASTNode visitDropReadwriteSplittingRule(final DropReadwriteSplittingRuleContext ctx) {
-        return new DropReadwriteSplittingRuleStatement(ctx.ruleName().stream().map(each -> getIdentifierValue(each)).collect(Collectors.toList()));
+        return new DropReadwriteSplittingRuleStatement(ctx.existClause() != null, ctx.ruleName().stream().map(each -> getIdentifierValue(each)).collect(Collectors.toList()));
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/DropReadwriteSplittingRuleStatement.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/DropReadwriteSplittingRuleStatement.java
@@ -26,9 +26,14 @@ import java.util.Collection;
 /**
  * Drop readwrite splitting rule statement.
  */
-@RequiredArgsConstructor
 @Getter
+@RequiredArgsConstructor
 public final class DropReadwriteSplittingRuleStatement extends DropRuleStatement {
     
     private final Collection<String> ruleNames;
+    
+    public DropReadwriteSplittingRuleStatement(final boolean containsExistClause, final Collection<String> ruleNames) {
+        setContainsExistClause(containsExistClause);
+        this.ruleNames = ruleNames;
+    }
 }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/DropReadwriteSplittingRuleStatement.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/DropReadwriteSplittingRuleStatement.java
@@ -26,8 +26,8 @@ import java.util.Collection;
 /**
  * Drop readwrite splitting rule statement.
  */
-@Getter
 @RequiredArgsConstructor
+@Getter
 public final class DropReadwriteSplittingRuleStatement extends DropRuleStatement {
     
     private final Collection<String> ruleNames;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropReadwriteSplittingRuleStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropReadwriteSplittingRuleStatementAssert.java
@@ -47,6 +47,7 @@ public final class DropReadwriteSplittingRuleStatementAssert {
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
             assertThat(assertContext.getText("readwrite splitting assertion error: "), actual.getRuleNames(), is(expected.getRules()));
+            assertThat(assertContext.getText("readwrite splitting assertion error: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/DropRuleStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/DropRuleStatementTestCase.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement;
 
 import lombok.Getter;
+import lombok.Setter;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
 @Getter
+@Setter
 public abstract class DropRuleStatementTestCase extends SQLParserTestCase {
     
     @XmlAttribute(name = "contains-exists-clause")

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropReadwriteSplittingRuleStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropReadwriteSplittingRuleStatementTestCase.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.DropRuleStatementTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
 import java.util.LinkedList;
@@ -30,7 +30,7 @@ import java.util.List;
  */
 @Getter
 @Setter
-public final class DropReadwriteSplittingRuleStatementTestCase extends SQLParserTestCase {
+public final class DropReadwriteSplittingRuleStatementTestCase extends DropRuleStatementTestCase {
     
     @XmlElement(name = "rule")
     private List<String> rules = new LinkedList<>();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -53,6 +53,11 @@
         <rule>ms_group_0</rule>
         <rule>ms_group_1</rule>
     </drop-readwrite-splitting-rule>
+
+    <drop-readwrite-splitting-rule sql-case-id="drop-readwrite-splitting-rule-if-exists" contains-exists-clause="true">
+        <rule>ms_group_0</rule>
+        <rule>ms_group_1</rule>
+    </drop-readwrite-splitting-rule>
     
     <drop-database-discovery-rule sql-case-id="drop-database-discovery-rule">
         <rule>ha_group_0</rule>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -26,6 +26,7 @@
     <distsql-case id="drop-sharding-broadcast-table-rules" value="DROP SHARDING BROADCAST TABLE RULES" />
     <distsql-case id="drop-sharding-broadcast-table-specified-table" value="DROP SHARDING BROADCAST TABLE RULES t_order" />
     <distsql-case id="drop-readwrite-splitting-rule" value="DROP READWRITE_SPLITTING RULE ms_group_0,ms_group_1" />
+    <distsql-case id="drop-readwrite-splitting-rule-if-exists" value="DROP READWRITE_SPLITTING RULE IF EXISTS ms_group_0,ms_group_1" />
     <distsql-case id="drop-database-discovery-rule" value="DROP DB_DISCOVERY RULE ha_group_0,ha_group_1" />
     <distsql-case id="drop-database-discovery-rule-if-exists" value="DROP DB_DISCOVERY RULE IF EXISTS ha_group_0,ha_group_1" />
     <distsql-case id="drop-database-discovery-type" value="DROP DB_DISCOVERY TYPE type_name_0,type_name_1" />


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/15623

Changes proposed in this pull request:
- `DROP READWRITE_SPLITTING RULE` syntax adds `IF EXISTS` keyword.


<img width="996" alt="image" src="https://user-images.githubusercontent.com/52209337/157159263-7c1d75ad-fe1e-4197-adfb-2c4a158cf258.png">
