### PR TITLE
Add basic framework for global lock by cluster mode

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/test/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/ProxyInfoCollectorTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/test/java/org/apache/shardingsphere/agent/metrics/prometheus/collector/ProxyInfoCollectorTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.instance.definition.InstanceDefinition;
+import org.apache.shardingsphere.mode.lock.LockContext;
 import org.apache.shardingsphere.mode.manager.memory.workerid.generator.MemoryWorkerIdGenerator;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -34,8 +35,8 @@ public final class ProxyInfoCollectorTest {
     
     @Test
     public void assertCollect() {
-        ProxyContext.getInstance().getContextManager().init(mock(MetaDataContexts.class), mock(TransactionContexts.class), 
-                new InstanceContext(new ComputeNodeInstance(mock(InstanceDefinition.class)), new MemoryWorkerIdGenerator(), new ModeConfiguration("Memory", null, false)));
+        ProxyContext.getInstance().getContextManager().init(mock(MetaDataContexts.class), mock(TransactionContexts.class), new InstanceContext(new ComputeNodeInstance(mock(InstanceDefinition.class)),
+                new MemoryWorkerIdGenerator(), new ModeConfiguration("Memory", null, false)), mock(LockContext.class));
         assertFalse(new ProxyInfoCollector().collect().isEmpty());
     }
 }

--- a/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/test/java/org/apache/shardingsphere/agent/metrics/prometheus/service/PrometheusPluginBootServiceTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/shardingsphere-agent-plugin-metrics/shardingsphere-agent-metrics-prometheus/src/test/java/org/apache/shardingsphere/agent/metrics/prometheus/service/PrometheusPluginBootServiceTest.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.instance.definition.InstanceDefinition;
+import org.apache.shardingsphere.mode.lock.LockContext;
 import org.apache.shardingsphere.mode.manager.memory.workerid.generator.MemoryWorkerIdGenerator;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -47,8 +48,8 @@ public final class PrometheusPluginBootServiceTest {
     
     @Test
     public void assertStart() throws IOException {
-        ProxyContext.getInstance().getContextManager().init(mock(MetaDataContexts.class), mock(TransactionContexts.class), 
-                new InstanceContext(new ComputeNodeInstance(mock(InstanceDefinition.class)), new MemoryWorkerIdGenerator(), new ModeConfiguration("Memory", null, false)));
+        ProxyContext.getInstance().getContextManager().init(mock(MetaDataContexts.class), mock(TransactionContexts.class), new InstanceContext(new ComputeNodeInstance(mock(InstanceDefinition.class)),
+                new MemoryWorkerIdGenerator(), new ModeConfiguration("Memory", null, false)), mock(LockContext.class));
         Properties props = new Properties();
         props.setProperty("JVM_INFORMATION_COLLECTOR_ENABLED", Boolean.TRUE.toString());
         PROMETHEUS_PLUGIN_BOOT_SERVICE.start(new PluginConfiguration("localhost", 8090, "", props));

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/lock/ShardingSphereGlobalLock.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/lock/ShardingSphereGlobalLock.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.lock;
+
+/**
+ * Global lock of ShardingSphere.
+ */
+public interface ShardingSphereGlobalLock extends ShardingSphereLock {
+    
+    /**
+     * Ack locked.
+     *
+     * @param lockName lock name
+     * @param instanceId instance id
+     */
+    void ackLock(String lockName, String instanceId);
+    
+    /**
+     * Release ack lock.
+     *
+     * @param lockName lock name
+     * @param instanceId instance id
+     */
+    void releaseAckLock(String lockName, String instanceId);
+    
+    /**
+     * Add locked instance id.
+     *
+     * @param instanceId instance id
+     */
+    void addLockedInstance(String instanceId);
+}

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/lock/LockContext.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/lock/LockContext.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.lock;
+
+import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
+
+import java.util.Optional;
+
+/**
+ * Lock context.
+ */
+public interface LockContext {
+    
+    /**
+     * Create schema lock.
+     *
+     * @param schemaName schema name
+     * @return schema lock
+     */
+    Optional<ShardingSphereGlobalLock> createSchemaLock(String schemaName);
+    
+    /**
+     * Get schema lock.
+     *
+     * @param schemaName schema name
+     * @return schema lock
+     */
+    Optional<ShardingSphereGlobalLock> getSchemaLock(String schemaName);
+    
+    /**
+     *  Is locked schema.
+     *
+     * @param schemaName schema name
+     * @return is locked schema or not
+     */
+    boolean isLockedSchema(String schemaName);
+}

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -43,6 +43,7 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder;
 import org.apache.shardingsphere.infra.rule.builder.schema.SchemaRulesBuilder;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
+import org.apache.shardingsphere.mode.lock.LockContext;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.MetaDataContextsBuilder;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
@@ -80,17 +81,21 @@ public final class ContextManager implements AutoCloseable {
     
     private volatile InstanceContext instanceContext;
     
+    private volatile LockContext lockContext;
+    
     /**
      * Initialize context manager.
      *
      * @param metaDataContexts meta data contexts
      * @param transactionContexts transaction contexts
      * @param instanceContext instance context
+     * @param lockContext lock context
      */
-    public void init(final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final InstanceContext instanceContext) {
+    public void init(final MetaDataContexts metaDataContexts, final TransactionContexts transactionContexts, final InstanceContext instanceContext, final LockContext lockContext) {
         this.metaDataContexts = metaDataContexts;
         this.transactionContexts = transactionContexts;
         this.instanceContext = instanceContext;
+        this.lockContext = lockContext;
     }
     
     /**

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/ContextManagerTest.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
 import org.apache.shardingsphere.infra.metadata.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.mode.lock.LockContext;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.mode.metadata.persist.service.SchemaMetaDataPersistService;
@@ -80,7 +81,7 @@ public final class ContextManagerTest {
     @Before
     public void setUp() throws SQLException {
         contextManager = new ContextManager();
-        contextManager.init(metaDataContexts, mock(TransactionContexts.class), mock(InstanceContext.class));
+        contextManager.init(metaDataContexts, mock(TransactionContexts.class), mock(InstanceContext.class), mock(LockContext.class));
         when(metaDataContexts.getGlobalRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         when(metaDataContexts.getOptimizerContext().getFederationMetaData().getSchemas()).thenReturn(new LinkedHashMap<>());
         when(metaDataContexts.getProps()).thenReturn(new ConfigurationProperties(new Properties()));

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/ClusterContextManagerBuilder.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/ClusterContextManagerBuilder.java
@@ -32,6 +32,8 @@ import org.apache.shardingsphere.mode.manager.ContextManagerBuilder;
 import org.apache.shardingsphere.mode.manager.ContextManagerBuilderParameter;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.ClusterContextManagerCoordinator;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.RegistryCenter;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.DistributeLockContext;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.service.GlobalLockRegistryService;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.workerid.generator.ClusterWorkerIdGenerator;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.MetaDataContextsBuilder;
@@ -150,10 +152,12 @@ public final class ClusterContextManagerBuilder implements ContextManagerBuilder
                                                 final Properties transactionProps, final ModeConfiguration modeConfiguration) {
         InstanceContext instanceContext = new InstanceContext(metaDataPersistService.getComputeNodePersistService().loadComputeNodeInstance(instanceDefinition),
                 new ClusterWorkerIdGenerator(repository, metaDataPersistService, instanceDefinition), modeConfiguration);
+        DistributeLockContext distributeLockContext = new DistributeLockContext(instanceContext, new GlobalLockRegistryService(repository));
+        distributeLockContext.synchronizeGlobalLock();
         generateTransactionConfigurationFile(instanceContext, metaDataContexts, transactionProps);
         TransactionContexts transactionContexts = new TransactionContextsBuilder(metaDataContexts.getMetaDataMap(), metaDataContexts.getGlobalRuleMetaData().getRules()).build();
         ContextManager result = new ContextManager();
-        result.init(metaDataContexts, transactionContexts, instanceContext);
+        result.init(metaDataContexts, transactionContexts, instanceContext, distributeLockContext);
         return result;
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/DistributeLockContext.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/DistributeLockContext.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
+import org.apache.shardingsphere.mode.lock.LockContext;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.AckLockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.AckLockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.LockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.LockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.service.GlobalLockRegistryService;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Distribute lock context.
+ */
+@RequiredArgsConstructor
+public final class DistributeLockContext implements LockContext {
+    
+    private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
+    
+    private final Map<String, ShardingSphereGlobalLock> globalLocks = new LinkedHashMap<>();
+    
+    private final InstanceContext instanceContext;
+    
+    private final GlobalLockRegistryService globalLockService;
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> createSchemaLock(final String schemaName) {
+        LOCK.writeLock().lock();
+        try {
+            ShardingSphereGlobalLock result = globalLocks.get(schemaName);
+            if (null != result) {
+                return Optional.empty();
+            }
+            result = new ShardingSphereDistributeGlobalLock(instanceContext, globalLockService);
+            globalLocks.put(schemaName, result);
+            return Optional.of(result);
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> getSchemaLock(final String schemaName) {
+        LOCK.readLock().lock();
+        try {
+            return Optional.ofNullable(globalLocks.get(schemaName));
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+    
+    @Override
+    public boolean isLockedSchema(final String schemaName) {
+        LOCK.readLock().lock();
+        try {
+            return getSchemaLock(schemaName).map(shardingSphereGlobalLock -> shardingSphereGlobalLock.isLocked(schemaName)).orElse(false);
+        } finally {
+            LOCK.readLock().lock();
+        }
+    }
+    
+    /**
+     * Synchronize global lock.
+     */
+    public void synchronizeGlobalLock() {
+        // TODO synchronize all global locks from zookeeper path at '/lock/global/locks'
+        ackAllGlobalLocks();
+    }
+    
+    private void ackAllGlobalLocks() {
+        LOCK.readLock().lock();
+        try {
+            globalLocks.forEach((key, value) -> value.ackLock(key, getCurrentInstanceId()));
+        } finally {
+            LOCK.readLock().lock();
+        }
+    }
+    
+    private boolean isSameInstanceId(final String instanceId) {
+        return getCurrentInstanceId().equals(instanceId);
+    }
+    
+    private String getCurrentInstanceId() {
+        return instanceContext.getInstance().getInstanceDefinition().getInstanceId().getId();
+    }
+    
+    /**
+     * Locked event.
+     *
+     * @param event locked event
+     */
+    public void renew(final LockedEvent event) {
+        String schema = event.getSchema();
+        String ownerInstanceId = event.getOwnerInstanceId();
+        if (isSameInstanceId(ownerInstanceId)) {
+            return;
+        }
+        Optional<ShardingSphereGlobalLock> globalLock = createSchemaLock(schema);
+        globalLock.ifPresent(shardingSphereGlobalLock -> shardingSphereGlobalLock.ackLock(schema, getCurrentInstanceId()));
+    }
+    
+    /**
+     * Lock released event.
+     *
+     * @param event lock released event
+     */
+    public void renew(final LockReleasedEvent event) {
+        String schema = event.getSchema();
+        String ownerInstanceId = event.getOwnerInstanceId();
+        if (isSameInstanceId(ownerInstanceId)) {
+            removeGlobalLock(schema);
+            return;
+        }
+        getSchemaLock(schema).ifPresent(shardingSphereGlobalLock -> {
+            shardingSphereGlobalLock.releaseAckLock(schema, getCurrentInstanceId());
+            removeGlobalLock(schema);
+        });
+    }
+    
+    /**
+     * Ack locked event.
+     *
+     * @param event ack locked event
+     */
+    public void renew(final AckLockedEvent event) {
+        String schema = event.getSchema();
+        String lockedInstanceId = event.getLockedInstanceId();
+        Optional<ShardingSphereGlobalLock> globalLock = getSchemaLock(schema);
+        globalLock.ifPresent(shardingSphereGlobalLock -> shardingSphereGlobalLock.addLockedInstance(lockedInstanceId));
+    }
+    
+    /**
+     * Ack lock released event.
+     *
+     * @param event ack lock released event.
+     */
+    public void renew(final AckLockReleasedEvent event) {
+        String schema = event.getSchema();
+        String lockedInstanceId = event.getLockedInstanceId();
+        if (isSameInstanceId(lockedInstanceId)) {
+            removeGlobalLock(schema);
+            return;
+        }
+        Optional<ShardingSphereGlobalLock> globalLock = getSchemaLock(schema);
+        globalLock.ifPresent(shardingSphereGlobalLock -> shardingSphereGlobalLock.addLockedInstance(lockedInstanceId));
+    }
+    
+    private void removeGlobalLock(final String schema) {
+        LOCK.writeLock().lock();
+        try {
+            globalLocks.remove(schema);
+        } finally {
+            LOCK.writeLock().lock();
+        }
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/ShardingSphereDistributeGlobalLock.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/ShardingSphereDistributeGlobalLock.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock;
+
+import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
+import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.service.GlobalLockRegistryService;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.util.GlobalLockNode;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Global distribute lock of ShardingSphere.
+ */
+public final class ShardingSphereDistributeGlobalLock implements ShardingSphereGlobalLock {
+    
+    private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
+    
+    private static final int CHECK_ACK_INTERVAL_SECONDS = 1;
+    
+    private static final long DEFAULT_TRY_LOCK_TIMEOUT_MILLISECONDS = 3 * 60 * 1000;
+    
+    private static final long DEFAULT_REGISTRY_TIMEOUT_MILLISECONDS = 3 * 1000;
+    
+    private final InstanceContext instanceContext;
+    
+    private final String ownerInstanceId;
+    
+    private final GlobalLockRegistryService lockService;
+    
+    private final Set<String> lockedInstances = new LinkedHashSet<>();
+    
+    public ShardingSphereDistributeGlobalLock(final InstanceContext instanceContext, final GlobalLockRegistryService lockService) {
+        this.lockService = lockService;
+        this.instanceContext = instanceContext;
+        this.ownerInstanceId = instanceContext.getInstance().getInstanceDefinition().getInstanceId().getId();
+        initLockedInstances(instanceContext);
+        
+    }
+    
+    private void initLockedInstances(final InstanceContext instanceContext) {
+        instanceContext.getComputeNodeInstances().forEach(each -> lockedInstances.add(each.getInstanceDefinition().getInstanceId().getId()));
+    }
+    
+    @Override
+    public boolean tryLock(final String lockName) {
+        return lockService.tryLock(GlobalLockNode.generateSchemaLockName(lockName, ownerInstanceId), DEFAULT_REGISTRY_TIMEOUT_MILLISECONDS);
+    }
+    
+    @Override
+    public boolean tryLock(final String lockName, final long timeout) {
+        long count = 0;
+        while (count > timeout) {
+            if (tryLock(lockName)) {
+                return isAckOK(lockName, DEFAULT_TRY_LOCK_TIMEOUT_MILLISECONDS - count);
+            }
+            count += DEFAULT_REGISTRY_TIMEOUT_MILLISECONDS;
+        }
+        return false;
+    }
+    
+    private boolean isAckOK(final String lockName, final long timeout) {
+        long count = 0;
+        while (count > timeout) {
+            if (isLocked(lockName)) {
+                return true;
+            }
+            sleepInterval();
+            count += CHECK_ACK_INTERVAL_SECONDS;
+        }
+        return false;
+    }
+    
+    private void sleepInterval() {
+        try {
+            TimeUnit.SECONDS.sleep(CHECK_ACK_INTERVAL_SECONDS);
+        } catch (final InterruptedException ignore) {
+        }
+    }
+    
+    @Override
+    public void releaseLock(final String lockName) {
+        lockService.releaseLock(GlobalLockNode.generateSchemaLockName(lockName, ownerInstanceId));
+        removeLockedInstance(ownerInstanceId);
+    }
+    
+    private void removeLockedInstance(final String instanceId) {
+        LOCK.writeLock().lock();
+        try {
+            lockedInstances.remove(ownerInstanceId);
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+    
+    @Override
+    public boolean isLocked(final String lockName) {
+        String instanceId = instanceContext.getInstance().getInstanceDefinition().getInstanceId().getId();
+        if (!isOwnerInstanceId(instanceId)) {
+            return isContainsLockedInstances(instanceId);
+        }
+        if (!lockedInstances.contains(ownerInstanceId)) {
+            return false;
+        }
+        return isAckCompleted();
+    }
+    
+    private boolean isContainsLockedInstances(final String instanceId) {
+        LOCK.readLock().lock();
+        try {
+            return lockedInstances.contains(instanceId);
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+    
+    private boolean isAckCompleted() {
+        Collection<ComputeNodeInstance> computeNodeInstances = instanceContext.getComputeNodeInstances();
+        if (computeNodeInstances.size() > lockedInstances.size()) {
+            return false;
+        }
+        LOCK.readLock().lock();
+        try {
+            for (ComputeNodeInstance each : computeNodeInstances) {
+                if (!lockedInstances.contains(each.getInstanceDefinition().getInstanceId().getId())) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            LOCK.readLock().unlock();
+        }
+    }
+    
+    @Override
+    public long getDefaultTimeOut() {
+        return DEFAULT_TRY_LOCK_TIMEOUT_MILLISECONDS;
+    }
+    
+    @Override
+    public void addLockedInstance(final String lockedInstanceId) {
+        LOCK.writeLock().lock();
+        try {
+            lockedInstances.add(ownerInstanceId);
+        } finally {
+            LOCK.writeLock().unlock();
+        }
+    }
+    
+    @Override
+    public void ackLock(final String lockName, final String lockedInstanceId) {
+        lockService.ackLock(GlobalLockNode.generateSchemaAckLockName(lockName, lockedInstanceId), lockedInstanceId);
+        addLockedInstance(lockedInstanceId);
+    }
+    
+    @Override
+    public void releaseAckLock(final String lockName, final String lockedInstanceId) {
+        lockService.releaseAckLock(GlobalLockNode.generateSchemaAckLockName(lockName, lockedInstanceId));
+        removeLockedInstance(lockedInstanceId);
+    }
+    
+    private boolean isOwnerInstanceId(final String lockedInstanceId) {
+        return ownerInstanceId.equals(lockedInstanceId);
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/AckLockReleasedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/AckLockReleasedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+
+/**
+ * Ack released Lock event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class AckLockReleasedEvent implements GovernanceEvent {
+    
+    private final String schema;
+    
+    private final String lockedInstanceId;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/AckLockedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/AckLockedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+
+/**
+ * Ack locked event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class AckLockedEvent implements GovernanceEvent {
+    
+    private final String schema;
+    
+    private final String lockedInstanceId;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/LockReleasedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/LockReleasedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+
+/**
+ * Lock released event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class LockReleasedEvent implements GovernanceEvent {
+    
+    private final String schema;
+    
+    private final String ownerInstanceId;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/LockedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/event/LockedEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+
+/**
+ * Locked event.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class LockedEvent implements GovernanceEvent {
+    
+    private final String schema;
+    
+    private final String ownerInstanceId;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/service/GlobalLockRegistryService.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/service/GlobalLockRegistryService.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.service;
+
+import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Global lock registry service.
+ */
+public final class GlobalLockRegistryService {
+    
+    private final ClusterPersistRepository repository;
+    
+    public GlobalLockRegistryService(final ClusterPersistRepository repository) {
+        this.repository = repository;
+    }
+    
+    /**
+     * Try to get lock.
+     *
+     * @param lockName lock name
+     * @param timeoutMilliseconds the maximum time in milliseconds to acquire lock
+     * @return true if get the lock, false if not
+     */
+    public boolean tryLock(final String lockName, final long timeoutMilliseconds) {
+        return repository.tryLock(lockName, timeoutMilliseconds, TimeUnit.MILLISECONDS);
+    }
+    
+    /**
+     * Release lock.
+     *
+     * @param lockName lock name
+     */
+    public void releaseLock(final String lockName) {
+        repository.releaseLock(lockName);
+    }
+    
+    /**
+     * Ack lock.
+     *
+     * @param lockName lock name
+     * @param lockValue lock value
+     */
+    public void ackLock(final String lockName, final String lockValue) {
+        repository.persistEphemeral(lockName, lockValue);
+    }
+    
+    /**
+     * Release ack lock.
+     *
+     * @param lockName lock name
+     */
+    public void releaseAckLock(final String lockName) {
+        repository.delete(lockName);
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/util/GlobalLockNode.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/util/GlobalLockNode.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.util;
+
+import com.google.common.base.Joiner;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Global lock node.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class GlobalLockNode {
+    
+    private static final String LOCK_DELIMITER = "-";
+    
+    private static final String LOCK_ROOT = "lock";
+    
+    private static final String LOCK_SCOPE = "global";
+    
+    private static final String LOCKS_NODE = "locks";
+    
+    private static final String LOCKED_ACK_NODE = "ack";
+    
+    /**
+     * Get locks node path.
+     *
+     * @return locks node path
+     */
+    public static String getGlobalLocksNodePath() {
+        return Joiner.on("/").join("", LOCK_ROOT, LOCK_SCOPE, LOCKS_NODE);
+    }
+    
+    /**
+     * Get ack node path.
+     *
+     * @return ack node path
+     */
+    public static String getGlobalAckNodePath() {
+        return Joiner.on("/").join("", LOCK_ROOT, LOCK_SCOPE, LOCKED_ACK_NODE);
+    }
+    
+    /**
+     * Generate schema lock name.
+     *
+     * @param schema schema
+     * @param instanceId instance id
+     * @return schema lock name
+     */
+    public static String generateSchemaLockName(final String schema, final String instanceId) {
+        return generateLockName(schema, instanceId);
+    }
+    
+    /**
+     * Generate schema ack lock name.
+     *
+     * @param schema schema
+     * @param lockedInstanceId locked instance id
+     * @return schema ack lock name
+     */
+    public static String generateSchemaAckLockName(final String schema, final String lockedInstanceId) {
+        return generateLockName(schema, lockedInstanceId);
+    }
+    
+    private static String generateLockName(final String schema, final String instanceId) {
+        return schema + LOCK_DELIMITER + instanceId;
+    }
+    
+    
+    /**
+     * Get locked key name by locks node path.
+     *
+     * @param locksNodePath locks node path
+     * @return schema name
+     */
+    public static Optional<String> getLockedKey(final String locksNodePath) {
+        Pattern pattern = Pattern.compile(getGlobalLocksNodePath() + "/" + "(.+)/(.+)$", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(locksNodePath);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+    
+    /**
+     * Get ack locked key name by ack node path.
+     *
+     * @param ackNodePath ack node path
+     * @return locked instance id
+     */
+    public static Optional<String> getAckLockedKey(final String ackNodePath) {
+        Pattern pattern = Pattern.compile(getGlobalAckNodePath() + "/" + "(.+)/(.+)$", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(ackNodePath);
+        return matcher.find() ? Optional.of(matcher.group(1)) : Optional.empty();
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/watcher/GlobalAckChangedWatcher.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/watcher/GlobalAckChangedWatcher.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.watcher;
+
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.AckLockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.AckLockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.util.GlobalLockNode;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcher;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Global ack changed watcher.
+ */
+public final class GlobalAckChangedWatcher implements GovernanceWatcher<GovernanceEvent> {
+    
+    @Override
+    public Collection<String> getWatchingKeys() {
+        return Collections.singleton(GlobalLockNode.getGlobalAckNodePath());
+    }
+    
+    @Override
+    public Collection<DataChangedEvent.Type> getWatchingTypes() {
+        return Arrays.asList(DataChangedEvent.Type.ADDED, DataChangedEvent.Type.DELETED);
+    }
+    
+    @Override
+    public Optional<GovernanceEvent> createGovernanceEvent(final DataChangedEvent event) {
+        String key = event.getKey();
+        Optional<String> ackLockedKey = GlobalLockNode.getAckLockedKey(key);
+        if (ackLockedKey.isPresent()) {
+            String[] schemaInstance = ackLockedKey.get().split("-");
+            return handleGlobalAckEvent(event.getType(), schemaInstance[0], schemaInstance[1]);
+        }
+        return Optional.empty();
+    }
+    
+    private Optional<GovernanceEvent> handleGlobalAckEvent(final DataChangedEvent.Type eventType, final String schema, final String lockedInstanceId) {
+        if (DataChangedEvent.Type.ADDED == eventType) {
+            return Optional.of(new AckLockedEvent(schema, lockedInstanceId));
+        } else if (DataChangedEvent.Type.DELETED == eventType) {
+            return Optional.of(new AckLockReleasedEvent(schema, lockedInstanceId));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/watcher/GlobalLocksChangedWatcher.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/watcher/GlobalLocksChangedWatcher.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.watcher;
+
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.LockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.event.LockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.util.GlobalLockNode;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcher;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+/**
+ * Global locks changed watcher.
+ */
+public final class GlobalLocksChangedWatcher implements GovernanceWatcher<GovernanceEvent> {
+    
+    @Override
+    public Collection<String> getWatchingKeys() {
+        return Collections.singleton(GlobalLockNode.getGlobalLocksNodePath());
+    }
+    
+    @Override
+    public Collection<DataChangedEvent.Type> getWatchingTypes() {
+        return Arrays.asList(DataChangedEvent.Type.ADDED, DataChangedEvent.Type.DELETED);
+    }
+    
+    @Override
+    public Optional<GovernanceEvent> createGovernanceEvent(final DataChangedEvent event) {
+        Optional<String> lockedKey = GlobalLockNode.getLockedKey(event.getKey());
+        if (lockedKey.isPresent()) {
+            String[] schemaInstance = lockedKey.get().split("-");
+            return handleGlobalLocksEvent(event.getType(), schemaInstance[0], schemaInstance[1]);
+        }
+        return Optional.empty();
+    }
+    
+    private Optional<GovernanceEvent> handleGlobalLocksEvent(final DataChangedEvent.Type eventType, final String schema, final String instanceId) {
+        if (DataChangedEvent.Type.ADDED == eventType) {
+            return Optional.of(new LockedEvent(schema, instanceId));
+        } else if (DataChangedEvent.Type.DELETED == eventType) {
+            return Optional.of(new LockReleasedEvent(schema, instanceId));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/resources/META-INF/services/org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcher
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/resources/META-INF/services/org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcher
@@ -21,3 +21,5 @@ org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.watch
 org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.watcher.PropertiesChangedWatcher
 org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.watcher.ComputeNodeStateChangedWatcher
 org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.watcher.LockChangedWatcher
+org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.watcher.GlobalLocksChangedWatcher
+org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.watcher.GlobalAckChangedWatcher

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/util/GlobalLockNodeTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/util/GlobalLockNodeTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.future.lock.util;
+
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class GlobalLockNodeTest {
+    
+    @Test
+    public void assertGetLockedKey() {
+        Optional<String> lockName = GlobalLockNode.getLockedKey("/lock/global/locks/schema-127.0.0.1@3307/_c_c2d-lock-00000");
+        assertTrue(lockName.isPresent());
+        assertThat(lockName.get(), is("schema-127.0.0.1@3307"));
+    }
+    
+    @Test
+    public void assertGetAckLockedKey() {
+        Optional<String> lockName = GlobalLockNode.getAckLockedKey("/lock/global/ack/schema-127.0.0.1@3308/_c_c2d-lock-00000");
+        assertTrue(lockName.isPresent());
+        assertThat(lockName.get(), is("schema-127.0.0.1@3308"));
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-memory-mode/shardingsphere-memory-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/memory/MemoryContextManagerBuilder.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-memory-mode/shardingsphere-memory-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/memory/MemoryContextManagerBuilder.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.rule.identifier.type.InstanceAwareRule;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.manager.ContextManagerBuilder;
 import org.apache.shardingsphere.mode.manager.ContextManagerBuilderParameter;
+import org.apache.shardingsphere.mode.manager.memory.lock.MemoryLockContext;
 import org.apache.shardingsphere.mode.manager.memory.workerid.generator.MemoryWorkerIdGenerator;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.MetaDataContextsBuilder;
@@ -54,7 +55,7 @@ public final class MemoryContextManagerBuilder implements ContextManagerBuilder 
         generateTransactionConfigurationFile(instanceContext, metaDataContexts);
         TransactionContexts transactionContexts = new TransactionContextsBuilder(metaDataContexts.getMetaDataMap(), metaDataContexts.getGlobalRuleMetaData().getRules()).build();
         ContextManager result = new ContextManager();
-        result.init(metaDataContexts, transactionContexts, buildInstanceContext(parameter));
+        result.init(metaDataContexts, transactionContexts, buildInstanceContext(parameter), new MemoryLockContext());
         setInstanceContext(result);
         return result;
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-memory-mode/shardingsphere-memory-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/memory/lock/MemoryLockContext.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-memory-mode/shardingsphere-memory-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/memory/lock/MemoryLockContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.memory.lock;
+
+import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
+import org.apache.shardingsphere.mode.lock.LockContext;
+
+import java.util.Optional;
+
+/**
+ * Memory lock context.
+ */
+public class MemoryLockContext implements LockContext {
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> createSchemaLock(final String schemaName) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> getSchemaLock(final String schemaName) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public boolean isLockedSchema(final String schemaName) {
+        return false;
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/StandaloneContextManagerBuilder.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/StandaloneContextManagerBuilder.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.rule.identifier.type.InstanceAwareRule;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.manager.ContextManagerBuilder;
 import org.apache.shardingsphere.mode.manager.ContextManagerBuilderParameter;
+import org.apache.shardingsphere.mode.manager.standalone.lock.StandaloneLockContext;
 import org.apache.shardingsphere.mode.manager.standalone.workerid.generator.StandaloneWorkerIdGenerator;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.MetaDataContextsBuilder;
@@ -82,7 +83,7 @@ public final class StandaloneContextManagerBuilder implements ContextManagerBuil
                 metaDataPersistService.getComputeNodePersistService().loadComputeNodeInstance(parameter.getInstanceDefinition()), new StandaloneWorkerIdGenerator(), parameter.getModeConfig());
         generateTransactionConfigurationFile(instanceContext, metaDataContexts);
         TransactionContexts transactionContexts = new TransactionContextsBuilder(metaDataContexts.getMetaDataMap(), metaDataContexts.getGlobalRuleMetaData().getRules()).build();
-        result.init(metaDataContexts, transactionContexts, instanceContext);
+        result.init(metaDataContexts, transactionContexts, instanceContext, new StandaloneLockContext());
         setInstanceContext(result);
         return result;
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/lock/StandaloneLockContext.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/standalone/lock/StandaloneLockContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.manager.standalone.lock;
+
+import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
+import org.apache.shardingsphere.mode.lock.LockContext;
+
+import java.util.Optional;
+
+/**
+ * Standalone lock context.
+ */
+public final class StandaloneLockContext implements LockContext {
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> createSchemaLock(final String schemaName) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<ShardingSphereGlobalLock> getSchemaLock(final String schemaName) {
+        return Optional.empty();
+    }
+    
+    @Override
+    public boolean isLockedSchema(final String schemaName) {
+        return false;
+    }
+}

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineContextUtil.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineContextUtil.java
@@ -100,7 +100,7 @@ public final class PipelineContextUtil {
         ContextManager contextManager = shardingSphereDataSource.getContextManager();
         MetaDataPersistService metaDataPersistService = new MetaDataPersistService(getClusterPersistRepository());
         MetaDataContexts metaDataContexts = renewMetaDataContexts(contextManager.getMetaDataContexts(), metaDataPersistService);
-        contextManager.init(metaDataContexts, contextManager.getTransactionContexts(), contextManager.getInstanceContext());
+        contextManager.init(metaDataContexts, contextManager.getTransactionContexts(), contextManager.getInstanceContext(), contextManager.getLockContext());
         PipelineContext.initContextManager(contextManager);
     }
     


### PR DESCRIPTION
## Add basic framework for global lock by cluster mode

Related to #16269.

Changes proposed in this pull request:
- Add interface `ShardingSphereGlobalLock` extended `ShardingSphereLock`
- Add interface `LockContext`
- Add `DistributeLockContext` implemented  `LockContext` in cluster mode
- Add `ShardingSphereDistributeGlobalLock` implemented `ShardingSphereGlobalLock` in cluster mode 

