### PR TITLE
Removed useless worker-id props for sharding key generator

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingKeyGeneratorsQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingKeyGeneratorsQueryResultSetTest.java
@@ -48,7 +48,7 @@ public final class ShardingKeyGeneratorsQueryResultSetTest {
         assertThat(actual.size(), is(3));
         assertThat(actual.get(0), is("snowflake"));
         assertThat(actual.get(1), is("SNOWFLAKE"));
-        assertThat(actual.get(2).toString(), is("{work-id=123}"));
+        assertThat(actual.get(2).toString(), is("{}"));
     }
     
     private Collection<ShardingRuleConfiguration> createRuleConfigurations() {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingKeyGeneratorsQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingKeyGeneratorsQueryResultSetTest.java
@@ -53,9 +53,7 @@ public final class ShardingKeyGeneratorsQueryResultSetTest {
     
     private Collection<ShardingRuleConfiguration> createRuleConfigurations() {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
-        Properties props = new Properties();
-        props.put("work-id", 123);
-        result.getKeyGenerators().put("snowflake", new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", props));
+        result.getKeyGenerators().put("snowflake", new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", new Properties()));
         return Collections.singleton(result);
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedAlgorithmQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedAlgorithmQueryResultSetTest.java
@@ -108,8 +108,6 @@ public final class ShowShardingTableRulesUsedAlgorithmQueryResultSetTest {
     }
 
     private ShardingSphereAlgorithmConfiguration createKeyGeneratorConfiguration() {
-        Properties props = new Properties();
-        props.put("worker-id", "123");
-        return new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", props);
+        return new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", new Properties());
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/UnusedShardingKeyGeneratorsQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/UnusedShardingKeyGeneratorsQueryResultSetTest.java
@@ -62,9 +62,7 @@ public final class UnusedShardingKeyGeneratorsQueryResultSetTest {
     }
     
     private ShardingSphereAlgorithmConfiguration createSnowflakeKeyGeneratorConfiguration() {
-        Properties props = new Properties();
-        props.put("work-id", 123);
-        return new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", props);
+        return new ShardingSphereAlgorithmConfiguration("SNOWFLAKE", new Properties());
     }
     
     private ShardingAutoTableRuleConfiguration createShardingAutoTableRuleConfiguration() {


### PR DESCRIPTION
Signed-off-by: Abhijeet Jejurkar <abhijeet.jejurkar2@gmail.com>

Fixes #16302 .

Changes proposed in this pull request:
- Removed useless worker-id props for sharding key generator
