### PR TITLE
[CI] Disable scheduled 'ISSUE Standardized Process' workflow

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -18,8 +18,8 @@
 name: ISSUE Standardized Process
 
 on:
-  schedule:
-    - cron: '0 0 */1 * *'  # once a day
+#  schedule:
+#    - cron: '0 0 */1 * *'  # once a day
   issue_comment:
     types: [created,edited]
   issues:


### PR DESCRIPTION
Currently, the `ISSUE Standardized Process` workflow is `disabled` in Actions page, but it's still scheduled in active forked repository, it's not necessary to run it.

Changes proposed in this pull request:
- Disable scheduled `ISSUE Standardized Process` workflow. Comment `schedule cron` settings.
