### PR TITLE
support parsing Postgre sql DROP AGGREGATE

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
@@ -124,5 +124,6 @@ execute
     | dropMaterializedView
     | dropGroup
     | dropEventTrigger
+    | dropAggregate
     ) SEMI_?
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -106,6 +106,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Di
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DropOwnedContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DropOperatorContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DropMaterializedViewContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.DropAggregateContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
@@ -190,6 +191,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropOperatorStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropMaterializedViewStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropEventTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLDropAggregateStatement;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -798,5 +800,10 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitDropEventTrigger(final DropEventTriggerContext ctx) {
         return new PostgreSQLDropEventTriggerStatement();
+    }
+    
+    @Override
+    public ASTNode visitDropAggregate(final DropAggregateContext ctx) {
+        return new PostgreSQLDropAggregateStatement();
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -444,7 +444,9 @@ public enum SQLVisitorRule {
     
     DROP_OPERATOR("DropOperator", SQLStatementType.DDL),
     
-    DROP_MATERIALIZED_VIEW("DropMaterializedView", SQLStatementType.DDL);
+    DROP_MATERIALIZED_VIEW("DropMaterializedView", SQLStatementType.DDL),
+
+    DROP_AGGREGATE("DropAggregate", SQLStatementType.DDL);
     
     private final String name;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropAggregateStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropAggregateStatement.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.statement.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+/**
+ * Drop aggregate statement.
+ */
+@ToString
+public abstract class DropAggregateStatement extends AbstractSQLStatement implements DDLStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropAggregateStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLDropAggregateStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropAggregateStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
+
+/**
+ * PostgreSQL drop aggregate statement.
+ */
+@ToString
+public final class PostgreSQLDropAggregateStatement extends DropAggregateStatement implements PostgreSQLStatement {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -174,6 +174,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOwnedStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropMaterializedViewStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropAggregateStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AlterInstanceStatementTestCase;
@@ -1207,6 +1208,9 @@ public final class SQLParserTestCases {
 
     @XmlElement(name = "drop-materialized-view")
     private final List<DropMaterializedViewStatementTestCase> dropMaterializedViewStatementTestCases = new LinkedList<>();
+
+    @XmlElement(name = "drop-aggregate")
+    private final List<DropAggregateStatementTestCase> dropAggregateStatementTestCases = new LinkedList<>();
     
     /**
      * Get all SQL parser test cases.
@@ -1509,6 +1513,7 @@ public final class SQLParserTestCases {
         putAll(dropOwnedStatementTestCases, result);
         putAll(dropOperatorStatementTestCases, result);
         putAll(dropMaterializedViewStatementTestCases, result);
+        putAll(dropAggregateStatementTestCases, result);
         return result;
     }
     // CHECKSTYLE:ON

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DropAggregateStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/DropAggregateStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
+
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+/**
+ * Drop aggregate statement test case.
+ */
+public final class DropAggregateStatementTestCase extends SQLParserTestCase {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-aggregate.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-aggregate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <drop-aggregate sql-case-id="drop_aggregate" />
+    <drop-aggregate sql-case-id="drop_aggregate_exist" />
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-aggregate.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-aggregate.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="drop_aggregate" value="DROP AGGREGATE test_aggregate_exists(*)" db-types="PostgreSQL" />
+    <sql-case id="drop_aggregate_exist" value="DROP AGGREGATE IF EXISTS test_aggregate_exists(*)" db-types="PostgreSQL" />
+</sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -5549,15 +5549,6 @@
     <sql-case id="drop_by_postgresql_source_test_case4" value="DROP ACCESS METHOD heap2;" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case5" value="DROP ACCESS METHOD heap_psql;" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case6" value="DROP ACCESS METHOD no_such_am;" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case7" value="DROP AGGREGATE IF EXISTS foo(no_such_schema.no_such_type);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case8" value="DROP AGGREGATE IF EXISTS foo(no_such_type);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case9" value="DROP AGGREGATE IF EXISTS no_such_schema.foo(int);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case10" value="DROP AGGREGATE IF EXISTS test_aggregate_exists(*);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case11" value="DROP AGGREGATE IF EXISTS test_aggregate_exists(int);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case12" value="DROP AGGREGATE myavg (numeric);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case13" value="DROP AGGREGATE myavg (numeric);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case14" value="DROP AGGREGATE test_aggregate_exists(*);" db-types="PostgreSQL"/>
-    <sql-case id="drop_by_postgresql_source_test_case15" value="DROP AGGREGATE test_aggregate_exists(int);" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case16" value="DROP CAST (int4 AS casttesttype);" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case17" value="DROP CAST (text AS casttesttype);" db-types="PostgreSQL"/>
     <sql-case id="drop_by_postgresql_source_test_case18" value="DROP CAST (text AS text);" db-types="PostgreSQL"/>
@@ -8800,12 +8791,6 @@
     <sql-case id="low_do_by_postgresql_source_test_case29" value="do $$ declare x text[]; begin x := &apos;{1.23, 4.56}&apos;::numeric[]; end $$;" db-types="PostgreSQL"/>
     <sql-case id="low_do_by_postgresql_source_test_case30" value="do $$ declare y int := x + 1;          x int := 42; begin   raise notice &apos;x = %, y = %&apos;, x, y; end; $$;" db-types="PostgreSQL"/>
     <sql-case id="low_do_by_postgresql_source_test_case31" value="do $outer$ begin   for i in 1..10 loop    begin     execute $ex$       do $$       declare x int = 0;       begin         x := 1 / x;       end;       $$;     $ex$;   exception when division_by_zero then     raise notice &apos;caught division by zero&apos;;   end;   end loop; end; $outer$;" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case1" value="drop aggregate 314159 (int);" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case2" value="drop aggregate newcnt (float4);" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case3" value="drop aggregate newcnt (nonesuch);" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case4" value="drop aggregate newcnt1;" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case5" value="drop aggregate nonesuch (int4);" db-types="PostgreSQL"/>
-    <sql-case id="low_drop_by_postgresql_source_test_case6" value="drop aggregate;" db-types="PostgreSQL"/>
     <sql-case id="low_drop_by_postgresql_source_test_case13" value="drop function ();" db-types="PostgreSQL"/>
     <sql-case id="low_drop_by_postgresql_source_test_case14" value="drop function 314159();" db-types="PostgreSQL"/>
     <sql-case id="low_drop_by_postgresql_source_test_case15" value="drop index 314159;" db-types="PostgreSQL"/>


### PR DESCRIPTION
Fixes #15741.

Changes proposed in this pull request:
- support parsing Postgre sql DROP AGGREGATE.
- add a new corresponding SQL case in [SQL Cases](https://github.com/apache/shardingsphere/tree/master/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported?rgh-link-date=2022-03-02T05%3A48%3A59Z) and expected parsed result in [Expected Statment XML](https://github.com/apache/shardingsphere/tree/master/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case?rgh-link-date=2022-03-02T05%3A48%3A59Z).
- Run [SQLParserParameterizedTest](https://github.com/apache/shardingsphere/blob/master/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/engine/SQLParserParameterizedTest.java?rgh-link-date=2022-03-02T05%3A48%3A59Z) and [UnsupportedSQLParserParameterizedTest](https://github.com/apache/shardingsphere/blob/master/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/engine/UnsupportedSQLParserParameterizedTest.java?rgh-link-date=2022-03-02T05%3A48%3A59Z) to make sure no exceptions.
