### PR TITLE
[CI] Recover fail-fast as default value true to speedup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
         java:
@@ -116,7 +115,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
-      fail-fast: false
       matrix:
         os: [ macos-latest ]
         java:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -40,7 +40,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
-      fail-fast: false
       matrix:
         env: [ docker ]
         adapter: [ proxy, jdbc ]
@@ -71,7 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
-      fail-fast: false
       matrix:
         env: [ docker ]
         adapter: [ proxy, jdbc ]
@@ -102,7 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
-      fail-fast: false
       matrix:
         env: [ docker ]
         adapter: [ proxy, jdbc ]


### PR DESCRIPTION
Purpose:
- Currently, `fail-fast` is set to `false` in CI and IT manually. Since we just change snippets of project, the failure in matrix jobs are almost the same, it's not necessary to run all of them if any one them is failed. Improvement: recover `fail-fast: true` to speedup CI when there's failure.

Changes proposed in this pull request:
- `fail-fast: false` is removed in `ci.yml` and `it.yml`
