### PR TITLE
Add read-write splitting to obtain write data source unit test (#15801)

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
@@ -97,7 +97,7 @@ public final class ReadwriteSplittingDataSourceRuleTest {
     }
 
     @Test
-    public void assertGetStaticWriteDataSource() {
+    public void assertGetWriteDataSource() {
         String writeDataSourceName = readwriteSplittingDataSourceRule.getWriteDataSource();
         assertThat(writeDataSourceName, is("write_ds"));
     }

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
@@ -95,7 +95,13 @@ public final class ReadwriteSplittingDataSourceRuleTest {
         Map<String, Collection<String>> expected = ImmutableMap.of("test_pr", Arrays.asList("write_ds", "read_ds_0", "read_ds_1"));
         assertThat(actual, is(expected));
     }
-    
+
+    @Test
+    public void assertGetStaticWriteDataSource() {
+        String writeDataSourceName = readwriteSplittingDataSourceRule.getWriteDataSource();
+        assertThat(writeDataSourceName, is("write_ds"));
+    }
+
     private Properties getProperties(final String writeDataSource, final String readDataSources) {
         Properties result = new Properties();
         result.setProperty("write-data-source-name", writeDataSource);

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
@@ -95,13 +95,13 @@ public final class ReadwriteSplittingDataSourceRuleTest {
         Map<String, Collection<String>> expected = ImmutableMap.of("test_pr", Arrays.asList("write_ds", "read_ds_0", "read_ds_1"));
         assertThat(actual, is(expected));
     }
-
+    
     @Test
     public void assertGetWriteDataSource() {
         String writeDataSourceName = readwriteSplittingDataSourceRule.getWriteDataSource();
         assertThat(writeDataSourceName, is("write_ds"));
     }
-
+    
     private Properties getProperties(final String writeDataSource, final String readDataSources) {
         Properties result = new Properties();
         result.setProperty("write-data-source-name", writeDataSource);


### PR DESCRIPTION
Fixes #15801.

Changes proposed in this pull request:
- Add read-write splitting to obtain write data source unit test