### PR TITLE
Supplement ShardingSphere-Proxy download link

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
@@ -5,7 +5,7 @@ weight = 1
 
 ## 启动步骤
 
-1. 下载 ShardingSphere-Proxy 的最新发行版。
+1. 通过[下载页面](https://shardingsphere.apache.org/document/current/cn/downloads/)获取 ShardingSphere-Proxy 安装包。
 2. 解压缩后修改 `conf/server.yaml` 和以 `config-` 前缀开头的文件，如：`conf/config-xxx.yaml` 文件，进行分片规则、读写分离规则配置。配置方式请参考[配置手册](/cn/user-manual/shardingsphere-proxy/yaml-config/)。
 3. Linux 操作系统请运行 `bin/start.sh`，Windows 操作系统请运行 `bin/start.bat` 启动 ShardingSphere-Proxy。如需配置启动端口、配置文件位置，可参考[快速入门](/cn/quick-start/shardingsphere-proxy-quick-start/)。
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
@@ -5,7 +5,7 @@ weight = 1
 
 ## Startup Steps
 
-1. Download the latest version of ShardingSphere-Proxy.
+1. Get ShardingSphere-Proxy binary package from [download page](https://shardingsphere.apache.org/document/current/en/downloads/).
 2. After the decompression, revise `conf/server.yaml` and documents begin with `config-` prefix, `conf/config-xxx.yaml` for example, to configure sharding rules and readwrite-splitting rules. Please refer to [Configuration Manual](/en/user-manual/shardingsphere-proxy/yaml-config/) for the configuration method.
 3. Please run `bin/start.sh` for Linux operating system; run `bin/start.bat` for Windows operating system to start ShardingSphere-Proxy. To configure start port and document location, please refer to [Quick Start](/en/quick-start/shardingsphere-proxy-quick-start/).
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Supplement ShardingSphere-Proxy download link(When a novice reads the ShardingSphere-Proxy startup document for the first time, it is not easy to find the download method).
