### PR TITLE
CI ignore docs change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,12 @@ name: Continuous Integration
 on:
   push:
     branches: [ master, dev ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
   repository_dispatch:
     types: [rerun-ci]
 

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -20,8 +20,12 @@ name: Integration Test
 on:
   push:
     branches: [ master, dev ]
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Purpose:
- Currently, if we just modify documents, it will trigger `Continuous Integration` and `Integration Test`, it's not necessary to do it. Improvement: skip CI and IT for docs change.

Changes proposed in this pull request:
- Add `paths-ignore` in `ci.yml` and `it.yml`. Refer to [Running your workflow based on files changed in a pull request]( https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-based-on-files-changed-in-a-pull-request ) for more details.
