### PR TITLE
Fixes 15983, make the `if not exists` clause in `CREATE DATABASE` statement effective.

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/database/CreateDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/database/CreateDatabaseBackendHandler.java
@@ -43,7 +43,7 @@ public final class CreateDatabaseBackendHandler implements TextProtocolBackendHa
     }
     
     private void check(final CreateDatabaseStatement sqlStatement) {
-        if (ProxyContext.getInstance().getAllSchemaNames().contains(sqlStatement.getDatabaseName())) {
+        if (!sqlStatement.isContainsNotExistClause() && ProxyContext.getInstance().getAllSchemaNames().contains(sqlStatement.getDatabaseName())) {
             throw new DBCreateExistsException(sqlStatement.getDatabaseName());
         }
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/database/CreateDatabaseBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/database/CreateDatabaseBackendHandlerTest.java
@@ -55,7 +55,7 @@ public final class CreateDatabaseBackendHandlerTest {
         handler = new CreateDatabaseBackendHandler(statement);
         when(metaDataContexts.getAllSchemaNames()).thenReturn(Collections.singleton("test_db"));
     }
-
+    
     @SneakyThrows
     @Test
     public void assertExecuteCreateNewDatabase() {
@@ -63,11 +63,20 @@ public final class CreateDatabaseBackendHandlerTest {
         ResponseHeader responseHeader = handler.execute();
         Assert.assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
-
+    
     @SneakyThrows
     @Test(expected = DBCreateExistsException.class)
     public void assertExecuteCreateExistDatabase() {
         when(statement.getDatabaseName()).thenReturn("test_db");
+        ResponseHeader responseHeader = handler.execute();
+        Assert.assertTrue(responseHeader instanceof UpdateResponseHeader);
+    }
+    
+    @SneakyThrows
+    @Test
+    public void assertExecuteCreateExistDatabaseWithIfNotExists() {
+        when(statement.getDatabaseName()).thenReturn("test_db");
+        when(statement.isContainsNotExistClause()).thenReturn(true);
         ResponseHeader responseHeader = handler.execute();
         Assert.assertTrue(responseHeader instanceof UpdateResponseHeader);
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/database/DropDatabaseBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/database/DropDatabaseBackendHandlerTest.java
@@ -90,7 +90,7 @@ public final class DropDatabaseBackendHandlerTest {
         assertNotNull(responseHeader);
         assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
-
+    
     @Test
     public void assertExecuteDropCurrentDatabase() {
         when(connectionSession.getSchemaName()).thenReturn("test_db");
@@ -100,7 +100,7 @@ public final class DropDatabaseBackendHandlerTest {
         assertNotNull(responseHeader);
         assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
-
+    
     @Test
     public void assertExecuteDropOtherDatabase() {
         when(connectionSession.getSchemaName()).thenReturn("test_db");

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLDDLStatementSQLVisitor.java
@@ -210,6 +210,7 @@ public final class MySQLDDLStatementSQLVisitor extends MySQLStatementSQLVisitor 
     public ASTNode visitCreateDatabase(final CreateDatabaseContext ctx) {
         MySQLCreateDatabaseStatement result = new MySQLCreateDatabaseStatement();
         result.setDatabaseName(new IdentifierValue(ctx.schemaName().getText()).getValue());
+        result.setContainsNotExistClause(null != ctx.notExistClause());
         return result;
     }
     
@@ -222,9 +223,7 @@ public final class MySQLDDLStatementSQLVisitor extends MySQLStatementSQLVisitor 
     public ASTNode visitDropDatabase(final DropDatabaseContext ctx) {
         MySQLDropDatabaseStatement result = new MySQLDropDatabaseStatement();
         result.setDatabaseName(new IdentifierValue(ctx.schemaName().getText()).getValue());
-        if (null != ctx.existClause()) {
-            result.setContainsExistClause(true);
-        }
+        result.setContainsExistClause(null != ctx.existClause());
         return result;
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
@@ -555,9 +555,7 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     public ASTNode visitDropDatabase(final DropDatabaseContext ctx) {
         OpenGaussDropDatabaseStatement result = new OpenGaussDropDatabaseStatement();
         result.setDatabaseName(((IdentifierValue) visit(ctx.name())).getValue());
-        if (null != ctx.existClause()) {
-            result.setContainsExistClause(true);
-        }
+        result.setContainsExistClause(null != ctx.existClause());
         return result;
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -571,9 +571,7 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     public ASTNode visitDropDatabase(final DropDatabaseContext ctx) {
         PostgreSQLDropDatabaseStatement result = new PostgreSQLDropDatabaseStatement();
         result.setDatabaseName(((IdentifierValue) visit(ctx.name())).getValue());
-        if (null != ctx.existClause()) {
-            result.setContainsExistClause(true);
-        }
+        result.setContainsExistClause(null != ctx.existClause());
         return result;
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateDatabaseStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateDatabaseStatement.java
@@ -31,4 +31,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStat
 public abstract class CreateDatabaseStatement extends AbstractSQLStatement implements DDLStatement {
     
     private String databaseName;
+    
+    private boolean containsNotExistClause;
 }


### PR DESCRIPTION
Fixes #15983.
Make the `if not exists` clause in the CREATE DATABASE statement effective.
