### PR TITLE
Remove HikariCP dependency in pipeline modules

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/pom.xml
@@ -48,11 +48,6 @@
         </dependency>
         
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.data.pipeline.mysql.ingest;
 
 import com.google.common.base.Preconditions;
-import com.zaxxer.hikari.HikariConfig;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.ingest.DumperConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.StandardPipelineDataSourceConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml.YamlJdbcConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.ingest.channel.PipelineChannel;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IngestPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.PlaceholderPosition;
@@ -93,10 +93,10 @@ public final class MySQLIncrementalDumper extends AbstractIncrementalDumper<Binl
     }
     
     private void dump() {
-        HikariConfig hikariConfig = ((StandardPipelineDataSourceConfiguration) dumperConfig.getDataSourceConfig()).getHikariConfig();
-        log.info("incremental dump, jdbcUrl={}", hikariConfig.getJdbcUrl());
-        DataSourceMetaData metaData = DatabaseTypeRegistry.getActualDatabaseType("MySQL").getDataSourceMetaData(hikariConfig.getJdbcUrl(), null);
-        MySQLClient client = new MySQLClient(new ConnectInfo(random.nextInt(), metaData.getHostname(), metaData.getPort(), hikariConfig.getUsername(), hikariConfig.getPassword()));
+        YamlJdbcConfiguration jdbcConfig = ((StandardPipelineDataSourceConfiguration) dumperConfig.getDataSourceConfig()).getJdbcConfig();
+        log.info("incremental dump, jdbcUrl={}", jdbcConfig.getJdbcUrl());
+        DataSourceMetaData metaData = DatabaseTypeRegistry.getActualDatabaseType("MySQL").getDataSourceMetaData(jdbcConfig.getJdbcUrl(), null);
+        MySQLClient client = new MySQLClient(new ConnectInfo(random.nextInt(), metaData.getHostname(), metaData.getPort(), jdbcConfig.getUsername(), jdbcConfig.getPassword()));
         client.connect();
         client.subscribe(binlogPosition.getFilename(), binlogPosition.getPosition());
         int eventCount = 0;

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/pom.xml
@@ -41,11 +41,6 @@
         </dependency>
         
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.opengauss</groupId>
             <artifactId>opengauss-jdbc</artifactId>
             <scope>provided</scope>

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/OpenGaussLogicalReplication.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/ingest/wal/OpenGaussLogicalReplication.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.opengauss.ingest.wal;
 
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.StandardPipelineDataSourceConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml.YamlJdbcConfiguration;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.decode.BaseLogSequenceNumber;
 import org.opengauss.PGProperty;
 import org.opengauss.jdbc.PgConnection;
@@ -53,12 +54,13 @@ public final class OpenGaussLogicalReplication {
      */
     public Connection createConnection(final StandardPipelineDataSourceConfiguration pipelineDataSourceConfig) throws SQLException {
         Properties props = new Properties();
-        PGProperty.USER.set(props, pipelineDataSourceConfig.getHikariConfig().getUsername());
-        PGProperty.PASSWORD.set(props, pipelineDataSourceConfig.getHikariConfig().getPassword());
+        YamlJdbcConfiguration jdbcConfig = pipelineDataSourceConfig.getJdbcConfig();
+        PGProperty.USER.set(props, jdbcConfig.getUsername());
+        PGProperty.PASSWORD.set(props, jdbcConfig.getPassword());
         PGProperty.ASSUME_MIN_SERVER_VERSION.set(props, "9.4");
         PGProperty.REPLICATION.set(props, "database");
         PGProperty.PREFER_QUERY_MODE.set(props, "simple");
-        return DriverManager.getConnection(pipelineDataSourceConfig.getHikariConfig().getJdbcUrl(), props);
+        return DriverManager.getConnection(jdbcConfig.getJdbcUrl(), props);
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/pom.xml
@@ -36,12 +36,6 @@
         </dependency>
         
         <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>provided</scope>

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/LogicalReplication.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ingest/wal/LogicalReplication.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal;
 
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.StandardPipelineDataSourceConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml.YamlJdbcConfiguration;
 import org.apache.shardingsphere.data.pipeline.postgresql.ingest.wal.decode.BaseLogSequenceNumber;
 import org.postgresql.PGConnection;
 import org.postgresql.PGProperty;
@@ -43,12 +44,13 @@ public final class LogicalReplication {
      */
     public Connection createConnection(final StandardPipelineDataSourceConfiguration pipelineDataSourceConfig) throws SQLException {
         Properties props = new Properties();
-        PGProperty.USER.set(props, pipelineDataSourceConfig.getHikariConfig().getUsername());
-        PGProperty.PASSWORD.set(props, pipelineDataSourceConfig.getHikariConfig().getPassword());
+        YamlJdbcConfiguration jdbcConfig = pipelineDataSourceConfig.getJdbcConfig();
+        PGProperty.USER.set(props, jdbcConfig.getUsername());
+        PGProperty.PASSWORD.set(props, jdbcConfig.getPassword());
         PGProperty.ASSUME_MIN_SERVER_VERSION.set(props, "9.6");
         PGProperty.REPLICATION.set(props, "database");
         PGProperty.PREFER_QUERY_MODE.set(props, "simple");
-        return DriverManager.getConnection(pipelineDataSourceConfig.getHikariConfig().getJdbcUrl(), props);
+        return DriverManager.getConnection(jdbcConfig.getJdbcUrl(), props);
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/pom.xml
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/pom.xml
@@ -43,11 +43,5 @@
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
-        
-        <dependency>
-            <groupId>com.zaxxer</groupId>
-            <artifactId>HikariCP</artifactId>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfiguration.java
@@ -17,15 +17,15 @@
 
 package org.apache.shardingsphere.data.pipeline.api.datasource.config.impl;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.PipelineDataSourceConfiguration;
-import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml.YamlJdbcConfiguration;
 import org.apache.shardingsphere.infra.database.metadata.url.JdbcUrlAppender;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.infra.datasource.pool.metadata.type.hikari.HikariDataSourcePoolFieldMetaData;
+import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
@@ -49,7 +49,7 @@ public final class StandardPipelineDataSourceConfiguration implements PipelineDa
     private final DataSourceProperties dataSourceProperties;
     
     @Getter
-    private final HikariConfig hikariConfig;
+    private final YamlJdbcConfiguration jdbcConfig;
     
     @Getter
     private final DatabaseType databaseType;
@@ -66,12 +66,12 @@ public final class StandardPipelineDataSourceConfiguration implements PipelineDa
     private StandardPipelineDataSourceConfiguration(final String parameter, final Map<String, Object> yamlConfig) {
         this.parameter = parameter;
         if (!yamlConfig.containsKey(DATA_SOURCE_CLASS_NAME)) {
-            yamlConfig.put(DATA_SOURCE_CLASS_NAME, HikariDataSource.class.getName());
+            yamlConfig.put(DATA_SOURCE_CLASS_NAME, "com.zaxxer.hikari.HikariDataSource");
         }
         dataSourceProperties = new YamlDataSourceConfigurationSwapper().swapToDataSourceProperties(yamlConfig);
         yamlConfig.remove(DATA_SOURCE_CLASS_NAME);
-        hikariConfig = YamlEngine.unmarshal(YamlEngine.marshal(yamlConfig), HikariConfig.class, true);
-        databaseType = DatabaseTypeRegistry.getDatabaseTypeByURL(hikariConfig.getJdbcUrl());
+        jdbcConfig = YamlEngine.unmarshal(YamlEngine.marshal(yamlConfig), YamlJdbcConfiguration.class, true);
+        databaseType = DatabaseTypeRegistry.getDatabaseTypeByURL(jdbcConfig.getJdbcUrl());
     }
     
     public StandardPipelineDataSourceConfiguration(final String jdbcUrl, final String username, final String password) {
@@ -80,9 +80,10 @@ public final class StandardPipelineDataSourceConfiguration implements PipelineDa
     
     private static Map<String, Object> wrapParameter(final String jdbcUrl, final String username, final String password) {
         Map<String, Object> result = new LinkedHashMap<>(3, 1);
-        result.put("jdbcUrl", jdbcUrl);
-        result.put("username", username);
-        result.put("password", password);
+        HikariDataSourcePoolFieldMetaData fieldMetaData = new HikariDataSourcePoolFieldMetaData();
+        result.put(fieldMetaData.getJdbcUrlFieldName(), jdbcUrl);
+        result.put(fieldMetaData.getUsernameFieldName(), username);
+        result.put(fieldMetaData.getPasswordFieldName(), password);
         return result;
     }
     
@@ -98,7 +99,7 @@ public final class StandardPipelineDataSourceConfiguration implements PipelineDa
     
     @Override
     public void appendJDBCQueryProperties(final Properties queryProps) {
-        hikariConfig.setJdbcUrl(new JdbcUrlAppender().appendQueryProperties(hikariConfig.getJdbcUrl(), queryProps));
+        jdbcConfig.setJdbcUrl(new JdbcUrlAppender().appendQueryProperties(jdbcConfig.getJdbcUrl(), queryProps));
     }
     
     // TODO toShardingSphereJDBCDataSource(final String actualDataSourceName, final String logicTableName, final String actualTableName)

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfiguration.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * JDBC configuration for YAML.
+ */
+@Getter
+@Setter
+public final class YamlJdbcConfiguration {
+    
+    private String jdbcUrl;
+    
+    private String username;
+    
+    private String password;
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfigurationTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfigurationTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.api.datasource.config.impl;
 
-import com.zaxxer.hikari.HikariConfig;
+import org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml.YamlJdbcConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.junit.Before;
@@ -36,11 +36,17 @@ public final class StandardPipelineDataSourceConfigurationTest {
     
     private static final String WINDOWS = "Windows";
     
+    private static final String JDBC_URL = "jdbc:mysql://127.0.0.1:3306/demo_ds?serverTimezone=UTC&useSSL=false";
+    
+    private static final String USERNAME = "userName";
+    
+    private static final String PASSWORD = "password";
+    
     private StandardPipelineDataSourceConfiguration dataSourceConfig;
     
     @Before
     public void setUp() throws SQLException {
-        dataSourceConfig = new StandardPipelineDataSourceConfiguration("jdbc:mysql://127.0.0.1:3306/demo_ds?serverTimezone=UTC&useSSL=false", "userName", "password");
+        dataSourceConfig = new StandardPipelineDataSourceConfiguration(JDBC_URL, USERNAME, PASSWORD);
     }
     
     @Test
@@ -69,14 +75,15 @@ public final class StandardPipelineDataSourceConfigurationTest {
     
     @Test
     public void assertGetHikariConfigSuccess() {
-        HikariConfig actualHikariConfig = dataSourceConfig.getHikariConfig();
-        long actualActualHikariConfigConnectionTimeout = actualHikariConfig.getConnectionTimeout();
-        long expectedActualHikariConfigConnectionTimeout = 30000;
-        assertThat(actualActualHikariConfigConnectionTimeout, is(expectedActualHikariConfigConnectionTimeout));
+        YamlJdbcConfiguration actual = dataSourceConfig.getJdbcConfig();
+        assertThat(actual.getJdbcUrl(), is(JDBC_URL));
+        assertThat(actual.getUsername(), is(USERNAME));
+        assertThat(actual.getPassword(), is(PASSWORD));
     }
     
     @Test
     public void assertGetParameterSuccess() {
+        // TODO could be OS independent?
         String os = System.getProperty("os.name");
         String expectedParameter = "jdbcUrl: jdbc:mysql://127.0.0.1:3306/demo_ds?serverTimezone=UTC&useSSL=false\n"
                 + "username: userName\n"

--- a/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/config/TargetConfiguration.java
+++ b/shardingsphere-test/shardingsphere-integration-scaling-test/shardingsphere-integration-scaling-test-mysql/src/test/java/org/apache/shardingsphere/integration/scaling/test/mysql/env/config/TargetConfiguration.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.integration.scaling.test.mysql.env.config;
 
-import com.zaxxer.hikari.HikariDataSource;
-import org.apache.shardingsphere.integration.scaling.test.mysql.env.IntegrationTestEnvironment;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.StandardPipelineDataSourceConfiguration;
+import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceFactory;
+import org.apache.shardingsphere.integration.scaling.test.mysql.env.IntegrationTestEnvironment;
 
 import javax.sql.DataSource;
 import java.util.Properties;
@@ -61,6 +61,6 @@ public final class TargetConfiguration {
      * @return data source
      */
     public static DataSource createHostDataSource() {
-        return new HikariDataSource(TargetConfiguration.getHostConfiguration().getHikariConfig());
+        return new PipelineDataSourceFactory().newInstance(getHostConfiguration());
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- Replacement: 1) `HikariConfig` to `YamlJdbcConfiguration`, 2) `HikariDataSource.class.getName()` to `"com.zaxxer.hikari.HikariDataSource"`.
- Related classes refactoring
