### PR TITLE
Fix NullPointerException when start up proxy with memory mode and postgres schema name

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/type/DatabaseType.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/type/DatabaseType.java
@@ -118,9 +118,6 @@ public interface DatabaseType {
      * @return whether contains system schema or not
      */
     default boolean containsSystemSchema(final String schemaName) {
-        if (getSystemSchemas().containsKey(schemaName)) {
-            return true;
-        }
         for (Collection<String> each : getSystemSchemas().values()) {
             if (each.contains(schemaName)) {
                 return true;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/type/dialect/MySQLDatabaseTypeTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/type/dialect/MySQLDatabaseTypeTest.java
@@ -27,7 +27,9 @@ import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,5 +67,14 @@ public final class MySQLDatabaseTypeTest {
         QuoteCharacter actual = new MySQLDatabaseType().getQuoteCharacter();
         assertThat(actual.getStartDelimiter(), is("`"));
         assertThat(actual.getEndDelimiter(), is("`"));
+    }
+    
+    @Test
+    public void assertContainsSystemSchema() {
+        assertTrue(new MySQLDatabaseType().containsSystemSchema("information_schema"));
+        assertTrue(new MySQLDatabaseType().containsSystemSchema("performance_schema"));
+        assertTrue(new MySQLDatabaseType().containsSystemSchema("mysql"));
+        assertTrue(new MySQLDatabaseType().containsSystemSchema("sys"));
+        assertFalse(new MySQLDatabaseType().containsSystemSchema("sharding_db"));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/type/dialect/PostgreSQLDatabaseTypeTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/database/type/dialect/PostgreSQLDatabaseTypeTest.java
@@ -27,7 +27,9 @@ import java.util.Collections;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,5 +67,13 @@ public final class PostgreSQLDatabaseTypeTest {
         QuoteCharacter actual = new PostgreSQLDatabaseType().getQuoteCharacter();
         assertThat(actual.getStartDelimiter(), is("\""));
         assertThat(actual.getEndDelimiter(), is("\""));
+    }
+    
+    @Test
+    public void assertContainsSystemSchema() {
+        assertTrue(new PostgreSQLDatabaseType().containsSystemSchema("information_schema"));
+        assertTrue(new PostgreSQLDatabaseType().containsSystemSchema("pg_catalog"));
+        assertFalse(new MySQLDatabaseType().containsSystemSchema("postgres"));
+        assertFalse(new MySQLDatabaseType().containsSystemSchema("sharding_db"));
     }
 }

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilder.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilder.java
@@ -91,6 +91,9 @@ public final class MetaDataContextsBuilder {
      */
     public void addSystemSchemas(final DatabaseType databaseType) {
         for (Entry<String, Collection<String>> entry : databaseType.getSystemSchemas().entrySet()) {
+            if (databaseMap.containsKey(entry.getKey())) {
+                continue;
+            }
             ShardingSphereDatabase database = DatabaseLoader.load(entry.getKey(), databaseType);
             databaseMap.put(entry.getKey(), database);
         }


### PR DESCRIPTION
Fixes #16301.

Changes proposed in this pull request:
- fix NullPointerException when start up proxy with memory mode and postgres schema name
- add unit test for containsSystemSchema method
