### PR TITLE
Adjust the results displayed by the `SHOW INSTANCE MODE` syntax

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowInstanceModeHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowInstanceModeHandler.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable;
 
+import com.google.gson.Gson;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceModeStatement;
 import org.apache.shardingsphere.infra.config.mode.PersistRepositoryConfiguration;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
-import org.apache.shardingsphere.infra.properties.PropertiesConverter;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.QueryableRALBackendHandler;
@@ -54,8 +54,11 @@ public final class ShowInstanceModeHandler extends QueryableRALBackendHandler<Sh
     protected Collection<List<Object>> getRows(final ContextManager contextManager) {
         InstanceContext instanceContext = ProxyContext.getInstance().getContextManager().getInstanceContext();
         PersistRepositoryConfiguration repositoryConfiguration = instanceContext.getModeConfiguration().getRepository();
-        return Collections.singleton(Arrays.asList(instanceContext.getInstance().getInstanceDefinition().getInstanceId().getId(), instanceContext.getModeConfiguration().getType(),
-                null == repositoryConfiguration ? "" : repositoryConfiguration.getType(), null == repositoryConfiguration ? "" : PropertiesConverter.convert(repositoryConfiguration.getProps()),
-                String.valueOf(instanceContext.getModeConfiguration().isOverwrite())));
+        String instanceId = instanceContext.getInstance().getInstanceDefinition().getInstanceId().getId();
+        String modeType = instanceContext.getModeConfiguration().getType();
+        String repositoryType = null == repositoryConfiguration ? "" : repositoryConfiguration.getType();
+        String props = null == repositoryConfiguration || null == repositoryConfiguration.getProps() ? "" : new Gson().toJson(repositoryConfiguration.getProps());
+        String overwrite = String.valueOf(instanceContext.getModeConfiguration().isOverwrite());
+        return Collections.singleton(Arrays.asList(instanceId, modeType, repositoryType, props, overwrite));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowInstanceModeHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ShowInstanceModeHandlerTest.java
@@ -51,7 +51,7 @@ public final class ShowInstanceModeHandlerTest {
         assertThat(data.get(0), is("127.0.0.1@3309"));
         assertThat(data.get(1), is("Cluster"));
         assertThat(data.get(2), is("ZooKeeper"));
-        assertThat(data.get(3), is("key=value"));
+        assertThat(data.get(3), is("{\"key\":\"value1,value2\"}"));
         assertThat(data.get(4), is("false"));
     }
     
@@ -59,7 +59,7 @@ public final class ShowInstanceModeHandlerTest {
         InstanceContext result = mock(InstanceContext.class, RETURNS_DEEP_STUBS);
         when(result.getInstance().getInstanceDefinition().getInstanceId().getId()).thenReturn("127.0.0.1@3309");
         when(result.getModeConfiguration()).thenReturn(new ModeConfiguration("Cluster", 
-                new ClusterPersistRepositoryConfiguration("ZooKeeper", "governance_ds", "127.0.0.1:2181", createProperties("key", "value")), false));
+                new ClusterPersistRepositoryConfiguration("ZooKeeper", "governance_ds", "127.0.0.1:2181", createProperties("key", "value1,value2")), false));
         return result;
     }
     


### PR DESCRIPTION
Changes proposed in this pull request:
- Adjust from splitting with `,` to json

```
mysql> show instance mode;
+-----------------+---------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| instance_id     | type    | repository | props                                                                                                                                                                  | overwrite |
+-----------------+---------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
| 10.7.5.135@3309 | Cluster | ZooKeeper  | {"timeToLiveSeconds":60,"retryIntervalMilliseconds":500,"operationTimeoutMilliseconds":500,"namespace":"governance_ds","server-lists":"localhost:2181","maxRetries":3} | false     |
+-----------------+---------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------+
1 row in set (4.43 sec)
```