### PR TITLE
Disable status check on master branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -46,8 +46,6 @@ github:
     master:
       required_status_checks:
         strict: true
-        contexts:
-          - check-license
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ name: Continuous Integration
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ master, dev ]
     paths-ignore:
       - 'docs/**'
   pull_request:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -19,7 +19,7 @@ name: Integration Test
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ master, dev ]
     paths-ignore:
       - 'docs/**'
   pull_request:


### PR DESCRIPTION
The CI is too slow. Disable status check until we have a solution.
