### PR TITLE
`ADD/ALTER RESOURCE` syntax supports using `password` as password

### DIFF
--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RDLStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RDLStatement.g4
@@ -80,7 +80,7 @@ password
     | TILDE | NOT | AT | POUND | DL | MOD | CARET 
     | AMPERSAND | ASTERISK | LP | RP | UL | MINUS | PLUS 
     | EQ| LBE | RBE | LBT | RBT | SLASH | LT | GT | COMMA 
-    | DOT | SEMI | QUESTION | SQ | COLON | VERTICALBAR                    
+    | DOT | SEMI | QUESTION | SQ | COLON | VERTICALBAR | PASSWORD                    
     ;
 
 ignoreSingleTables


### PR DESCRIPTION
Changes proposed in this pull request:
- `ADD/ALTER RESOURCE` syntax supports using `password` as password
