### PR TITLE
`DROP SHARDING BROADCAST TABLE RULE` syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBroadcastTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBroadcastTableRuleStatementUpdater.java
@@ -62,6 +62,9 @@ public final class DropShardingBroadcastTableRuleStatementUpdater implements Rul
     
     @Override
     public boolean hasAnyOneToBeDropped(final DropShardingBroadcastTableRulesStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
+        if (sqlStatement.getRules().isEmpty()) {
+            return true;
+        }
         return isExistRuleConfig(currentRuleConfig) && !getIdenticalData(currentRuleConfig.getBroadcastTables(), sqlStatement.getRules()).isEmpty();
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBroadcastTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingBroadcastTableRuleStatementUpdater.java
@@ -37,12 +37,18 @@ public final class DropShardingBroadcastTableRuleStatementUpdater implements Rul
     public void checkSQLStatement(final ShardingSphereMetaData shardingSphereMetaData, final DropShardingBroadcastTableRulesStatement sqlStatement,
                                   final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         String schemaName = shardingSphereMetaData.getName();
+        if (!isExistRuleConfig(currentRuleConfig) && sqlStatement.isContainsExistClause()) {
+            return;
+        }
         checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
         checkBroadCastTableRuleExist(schemaName, sqlStatement, currentRuleConfig);
     }
     
     private void checkBroadCastTableRuleExist(final String schemaName, final DropShardingBroadcastTableRulesStatement sqlStatement,
                                               final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
+        if (sqlStatement.isContainsExistClause()) {
+            return;
+        }
         if (!sqlStatement.getRules().isEmpty()) {
             Collection<String> currentRules = currentRuleConfig.getBroadcastTables();
             LinkedList<String> notExistRules = sqlStatement.getRules().stream().filter(each -> !currentRules.contains(each)).collect(Collectors.toCollection(LinkedList::new));
@@ -52,6 +58,11 @@ public final class DropShardingBroadcastTableRuleStatementUpdater implements Rul
     
     private void checkCurrentRuleConfiguration(final String schemaName, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         DistSQLException.predictionThrow(null != currentRuleConfig, new RequiredRuleMissedException("Broadcast", schemaName));
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropShardingBroadcastTableRulesStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
+        return isExistRuleConfig(currentRuleConfig) && !getIdenticalData(currentRuleConfig.getBroadcastTables(), sqlStatement.getRules()).isEmpty();
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingBroadcastTableRuleStatementUpdaterTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingBroadcastTableRuleStatementUpdaterTest.java
@@ -32,6 +32,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -50,6 +51,19 @@ public final class DropShardingBroadcastTableRuleStatementUpdaterTest {
     @Test(expected = RequiredRuleMissedException.class)
     public void assertCheckSQLStatementWithoutExistBroadcastTableRule() throws DistSQLException {
         updater.checkSQLStatement(shardingSphereMetaData, createSQLStatement("t_order"), new ShardingRuleConfiguration());
+    }
+    
+    @Test
+    public void assertCheckSQLStatementWithIfExists() throws DistSQLException {
+        updater.checkSQLStatement(shardingSphereMetaData, createSQLStatement(true, "t_order"), new ShardingRuleConfiguration());
+        updater.checkSQLStatement(shardingSphereMetaData, createSQLStatement(true, "t_order"), null);
+    }
+    
+    @Test
+    public void assertHasAnyOneToBeDropped() {
+        assertFalse(updater.hasAnyOneToBeDropped(createSQLStatement(true, "t_order"), new ShardingRuleConfiguration()));
+        assertFalse(updater.hasAnyOneToBeDropped(createSQLStatement(true, "t_order"), null));
+        assertTrue(updater.hasAnyOneToBeDropped(createSQLStatement(true, "t_order"), createCurrentRuleConfiguration()));
     }
     
     @Test(expected = RequiredRuleMissedException.class)
@@ -74,6 +88,11 @@ public final class DropShardingBroadcastTableRuleStatementUpdaterTest {
     private DropShardingBroadcastTableRulesStatement createSQLStatement(final String tableName) {
         return null == tableName ? new DropShardingBroadcastTableRulesStatement(Collections.emptyList())
                 : new DropShardingBroadcastTableRulesStatement(Collections.singleton(tableName));
+    }
+    
+    private DropShardingBroadcastTableRulesStatement createSQLStatement(final boolean containsExistClause, String tableName) {
+        return null == tableName ? new DropShardingBroadcastTableRulesStatement(Collections.emptyList())
+                : new DropShardingBroadcastTableRulesStatement(containsExistClause, Collections.singleton(tableName));
     }
     
     private ShardingRuleConfiguration createCurrentRuleConfiguration() {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingBroadcastTableRuleStatementUpdaterTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropShardingBroadcastTableRuleStatementUpdaterTest.java
@@ -90,7 +90,7 @@ public final class DropShardingBroadcastTableRuleStatementUpdaterTest {
                 : new DropShardingBroadcastTableRulesStatement(Collections.singleton(tableName));
     }
     
-    private DropShardingBroadcastTableRulesStatement createSQLStatement(final boolean containsExistClause, String tableName) {
+    private DropShardingBroadcastTableRulesStatement createSQLStatement(final boolean containsExistClause, final String tableName) {
         return null == tableName ? new DropShardingBroadcastTableRulesStatement(Collections.emptyList())
                 : new DropShardingBroadcastTableRulesStatement(containsExistClause, Collections.singleton(tableName));
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
@@ -80,7 +80,7 @@ dropShardingBindingTableRules
     ;
 
 dropShardingBroadcastTableRules
-    : DROP SHARDING BROADCAST TABLE RULES (tableName (COMMA tableName)*)?
+    : DROP SHARDING BROADCAST TABLE RULES existsClause? (tableName (COMMA tableName)*)?
     ;
 
 dropShardingAlgorithm

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -273,7 +273,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     public ASTNode visitDropShardingBroadcastTableRules(final DropShardingBroadcastTableRulesContext ctx) {
         Collection<String> tableNames = null == ctx.tableName() ? Collections.emptyList()
                 : ctx.tableName().stream().map(this::getIdentifierValue).collect(Collectors.toCollection(LinkedList::new));
-        return new DropShardingBroadcastTableRulesStatement(tableNames);
+        return new DropShardingBroadcastTableRulesStatement(null != ctx.existsClause(), tableNames);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropShardingBroadcastTableRulesStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropShardingBroadcastTableRulesStatement.java
@@ -31,4 +31,9 @@ import java.util.Collection;
 public final class DropShardingBroadcastTableRulesStatement extends DropRuleStatement {
     
     private final Collection<String> rules;
+    
+    public DropShardingBroadcastTableRulesStatement(final boolean containsExistClause, final Collection<String> rules) {
+        setContainsExistClause(containsExistClause);
+        this.rules = rules;
+    }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingBroadcastTableRulesStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingBroadcastTableRulesStatementAssert.java
@@ -47,6 +47,7 @@ public final class DropShardingBroadcastTableRulesStatementAssert {
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
             assertThat(assertContext.getText("readwrite splitting assertion error: "), actual.getRules(), is(expected.getTableName()));
+            assertThat(assertContext.getText("readwrite splitting assertion error: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingBroadcastTableRulesStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingBroadcastTableRulesStatementTestCase.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.DropRuleStatementTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
 import java.util.LinkedList;
@@ -30,7 +30,7 @@ import java.util.List;
  */
 @Getter
 @Setter
-public final class DropShardingBroadcastTableRulesStatementTestCase extends SQLParserTestCase {
+public final class DropShardingBroadcastTableRulesStatementTestCase extends DropRuleStatementTestCase {
     
     @XmlElement(name = "table")
     private final List<String> tableName = new LinkedList<>();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -49,6 +49,10 @@
         <table>t_order</table>
     </drop-sharding-broadcast-table-rules>
 
+    <drop-sharding-broadcast-table-rules sql-case-id="drop-sharding-broadcast-table-specified-table-if-exist" contains-exists-clause="true">
+        <table>t_order</table>
+    </drop-sharding-broadcast-table-rules>
+
     <drop-readwrite-splitting-rule sql-case-id="drop-readwrite-splitting-rule">
         <rule>ms_group_0</rule>
         <rule>ms_group_1</rule>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -25,6 +25,7 @@
     <distsql-case id="drop-sharding-binding-table-specified-rules" value="DROP SHARDING BINDING TABLE RULES (t_1,t_2)" />
     <distsql-case id="drop-sharding-broadcast-table-rules" value="DROP SHARDING BROADCAST TABLE RULES" />
     <distsql-case id="drop-sharding-broadcast-table-specified-table" value="DROP SHARDING BROADCAST TABLE RULES t_order" />
+    <distsql-case id="drop-sharding-broadcast-table-specified-table-if-exist" value="DROP SHARDING BROADCAST TABLE RULES IF EXISTS t_order" />
     <distsql-case id="drop-readwrite-splitting-rule" value="DROP READWRITE_SPLITTING RULE ms_group_0,ms_group_1" />
     <distsql-case id="drop-readwrite-splitting-rule-if-exists" value="DROP READWRITE_SPLITTING RULE IF EXISTS ms_group_0,ms_group_1" />
     <distsql-case id="drop-database-discovery-rule" value="DROP DB_DISCOVERY RULE ha_group_0,ha_group_1" />


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/15623

Changes proposed in this pull request:
- `DROP SHARDING BROADCAST TABLE RULE` syntax adds `IF EXISTS` keyword.


<img width="521" alt="image" src="https://user-images.githubusercontent.com/52209337/157214628-b1631806-e315-4e96-81dd-ad692716f5fe.png">
