### PR TITLE
Fix statement close exception when use BatchPreparedStatementExecutor

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/executor/batch/BatchPreparedStatementExecutor.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/executor/batch/BatchPreparedStatementExecutor.java
@@ -246,16 +246,9 @@ public final class BatchPreparedStatementExecutor {
      * @throws SQLException SQL exception
      */
     public void clear() throws SQLException {
-        closeStatements();
         getStatements().clear();
         executionGroupContext.getInputGroups().clear();
         batchCount = 0;
         batchExecutionUnits.clear();
-    }
-    
-    private void closeStatements() throws SQLException {
-        for (Statement each : getStatements()) {
-            each.close();
-        }
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/statement/ShardingSpherePreparedStatementTest.java
@@ -555,6 +555,24 @@ public final class ShardingSpherePreparedStatementTest extends AbstractShardingS
     }
     
     @Test
+    public void assertExecuteBatchRepeatedly() throws SQLException {
+        try (Connection connection = getShardingSphereDataSource().getConnection(); PreparedStatement preparedStatement = connection.prepareStatement(INSERT_WITH_GENERATE_KEY_SQL)) {
+            preparedStatement.setInt(1, 3101);
+            preparedStatement.setInt(2, 11);
+            preparedStatement.setInt(3, 11);
+            preparedStatement.setString(4, "BATCH");
+            preparedStatement.addBatch();
+            assertThat(preparedStatement.executeBatch().length, is(1));
+            preparedStatement.setInt(1, 3103);
+            preparedStatement.setInt(2, 13);
+            preparedStatement.setInt(3, 13);
+            preparedStatement.setString(4, "BATCH");
+            preparedStatement.addBatch();
+            assertThat(preparedStatement.executeBatch().length, is(1));
+        }
+    }
+    
+    @Test
     public void assertInitPreparedStatementExecutorWithReplayMethod() throws SQLException {
         try (PreparedStatement preparedStatement = getShardingSphereDataSource().getConnection().prepareStatement(SELECT_SQL_WITH_PARAMETER_MARKER)) {
             preparedStatement.setQueryTimeout(1);


### PR DESCRIPTION
Fixes #15968.

Changes proposed in this pull request:
- fix statement close exception when use BatchPreparedStatementExecutor
- add unit test for executeBatch repeatedly
