### PR TITLE
[CI] Disable scheduled CI in forked repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ env:
 
 jobs:
   windows:
-    if: (github.event_name == 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere') || (github.event_name != 'schedule')
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -120,7 +120,7 @@ jobs:
         run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
   
   macos:
-    if: (github.event_name == 'schedule')
+    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere') || (github.event_name != 'schedule')
     name: macos
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60


### PR DESCRIPTION
CI scheduling was added recently in  #16414, I found another schedule workflow run in forked repository, it's not necessary. This scheduled workflow should be the same logic in forked repository.

Changes proposed in this pull request:
- Disable scheduled CI in forked repository. Add more condition `github.repository == 'apache/shardingsphere'`.
