### PR TITLE
Add unit test for AlterInstanceHandler to cover the thrown exception

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
@@ -38,7 +38,7 @@ public final class AlterInstanceHandlerTest {
         String instanceId = "instance_id";
         String key = "key_1";
         String value = "value_1";
-        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId, key, value)).execute();
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -49,7 +49,7 @@ public final class AlterInstanceHandlerTest {
         String instanceId = "instance_id";
         String key = "xa_recovery_nodes";
         String value = "value_1";
-        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId, key, value)).execute();
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -61,10 +61,10 @@ public final class AlterInstanceHandlerTest {
         String instanceId = "instance_id";
         String key = "xa_recovery_nodes";
         String value = "value_1";
-        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId, key, value)).execute();
     }
 
-    private AlterInstanceStatement getSQLStatement(final String instanceId , final String key , final String value) {
-        return new AlterInstanceStatement(instanceId , key , value);
+    private AlterInstanceStatement getSQLStatement(final String instanceId, final String key, final String value) {
+        return new AlterInstanceStatement(instanceId, key, value);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
@@ -1,0 +1,54 @@
+package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable;
+
+
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.AlterInstanceStatement;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
+import org.apache.shardingsphere.mode.persist.PersistRepository;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.*;
+
+import static org.mockito.Mockito.*;
+
+public class AlterInstanceHandlerTest {
+
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void assertUpdateWithNotSupportedKey() throws SQLException {
+        String instanceId = "instance_id";
+        String key = "key_1";
+        String value = "value_1";
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void assertCheckWithNoPersistenceConfigurationFound() throws SQLException {
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        when(contextManager.getMetaDataContexts().getMetaDataPersistService()).thenReturn(Optional.empty());
+        ProxyContext.getInstance().init(contextManager);
+        String instanceId = "instance_id";
+        String key = "xa_recovery_nodes";
+        String value = "value_1";
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void assertCheckWithNotExistInstanceId() throws SQLException {
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        MetaDataPersistService metaDataPersistService = new MetaDataPersistService(mock(PersistRepository.class));
+        when(contextManager.getMetaDataContexts().getMetaDataPersistService()).thenReturn(Optional.of(metaDataPersistService));
+        ProxyContext.getInstance().init(contextManager);
+        String instanceId = "instance_id";
+        String key = "xa_recovery_nodes";
+        String value = "value_1";
+        new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
+    }
+
+
+    private AlterInstanceStatement getSQLStatement(final String instanceId , final String key , final String value) {
+        return new AlterInstanceStatement(instanceId , key , value);
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable;
 
 

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
@@ -25,9 +25,11 @@ import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.junit.Test;
 
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Optional;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public final class AlterInstanceHandlerTest {
 

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/AlterInstanceHandlerTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable;
 
-
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.AlterInstanceStatement;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
@@ -30,8 +29,7 @@ import java.util.*;
 
 import static org.mockito.Mockito.*;
 
-public class AlterInstanceHandlerTest {
-
+public final class AlterInstanceHandlerTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void assertUpdateWithNotSupportedKey() throws SQLException {
@@ -63,7 +61,6 @@ public class AlterInstanceHandlerTest {
         String value = "value_1";
         new AlterInstanceHandler().initStatement(getSQLStatement(instanceId , key , value)).execute();
     }
-
 
     private AlterInstanceStatement getSQLStatement(final String instanceId , final String key , final String value) {
         return new AlterInstanceStatement(instanceId , key , value);


### PR DESCRIPTION
Fixes #16359.

Changes proposed in this pull request:
- adding unit test to check alterInstanceHandler with not supported key.
- adding unit test to check alterInstanceHandler with no persistence configuration found.
- adding unit test to check alterInstanceHandler with Not exist InstanceId
