### PR TITLE
Reduce unnecessary layer in ShardingSphere-Proxy Dockerfile

### DIFF
--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/Dockerfile
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/Dockerfile
@@ -22,7 +22,6 @@ ARG APP_NAME
 ENV LOCAL_PATH /opt/shardingsphere-proxy
 
 ADD target/${APP_NAME}.tar.gz /opt
-RUN mv /opt/${APP_NAME} ${LOCAL_PATH}
-RUN mkdir -p ${LOCAL_PATH}/ext-lib
+RUN mv /opt/${APP_NAME} ${LOCAL_PATH} && mkdir -p ${LOCAL_PATH}/ext-lib
 
 ENTRYPOINT ${LOCAL_PATH}/bin/start.sh ${PORT} && tail -f ${LOCAL_PATH}/logs/stdout.log

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/Dockerfile
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/Dockerfile
@@ -14,9 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-FROM openjdk:8-jdk-slim
-MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
+FROM alpine AS prepare
 
 ARG APP_NAME
 ENV LOCAL_PATH /opt/shardingsphere-proxy
@@ -24,4 +22,10 @@ ENV LOCAL_PATH /opt/shardingsphere-proxy
 ADD target/${APP_NAME}.tar.gz /opt
 RUN mv /opt/${APP_NAME} ${LOCAL_PATH} && mkdir -p ${LOCAL_PATH}/ext-lib
 
+FROM openjdk:8-jdk-slim
+MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
+
+ENV LOCAL_PATH /opt/shardingsphere-proxy
+
+COPY --from=prepare ${LOCAL_PATH} ${LOCAL_PATH}
 ENTRYPOINT ${LOCAL_PATH}/bin/start.sh ${PORT} && tail -f ${LOCAL_PATH}/logs/stdout.log


### PR DESCRIPTION
Related to #16287.

5.1.0: 247.69 MB
https://hub.docker.com/layers/shardingsphere-proxy/apache/shardingsphere-proxy/5.1.0/images/sha256-2ace301ee85ead48c37943203238c6ffdccca603f6a6550f66a99b63b6fac4af?context=explore

![image](https://user-images.githubusercontent.com/20503072/160061480-1d956c58-7b35-46de-a8d7-6e683135bd0d.png)


Reduced: 191.82 MB
https://hub.docker.com/layers/shardingsphere-proxy/teslacn/shardingsphere-proxy/aff9146e0e/images/sha256-40599b77eb736ac88ead9d3ed8b2a27d6b4d83ffdd68358e69df99cfc1101d2f?context=repo

![image](https://user-images.githubusercontent.com/20503072/160061540-23311f8e-2e4c-41c2-abe6-639993785614.png)
