### PR TITLE
add / to show correct xml path in testcases

### DIFF
--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/engine/parameter/SQLRewriteEngineTestParametersBuilder.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/engine/parameter/SQLRewriteEngineTestParametersBuilder.java
@@ -87,7 +87,7 @@ public final class SQLRewriteEngineTestParametersBuilder {
     
     private static void appendFromFile(final String type, final File file, final String path, final Map<String, RewriteAssertionsRootEntity> result) {
         if (file.getName().endsWith(".xml")) {
-            String key = path.toLowerCase().replace(type.toLowerCase() + "/", "") + file.getName();
+            String key = path.toLowerCase().replace(type.toLowerCase() + "/", "") + "/" + file.getName();
             result.put(key, new RewriteAssertionsRootEntityLoader().load(path + "/" + file.getName()));
         }
     }


### PR DESCRIPTION
Ref #15722

The original fix miss the `/` in xml path as below
![1646787385145](https://user-images.githubusercontent.com/25882819/157351714-41580c54-8574-4275-9002-bc1a7415b5c4.jpg)

Changes proposed in this pull request:
-add / to show correct xml path in testcases