### PR TITLE
Fix UnsupportedOperationException when refreshRules with emptyList

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilder.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilder.java
@@ -39,9 +39,9 @@ import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
@@ -124,8 +124,8 @@ public final class MetaDataContextsBuilder {
         for (Entry<String, ShardingSphereDatabase> entry : databaseMap.entrySet()) {
             String databaseName = entry.getKey();
             // TODO support database and schema configuration separately
-            SchemaConfiguration schemaConfig = schemaConfigMap.getOrDefault(databaseName, new DataSourceProvidedSchemaConfiguration(Collections.emptyMap(), Collections.emptyList()));
-            Collection<ShardingSphereRule> rules = schemaRulesMap.getOrDefault(databaseName, Collections.emptyList());
+            SchemaConfiguration schemaConfig = schemaConfigMap.getOrDefault(databaseName, new DataSourceProvidedSchemaConfiguration(new LinkedHashMap<>(), new LinkedList<>()));
+            Collection<ShardingSphereRule> rules = schemaRulesMap.getOrDefault(databaseName, new LinkedList<>());
             result.put(databaseName, ShardingSphereMetaData.create(databaseName, entry.getValue().getSchemas(), schemaConfig, rules, defaultDatabaseType));
         }
         return result;

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilderTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilderTest.java
@@ -23,6 +23,9 @@ import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmC
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.schema.impl.DataSourceProvidedSchemaConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.mode.metadata.fixture.FixtureRule;
@@ -35,6 +38,7 @@ import org.junit.Test;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -69,6 +73,34 @@ public final class MetaDataContextsBuilderTest {
         assertThat(actual.getGlobalRuleMetaData().getRules().stream().filter(each -> each instanceof AuthorityRule).count(), is(1L));
         assertThat(actual.getGlobalRuleMetaData().getRules().stream().filter(each -> each instanceof TransactionRule).count(), is(1L));
         assertThat(actual.getGlobalRuleMetaData().getRules().stream().filter(each -> each instanceof SQLParserRule).count(), is(1L));
+    }
+    
+    @Test
+    public void assertBuildWithEmptyRuleConfigurations() throws SQLException {
+        MetaDataContextsBuilder builder = new MetaDataContextsBuilder(Collections.emptyList(), new Properties());
+        builder.addSystemSchemas(new MySQLDatabaseType());
+        MetaDataContexts actual = builder.build(mock(MetaDataPersistService.class));
+        assertThat(actual.getMetaDataMap().size(), is(4));
+        assertTrue(actual.getMetaDataMap().containsKey("information_schema"));
+        assertTrue(actual.getMetaDataMap().containsKey("performance_schema"));
+        assertTrue(actual.getMetaDataMap().containsKey("mysql"));
+        assertTrue(actual.getMetaDataMap().containsKey("sys"));
+        assertThat(actual.getMetaDataMap().get("information_schema").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
+        assertThat(actual.getMetaDataMap().get("performance_schema").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
+        assertThat(actual.getMetaDataMap().get("mysql").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
+        assertThat(actual.getMetaDataMap().get("sys").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
+    }
+    
+    @Test
+    public void assertGetSchemaMap() {
+        MetaDataContextsBuilder builder = new MetaDataContextsBuilder(Collections.emptyList(), new Properties());
+        builder.addSystemSchemas(new MySQLDatabaseType());
+        ShardingSphereSchema actual = builder.getSchemaMap("information_schema");
+        TableMetaData tableMetaData = actual.get("tables");
+        assertThat(tableMetaData.getName(), is("tables"));
+        assertThat(tableMetaData.getColumns().size(), is(21));
+        assertThat(tableMetaData.getIndexes().size(), is(0));
+        assertThat(tableMetaData.getConstrains().size(), is(0));
     }
     
     private void assertRules(final MetaDataContexts actual) {

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilderTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/MetaDataContextsBuilderTest.java
@@ -24,8 +24,6 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.schema.impl.DataSourceProvidedSchemaConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
-import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.mode.metadata.fixture.FixtureRule;
@@ -89,18 +87,6 @@ public final class MetaDataContextsBuilderTest {
         assertThat(actual.getMetaDataMap().get("performance_schema").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
         assertThat(actual.getMetaDataMap().get("mysql").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
         assertThat(actual.getMetaDataMap().get("sys").getRuleMetaData().getRules(), instanceOf(LinkedList.class));
-    }
-    
-    @Test
-    public void assertGetSchemaMap() {
-        MetaDataContextsBuilder builder = new MetaDataContextsBuilder(Collections.emptyList(), new Properties());
-        builder.addSystemSchemas(new MySQLDatabaseType());
-        ShardingSphereSchema actual = builder.getSchemaMap("information_schema");
-        TableMetaData tableMetaData = actual.get("tables");
-        assertThat(tableMetaData.getName(), is("tables"));
-        assertThat(tableMetaData.getColumns().size(), is(21));
-        assertThat(tableMetaData.getIndexes().size(), is(0));
-        assertThat(tableMetaData.getConstrains().size(), is(0));
     }
     
     private void assertRules(final MetaDataContexts actual) {


### PR DESCRIPTION
Fixes #16462.

Changes proposed in this pull request:
- fix UnsupportedOperationException when refreshRules with emptyList
- add unit test
