### PR TITLE
`DROP SHARDING BINDING` TABLE RULES syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingBindingTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingBindingTableRuleStatementUpdater.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.sharding.distsql.parser.statement.CreateShardin
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.stream.Collectors;
 
 /**
@@ -56,7 +57,7 @@ public final class CreateShardingBindingTableRuleStatementUpdater implements Rul
     private void checkToBeCreatedBindingTables(final String schemaName, final CreateShardingBindingTableRulesStatement sqlStatement,
                                                final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         Collection<String> currentLogicTables = getCurrentLogicTables(currentRuleConfig);
-        Collection<String> notExistedBindingTables = sqlStatement.getBindingTables().stream().filter(each -> !currentLogicTables.contains(each)).collect(Collectors.toSet());
+        Collection<String> notExistedBindingTables = sqlStatement.getBindingTables().stream().filter(each -> !currentLogicTables.contains(each)).collect(Collectors.toCollection(LinkedHashSet::new));
         DistSQLException.predictionThrow(notExistedBindingTables.isEmpty(), new RequiredRuleMissedException("Sharding", schemaName, notExistedBindingTables));
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
@@ -104,6 +104,9 @@ public final class DropShardingBindingTableRuleStatementUpdater implements RuleD
     
     private Collection<String> getExistedBindingGroups(final DropShardingBindingTableRulesStatement sqlStatement, final Map<String, String> bindingTableRules) {
         Collection<String> result = new LinkedList<>();
+        if (sqlStatement.getRules().isEmpty()) {
+            return new LinkedHashSet<>(bindingTableRules.values());
+        }
         for (BindingTableRuleSegment each : sqlStatement.getRules()) {
             if (isToBeDroppedRuleExists(each, bindingTableRules)) {
                 result.add(each.getTableGroups());

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
@@ -99,10 +99,10 @@ public final class DropShardingBindingTableRuleStatementUpdater implements RuleD
         if (bindingTableRules.isEmpty()) {
             bindingTableRules = buildBindingTableRule(currentRuleConfig);
         }
-        return !getExistBindingGroups(sqlStatement, bindingTableRules).isEmpty();
+        return !getExistedBindingGroups(sqlStatement, bindingTableRules).isEmpty();
     }
     
-    private Collection<String> getExistBindingGroups(final DropShardingBindingTableRulesStatement sqlStatement, final Map<String, String> bindingTableRules) {
+    private Collection<String> getExistedBindingGroups(final DropShardingBindingTableRulesStatement sqlStatement, final Map<String, String> bindingTableRules) {
         Collection<String> result = new LinkedList<>();
         for (BindingTableRuleSegment each : sqlStatement.getRules()) {
             if (isToBeDroppedRuleExists(each, bindingTableRules)) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBindingTableRuleStatementUpdater.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.sharding.distsql.parser.statement.DropShardingB
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -40,12 +41,15 @@ import java.util.Optional;
  */
 public final class DropShardingBindingTableRuleStatementUpdater implements RuleDefinitionDropUpdater<DropShardingBindingTableRulesStatement, ShardingRuleConfiguration> {
     
-    private Map<String, String> bindingTableRules;
+    private Map<String, String> bindingTableRules = Collections.emptyMap();
     
     @Override
     public void checkSQLStatement(final ShardingSphereMetaData shardingSphereMetaData, final DropShardingBindingTableRulesStatement sqlStatement,
                                   final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         String schemaName = shardingSphereMetaData.getName();
+        if (!isExistRuleConfig(currentRuleConfig) && sqlStatement.isContainsExistClause()) {
+            return;
+        }
         checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
         bindingTableRules = buildBindingTableRule(currentRuleConfig);
         checkBindingTableRuleExist(schemaName, sqlStatement, bindingTableRules);
@@ -63,6 +67,9 @@ public final class DropShardingBindingTableRuleStatementUpdater implements RuleD
     
     private void checkBindingTableRuleExist(final String schemaName, final DropShardingBindingTableRulesStatement sqlStatement,
                                             final Map<String, String> bindingRelationship) throws DistSQLException {
+        if (sqlStatement.isContainsExistClause()) {
+            return;
+        }
         Collection<String> notExistBindingGroups = new LinkedList<>();
         for (BindingTableRuleSegment each : sqlStatement.getRules()) {
             if (!isToBeDroppedRuleExists(each, bindingRelationship)) {
@@ -82,6 +89,27 @@ public final class DropShardingBindingTableRuleStatementUpdater implements RuleD
             }
         }
         return false;
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropShardingBindingTableRulesStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
+        if (!isExistRuleConfig(currentRuleConfig)) {
+            return false;
+        }
+        if (bindingTableRules.isEmpty()) {
+            bindingTableRules = buildBindingTableRule(currentRuleConfig);
+        }
+        return !getExistBindingGroups(sqlStatement, bindingTableRules).isEmpty();
+    }
+    
+    private Collection<String> getExistBindingGroups(final DropShardingBindingTableRulesStatement sqlStatement, final Map<String, String> bindingTableRules) {
+        Collection<String> result = new LinkedList<>();
+        for (BindingTableRuleSegment each : sqlStatement.getRules()) {
+            if (isToBeDroppedRuleExists(each, bindingTableRules)) {
+                result.add(each.getTableGroups());
+            }
+        }
+        return result;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
@@ -76,7 +76,7 @@ dropShardingTableRule
     ;
 
 dropShardingBindingTableRules
-    : DROP SHARDING BINDING TABLE RULES (bindTableRulesDefinition (COMMA bindTableRulesDefinition)*)?
+    : DROP SHARDING BINDING TABLE RULES existsClause? (bindTableRulesDefinition (COMMA bindTableRulesDefinition)*)?
     ;
 
 dropShardingBroadcastTableRules

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -202,7 +202,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     public ASTNode visitDropShardingBindingTableRules(final DropShardingBindingTableRulesContext ctx) {
         Collection<BindingTableRuleSegment> tableNames = null == ctx.bindTableRulesDefinition() ? Collections.emptyList()
                 : createBindingTableRuleSegment(ctx.bindTableRulesDefinition());
-        return new DropShardingBindingTableRulesStatement(tableNames);
+        return new DropShardingBindingTableRulesStatement(null != ctx.existsClause(), tableNames);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropShardingBindingTableRulesStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropShardingBindingTableRulesStatement.java
@@ -34,6 +34,11 @@ public final class DropShardingBindingTableRulesStatement extends DropRuleStatem
     
     private final Collection<BindingTableRuleSegment> rules;
     
+    public DropShardingBindingTableRulesStatement(final boolean containsExistClause, final Collection<BindingTableRuleSegment> rules) {
+        setContainsExistClause(containsExistClause);
+        this.rules = rules;
+    }
+    
     /**
      * Get binding groups.
      *

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingBindingTableRulesStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingBindingTableRulesStatementAssert.java
@@ -43,5 +43,6 @@ public final class DropShardingBindingTableRulesStatementAssert {
     public static void assertIs(final SQLCaseAssertContext assertContext, final DropShardingBindingTableRulesStatement actual, final DropShardingBindingTableRulesStatementTestCase expected) {
         assertNotNull(assertContext.getText("Actual statement should exist."), actual);
         assertThat(assertContext.getText("Binding table rule assertion error: "), actual.getBindingGroups(), is(expected.getRules()));
+        assertThat(assertContext.getText("Binding table rule assertion error: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingBindingTableRulesStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingBindingTableRulesStatementTestCase.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.DropRuleStatementTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
 import java.util.LinkedList;
@@ -30,7 +30,7 @@ import java.util.List;
  */
 @Setter
 @Getter
-public final class DropShardingBindingTableRulesStatementTestCase extends SQLParserTestCase {
+public final class DropShardingBindingTableRulesStatementTestCase extends DropRuleStatementTestCase {
     
     @XmlElement(name = "rule")
     private final List<String> rules = new LinkedList<>();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -43,6 +43,10 @@
         <rule>t_1,t_2</rule>
     </drop-sharding-binding-table-rules>
 
+    <drop-sharding-binding-table-rules sql-case-id="drop-sharding-binding-table-specified-rules-if-exists" contains-exists-clause="true">
+        <rule>t_1,t_2</rule>
+    </drop-sharding-binding-table-rules>
+    
     <drop-sharding-broadcast-table-rules sql-case-id="drop-sharding-broadcast-table-rules" />
 
     <drop-sharding-broadcast-table-rules sql-case-id="drop-sharding-broadcast-table-specified-table" >

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -23,6 +23,7 @@
     <distsql-case id="drop-sharding-table-rule" value="DROP SHARDING TABLE RULE t_order,t_order_item" />
     <distsql-case id="drop-sharding-binding-table-rules" value="DROP SHARDING BINDING TABLE RULES" />
     <distsql-case id="drop-sharding-binding-table-specified-rules" value="DROP SHARDING BINDING TABLE RULES (t_1,t_2)" />
+    <distsql-case id="drop-sharding-binding-table-specified-rules-if-exists" value="DROP SHARDING BINDING TABLE RULES IF EXISTS (t_1,t_2)" />
     <distsql-case id="drop-sharding-broadcast-table-rules" value="DROP SHARDING BROADCAST TABLE RULES" />
     <distsql-case id="drop-sharding-broadcast-table-specified-table" value="DROP SHARDING BROADCAST TABLE RULES t_order" />
     <distsql-case id="drop-readwrite-splitting-rule" value="DROP READWRITE_SPLITTING RULE ms_group_0,ms_group_1" />


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/15623

Changes proposed in this pull request:
- `DROP SHARDING BINDING` TABLE RULES syntax adds `IF EXISTS` keyword.
- Add tests.

<img width="617" alt="image" src="https://user-images.githubusercontent.com/52209337/157207640-a8644cf1-d7b2-4c54-bcab-cf1d320ee630.png">

