### PR TITLE
Workflow on Windows and MacOS scheduled daily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
   
   macos:
     if: (github.event_name == 'schedule')
-    name: JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
+    name: macos
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,11 @@ on:
       - '.*.yaml'
   repository_dispatch:
     types: [rerun-ci]
+  schedule:
+    - cron: '0 0 */1 * *'  # once a day. UTC time
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -47,6 +49,7 @@ env:
 
 jobs:
   windows:
+    if: (github.event_name == 'schedule')
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -117,6 +120,7 @@ jobs:
         run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
   
   macos:
+    if: (github.event_name == 'schedule')
     name: JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60


### PR DESCRIPTION
Purpose:
- Currently, CI has several jobs, include Linux-JDK8/Linux-JDK11/Linux-JDK17, windows-JDK8, macos-JDK8. windows-JDK8 and macos-JDK8 are the slowest jobs. Since ShardingSphere run on Linux at the most time, we'll test several JDK versions on Linux, and there should be almost no failure on Windows and MacOS when it pass on Linux. If we run workflow on Windows and MacOS daily but not every PR or push, it could speedup CI.

Changes proposed in this pull request:
- Workflow on Windows and MacOS scheduled daily. 1) update concurrency group, since push to master and schedule both will trigger CI on master branch, 2) add condition for `windows` and `macos` jobs, just trigger CI when `github.event_name` is `schedule`.

It might need some discussion about whether need to do it.
