### PR TITLE
`DROP SHARDING SCALING RULE` syntax adds `IF EXISTS` keyword.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropShardingScalingRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/DropShardingScalingRuleStatementUpdater.java
@@ -33,6 +33,9 @@ public final class DropShardingScalingRuleStatementUpdater implements RuleDefini
     public void checkSQLStatement(final ShardingSphereMetaData shardingSphereMetaData, final DropShardingScalingRuleStatement sqlStatement,
                                   final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
         String schemaName = shardingSphereMetaData.getName();
+        if (!isExistRuleConfig(currentRuleConfig) && sqlStatement.isContainsExistClause()) {
+            return;
+        }
         checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
         checkStatement(schemaName, sqlStatement, currentRuleConfig);
     }
@@ -49,9 +52,17 @@ public final class DropShardingScalingRuleStatementUpdater implements RuleDefini
     }
     
     private void checkExist(final String schemaName, final DropShardingScalingRuleStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
+        if (sqlStatement.isContainsExistClause()) {
+            return;
+        }
         if (!currentRuleConfig.getScaling().containsKey(sqlStatement.getScalingName())) {
             throw new RequiredRuleMissedException("Scaling", schemaName, sqlStatement.getScalingName());
         }
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropShardingScalingRuleStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
+        return isExistRuleConfig(currentRuleConfig) && currentRuleConfig.getScaling().containsKey(sqlStatement.getScalingName());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/scaling/distsql/handler/DropShardingScalingRuleStatementUpdaterTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/scaling/distsql/handler/DropShardingScalingRuleStatementUpdaterTest.java
@@ -57,6 +57,12 @@ public final class DropShardingScalingRuleStatementUpdaterTest {
     }
     
     @Test
+    public void assertCheckWithIfExists() throws DistSQLException {
+        updater.checkSQLStatement(shardingSphereMetaData, new DropShardingScalingRuleStatement(true, "default_scaling"), new ShardingRuleConfiguration());
+        updater.checkSQLStatement(shardingSphereMetaData, new DropShardingScalingRuleStatement(true, "default_scaling"), null);
+    }
+    
+    @Test
     public void assertCheckSuccess() throws DistSQLException {
         ShardingRuleConfiguration currentRuleConfig = new ShardingRuleConfiguration();
         currentRuleConfig.getScaling().put("default_scaling", null);

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/scaling/Keyword.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/scaling/Keyword.g4
@@ -158,3 +158,11 @@ ENABLE
 DISABLE
     : D I S A B L E
     ;
+
+IF
+    : I F
+    ;
+
+EXISTS
+    : E X I S T S
+    ;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/scaling/RDLStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/scaling/RDLStatement.g4
@@ -24,7 +24,7 @@ createShardingScalingRule
     ;
 
 dropShardingScalingRule
-    : DROP SHARDING SCALING RULE scalingName
+    : DROP SHARDING SCALING RULE existsClause? scalingName
     ;
 
 enableShardingScalingRule
@@ -77,4 +77,8 @@ streamChannel
 
 intValue
     : INT
+    ;
+
+existsClause
+    : IF EXISTS
     ;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/core/ScalingSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/scaling/distsql/parser/core/ScalingSQLStatementVisitor.java
@@ -225,7 +225,7 @@ public final class ScalingSQLStatementVisitor extends ScalingStatementBaseVisito
     
     @Override
     public ASTNode visitDropShardingScalingRule(final DropShardingScalingRuleContext ctx) {
-        return new DropShardingScalingRuleStatement(getIdentifierValue(ctx.scalingName()));
+        return new DropShardingScalingRuleStatement(null != ctx.existsClause(), getIdentifierValue(ctx.scalingName()));
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/DropShardingScalingRuleStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/scaling/distsql/statement/DropShardingScalingRuleStatement.java
@@ -29,4 +29,9 @@ import org.apache.shardingsphere.distsql.parser.statement.rdl.drop.DropRuleState
 public final class DropShardingScalingRuleStatement extends DropRuleStatement {
     
     private final String scalingName;
+    
+    public DropShardingScalingRuleStatement(final boolean containsExistClause, final String scalingName) {
+        setContainsExistClause(containsExistClause);
+        this.scalingName = scalingName;
+    }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingScalingRuleStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/rdl/drop/impl/DropShardingScalingRuleStatementAssert.java
@@ -48,6 +48,7 @@ public final class DropShardingScalingRuleStatementAssert {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
             assertThat(assertContext.getText(String.format("`%s`'s scaling name assertion error: ", actual.getClass().getSimpleName())), 
                     actual.getScalingName(), is(expected.getScalingName()));
+            assertThat(assertContext.getText("Contains exist clause assertion error: "), actual.isContainsExistClause(), is(expected.isContainsExistClause()));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingScalingRuleStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/rdl/drop/DropShardingScalingRuleStatementTestCase.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.DropRuleStatementTestCase;
 
 import javax.xml.bind.annotation.XmlAttribute;
 
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.XmlAttribute;
  */
 @Getter
 @Setter
-public final class DropShardingScalingRuleStatementTestCase extends SQLParserTestCase {
+public final class DropShardingScalingRuleStatementTestCase extends DropRuleStatementTestCase {
 
     @XmlAttribute(name = "scaling-name")
     private String scalingName;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/rdl/drop.xml
@@ -130,6 +130,8 @@
 
     <drop-sharding-scaling-rule sql-case-id="drop-sharding-scaling-rule" scaling-name="default_scaling"/>
     
+    <drop-sharding-scaling-rule sql-case-id="drop-sharding-scaling-rule-if-exists" scaling-name="default_scaling" contains-exists-clause="true"/>
+    
     <drop-sharding-algorithm sql-case-id="drop-sharding-algorithm" contains-exists-clause="true">
         <algorithm>t_order_hash_mod</algorithm>
     </drop-sharding-algorithm>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/rdl/drop.xml
@@ -44,5 +44,6 @@
     <distsql-case id="drop-sharding-key-generator-if-exists" value="DROP SHARDING KEY GENERATOR IF EXISTS uuid_key_generator" />
     <distsql-case id="drop-default-sharding-strategy" value="DROP DEFAULT SHARDING TABLE STRATEGY" />
     <distsql-case id="drop-sharding-scaling-rule" value="DROP SHARDING SCALING RULE default_scaling" />
+    <distsql-case id="drop-sharding-scaling-rule-if-exists" value="DROP SHARDING SCALING RULE IF EXISTS default_scaling" />
     <distsql-case id="drop-sharding-algorithm" value="DROP SHARDING ALGORITHM IF EXISTS t_order_hash_mod" />
 </sql-cases>


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/issues/15623

Changes proposed in this pull request:
- `DROP SHARDING SCALING RULE` syntax adds `IF EXISTS` keyword.
