### PR TITLE
support parsing Postgre sql DROP OWNED

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
@@ -118,5 +118,6 @@ execute
     | alterExtension
     | dropExtension
     | dropPolicy
+    | dropOwned
     ) SEMI_?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -100,6 +100,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Al
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterMaterializedViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DeclareContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DiscardContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DropOwnedContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
@@ -178,6 +179,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropViewStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLPrepareStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLTruncateStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropOwnedStatement;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -756,5 +758,10 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitDiscard(final DiscardContext ctx) {
         return new PostgreSQLDiscardStatement();
+    }
+
+    @Override
+    public ASTNode visitDropOwned(final DropOwnedContext ctx) {
+        return new PostgreSQLDropOwnedStatement();
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -431,8 +431,10 @@ public enum SQLVisitorRule {
     ALTER_TEXT_SEARCH_TEMPLATE("AlterTextSearchTemplate", SQLStatementType.DDL),
     
     ALTER_TEXT_SEARCH_PARSER("AlterTextSearchParser", SQLStatementType.DDL),
-    
-    DROP_POLICY("DropPolicy", SQLStatementType.DDL);
+
+    DROP_POLICY("DropPolicy", SQLStatementType.DDL),
+
+    DROP_OWNED("DropOwned", SQLStatementType.DDL);
 
     private final String name;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropOwnedStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropOwnedStatement.java
@@ -24,5 +24,5 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStat
  * Drop Owned statement.
  */
 @ToString
-public abstract class DropOwnedStatement extends AbstractSQLStatement implements DDLStatement{
+public abstract class DropOwnedStatement extends AbstractSQLStatement implements DDLStatement {
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropOwnedStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropOwnedStatement.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.statement.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+/**
+ * Drop Owned statement.
+ */
+@ToString
+public abstract class DropOwnedStatement extends AbstractSQLStatement implements DDLStatement{
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropOwnedStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropOwnedStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropOwnedStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
+
+/**
+ * PostgreSQL drop owned statement.
+ */
+@ToString
+public class PostgreSQLDropOwnedStatement extends DropOwnedStatement implements PostgreSQLStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropOwnedStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropOwnedStatement.java
@@ -25,5 +25,5 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.Pos
  * PostgreSQL drop owned statement.
  */
 @ToString
-public class PostgreSQLDropOwnedStatement extends DropOwnedStatement implements PostgreSQLStatement {
+public final class PostgreSQLDropOwnedStatement extends DropOwnedStatement implements PostgreSQLStatement {
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -168,6 +168,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.RenameStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.RenameTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.TruncateStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOwnedStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AlterInstanceStatementTestCase;
@@ -1177,6 +1178,9 @@ public final class SQLParserTestCases {
     
     @XmlElement(name = "drop-sharding-algorithm")
     private final List<DropShardingAlgorithmStatementTestCase> dropShardingAlgorithmStatementTestCases = new LinkedList<>();
+
+    @XmlElement(name = "drop-owned")
+    private final List<DropOwnedStatementTestCase> dropOwnedStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "create-tablespace")
     private final List<CreateTablespaceStatementTestCase> createTablespaceTestCases = new LinkedList<>();
@@ -1479,6 +1483,7 @@ public final class SQLParserTestCases {
         putAll(dropShardingAlgorithmStatementTestCases, result);
         putAll(createTablespaceTestCases, result);
         putAll(importSchemaConfigurationStatementTestCases, result);
+        putAll(dropOwnedStatementTestCases, result);
         return result;
     }
     // CHECKSTYLE:ON

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DropOwnedStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DropOwnedStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
+
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+/**
+ * Drop owned statement test case.
+ */
+public final class DropOwnedStatementTestCase extends SQLParserTestCase {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-owned.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-owned.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <drop-owned sql-case-id="drop_owned_by_one" />
+    <drop-owned sql-case-id="drop_owned_by_two" />
+    <drop-owned sql-case-id="drop_owned_by_one_cascade" />
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-owned.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-owned.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="drop_owned_by_one" value="DROP OWNED BY regress_dep_user0;" db-types="PostgreSQL" />
+    <sql-case id="drop_owned_by_two" value="DROP OWNED BY regress_dep_user0, regress_dep_user2;" db-types="PostgreSQL" />
+    <sql-case id="drop_owned_by_one_cascade" value="DROP OWNED BY regress_user_mvtest CASCADE;" db-types="PostgreSQL" />
+</sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -5917,22 +5917,6 @@
     <sql-case id="drop_by_postgresql_source_test_case132" value="DROP OPERATOR IF EXISTS @#@ (int, int);" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case133" value="DROP OPERATOR IF EXISTS no_such_schema.+ (int, int);" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case134" value="DROP OPERATOR |&gt;(bigint, bigint);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case135" value="DROP OWNED BY regress_addr_user;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case136" value="DROP OWNED BY regress_dep_user0, regress_dep_user2;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case137" value="DROP OWNED BY regress_dep_user0;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case138" value="DROP OWNED BY regress_dep_user1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case139" value="DROP OWNED BY regress_dep_user1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case140" value="DROP OWNED BY regress_dep_user1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case141" value="DROP OWNED BY regress_dep_user2, regress_dep_user0;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case142" value="DROP OWNED BY regress_evt_user;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case143" value="DROP OWNED BY regress_rls_dob_role1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case144" value="DROP OWNED BY regress_rls_dob_role1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case145" value="DROP OWNED BY regress_rls_dob_role1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case146" value="DROP OWNED BY regress_rls_dob_role1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case147" value="DROP OWNED BY regress_rls_dob_role1;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case148" value="DROP OWNED BY regress_test_role2 CASCADE;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case149" value="DROP OWNED BY regress_test_role2;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case150" value="DROP OWNED BY regress_user_mvtest CASCADE;" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case173" value="DROP PUBLICATION addr_pub;" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case174" value="DROP PUBLICATION addr_pub_schema;" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case175" value="DROP PUBLICATION pub;" db-types="PostgreSQL"/>


### PR DESCRIPTION
Fixes #15750 .

Changes proposed in this pull request:
- support parsing Postgre sql DROP OWNED
- add a new corresponding SQL case in [SQL Cases](https://github.com/apache/shardingsphere/tree/master/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported?rgh-link-date=2022-03-02T05%3A57%3A34Z) and expected parsed result in [Expected Statment XML](https://github.com/apache/shardingsphere/tree/master/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case?rgh-link-date=2022-03-02T05%3A57%3A34Z).
- Run [SQLParserParameterizedTest](https://github.com/apache/shardingsphere/blob/master/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/engine/SQLParserParameterizedTest.java?rgh-link-date=2022-03-02T05%3A57%3A34Z) and [UnsupportedSQLParserParameterizedTest](https://github.com/apache/shardingsphere/blob/master/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/engine/UnsupportedSQLParserParameterizedTest.java?rgh-link-date=2022-03-02T05%3A57%3A34Z) to make sure no exceptions.
