### PR TITLE
`DROP DEFAULT SHARDING STRATEGY ` syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
@@ -67,9 +67,8 @@ public final class DropDefaultStrategyStatementUpdater implements RuleDefinition
     public boolean hasAnyOneToBeDropped(final DropDefaultShardingStrategyStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
         if (sqlStatement.getDefaultType().equalsIgnoreCase(ShardingStrategyLevelType.TABLE.name())) {
             return null != currentRuleConfig && null != currentRuleConfig.getDefaultTableShardingStrategy();
-        } else {
-            return null != currentRuleConfig && null != currentRuleConfig.getDefaultDatabaseShardingStrategy();
         }
+        return null != currentRuleConfig && null != currentRuleConfig.getDefaultDatabaseShardingStrategy();
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
@@ -37,11 +37,17 @@ public final class DropDefaultStrategyStatementUpdater implements RuleDefinition
     public void checkSQLStatement(final ShardingSphereMetaData shardingSphereMetaData, final DropDefaultShardingStrategyStatement sqlStatement,
                                   final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         String schemaName = shardingSphereMetaData.getName();
+        if (!isExistRuleConfig(currentRuleConfig) && sqlStatement.isContainsExistClause()) {
+            return;
+        }
         checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
         checkExist(schemaName, sqlStatement, currentRuleConfig);
     }
     
     private void checkExist(final String schemaName, final DropDefaultShardingStrategyStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
+        if (sqlStatement.isContainsExistClause()) {
+            return;
+        }
         Optional<ShardingStrategyConfiguration> strategyConfiguration = getStrategyConfiguration(currentRuleConfig, sqlStatement.getDefaultType());
         DistSQLException.predictionThrow(strategyConfiguration.isPresent(),
                 new RequiredRuleMissedException(String.format("Default sharding %s strategy", sqlStatement.getDefaultType().toLowerCase()), schemaName));
@@ -55,6 +61,15 @@ public final class DropDefaultStrategyStatementUpdater implements RuleDefinition
     
     private void checkCurrentRuleConfiguration(final String schemaName, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         DistSQLException.predictionThrow(currentRuleConfig != null, new RequiredRuleMissedException("Sharding", schemaName));
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropDefaultShardingStrategyStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
+        if (sqlStatement.getDefaultType().equalsIgnoreCase(ShardingStrategyLevelType.TABLE.name())) {
+            return null != currentRuleConfig && null != currentRuleConfig.getDefaultTableShardingStrategy();
+        } else {
+            return null != currentRuleConfig && null != currentRuleConfig.getDefaultDatabaseShardingStrategy();
+        }
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropDefaultShardingStrategyStatementUpdaterTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropDefaultShardingStrategyStatementUpdaterTest.java
@@ -50,6 +50,12 @@ public final class DropDefaultShardingStrategyStatementUpdaterTest {
     }
     
     @Test
+    public void assertCheckSQLStatementWithIfExists() throws DistSQLException {
+        updater.checkSQLStatement(shardingSphereMetaData, new DropDefaultShardingStrategyStatement(true, "table"), new ShardingRuleConfiguration());
+        updater.checkSQLStatement(shardingSphereMetaData, new DropDefaultShardingStrategyStatement(true, "table"), null);
+    }
+    
+    @Test
     public void assertUpdateCurrentRuleConfiguration() {
         ShardingRuleConfiguration currentRuleConfig = createCurrentRuleConfiguration();
         updater.updateCurrentRuleConfiguration(createSQLStatement("Database"), currentRuleConfig);

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/sharding/RDLStatement.g4
@@ -44,7 +44,7 @@ alterDefaultShardingStrategy
     ;
 
 dropDefaultShardingStrategy
-    : DROP DEFAULT SHARDING type=(DATABASE | TABLE) STRATEGY 
+    : DROP DEFAULT SHARDING type=(DATABASE | TABLE) STRATEGY existsClause?
     ;
 
 createShardingKeyGenerator

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -261,7 +261,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     
     @Override
     public ASTNode visitDropDefaultShardingStrategy(final DropDefaultShardingStrategyContext ctx) {
-        return new DropDefaultShardingStrategyStatement(new IdentifierValue(ctx.type.getText()).getValue().toLowerCase());
+        return new DropDefaultShardingStrategyStatement(null != ctx.existsClause(), new IdentifierValue(ctx.type.getText()).getValue().toLowerCase());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropDefaultShardingStrategyStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/DropDefaultShardingStrategyStatement.java
@@ -29,4 +29,9 @@ import org.apache.shardingsphere.distsql.parser.statement.rdl.drop.DropRuleState
 public final class DropDefaultShardingStrategyStatement extends DropRuleStatement {
     
     private final String defaultType;
+    
+    public DropDefaultShardingStrategyStatement(final boolean containsExistClause, final String defaultType) {
+        setContainsExistClause(containsExistClause);
+        this.defaultType = defaultType;
+    }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropDefaultShardingStrategyStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropDefaultShardingStrategyStatementAssert.java
@@ -47,6 +47,7 @@ public final class DropDefaultShardingStrategyStatementAssert {
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
             assertThat(assertContext.getText("default sharding strategy  assertion error: "), actual.getDefaultType(), is(expected.getDefaultType()));
+            assertThat(assertContext.getText("default sharding strategy  assertion error: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropDefaultShardingStrategyStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropDefaultShardingStrategyStatementTestCase.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.DropRuleStatementTestCase;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  */
 @Getter
 @Setter
-public final class DropDefaultShardingStrategyStatementTestCase extends SQLParserTestCase {
+public final class DropDefaultShardingStrategyStatementTestCase extends DropRuleStatementTestCase {
     
     @XmlAttribute(name = "type")
     private String defaultType;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -127,6 +127,8 @@
     </drop-sharding-key-generator>
     
     <drop-default-sharding-strategy sql-case-id="drop-default-sharding-strategy" type="table"/>
+    
+    <drop-default-sharding-strategy sql-case-id="drop-default-sharding-strategy-if-exists" type="table" contains-exists-clause="true"/>
 
     <drop-sharding-scaling-rule sql-case-id="drop-sharding-scaling-rule" scaling-name="default_scaling"/>
     

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -43,6 +43,7 @@
     <distsql-case id="drop-sharding-key-generator" value="DROP SHARDING KEY GENERATOR uuid_key_generator" />
     <distsql-case id="drop-sharding-key-generator-if-exists" value="DROP SHARDING KEY GENERATOR IF EXISTS uuid_key_generator" />
     <distsql-case id="drop-default-sharding-strategy" value="DROP DEFAULT SHARDING TABLE STRATEGY" />
+    <distsql-case id="drop-default-sharding-strategy-if-exists" value="DROP DEFAULT SHARDING TABLE STRATEGY IF EXISTS" />
     <distsql-case id="drop-sharding-scaling-rule" value="DROP SHARDING SCALING RULE default_scaling" />
     <distsql-case id="drop-sharding-algorithm" value="DROP SHARDING ALGORITHM IF EXISTS t_order_hash_mod" />
 </sql-cases>


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/15623

Changes proposed in this pull request:
- `DROP DEFAULT SHARDING STRATEGY ` syntax adds `IF EXISTS` keyword.


<img width="1069" alt="image" src="https://user-images.githubusercontent.com/52209337/157398831-1db4b73e-7741-4e8f-b9d9-dbec982fc7bd.png">
