### PR TITLE
`CREATE/ALTER SHARDING BINDING TABLE RULES` syntax adds check for binding

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AlterShardingBindingTableRulesStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AlterShardingBindingTableRulesStatementUpdater.java
@@ -89,45 +89,45 @@ public final class AlterShardingBindingTableRulesStatementUpdater implements Rul
     }
     
     private void checkToBeAlteredCanBindBindingTables(final AlterShardingBindingTableRulesStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
-        Collection<String> cannotBindRules = sqlStatement.getRules().stream().map(BindingTableRuleSegment::getTableGroups)
-                .filter(each -> !canBind(currentRuleConfig, each)).collect(Collectors.toCollection(LinkedList::new));
-        DistSQLException.predictionThrow(cannotBindRules.isEmpty(),
-            () -> new InvalidRuleConfigurationException("binding", cannotBindRules, Collections.singleton("Unable to bind with different sharding strategies")));
+        Collection<String> invalidRules = sqlStatement.getRules().stream().map(BindingTableRuleSegment::getTableGroups)
+                .filter(each -> !isValid(currentRuleConfig, each)).collect(Collectors.toCollection(LinkedList::new));
+        DistSQLException.predictionThrow(invalidRules.isEmpty(),
+            () -> new InvalidRuleConfigurationException("binding", invalidRules, Collections.singleton("Unable to bind with different sharding strategies")));
     }
     
-    private boolean canBind(final ShardingRuleConfiguration currentRuleConfig, final String bindingRule) {
+    private boolean isValid(final ShardingRuleConfiguration currentRuleConfig, final String bindingRule) {
         LinkedList<String> shardingTables = new LinkedList<>(Splitter.on(",").trimResults().splitToList(bindingRule));
-        Collection<String> bindableShardingTables = getBindableShardingTable(currentRuleConfig, shardingTables.getFirst());
+        Collection<String> bindableShardingTables = getBindableShardingTables(currentRuleConfig, shardingTables.getFirst());
         return bindableShardingTables.containsAll(shardingTables);
     }
     
-    private Collection<String> getBindableShardingTable(final ShardingRuleConfiguration currentRuleConfig, final String shardingTable) {
+    private Collection<String> getBindableShardingTables(final ShardingRuleConfiguration currentRuleConfig, final String shardingTable) {
         Collection<String> result = new ArrayList<>();
-        Optional<ShardingTableRuleConfiguration> tableRule = getFromTable(currentRuleConfig.getTables(), shardingTable);
-        tableRule.ifPresent(op -> result.addAll(getBindableShardingTable(currentRuleConfig, op)));
-        Optional<ShardingAutoTableRuleConfiguration> autoTableRule = getFromAutoTable(currentRuleConfig.getAutoTables(), shardingTable);
-        autoTableRule.ifPresent(op -> result.addAll(getBindableShardingAutoTable(currentRuleConfig, op)));
+        Optional<ShardingTableRuleConfiguration> tableRule = getConfigurationFromTable(currentRuleConfig.getTables(), shardingTable);
+        tableRule.ifPresent(op -> result.addAll(getBindableShardingTables(currentRuleConfig, op)));
+        Optional<ShardingAutoTableRuleConfiguration> autoTableRule = getConfigurationFromAutoTable(currentRuleConfig.getAutoTables(), shardingTable);
+        autoTableRule.ifPresent(op -> result.addAll(getBindableShardingAutoTables(currentRuleConfig, op)));
         return result;
     }
     
-    private Collection<String> getBindableShardingTable(final ShardingRuleConfiguration currentRuleConfig, final ShardingTableRuleConfiguration tableRule) {
+    private Collection<String> getBindableShardingTables(final ShardingRuleConfiguration currentRuleConfig, final ShardingTableRuleConfiguration tableRule) {
         return currentRuleConfig.getTables().stream()
                 .filter(each -> hasSameShardingStrategy(each.getTableShardingStrategy(), tableRule.getTableShardingStrategy()))
                 .filter(each -> hasSameShardingStrategy(each.getDatabaseShardingStrategy(), tableRule.getDatabaseShardingStrategy()))
                 .map(ShardingTableRuleConfiguration::getLogicTable).collect(Collectors.toSet());
     }
     
-    private Collection<String> getBindableShardingAutoTable(final ShardingRuleConfiguration currentRuleConfig, final ShardingAutoTableRuleConfiguration autoTableRule) {
+    private Collection<String> getBindableShardingAutoTables(final ShardingRuleConfiguration currentRuleConfig, final ShardingAutoTableRuleConfiguration autoTableRule) {
         return currentRuleConfig.getAutoTables().stream()
                 .filter(each -> hasSameShardingStrategy(each.getShardingStrategy(), autoTableRule.getShardingStrategy()))
                 .map(ShardingAutoTableRuleConfiguration::getLogicTable).collect(Collectors.toSet());
     }
     
-    private Optional<ShardingAutoTableRuleConfiguration> getFromAutoTable(final Collection<ShardingAutoTableRuleConfiguration> autoTableConfigurations, final String tableName) {
+    private Optional<ShardingAutoTableRuleConfiguration> getConfigurationFromAutoTable(final Collection<ShardingAutoTableRuleConfiguration> autoTableConfigurations, final String tableName) {
         return autoTableConfigurations.stream().filter(each -> each.getLogicTable().equals(tableName)).findAny();
     }
     
-    private Optional<ShardingTableRuleConfiguration> getFromTable(final Collection<ShardingTableRuleConfiguration> tableConfigurations, final String tableName) {
+    private Optional<ShardingTableRuleConfiguration> getConfigurationFromTable(final Collection<ShardingTableRuleConfiguration> tableConfigurations, final String tableName) {
         return tableConfigurations.stream().filter(each -> each.getLogicTable().equals(tableName)).findAny();
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingBindingTableRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingBindingTableRuleStatementUpdater.java
@@ -17,21 +17,31 @@
 
 package org.apache.shardingsphere.sharding.distsql.handler.update;
 
+import com.google.common.base.Splitter;
 import org.apache.shardingsphere.infra.distsql.exception.DistSQLException;
 import org.apache.shardingsphere.infra.distsql.exception.rule.DuplicateRuleException;
+import org.apache.shardingsphere.infra.distsql.exception.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.infra.distsql.exception.rule.RequiredRuleMissedException;
 import org.apache.shardingsphere.infra.distsql.update.RuleDefinitionCreateUpdater;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ComplexShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.BindingTableRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.CreateShardingBindingTableRulesStatement;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -46,6 +56,7 @@ public final class CreateShardingBindingTableRuleStatementUpdater implements Rul
         checkCurrentRuleConfiguration(schemaName, currentRuleConfig);
         checkToBeCreatedBindingTables(schemaName, sqlStatement, currentRuleConfig);
         checkToBeCreatedDuplicateBindingTables(schemaName, sqlStatement, currentRuleConfig);
+        checkToBeCreatedCanBindBindingTables(sqlStatement, currentRuleConfig);
     }
     
     private void checkCurrentRuleConfiguration(final String schemaName, final ShardingRuleConfiguration currentRuleConfig) throws RequiredRuleMissedException {
@@ -80,6 +91,73 @@ public final class CreateShardingBindingTableRuleStatementUpdater implements Rul
     
     private Collection<String> getCurrentBindingTables(final ShardingRuleConfiguration currentRuleConfig) {
         return currentRuleConfig.getBindingTableGroups().stream().flatMap(each -> Arrays.stream(each.split(","))).map(String::trim).collect(Collectors.toList());
+    }
+    
+    private void checkToBeCreatedCanBindBindingTables(final CreateShardingBindingTableRulesStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) throws DistSQLException {
+        Collection<String> cannotBindRules = sqlStatement.getRules().stream().map(BindingTableRuleSegment::getTableGroups)
+                .filter(each -> !canBind(currentRuleConfig, each)).collect(Collectors.toCollection(LinkedList::new));
+        DistSQLException.predictionThrow(cannotBindRules.isEmpty(),
+            () -> new InvalidRuleConfigurationException("binding", cannotBindRules, Collections.singleton("Unable to bind with different sharding strategies")));
+    }
+    
+    private boolean canBind(final ShardingRuleConfiguration currentRuleConfig, final String bindingRule) {
+        LinkedList<String> shardingTables = new LinkedList<>(Splitter.on(",").trimResults().splitToList(bindingRule));
+        Collection<String> bindableShardingTables = getBindableShardingTable(currentRuleConfig, shardingTables.getFirst());
+        return bindableShardingTables.containsAll(shardingTables);
+    }
+    
+    private Collection<String> getBindableShardingTable(final ShardingRuleConfiguration currentRuleConfig, final String shardingTable) {
+        Collection<String> result = new ArrayList<>();
+        Optional<ShardingTableRuleConfiguration> tableRule = getFromTable(currentRuleConfig.getTables(), shardingTable);
+        tableRule.ifPresent(op -> result.addAll(getBindableShardingTable(currentRuleConfig, op)));
+        Optional<ShardingAutoTableRuleConfiguration> autoTableRule = getFromAutoTable(currentRuleConfig.getAutoTables(), shardingTable);
+        autoTableRule.ifPresent(op -> result.addAll(getBindableShardingAutoTable(currentRuleConfig, op)));
+        return result;
+    }
+    
+    private Collection<String> getBindableShardingTable(final ShardingRuleConfiguration currentRuleConfig, final ShardingTableRuleConfiguration tableRule) {
+        return currentRuleConfig.getTables().stream()
+                .filter(each -> hasSameShardingStrategy(each.getTableShardingStrategy(), tableRule.getTableShardingStrategy()))
+                .filter(each -> hasSameShardingStrategy(each.getDatabaseShardingStrategy(), tableRule.getDatabaseShardingStrategy()))
+                .map(ShardingTableRuleConfiguration::getLogicTable).collect(Collectors.toSet());
+    }
+    
+    private Collection<String> getBindableShardingAutoTable(final ShardingRuleConfiguration currentRuleConfig, final ShardingAutoTableRuleConfiguration autoTableRule) {
+        return currentRuleConfig.getAutoTables().stream()
+                .filter(each -> hasSameShardingStrategy(each.getShardingStrategy(), autoTableRule.getShardingStrategy()))
+                .map(ShardingAutoTableRuleConfiguration::getLogicTable).collect(Collectors.toSet());
+    }
+    
+    private Optional<ShardingAutoTableRuleConfiguration> getFromAutoTable(final Collection<ShardingAutoTableRuleConfiguration> autoTableConfigurations, final String tableName) {
+        return autoTableConfigurations.stream().filter(each -> each.getLogicTable().equals(tableName)).findAny();
+    }
+    
+    private Optional<ShardingTableRuleConfiguration> getFromTable(final Collection<ShardingTableRuleConfiguration> tableConfigurations, final String tableName) {
+        return tableConfigurations.stream().filter(each -> each.getLogicTable().equals(tableName)).findAny();
+    }
+    
+    private boolean hasSameShardingStrategy(final ShardingStrategyConfiguration boundTableShardingStrategy, final ShardingStrategyConfiguration matchedTableShardingStrategy) {
+        if (null == boundTableShardingStrategy && null == matchedTableShardingStrategy) {
+            return true;
+        }
+        if (null != boundTableShardingStrategy && null != matchedTableShardingStrategy) {
+            if (!boundTableShardingStrategy.getClass().getCanonicalName().equals(matchedTableShardingStrategy.getClass().getCanonicalName())) {
+                return false;
+            }
+            String boundTableColumn;
+            String matchTableColumn;
+            if (boundTableShardingStrategy instanceof StandardShardingStrategyConfiguration) {
+                boundTableColumn = ((StandardShardingStrategyConfiguration) boundTableShardingStrategy).getShardingColumn();
+                matchTableColumn = ((StandardShardingStrategyConfiguration) matchedTableShardingStrategy).getShardingColumn();
+            } else if (boundTableShardingStrategy instanceof ComplexShardingStrategyConfiguration) {
+                boundTableColumn = ((ComplexShardingStrategyConfiguration) boundTableShardingStrategy).getShardingColumns();
+                matchTableColumn = ((ComplexShardingStrategyConfiguration) matchedTableShardingStrategy).getShardingColumns();
+            } else {
+                return boundTableShardingStrategy instanceof NoneShardingStrategyConfiguration;
+            }
+            return boundTableColumn.equals(matchTableColumn);
+        }
+        return false;
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateShardingBindingTableRuleStatementUpdaterTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateShardingBindingTableRuleStatementUpdaterTest.java
@@ -19,10 +19,12 @@ package org.apache.shardingsphere.sharding.distsql.update;
 
 import org.apache.shardingsphere.infra.distsql.exception.DistSQLException;
 import org.apache.shardingsphere.infra.distsql.exception.rule.DuplicateRuleException;
+import org.apache.shardingsphere.infra.distsql.exception.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.infra.distsql.exception.rule.RequiredRuleMissedException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.distsql.handler.update.CreateShardingBindingTableRuleStatementUpdater;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.BindingTableRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.CreateShardingBindingTableRulesStatement;
@@ -32,6 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class CreateShardingBindingTableRuleStatementUpdaterTest {
@@ -51,6 +54,12 @@ public final class CreateShardingBindingTableRuleStatementUpdaterTest {
         updater.checkSQLStatement(shardingSphereMetaData, createDuplicatedSQLStatement(), getCurrentRuleConfig());
     }
     
+    @Test(expected = InvalidRuleConfigurationException.class)
+    public void assertCheckSQLStatementWithCanNotBindShardingTable() throws DistSQLException {
+        CreateShardingBindingTableRulesStatement statement = new CreateShardingBindingTableRulesStatement(Collections.singletonList(new BindingTableRuleSegment("t_1,t_2")));
+        updater.checkSQLStatement(shardingSphereMetaData, statement, getCurrentRuleConfig());
+    }
+    
     private CreateShardingBindingTableRulesStatement createSQLStatement() {
         return new CreateShardingBindingTableRulesStatement(Arrays.asList(new BindingTableRuleSegment("t_order,t_order_item"), new BindingTableRuleSegment("t_1,t_2")));
     }
@@ -63,7 +72,9 @@ public final class CreateShardingBindingTableRuleStatementUpdaterTest {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
         result.getTables().add(new ShardingTableRuleConfiguration("t_order"));
         result.getTables().add(new ShardingTableRuleConfiguration("t_order_item"));
-        result.getTables().add(new ShardingTableRuleConfiguration("t_1"));
+        ShardingTableRuleConfiguration tableRule1 = new ShardingTableRuleConfiguration("t_1");
+        tableRule1.setTableShardingStrategy(new StandardShardingStrategyConfiguration("column_name", "algorithmName"));
+        result.getTables().add(tableRule1);
         result.getTables().add(new ShardingTableRuleConfiguration("t_2"));
         return result;
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add a check on whether to bind, check whether it has the same sharding strategy and the same sharding key

<img width="831" alt="image" src="https://user-images.githubusercontent.com/52209337/158927603-2dcbf1a6-33c3-442b-bc5f-2b84ded3737f.png">

