### PR TITLE
Improve the base version of H2Database's JDBC driver to 2.X.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -47,7 +47,7 @@
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <postgresql.version>42.3.3</postgresql.version>
-        <h2.version>1.4.196</h2.version>
+        <h2.version>2.1.210</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.10</logback.version>
         <lombok.version>1.18.20</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <commons-dbcp2.version>2.2.0</commons-dbcp2.version>
-        <h2.version>1.4.196</h2.version>
+        <h2.version>2.1.210</h2.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <postgresql.version>42.3.3</postgresql.version>
         <opengauss.version>2.0.1-compatibility</opengauss.version>


### PR DESCRIPTION
Fixes #15327 .

Changes proposed in this pull request:
- Improve the base version of H2Database's JDBC driver to 2.X.
- Using the JDBC driver of H2Database 1.X to access the server of H2Database 2.X will cause SQL execution failure. Therefore, the version is improved. See https://github.com/h2database/h2database/issues/2180 .
- Verify and fixes #14617 . 
