### PR TITLE
Disable trimStackTrace in maven-surefire-plugin for better troubleshooting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -793,6 +793,7 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <configuration>
+                        <trimStackTrace>false</trimStackTrace>
                         <excludes>
                             <exclude />
                         </excludes>
@@ -1188,6 +1189,7 @@
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <configuration>
+                                <trimStackTrace>false</trimStackTrace>
                                 <excludes>
                                     <exclude />
                                 </excludes>


### PR DESCRIPTION
Purpose:
Currently, if there's exception thrown in unit test, `mvn install` just print trimmed stack trace, we could not find out where the exception throw, specially when the error occur on GitHub CI.

`trimStackTrace` is enabled by default in `maven-surefire-plugin`. Improvement: disable `trimStackTrace` to show full stack trace.

Example:
Previous error output, it just show `assertXxx` method error occur:
```
[INFO] Running org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.344 s <<< FAILURE! - in org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest
[ERROR] assertExecuteAllDisabledJob(org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest)  Time elapsed: 3.723 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest.assertExecuteAllDisabledJob(FinishedCheckJobTest.java:61)

[ERROR] assertExecuteActiveJob(org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest)  Time elapsed: 0.035 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest.assertExecuteActiveJob(FinishedCheckJobTest.java:71)
```

New error output, it not only show `assertXxx` method error occur, but also show the exact exception thrown source file and code line:
```
[INFO] Running org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 4.54 s <<< FAILURE! - in org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest
[ERROR] assertExecuteAllDisabledJob(org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest)  Time elapsed: 3.814 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory$1.initialize(PipelineAPIFactory.java:51)
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory$1.initialize(PipelineAPIFactory.java:48)
	at org.apache.commons.lang3.concurrent.LazyInitializer.get(LazyInitializer.java:106)
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory.getGovernanceRepositoryAPI(PipelineAPIFactory.java:67)
	at org.apache.shardingsphere.data.pipeline.core.api.impl.RuleAlteredJobAPIImpl.start(RuleAlteredJobAPIImpl.java:118)
	at org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest.assertExecuteAllDisabledJob(FinishedCheckJobTest.java:61)

[ERROR] assertExecuteActiveJob(org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest)  Time elapsed: 0.044 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory$1.initialize(PipelineAPIFactory.java:51)
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory$1.initialize(PipelineAPIFactory.java:48)
	at org.apache.commons.lang3.concurrent.LazyInitializer.get(LazyInitializer.java:106)
	at org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory.getGovernanceRepositoryAPI(PipelineAPIFactory.java:67)
	at org.apache.shardingsphere.data.pipeline.core.api.impl.RuleAlteredJobAPIImpl.start(RuleAlteredJobAPIImpl.java:118)
	at org.apache.shardingsphere.data.pipeline.core.job.FinishedCheckJobTest.assertExecuteActiveJob(FinishedCheckJobTest.java:71)
```

Changes proposed in this pull request:
- Disable trimStackTrace in maven-surefire-plugin
