### PR TITLE
Ignore CI triggering on push to master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ dev ]
     paths-ignore:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -19,7 +19,7 @@ name: Integration Test
 
 on:
   push:
-    branches: [ master, dev ]
+    branches: [ dev ]
     paths-ignore:
       - 'docs/**'
   pull_request:


### PR DESCRIPTION
Purpose:
- Currently, on pull_request, GitHub Action workflow will be triggered and run on master branch. And on push to master branch, the same workflow will be triggered and run again (include CI and IT jobs), it's not necessary. Improvement: ignore it to improve GitHub Actions performance.

Changes proposed in this pull request:
- Ignore CI triggering on push to master branch
