### PR TITLE
Add unit test for GlobalLockNode.getGlobalAckNodePath in GlobalLockNo…

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/service/GlobalLockNodeTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/future/lock/service/GlobalLockNodeTest.java
@@ -40,4 +40,9 @@ public final class GlobalLockNodeTest {
         assertTrue(lockName.isPresent());
         assertThat(lockName.get(), is("schema-127.0.0.1@3308"));
     }
+
+    @Test
+    public void assertGetGlobalAckNodePath() {
+        assertThat(GlobalLockNode.getGlobalAckNodePath(), is("/lock/global/ack"));
+    }
 }


### PR DESCRIPTION
…deTest class

Fixes #16390.

Changes proposed in this pull request:
-
-
-
