### PR TITLE
Fix exception when execute use information_schema statement

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtil.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.schema.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
+
+import java.util.Collection;
+
+/**
+ * System schema utility class.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class SystemSchemaUtil {
+    
+    /**
+     * Judge whether sql statement contains system schema or not.
+     * @param databaseType databaseType
+     * @param schemaNames schema names
+     * @param sessionSchemaName session schema name
+     * @return whether sql statement contains system schema or not
+     */
+    public static boolean containsSystemSchema(final DatabaseType databaseType, final Collection<String> schemaNames, final String sessionSchemaName) {
+        for (String each : schemaNames) {
+            if (!databaseType.getSystemSchemas().contains(each)) {
+                continue;
+            }
+            return true;
+        }
+        return databaseType.getSystemSchemas().contains(sessionSchemaName);
+    }
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtil.java
@@ -31,6 +31,7 @@ public class SystemSchemaUtil {
     
     /**
      * Judge whether sql statement contains system schema or not.
+     * 
      * @param databaseType databaseType
      * @param schemaNames schema names
      * @param sessionSchemaName session schema name

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtilTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/util/SystemSchemaUtilTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.schema.util;
+
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class SystemSchemaUtilTest {
+    
+    @Test
+    public void assertContainsSystemSchemaForPostgreSQL() {
+        assertTrue(SystemSchemaUtil.containsSystemSchema(new PostgreSQLDatabaseType(), Arrays.asList("information_schema", "pg_catalog"), "information_schema"));
+        assertFalse(SystemSchemaUtil.containsSystemSchema(new PostgreSQLDatabaseType(), Collections.singletonList("sharding_db"), "sharding_db"));
+    }
+    
+    @Test
+    public void assertContainsSystemSchemaForMySQL() {
+        assertTrue(SystemSchemaUtil.containsSystemSchema(new MySQLDatabaseType(), Arrays.asList("information_schema", "mysql"), "information_schema"));
+        assertFalse(SystemSchemaUtil.containsSystemSchema(new MySQLDatabaseType(), Collections.singletonList("sharding_db"), "sharding_db"));
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/SchemaAssignedDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/SchemaAssignedDatabaseBackendHandler.java
@@ -20,10 +20,8 @@ package org.apache.shardingsphere.proxy.backend.text.data.impl;
 import io.vertx.core.Future;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
-import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.OpenGaussDatabaseType;
-import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.infra.distsql.exception.resource.RequiredResourceMissedException;
+import org.apache.shardingsphere.infra.metadata.schema.util.SystemSchemaUtil;
 import org.apache.shardingsphere.proxy.backend.communication.DatabaseCommunicationEngine;
 import org.apache.shardingsphere.proxy.backend.communication.DatabaseCommunicationEngineFactory;
 import org.apache.shardingsphere.proxy.backend.communication.jdbc.JDBCDatabaseCommunicationEngine;
@@ -71,7 +69,8 @@ public final class SchemaAssignedDatabaseBackendHandler implements DatabaseBacke
     }
     
     private void prepareDatabaseCommunicationEngine() throws RequiredResourceMissedException {
-        boolean isSystemSchema = containsSystemSchema(sqlStatementContext.getDatabaseType(), sqlStatementContext.getTablesContext().getSchemaNames());
+        boolean isSystemSchema = SystemSchemaUtil.containsSystemSchema(
+                sqlStatementContext.getDatabaseType(), sqlStatementContext.getTablesContext().getSchemaNames(), connectionSession.getSchemaName());
         if (!isSystemSchema && !ProxyContext.getInstance().getMetaData(connectionSession.getSchemaName()).hasDataSource()) {
             throw new RequiredResourceMissedException(connectionSession.getSchemaName());
         }
@@ -79,18 +78,6 @@ public final class SchemaAssignedDatabaseBackendHandler implements DatabaseBacke
             throw new RuleNotExistedException();
         }
         databaseCommunicationEngine = databaseCommunicationEngineFactory.newTextProtocolInstance(sqlStatementContext, sql, connectionSession.getBackendConnection());
-    }
-    
-    private boolean containsSystemSchema(final DatabaseType databaseType, final Collection<String> schemaNames) {
-        if (databaseType instanceof PostgreSQLDatabaseType || databaseType instanceof OpenGaussDatabaseType) {
-            for (String each : schemaNames) {
-                if (!databaseType.getSystemSchemas().contains(each)) {
-                    continue;
-                }
-                return true;
-            }
-        }
-        return databaseType.getSystemSchemas().contains(connectionSession.getSchemaName());
     }
     
     @Override


### PR DESCRIPTION
Fixes #16495.

Changes proposed in this pull request:
- fix exception when execute use information_schema statement
- extract common logic to SystemSchemaUtil
- add unit test
