### PR TITLE
Optimize traffic rule getComputeNodeInstanceIds logic

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.instance;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.infra.instance.definition.InstanceType;
 import org.apache.shardingsphere.infra.instance.workerid.WorkerIdGenerator;
 import org.apache.shardingsphere.infra.state.StateContext;
@@ -27,6 +28,7 @@ import org.apache.shardingsphere.infra.state.StateType;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -141,13 +143,13 @@ public final class InstanceContext {
      * @param labels collection of contained label
      * @return compute node instances
      */
-    public Collection<ComputeNodeInstance> getComputeNodeInstances(final InstanceType instanceType, final Collection<String> labels) {
-        Collection<ComputeNodeInstance> result = new ArrayList<>(computeNodeInstances.size());
-        computeNodeInstances.forEach(each -> {
+    public List<InstanceId> getComputeNodeInstanceIds(final InstanceType instanceType, final Collection<String> labels) {
+        List<InstanceId> result = new ArrayList<>(computeNodeInstances.size());
+        for (ComputeNodeInstance each : computeNodeInstances) {
             if (each.getInstanceDefinition().getInstanceType() == instanceType && each.getLabels().stream().anyMatch(labels::contains)) {
-                result.add(each);
+                result.add(each.getInstanceDefinition().getInstanceId());
             }
-        });
+        }
         return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.instance;
 
 import lombok.Getter;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.infra.instance.definition.InstanceType;
@@ -146,7 +147,7 @@ public final class InstanceContext {
     public List<InstanceId> getComputeNodeInstanceIds(final InstanceType instanceType, final Collection<String> labels) {
         List<InstanceId> result = new ArrayList<>(computeNodeInstances.size());
         for (ComputeNodeInstance each : computeNodeInstances) {
-            if (each.getInstanceDefinition().getInstanceType() == instanceType && each.getLabels().stream().anyMatch(labels::contains)) {
+            if (each.getInstanceDefinition().getInstanceType() == instanceType && CollectionUtils.containsAny(labels, each.getLabels())) {
                 result.add(each.getInstanceDefinition().getInstanceId());
             }
         }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
@@ -23,8 +23,7 @@ import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.datasource.pool.creator.DataSourcePoolCreator;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMode;
-import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
-import org.apache.shardingsphere.infra.instance.definition.InstanceDefinition;
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.infra.instance.definition.InstanceType;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.mode.manager.ContextManager;
@@ -94,7 +93,7 @@ public final class ConnectionManagerTest {
         when(result.getMetaDataContexts().getMetaDataPersistService()).thenReturn(Optional.of(metaDataPersistService));
         when(result.getMetaDataContexts().getGlobalRuleMetaData().findSingleRule(TransactionRule.class)).thenReturn(Optional.empty());
         when(result.getMetaDataContexts().getGlobalRuleMetaData().findSingleRule(TrafficRule.class)).thenReturn(Optional.of(trafficRule));
-        when(result.getInstanceContext().getComputeNodeInstances(InstanceType.PROXY, Arrays.asList("OLTP", "OLAP"))).thenReturn(Collections.singletonList(mockComputeNodeInstance()));
+        when(result.getInstanceContext().getComputeNodeInstanceIds(InstanceType.PROXY, Arrays.asList("OLTP", "OLAP"))).thenReturn(Collections.singletonList(new InstanceId("127.0.0.1@3307")));
         dataSourcePoolCreator = mockStatic(DataSourcePoolCreator.class);
         Map<String, DataSource> trafficDataSourceMap = mockTrafficDataSourceMap();
         when(DataSourcePoolCreator.create((Map) any())).thenReturn(trafficDataSourceMap);
@@ -125,12 +124,6 @@ public final class ConnectionManagerTest {
         result.put("jdbcUrl", "jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false");
         result.put("username", "root");
         result.put("password", "123456");
-        return result;
-    }
-    
-    private ComputeNodeInstance mockComputeNodeInstance() {
-        ComputeNodeInstance result = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
-        result.setLabels(Collections.singletonList("OLTP"));
         return result;
     }
     

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-api/src/main/java/org/apache/shardingsphere/traffic/spi/TrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-api/src/main/java/org/apache/shardingsphere/traffic/spi/TrafficLoadBalanceAlgorithm.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.traffic.spi;
 
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.spi.required.RequiredSPI;
 
 import java.util.List;
@@ -34,5 +35,5 @@ public interface TrafficLoadBalanceAlgorithm extends ShardingSphereAlgorithm, Re
      * @param instanceIds instance id collection
      * @return instance id
      */
-    String getInstanceId(String name, List<String> instanceIds);
+    InstanceId getInstanceId(String name, List<InstanceId> instanceIds);
 }

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithm.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm;
 
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.concurrent.ThreadLocalRandom;
 public final class RandomTrafficLoadBalanceAlgorithm implements TrafficLoadBalanceAlgorithm {
     
     @Override
-    public String getInstanceId(final String name, final List<String> instanceIds) {
+    public InstanceId getInstanceId(final String name, final List<InstanceId> instanceIds) {
         return instanceIds.get(ThreadLocalRandom.current().nextInt(instanceIds.size()));
     }
     

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm;
 
 import java.util.List;
@@ -31,7 +32,7 @@ public final class RoundRobinTrafficLoadBalanceAlgorithm implements TrafficLoadB
     private static final ConcurrentHashMap<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
     
     @Override
-    public String getInstanceId(final String name, final List<String> instanceIds) {
+    public InstanceId getInstanceId(final String name, final List<InstanceId> instanceIds) {
         AtomicInteger count = COUNTS.containsKey(name) ? COUNTS.get(name) : new AtomicInteger(0);
         COUNTS.putIfAbsent(name, count);
         count.compareAndSet(instanceIds.size(), 0);

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/rule/TrafficRule.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/rule/TrafficRule.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -108,7 +109,7 @@ public final class TrafficRule implements GlobalRule {
             result = new TrafficStrategyRule(strategyConfig.getName(), Collections.emptyList(), trafficAlgorithm, null);
         } else {
             TrafficLoadBalanceAlgorithm loadBalancer = getLoadBalancer(loadBalancers, strategyConfig.getLoadBalancerName());
-            result = new TrafficStrategyRule(strategyConfig.getName(), strategyConfig.getLabels(), trafficAlgorithm, loadBalancer);
+            result = new TrafficStrategyRule(strategyConfig.getName(), new LinkedHashSet<>(strategyConfig.getLabels()), trafficAlgorithm, loadBalancer);
         }
         return result;
     }

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/engine/TrafficEngineTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/engine/TrafficEngineTest.java
@@ -18,9 +18,8 @@
 package org.apache.shardingsphere.traffic.algorithm.engine;
 
 import org.apache.shardingsphere.infra.binder.LogicSQL;
-import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
-import org.apache.shardingsphere.infra.instance.definition.InstanceDefinition;
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.infra.instance.definition.InstanceType;
 import org.apache.shardingsphere.traffic.context.TrafficContext;
 import org.apache.shardingsphere.traffic.engine.TrafficEngine;
@@ -32,10 +31,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -92,22 +91,19 @@ public final class TrafficEngineTest {
         when(trafficRule.findMatchedStrategyRule(logicSQL, false)).thenReturn(Optional.of(strategyRule));
         when(strategyRule.getLabels()).thenReturn(Arrays.asList("OLTP", "OLAP"));
         TrafficLoadBalanceAlgorithm loadBalancer = mock(TrafficLoadBalanceAlgorithm.class);
-        when(loadBalancer.getInstanceId("traffic", Arrays.asList("127.0.0.1@3307", "127.0.0.1@3308"))).thenReturn("127.0.0.1@3307");
+        List<InstanceId> instanceIds = mockComputeNodeInstances();
+        when(loadBalancer.getInstanceId("traffic", instanceIds)).thenReturn(new InstanceId("127.0.0.1@3307"));
         when(strategyRule.getLoadBalancer()).thenReturn(loadBalancer);
         when(strategyRule.getName()).thenReturn("traffic");
-        when(instanceContext.getComputeNodeInstances(InstanceType.PROXY, Arrays.asList("OLTP", "OLAP"))).thenReturn(mockComputeNodeInstances());
+        when(instanceContext.getComputeNodeInstanceIds(InstanceType.PROXY, Arrays.asList("OLTP", "OLAP"))).thenReturn(instanceIds);
         TrafficContext actual = trafficEngine.dispatch(logicSQL, false);
         assertThat(actual.getInstanceId(), is("127.0.0.1@3307"));
     }
     
-    private Collection<ComputeNodeInstance> mockComputeNodeInstances() {
-        Collection<ComputeNodeInstance> result = new LinkedList<>();
-        ComputeNodeInstance instanceOLAP = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
-        instanceOLAP.setLabels(Collections.singletonList("OLAP"));
-        result.add(instanceOLAP);
-        ComputeNodeInstance instanceOLTP = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3308"));
-        instanceOLTP.setLabels(Collections.singletonList("OLTP"));
-        result.add(instanceOLTP);
+    private List<InstanceId> mockComputeNodeInstances() {
+        List<InstanceId> result = new ArrayList<>();
+        result.add(new InstanceId("127.0.0.1@3307"));
+        result.add(new InstanceId("127.0.0.1@3308"));
         return result;
     }
 }

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithmTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithmTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -33,7 +34,7 @@ public final class RandomTrafficLoadBalanceAlgorithmTest {
     
     @Test
     public void assertGetInstanceId() {
-        List<String> instanceIds = Arrays.asList("127.0.0.1@3307", "127.0.0.1@3308");
+        List<InstanceId> instanceIds = Arrays.asList(new InstanceId("127.0.0.1@3307"), new InstanceId("127.0.0.1@3308"));
         assertTrue(instanceIds.contains(randomAlgorithm.getInstanceId("simple_traffic", instanceIds)));
         assertTrue(instanceIds.contains(randomAlgorithm.getInstanceId("simple_traffic", instanceIds)));
         assertTrue(instanceIds.contains(randomAlgorithm.getInstanceId("simple_traffic", instanceIds)));

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,9 +45,9 @@ public final class RoundRobinTrafficLoadBalanceAlgorithmTest {
     
     @Test
     public void assertGetInstanceId() {
-        String instanceId1 = "127.0.0.1@3307";
-        String instanceId2 = "127.0.0.1@3308";
-        List<String> instanceIds = Arrays.asList(instanceId1, instanceId2);
+        InstanceId instanceId1 = new InstanceId("127.0.0.1@3307");
+        InstanceId instanceId2 = new InstanceId("127.0.0.1@3308");
+        List<InstanceId> instanceIds = Arrays.asList(instanceId1, instanceId2);
         assertThat(roundRobinAlgorithm.getInstanceId("simple_traffic", instanceIds), is(instanceId1));
         assertThat(roundRobinAlgorithm.getInstanceId("simple_traffic", instanceIds), is(instanceId2));
         assertThat(roundRobinAlgorithm.getInstanceId("simple_traffic", instanceIds), is(instanceId1));

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/rule/TrafficRuleTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/rule/TrafficRuleTest.java
@@ -63,7 +63,7 @@ public final class TrafficRuleTest {
         Optional<TrafficStrategyRule> actual = trafficRule.findMatchedStrategyRule(createLogicSQL(true), false);
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("sql_hint_traffic"));
-        assertThat(actual.get().getLabels(), is(Arrays.asList("OLTP", "OLAP")));
+        assertThat(actual.get().getLabels(), is(Sets.newHashSet("OLTP", "OLAP")));
         assertThat(actual.get().getTrafficAlgorithm(), instanceOf(SQLHintTrafficAlgorithm.class));
         assertThat(actual.get().getLoadBalancer(), instanceOf(RandomTrafficLoadBalanceAlgorithm.class));
     }
@@ -81,7 +81,7 @@ public final class TrafficRuleTest {
         Optional<TrafficStrategyRule> actual = trafficRule.findMatchedStrategyRule(createLogicSQL(false), true);
         assertTrue(actual.isPresent());
         assertThat(actual.get().getName(), is("transaction_traffic"));
-        assertThat(actual.get().getLabels(), is(Collections.singletonList("OLAP")));
+        assertThat(actual.get().getLabels(), is(Sets.newHashSet("OLAP")));
         assertThat(actual.get().getTrafficAlgorithm(), instanceOf(ProxyTrafficAlgorithm.class));
         assertThat(actual.get().getLoadBalancer(), instanceOf(RandomTrafficLoadBalanceAlgorithm.class));
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/fixture/TestTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/fixture/TestTrafficLoadBalanceAlgorithm.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.backend.text.distsql.fixture;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm;
 
 import java.util.List;
@@ -36,7 +37,7 @@ public final class TestTrafficLoadBalanceAlgorithm implements TrafficLoadBalance
     }
     
     @Override
-    public String getInstanceId(final String name, final List<String> instanceIds) {
+    public InstanceId getInstanceId(final String name, final List<InstanceId> instanceIds) {
         return null;
     }
 }


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/14282.

Changes proposed in this pull request:
- optimize traffic rule getComputeNodeInstanceIds logic
- update unit test

performance test result:

```
Before

Benchmark                                                Mode  Cnt      Score     Error   Units
InstanceContextBenchmark.testGetComputeNodeInstanceIds  thrpt    5  22192.722 ± 436.163  ops/ms

After 

Benchmark                                                Mode  Cnt      Score      Error   Units
InstanceContextBenchmark.testGetComputeNodeInstanceIds  thrpt    5  45254.699 ± 3584.312  ops/ms
```

JMH source code:

```java
package com.strongduanmu.performance.instance;

import com.google.common.collect.Sets;
import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
import org.apache.shardingsphere.infra.instance.InstanceContext;
import org.apache.shardingsphere.infra.instance.definition.InstanceDefinition;
import org.apache.shardingsphere.infra.instance.definition.InstanceType;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Threads;
import org.openjdk.jmh.annotations.Warmup;

import java.util.concurrent.TimeUnit;

/**
 * Instance context benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(10)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class InstanceContextBenchmark {
    
    private InstanceContext instanceContext;
    
    @Setup(Level.Trial)
    public void setUp() {
        instanceContext = new InstanceContext(new ComputeNodeInstance(null), null, null);
        ComputeNodeInstance instance1 = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
        instance1.setLabels(Sets.newHashSet("OLAP", "OLTP", "CAR", "GOODS", "ORDER"));
        instanceContext.getComputeNodeInstances().add(instance1);
        ComputeNodeInstance instance2 = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
        instance2.setLabels(Sets.newHashSet("OLAP", "OLTP"));
        instanceContext.getComputeNodeInstances().add(instance2);
        ComputeNodeInstance instance3 = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
        instance3.setLabels(Sets.newHashSet("OLAP", "CAR"));
        instanceContext.getComputeNodeInstances().add(instance3);
        ComputeNodeInstance instance4 = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
        instance4.setLabels(Sets.newHashSet("OLAP", "CAR"));
        instanceContext.getComputeNodeInstances().add(instance4);
        ComputeNodeInstance instance5 = new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"));
        instance5.setLabels(Sets.newHashSet("OLAP", "ORDER"));
        instanceContext.getComputeNodeInstances().add(instance5);
    }
    
    @Benchmark
    public void testGetComputeNodeInstanceIds() {
        instanceContext.getComputeNodeInstances(InstanceType.PROXY, Sets.newHashSet("OLAP", "CAR"));
    }
}
```