### PR TITLE
Removed cobertura from ci.yml (#11580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build with Maven
         shell: cmd
         run: |
-          .\mvnw -B clean cobertura:cobertura -D"maven.javadoc.skip"=true -D"rat.skip"=true install < nul
+          .\mvnw -B clean -D"maven.javadoc.skip"=true -D"rat.skip"=true install < nul
           echo "mvnw exited"
       - name: Build examples with Maven
         run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
@@ -85,7 +85,7 @@ jobs:
         java:
           - {
             version: 8,
-            maven_args: "cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true"
+            maven_args: "-Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true"
           }
           - {
             version: 11,
@@ -126,7 +126,7 @@ jobs:
         java:
           - {
             version: 8,
-            maven_args: "cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true"
+            maven_args: "-Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true"
           }
     steps:
       - name: Cache Maven Repos


### PR DESCRIPTION
Fixes #11580.

Changes proposed in this pull request:
- This pull request removes the use of the Cobertura plugin from the GitHub Actions (by changing the `ci.yml`), because generated code coverage files (by Cobertura) are not stored and are deleted as the build finishes.
- The Cobertura plugin is also used in the `.travis.yml` file, and code coverage files (generated by Cobertura) are saved into [codecov.io](http://codecov.io/).
- Replacing 
`./mvnw -B clean install cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true` with 
`./mvnw -B clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true` 
reduces the build time from 22:52 min to 11:15 min on my Ubuntu PC.
