### PR TITLE
Reduce duplicate overhead in Grantee

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/Grantee.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/Grantee.java
@@ -20,18 +20,31 @@ package org.apache.shardingsphere.infra.metadata.user;
 import com.google.common.base.Objects;
 import com.google.common.base.Strings;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 /**
  * Grantee.
  */
-@RequiredArgsConstructor
 public final class Grantee {
     
     @Getter
     private final String username;
     
+    @Getter
     private final String hostname;
+    
+    private final boolean isUnlimitedHost;
+    
+    private final int hashCode;
+    
+    private final String toString;
+    
+    public Grantee(final String username, final String hostname) {
+        this.username = username;
+        this.hostname = Strings.isNullOrEmpty(hostname) ? "%" : hostname;
+        isUnlimitedHost = "%".equals(this.hostname);
+        hashCode = isUnlimitedHost ? username.toUpperCase().hashCode() : Objects.hashCode(username.toUpperCase(), hostname.toUpperCase());
+        toString = username + "@" + hostname;
+    }
     
     @Override
     public boolean equals(final Object obj) {
@@ -43,29 +56,16 @@ public final class Grantee {
     }
     
     private boolean isPermittedHost(final Grantee grantee) {
-        return grantee.hostname.equalsIgnoreCase(hostname) || isUnlimitedHost();
-    }
-    
-    private boolean isUnlimitedHost() {
-        return Strings.isNullOrEmpty(hostname) || "%".equals(hostname);
-    }
-    
-    /**
-     * Get host name.
-     * 
-     * @return host name
-     */
-    public String getHostname() {
-        return Strings.isNullOrEmpty(hostname) ? "%" : hostname;
+        return isUnlimitedHost || grantee.hostname.equalsIgnoreCase(hostname);
     }
     
     @Override
     public int hashCode() {
-        return isUnlimitedHost() ? Objects.hashCode(username.toUpperCase()) : Objects.hashCode(username.toUpperCase(), hostname.toUpperCase());
+        return hashCode;
     }
     
     @Override
     public String toString() {
-        return String.format("%s@%s", username, hostname);
+        return toString;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/user/GranteeTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/user/GranteeTest.java
@@ -21,10 +21,25 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class GranteeTest {
+    
+    @Test
+    public void assertGetUsername() {
+        Grantee grantee = new Grantee("foo", "");
+        assertThat(grantee.getUsername(), is("foo"));
+    }
+    
+    @Test
+    public void assertGetHostname() {
+        Grantee grantee = new Grantee("name", "%");
+        Grantee grantee1 = new Grantee("name", "");
+        assertThat(grantee.getHostname(), is("%"));
+        assertThat(grantee1.getHostname(), is("%"));
+    }
     
     @Test
     public void assertEquals() {
@@ -33,10 +48,11 @@ public final class GranteeTest {
         Grantee grantee2 = new Grantee("name", "127.0.0.1");
         assertTrue(grantee.equals(grantee1));
         assertTrue(grantee.equals(grantee2));
+        assertFalse(grantee.equals(new Object()));
     }
     
     @Test
-    public void assertHashcode() {
+    public void assertHashCode() {
         Grantee grantee = new Grantee("name", "%");
         Grantee grantee1 = new Grantee("name", "");
         Grantee grantee2 = new Grantee("name", "127.0.0.1");
@@ -45,10 +61,9 @@ public final class GranteeTest {
     }
     
     @Test
-    public void assertHostname() {
-        Grantee grantee = new Grantee("name", "%");
-        Grantee grantee1 = new Grantee("name", "");
-        assertThat(grantee.getHostname(), is("%"));
-        assertThat(grantee1.getHostname(), is("%"));
+    public void assertToString() {
+        assertThat(new Grantee("name", "127.0.0.1").toString(), is("name@127.0.0.1"));
+        assertThat(new Grantee("name", "%").toString(), is("name@%"));
+        assertThat(new Grantee("name", "").toString(), is("name@"));
     }
 }


### PR DESCRIPTION
Related to #16336.

Since the Grantee is on the way of Proxy command, we have to reduce its overhead.