### PR TITLE
Proofread SQLServer DENY statement

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRule.java
@@ -193,7 +193,7 @@ public final class DatabaseDiscoveryRule implements SchemaRule, DataSourceContai
             for (Entry<String, DatabaseDiscoveryDataSourceRule> entry : dataSourceRules.entrySet()) {
                 Map<String, DataSource> dataSources = dataSourceMap.entrySet().stream().filter(dataSource -> !entry.getValue().getDisabledDataSourceNames().contains(dataSource.getKey()))
                         .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-                CronJob job = new CronJob(entry.getValue().getDatabaseDiscoveryType().getType() + "-" + entry.getValue().getGroupName(),
+                CronJob job = new CronJob(entry.getValue().getDatabaseDiscoveryType().getType() + "-" + schemaName + "-" + entry.getValue().getGroupName(),
                     each -> new HeartbeatJob(schemaName, dataSources, entry.getValue().getGroupName(), entry.getValue().getDatabaseDiscoveryType(), entry.getValue().getDisabledDataSourceNames())
                                 .execute(null), entry.getValue().getHeartbeatProps().getProperty("keep-alive-cron"));
                 modeScheduleContext.get().startCronJob(job);

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DCLStatement.g4
@@ -24,27 +24,27 @@ grant
     ;
 
 grantClassPrivilegesClause
-    : grantClassPrivileges (ON grantOnClassClause)? TO principal (COMMA_ principal)* (WITH GRANT OPTION)? (AS principal)?
+    : classPrivileges (ON onClassClause)? TO principal (COMMA_ principal)* (WITH GRANT OPTION)? (AS principal)?
     ;
 
 grantClassTypePrivilegesClause
-    : grantClassTypePrivileges (ON grantOnClassTypeClause)? TO principal (COMMA_ principal)* (WITH GRANT OPTION)?
+    : classTypePrivileges (ON onClassTypeClause)? TO principal (COMMA_ principal)* (WITH GRANT OPTION)?
     ;
 
-grantClassPrivileges
+classPrivileges
     : privilegeType columnNames? (COMMA_ privilegeType columnNames?)*
     ;
 
-grantOnClassClause
+onClassClause
     : (classItem COLON_ COLON_)? securable
     ;
 
-grantClassTypePrivileges
+classTypePrivileges
     : privilegeType (COMMA_ privilegeType)*
     ;
 
-grantOnClassTypeClause
-    : (grantClassType COLON_ COLON_)? securable
+onClassTypeClause
+    : (classType COLON_ COLON_)? securable
     ;
 
 securable
@@ -60,50 +60,34 @@ revoke
     ;
 
 revokeClassPrivilegesClause
-    : grantClassPrivileges (ON grantOnClassClause)? (TO | FROM) principal (COMMA_ principal)* (CASCADE)? (AS principal)?
+    : classPrivileges (ON onClassClause)? (TO | FROM) principal (COMMA_ principal)* (CASCADE)? (AS principal)?
     ;
 
 revokeClassTypePrivilegesClause
-    : grantClassTypePrivileges (ON grantOnClassTypeClause)? (TO | FROM) principal (COMMA_ principal)* (CASCADE)?
+    : classTypePrivileges (ON onClassTypeClause)? (TO | FROM) principal (COMMA_ principal)* (CASCADE)?
     ;
 
 deny
-    : DENY (classPrivilegesClause | classTypePrivilegesClause)
+    : DENY (denyClassPrivilegesClause | denyClassTypePrivilegesClause)
     ;
 
-classPrivilegesClause
-    : classPrivileges (ON onClassClause)?
+denyClassPrivilegesClause
+    : classPrivileges (ON onClassClause)? TO principal (COMMA_ principal)* (CASCADE)? (AS principal)?
     ;
 
-classTypePrivilegesClause
-    : classTypePrivileges (ON onClassTypeClause)?
+denyClassTypePrivilegesClause
+    : classTypePrivileges (ON onClassTypeClause)? TO principal (COMMA_ principal)* (CASCADE)?
     ;
 
 optionForClause
     : GRANT OPTION FOR
     ;
 
-classPrivileges
-    : privilegeType columnNames? (COMMA_ privilegeType columnNames?)*
-    ;
-
-onClassClause
-    : class_? tableName
-    ;
-
-classTypePrivileges
-    : privilegeType (COMMA_ privilegeType)*
-    ;
-
-onClassTypeClause
-    : classType? tableName
-    ;
-
 privilegeType
     : ALL PRIVILEGES?
     | assemblyPermission | asymmetricKeyPermission
     | availabilityGroupPermission | certificatePermission
-    | objectPermission
+    | objectPermission | systemObjectPermission
     | databasePermission | databasePrincipalPermission
     | databaseScopedCredentialPermission | endpointPermission
     | fullTextPermission
@@ -248,12 +232,12 @@ xmlSchemaCollectionPermission
     : ALTER | CONTROL | EXECUTE | REFERENCES | TAKE OWNERSHIP | VIEW DEFINITION
     ;
 
-class_
-    : IDENTIFIER_ COLON_ COLON_
+systemObjectPermission
+    : SELECT | EXECUTE
     ;
 
-classType
-    : (LOGIN | DATABASE | OBJECT | ROLE | SCHEMA | USER) COLON_ COLON_
+class_
+    : IDENTIFIER_ COLON_ COLON_
     ;
 
 classItem
@@ -263,7 +247,7 @@ classItem
     | SELECT | EXECUTE | TYPE | XML SCHEMA COLLECTION
     ;
 
-grantClassType
+classType
     : LOGIN | DATABASE | OBJECT | ROLE | SCHEMA | USER
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDenyUserStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDenyUserStatement.java
@@ -20,10 +20,14 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
+
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * SQLServer deny user statement.
@@ -34,4 +38,6 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLS
 public final class SQLServerDenyUserStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
     
     private SimpleTableSegment table;
+    
+    private final Collection<ColumnSegment> columns = new LinkedList<>();
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dcl/impl/DenyUserStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dcl/impl/DenyUserStatementAssert.java
@@ -21,11 +21,14 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDenyUserStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.column.ColumnAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.table.TableAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dcl.DenyUserStatementTestCase;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * Deny user statement assert.
@@ -42,6 +45,7 @@ public final class DenyUserStatementAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
         assertTable(assertContext, actual, expected);
+        assertColumns(assertContext, actual, expected);
     }
     
     private static void assertTable(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
@@ -50,6 +54,14 @@ public final class DenyUserStatementAssert {
             TableAssert.assertIs(assertContext, actual.getTable(), expected.getTable());
         } else {
             assertNull(assertContext.getText("Actual table segment should not exist."), actual.getTable());
+        }
+    }
+    
+    private static void assertColumns(final SQLCaseAssertContext assertContext, final SQLServerDenyUserStatement actual, final DenyUserStatementTestCase expected) {
+        if (0 != expected.getColumns().size()) {
+            ColumnAssert.assertIs(assertContext, actual.getColumns(), expected.getColumns());
+        } else {
+            assertThat(assertContext.getText("Actual columns segments should not exist."), actual.getColumns().size(), is(0));
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dcl/DenyUserStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dcl/DenyUserStatementTestCase.java
@@ -19,10 +19,13 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domai
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.column.ExpectedColumn;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * Deny user statement test case.
@@ -33,4 +36,7 @@ public final class DenyUserStatementTestCase extends SQLParserTestCase {
     
     @XmlElement
     private ExpectedSimpleTable table;
+    
+    @XmlElement(name = "column")
+    private final List<ExpectedColumn> columns = new LinkedList<>();
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dcl/deny-user.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dcl/deny-user.xml
@@ -27,10 +27,12 @@
     
     <deny-user sql-case-id="deny_select_column">
         <table name="t_order" start-index="26" stop-index="32" />
+        <column name="order_id" start-index="13" stop-index="20" />
     </deny-user>
     
     <deny-user sql-case-id="deny_select_to_users">
         <table name="t_order" start-index="26" stop-index="32" />
+        <column name="order_id" start-index="13" stop-index="20" />
     </deny-user>
     
     <deny-user sql-case-id="deny_crud">
@@ -39,5 +41,56 @@
     
     <deny-user sql-case-id="deny_all">
         <table name="t_order" start-index="23" stop-index="29" />
+    </deny-user>
+
+    <deny-user sql-case-id="deny_view_definition_on_availability_group_to_login" />
+    <deny-user sql-case-id="deny_take_ownership_on_availability_group_to_user" />
+    <deny-user sql-case-id="deny_create_certificate_to_user" />
+    <deny-user sql-case-id="deny_references_to_role" />
+    <deny-user sql-case-id="deny_view_definition_to_user" />
+    <deny-user sql-case-id="deny_control_on_user" />
+    <deny-user sql-case-id="deny_view_definition_on_role_to_user" />
+    <deny-user sql-case-id="deny_impersonate_on_user_to_role" />
+    <deny-user sql-case-id="deny_view_definition_on_endpoint_to_login" />
+    <deny-user sql-case-id="deny_take_ownership_on_endpoint_to_user" />
+
+    <deny-user sql-case-id="deny_select_on_object_to_user">
+        <table name="t_order" start-index="23" stop-index="33" >
+            <owner name="db1" start-index="23" stop-index="25" />
+        </table>
+    </deny-user>
+
+    <deny-user sql-case-id="deny_execute_on_object_to_role">
+        <table name="t_order" start-index="24" stop-index="34" >
+            <owner name="db1" start-index="24" stop-index="26" />
+        </table>
+    </deny-user>
+
+    <deny-user sql-case-id="deny_references_on_object_to_user">
+        <table name="t_order" start-index="38" stop-index="48" >
+            <owner name="db1" start-index="38" stop-index="40" />
+        </table>
+        <column name="order_id" start-index="17" stop-index="24" />
+    </deny-user>
+
+    <deny-user sql-case-id="deny_connect_sql_to_login" />
+    <deny-user sql-case-id="deny_create_endpoint_to_user_as_principal" />
+    <deny-user sql-case-id="deny_impersonate_on_login_to_windows_user" />
+    <deny-user sql-case-id="deny_view_definition_on_login" />
+    <deny-user sql-case-id="deny_view_definition_on_server_role" />
+    <deny-user sql-case-id="deny_alter_on_symmetric_key_to_user" />
+
+    <deny-user sql-case-id="deny_execute_on_system_object">
+        <table name="xp_cmdshell" start-index="16" stop-index="30" >
+            <owner name="sys" start-index="16" stop-index="18" />
+        </table>
+    </deny-user>
+    
+    <deny-user sql-case-id="deny_view_definition_on_type_to_user" />
+    
+    <deny-user sql-case-id="deny_execute_on_xml_schema_collection_to_user">
+        <table name="xmlschemacollection1" start-index="39" stop-index="66" >
+            <owner name="schema1" start-index="39" stop-index="45" />
+        </table>
     </deny-user>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dcl/deny-user.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dcl/deny-user.xml
@@ -23,4 +23,26 @@
     <sql-case id="deny_select_to_users" value="DENY SELECT (order_id) ON t_order TO user1, user2" db-types="SQLServer" />
     <sql-case id="deny_crud" value="DENY INSERT, SELECT, UPDATE, DELETE ON t_order TO user1" db-types="SQLServer" />
     <sql-case id="deny_all" value="DENY ALL PRIVILEGES ON t_order TO user1" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_availability_group_to_login" value="DENY VIEW DEFINITION ON AVAILABILITY GROUP::group1 TO login1" db-types="SQLServer" />
+    <sql-case id="deny_take_ownership_on_availability_group_to_user" value="DENY TAKE OWNERSHIP ON AVAILABILITY GROUP::group1 TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_create_certificate_to_user" value="DENY CREATE CERTIFICATE TO user1" db-types="SQLServer" />
+    <sql-case id="deny_references_to_role" value="DENY REFERENCES TO role1" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_to_user" value="DENY VIEW DEFINITION TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_control_on_user" value="DENY CONTROL ON USER::user1 TO user2" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_role_to_user" value="DENY VIEW DEFINITION ON ROLE::role1 TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_impersonate_on_user_to_role" value="DENY IMPERSONATE ON USER::user1 TO role1" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_endpoint_to_login" value="DENY VIEW DEFINITION ON ENDPOINT::endpoint1 TO login1" db-types="SQLServer" />
+    <sql-case id="deny_take_ownership_on_endpoint_to_user" value="DENY TAKE OWNERSHIP ON ENDPOINT::endpoint1 TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_select_on_object_to_user" value="DENY SELECT ON OBJECT::db1.t_order TO user1" db-types="SQLServer" />
+    <sql-case id="deny_execute_on_object_to_role" value="DENY EXECUTE ON OBJECT::db1.t_order TO role1" db-types="SQLServer" />
+    <sql-case id="deny_references_on_object_to_user" value="DENY REFERENCES (order_id) ON OBJECT::db1.t_order TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_connect_sql_to_login" value="DENY CONNECT SQL TO login1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_create_endpoint_to_user_as_principal" value="DENY CREATE ENDPOINT TO user1 AS principal1" db-types="SQLServer" />
+    <sql-case id="deny_impersonate_on_login_to_windows_user" value="DENY IMPERSONATE ON LOGIN::login1 TO [windows\user]" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_login" value="DENY VIEW DEFINITION ON LOGIN::login1 TO login2 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_server_role" value="DENY VIEW DEFINITION ON SERVER ROLE::role1 TO role2" db-types="SQLServer" />
+    <sql-case id="deny_alter_on_symmetric_key_to_user" value="DENY ALTER ON SYMMETRIC KEY::key1 TO user1" db-types="SQLServer" />
+    <sql-case id="deny_execute_on_system_object" value="DENY EXECUTE ON sys.xp_cmdshell TO public" db-types="SQLServer" />
+    <sql-case id="deny_view_definition_on_type_to_user" value="DENY VIEW DEFINITION ON TYPE::schema1.type1 TO user1 CASCADE" db-types="SQLServer" />
+    <sql-case id="deny_execute_on_xml_schema_collection_to_user" value="DENY EXECUTE ON XML SCHEMA COLLECTION::schema1.xmlschemacollection1 TO user1" db-types="SQLServer" />
 </sql-cases>


### PR DESCRIPTION
For #6478 

Changes proposed in this pull request:
- I've proofread the SQLServer [DENY](https://docs.microsoft.com/en-us/sql/t-sql/statements/deny-transact-sql?view=sql-server-ver15) statement.
- I've renamed the common rules to generic which belong to `GRANT`, `REVOKE`, and `DENY` statements and removed previous unnecessary rules.
- Although SQL case id `deny_execute_on_xml_schema_collection_to_user` doesn't belong to `objectPermission` due to ANTLR rule order, it matches with the `objectPermission`. Therefore, I had to expect the table in sql-case-id `deny_execute_on_xml_schema_collection_to_user` in the test case to successfully pass the all the test cases.

Please let me know if there is anything to improve.
