### PR TITLE
Add savepoint support for shardingsphere-proxy on xa transaction mode

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-tracing/shardingsphere-agent-tracing-test/src/main/java/org/apache/shardingsphere/agent/plugin/tracing/advice/AbstractCommandExecutorTaskAdviceTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-tracing/shardingsphere-agent-tracing-test/src/main/java/org/apache/shardingsphere/agent/plugin/tracing/advice/AbstractCommandExecutorTaskAdviceTest.java
@@ -21,10 +21,12 @@ import io.netty.util.DefaultAttributeMap;
 import lombok.Getter;
 import org.apache.shardingsphere.agent.api.advice.AdviceTargetObject;
 import org.apache.shardingsphere.agent.plugin.tracing.AgentRunner;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.CommandExecutorTask;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.junit.runner.RunWith;
+import static org.mockito.Mockito.mock;
 
 @RunWith(AgentRunner.class)
 public abstract class AbstractCommandExecutorTaskAdviceTest implements AdviceTestBase {
@@ -35,7 +37,7 @@ public abstract class AbstractCommandExecutorTaskAdviceTest implements AdviceTes
     @SuppressWarnings("ConstantConditions")
     @Override
     public final void prepare() {
-        ConnectionSession connectionSession = new ConnectionSession(TransactionType.BASE, new DefaultAttributeMap());
+        ConnectionSession connectionSession = new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.BASE, new DefaultAttributeMap());
         Object executorTask = new CommandExecutorTask(null, connectionSession, null, null);
         targetObject = (AdviceTargetObject) executorTask;
     }

--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/ConnectionSavepointManager.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-core/src/main/java/org/apache/shardingsphere/transaction/ConnectionSavepointManager.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction;
+package org.apache.shardingsphere.transaction;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/main/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGenerator.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/main/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGenerator.java
@@ -79,6 +79,7 @@ public final class NarayanaConfigurationFileGenerator implements TransactionConf
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.transactionStatusManagerAddress", ""));
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryListener", "NO"));
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryBackoffPeriod", "1"));
+        result.getEntries().add(createEntry("CoordinatorEnvironmentBean.defaultTimeout", "180"));
         return result;
     }
     

--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/test/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGeneratorTest.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/test/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGeneratorTest.java
@@ -96,7 +96,7 @@ public final class NarayanaConfigurationFileGeneratorTest {
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         InputStream inputStream = new FileInputStream(new File(ClassLoader.getSystemResource("").getPath(), "jbossts-properties.xml"));
         NarayanaConfiguration narayanaConfiguration = (NarayanaConfiguration) unmarshaller.unmarshal(inputStream);
-        assertThat(narayanaConfiguration.getEntries().size(), is(26));
+        assertThat(narayanaConfiguration.getEntries().size(), is(27));
         assertCommitOnePhase(narayanaConfiguration);
         assertTransactionSync(narayanaConfiguration);
         assertNodeIdentifier(narayanaConfiguration);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManager.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManager.java
@@ -18,14 +18,18 @@
 package org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction;
 
 import org.apache.shardingsphere.proxy.backend.communication.TransactionManager;
-import org.apache.shardingsphere.transaction.TransactionHolder;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.transaction.ConnectionSavepointManager;
 import org.apache.shardingsphere.transaction.ShardingSphereTransactionManagerEngine;
+import org.apache.shardingsphere.transaction.TransactionHolder;
 import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManager;
 
+import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Backend transaction manager.
@@ -102,37 +106,51 @@ public final class JDBCBackendTransactionManager implements TransactionManager<V
     
     @Override
     public Void setSavepoint(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
-            return null;
+        for (Connection each : connection.getCachedConnections().values()) {
+            ConnectionSavepointManager.getInstance().setSavepoint(each, savepointName);
         }
-        if (TransactionType.LOCAL == transactionType || null == shardingSphereTransactionManager) {
-            localTransactionManager.setSavepoint(savepointName);
-        }
+        connection.getConnectionPostProcessors().add(target -> {
+            try {
+                ConnectionSavepointManager.getInstance().setSavepoint(target, savepointName);
+            } catch (final SQLException ex) {
+                throw new RuntimeException(ex);
+            }
+        });
         return null;
-        // TODO Non-local transaction manager
     }
     
     @Override
     public Void rollbackTo(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
-            return null;
+        Collection<SQLException> result = new LinkedList<>();
+        for (Connection each : connection.getCachedConnections().values()) {
+            try {
+                ConnectionSavepointManager.getInstance().rollbackToSavepoint(each, savepointName);
+            } catch (final SQLException ex) {
+                result.add(ex);
+            }
         }
-        if (TransactionType.LOCAL == transactionType || null == shardingSphereTransactionManager) {
-            localTransactionManager.rollbackTo(savepointName);
-        }
-        return null;
-        // TODO Non-local transaction manager
+        return throwSQLExceptionIfNecessary(result);
     }
     
     @Override
     public Void releaseSavepoint(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
+        Collection<SQLException> result = new LinkedList<>();
+        for (Connection each : connection.getCachedConnections().values()) {
+            try {
+                ConnectionSavepointManager.getInstance().releaseSavepoint(each, savepointName);
+            } catch (final SQLException ex) {
+                result.add(ex);
+            }
+        }
+        return throwSQLExceptionIfNecessary(result);
+    }
+    
+    private Void throwSQLExceptionIfNecessary(final Collection<SQLException> exceptions) throws SQLException {
+        if (exceptions.isEmpty()) {
             return null;
         }
-        if (TransactionType.LOCAL == transactionType || null == shardingSphereTransactionManager) {
-            localTransactionManager.releaseSavepoint(savepointName);
-        }
-        return null;
-        // TODO Non-local transaction manager
+        SQLException ex = new SQLException("");
+        exceptions.forEach(ex::setNextException);
+        throw ex;
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/LocalTransactionManager.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/LocalTransactionManager.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.proxy.backend.communication.TransactionManager;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
+import org.apache.shardingsphere.transaction.ConnectionSavepointManager;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -93,58 +94,23 @@ public final class LocalTransactionManager implements TransactionManager<Void> {
     }
     
     @Override
-    public Void setSavepoint(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
-            return null;
-        }
-        for (Connection each : connection.getCachedConnections().values()) {
-            ConnectionSavepointManager.getInstance().setSavepoint(each, savepointName);
-        }
-        connection.getConnectionPostProcessors().add(target -> {
-            try {
-                ConnectionSavepointManager.getInstance().setSavepoint(target, savepointName);
-            } catch (final SQLException ex) {
-                throw new RuntimeException(ex);
-            }
-        });
+    public Void setSavepoint(final String savepointName) {
         return null;
     }
     
     @Override
-    public Void rollbackTo(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
-            return null;
-        }
-        Collection<SQLException> result = new LinkedList<>();
-        for (Connection each : connection.getCachedConnections().values()) {
-            try {
-                ConnectionSavepointManager.getInstance().rollbackToSavepoint(each, savepointName);
-            } catch (final SQLException ex) {
-                result.add(ex);
-            }
-        }
-        return throwSQLExceptionIfNecessary(result);
+    public Void rollbackTo(final String savepointName) {
+        return null;
     }
     
     @Override
-    public Void releaseSavepoint(final String savepointName) throws SQLException {
-        if (!connection.getConnectionSession().getTransactionStatus().isInTransaction()) {
-            return null;
-        }
-        Collection<SQLException> result = new LinkedList<>();
-        for (Connection each : connection.getCachedConnections().values()) {
-            try {
-                ConnectionSavepointManager.getInstance().releaseSavepoint(each, savepointName);
-            } catch (final SQLException ex) {
-                result.add(ex);
-            }
-        }
-        return throwSQLExceptionIfNecessary(result);
+    public Void releaseSavepoint(final String savepointName) {
+        return null;
     }
     
-    private Void throwSQLExceptionIfNecessary(final Collection<SQLException> exceptions) throws SQLException {
+    private void throwSQLExceptionIfNecessary(final Collection<SQLException> exceptions) throws SQLException {
         if (exceptions.isEmpty()) {
-            return null;
+            return;
         }
         SQLException ex = new SQLException("");
         exceptions.forEach(ex::setNextException);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSession.java
@@ -22,6 +22,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.ExecutorStatementManager;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
@@ -44,6 +45,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Getter
 @Setter
 public final class ConnectionSession {
+    
+    private final DatabaseType databaseType;
     
     @Setter(AccessLevel.NONE)
     private volatile String schemaName;
@@ -70,7 +73,8 @@ public final class ConnectionSession {
     
     private final ExecutorStatementManager statementManager;
     
-    public ConnectionSession(final TransactionType initialTransactionType, final AttributeMap attributeMap) {
+    public ConnectionSession(final DatabaseType databaseType, final TransactionType initialTransactionType, final AttributeMap attributeMap) {
+        this.databaseType = databaseType;
         transactionStatus = new TransactionStatus(initialTransactionType);
         this.attributeMap = attributeMap;
         backendConnection = determineBackendConnection();

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/transaction/TransactionBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/transaction/TransactionBackendHandler.java
@@ -129,21 +129,21 @@ public final class TransactionBackendHandler implements TextProtocolBackendHandl
     }
     
     private void handleSavepoint() throws SQLException {
-        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()) {
             throw new SQLFeatureNotSupportedException("SAVEPOINT can only be used in transaction blocks");
         }
         backendTransactionManager.setSavepoint(((SavepointStatement) tclStatement).getSavepointName());
     }
     
     private void handleRollbackToSavepoint() throws SQLException {
-        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()) {
             throw new SQLFeatureNotSupportedException("ROLLBACK TO SAVEPOINT can only be used in transaction blocks");
         }
         backendTransactionManager.rollbackTo(((RollbackStatement) tclStatement).getSavepointName().get());
     }
     
     private void handleReleaseSavepoint() throws SQLException {
-        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()) {
             throw new SQLFeatureNotSupportedException("RELEASE SAVEPOINT can only be used in transaction blocks");
         }
         backendTransactionManager.releaseSavepoint(((ReleaseSavepointStatement) tclStatement).getSavepointName());

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/transaction/TransactionBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/transaction/TransactionBackendHandler.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.proxy.backend.text.transaction;
 
 import io.vertx.core.Future;
+import org.apache.shardingsphere.infra.database.type.dialect.OpenGaussDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.proxy.backend.communication.TransactionManager;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction.JDBCBackendTransactionManager;
@@ -105,17 +107,13 @@ public final class TransactionBackendHandler implements TextProtocolBackendHandl
                 backendTransactionManager.begin();
                 break;
             case SAVEPOINT:
-                backendTransactionManager.setSavepoint(((SavepointStatement) tclStatement).getSavepointName());
+                handleSavepoint();
                 break;
             case ROLLBACK_TO_SAVEPOINT:
-                if (((RollbackStatement) tclStatement).getSavepointName().isPresent()) {
-                    backendTransactionManager.rollbackTo(((RollbackStatement) tclStatement).getSavepointName().get());
-                    break;
-                }
-                backendTransactionManager.rollback();
+                handleRollbackToSavepoint();
                 break;
             case RELEASE_SAVEPOINT:
-                backendTransactionManager.releaseSavepoint(((ReleaseSavepointStatement) tclStatement).getSavepointName());
+                handleReleaseSavepoint();
                 break;
             case COMMIT:
                 SQLStatement sqlStatement = getSQLStatementByCommit();
@@ -128,6 +126,34 @@ public final class TransactionBackendHandler implements TextProtocolBackendHandl
                 throw new SQLFeatureNotSupportedException(operationType.name());
         }
         return new UpdateResponseHeader(tclStatement);
+    }
+    
+    private void handleSavepoint() throws SQLException {
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+            throw new SQLFeatureNotSupportedException("SAVEPOINT can only be used in transaction blocks");
+        }
+        backendTransactionManager.setSavepoint(((SavepointStatement) tclStatement).getSavepointName());
+    }
+    
+    private void handleRollbackToSavepoint() throws SQLException {
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+            throw new SQLFeatureNotSupportedException("ROLLBACK TO SAVEPOINT can only be used in transaction blocks");
+        }
+        backendTransactionManager.rollbackTo(((RollbackStatement) tclStatement).getSavepointName().get());
+    }
+    
+    private void handleReleaseSavepoint() throws SQLException {
+        if (!connectionSession.getTransactionStatus().isInTransaction() && checkPostgreSQLOrOpengauss()){
+            throw new SQLFeatureNotSupportedException("RELEASE SAVEPOINT can only be used in transaction blocks");
+        }
+        backendTransactionManager.releaseSavepoint(((ReleaseSavepointStatement) tclStatement).getSavepointName());
+    }
+    
+    private boolean checkPostgreSQLOrOpengauss() {
+        if (connectionSession.getDatabaseType() instanceof PostgreSQLDatabaseType || connectionSession.getDatabaseType() instanceof OpenGaussDatabaseType) {
+            return true;
+        }
+        return false;
     }
     
     private SQLStatement getSQLStatementByCommit() {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
@@ -160,30 +160,6 @@ public final class JDBCBackendTransactionManagerTest {
         verify(shardingSphereTransactionManager, times(0)).rollback();
     }
     
-    @Test
-    public void assertSetSavepointWithoutTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, false);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.setSavepoint(savepointName);
-        verify(localTransactionManager, never()).setSavepoint(savepointName);
-    }
-    
-    @Test
-    public void assertRollbackToSavepointWithoutTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, false);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.rollbackTo(savepointName);
-        verify(localTransactionManager, never()).rollbackTo(savepointName);
-    }
-    
-    @Test
-    public void assertReleaseSavepointWithoutTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, false);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.releaseSavepoint(savepointName);
-        verify(localTransactionManager, never()).releaseSavepoint(savepointName);
-    }
-    
     private void newBackendTransactionManager(final TransactionType transactionType, final boolean inTransaction) {
         when(connectionSession.getTransactionStatus().getTransactionType()).thenReturn(transactionType);
         when(transactionStatus.isInTransaction()).thenReturn(inTransaction);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction;
 
+import com.google.common.collect.Multimap;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
@@ -69,6 +70,7 @@ public final class JDBCBackendTransactionManagerTest {
         when(connectionSession.getSchemaName()).thenReturn("schema");
         when(connectionSession.getTransactionStatus()).thenReturn(transactionStatus);
         when(backendConnection.getConnectionSession()).thenReturn(connectionSession);
+        when(backendConnection.getCachedConnections()).thenReturn(mock(Multimap.class));
     }
     
     @SneakyThrows(ReflectiveOperationException.class)
@@ -159,14 +161,6 @@ public final class JDBCBackendTransactionManagerTest {
     }
     
     @Test
-    public void assertSetSavepointForLocalTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, true);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.setSavepoint(savepointName);
-        verify(localTransactionManager).setSavepoint(savepointName);
-    }
-    
-    @Test
     public void assertSetSavepointWithoutTransaction() throws SQLException {
         newBackendTransactionManager(TransactionType.LOCAL, false);
         String savepointName = "JDBC_SAVEPOINT_0";
@@ -175,27 +169,11 @@ public final class JDBCBackendTransactionManagerTest {
     }
     
     @Test
-    public void assertRollbackToSavepointForLocalTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, true);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.rollbackTo(savepointName);
-        verify(localTransactionManager).rollbackTo(savepointName);
-    }
-    
-    @Test
     public void assertRollbackToSavepointWithoutTransaction() throws SQLException {
         newBackendTransactionManager(TransactionType.LOCAL, false);
         String savepointName = "JDBC_SAVEPOINT_0";
         backendTransactionManager.rollbackTo(savepointName);
         verify(localTransactionManager, never()).rollbackTo(savepointName);
-    }
-    
-    @Test
-    public void assertReleaseSavepointForLocalTransaction() throws SQLException {
-        newBackendTransactionManager(TransactionType.LOCAL, true);
-        String savepointName = "JDBC_SAVEPOINT_0";
-        backendTransactionManager.releaseSavepoint(savepointName);
-        verify(localTransactionManager).releaseSavepoint(savepointName);
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/communication/jdbc/transaction/JDBCBackendTransactionManagerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.proxy.backend.communication.jdbc.transaction;
 
-import com.google.common.collect.Multimap;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
@@ -39,7 +38,6 @@ import java.sql.SQLException;
 
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,7 +68,6 @@ public final class JDBCBackendTransactionManagerTest {
         when(connectionSession.getSchemaName()).thenReturn("schema");
         when(connectionSession.getTransactionStatus()).thenReturn(transactionStatus);
         when(backendConnection.getConnectionSession()).thenReturn(connectionSession);
-        when(backendConnection.getCachedConnections()).thenReturn(mock(Multimap.class));
     }
     
     @SneakyThrows(ReflectiveOperationException.class)

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/session/ConnectionSessionTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.session;
 
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
@@ -38,6 +39,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -61,7 +63,7 @@ public final class ConnectionSessionTest {
     @Before
     public void setup() {
         ProxyContext.getInstance().init(contextManager);
-        connectionSession = new ConnectionSession(TransactionType.LOCAL, null);
+        connectionSession = new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.LOCAL, null);
         when(backendConnection.getConnectionSession()).thenReturn(connectionSession);
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutorTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/executor/ShowProcessListExecutorTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.text.admin.mysql.executor;
 
 import io.netty.util.DefaultAttributeMap;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.transaction.core.TransactionType;
@@ -30,6 +31,7 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 public final class ShowProcessListExecutorTest {
     
@@ -60,7 +62,7 @@ public final class ShowProcessListExecutorTest {
     
     @Test
     public void assertExecute() throws SQLException {
-        showProcessListExecutor.execute(new ConnectionSession(TransactionType.LOCAL, new DefaultAttributeMap()));
+        showProcessListExecutor.execute(new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.LOCAL, new DefaultAttributeMap()));
         assertThat(showProcessListExecutor.getQueryResultMetaData().getColumnCount(), is(8));
         MergedResult mergedResult = showProcessListExecutor.getMergedResult();
         while (mergedResult.next()) {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowVariableBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowVariableBackendHandlerTest.java
@@ -21,6 +21,7 @@ import io.netty.util.DefaultAttributeMap;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowVariableStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -58,7 +59,7 @@ public final class ShowVariableBackendHandlerTest {
         contextManagerBefore = ProxyContext.getInstance().getContextManager();
         ProxyContext.getInstance().init(mock(ContextManager.class, RETURNS_DEEP_STUBS));
         when(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getProps().getValue(ConfigurationPropertyKey.PROXY_BACKEND_DRIVER_TYPE)).thenReturn("JDBC");
-        connectionSession = new ConnectionSession(TransactionType.LOCAL, new DefaultAttributeMap());
+        connectionSession = new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.LOCAL, new DefaultAttributeMap());
     }
     
     @Test

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/SetVariableBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/SetVariableBackendHandlerTest.java
@@ -75,7 +75,7 @@ public final class SetVariableBackendHandlerTest {
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         ProxyContext.getInstance().init(contextManager);
         when(contextManager.getMetaDataContexts()).thenReturn(metaDataContexts);
-        connectionSession = new ConnectionSession(TransactionType.LOCAL, new DefaultAttributeMap());
+        connectionSession = new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.LOCAL, new DefaultAttributeMap());
     }
     
     private Map<String, ShardingSphereMetaData> getMetaDataMap() {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/RuleDefinitionBackendHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/rql/RuleDefinitionBackendHandlerTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.text.distsql.rql;
 
 import io.netty.util.DefaultAttributeMap;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.distsql.update.RuleDefinitionUpdater;
 import org.apache.shardingsphere.infra.metadata.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.mode.manager.ContextManager;
@@ -59,7 +60,7 @@ public final class RuleDefinitionBackendHandlerTest {
     
     @Test
     public void assertExecute() throws SQLException {
-        ConnectionSession connectionSession = new ConnectionSession(TransactionType.LOCAL, new DefaultAttributeMap());
+        ConnectionSession connectionSession = new ConnectionSession(mock(MySQLDatabaseType.class), TransactionType.LOCAL, new DefaultAttributeMap());
         connectionSession.setCurrentSchema("test");
         ResponseHeader response = new RuleDefinitionBackendHandler<>(new CreateFixtureRuleStatement(), connectionSession).execute();
         assertThat(response, instanceOf(UpdateResponseHeader.class));

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandler.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
+import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.connection.JDBCBackendConnection;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -52,7 +53,7 @@ public final class FrontendChannelInboundHandler extends ChannelInboundHandlerAd
     
     public FrontendChannelInboundHandler(final DatabaseProtocolFrontendEngine databaseProtocolFrontendEngine, final Channel channel) {
         this.databaseProtocolFrontendEngine = databaseProtocolFrontendEngine;
-        connectionSession = new ConnectionSession(getTransactionRule().getDefaultType(), channel);
+        connectionSession = new ConnectionSession(DatabaseTypeRegistry.getActualDatabaseType(databaseProtocolFrontendEngine.getDatabaseType()), getTransactionRule().getDefaultType(), channel);
     }
     
     private TransactionRule getTransactionRule() {

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandlerTest.java
@@ -66,6 +66,7 @@ public final class FrontendChannelInboundHandlerTest {
     @Before
     public void setup() {
         when(frontendEngine.getAuthenticationEngine()).thenReturn(authenticationEngine);
+        when(frontendEngine.getDatabaseType()).thenReturn("MySQL");
         when(authenticationEngine.handshake(any(ChannelHandlerContext.class))).thenReturn(CONNECTION_ID);
         channel = new EmbeddedChannel(false, true);
         frontendChannelInboundHandler = new FrontendChannelInboundHandler(frontendEngine, channel);


### PR DESCRIPTION


Changes proposed in this pull request:
- add savepoint support for shardingsphere-proxy on xa transaction mode
- move some test cases to `auto-test`
- add `dabaseType` in `ConnectionSession`

### Test
[test cases](https://github.com/SphereEx/auto-test/tree/master/src/main/java/com/sphereex/cases/transaction/savepoint)
