### PR TITLE
ReadwriteSplittingDataSourceRule.getDataSources() need add unit test

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingDataSourceRuleTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.readwritesplitting.rule;
 
 import com.google.common.collect.ImmutableMap;
+import org.apache.shardingsphere.infra.distsql.constant.ExportableConstants;
 import org.apache.shardingsphere.readwritesplitting.algorithm.loadbalance.RandomReplicaLoadBalanceAlgorithm;
 import org.apache.shardingsphere.readwritesplitting.algorithm.loadbalance.RoundRobinReplicaLoadBalanceAlgorithm;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
@@ -100,6 +101,17 @@ public final class ReadwriteSplittingDataSourceRuleTest {
     public void assertGetWriteDataSource() {
         String writeDataSourceName = readwriteSplittingDataSourceRule.getWriteDataSource();
         assertThat(writeDataSourceName, is("write_ds"));
+    }
+    
+    @Test
+    public void assertGetDataSources() {
+        Map<String, String> dataSources = readwriteSplittingDataSourceRule.getDataSources(false);
+        assertThat(dataSources.get(ExportableConstants.PRIMARY_DATA_SOURCE_NAME), is("write_ds"));
+        assertThat(dataSources.get(ExportableConstants.REPLICA_DATA_SOURCE_NAMES), is("read_ds_0,read_ds_1"));
+        readwriteSplittingDataSourceRule.updateDisabledDataSourceNames("read_ds_0", true);
+        Map<String, String> dataSourcesByRemoveDisabled = readwriteSplittingDataSourceRule.getDataSources(true);
+        assertThat(dataSourcesByRemoveDisabled.get(ExportableConstants.PRIMARY_DATA_SOURCE_NAME), is("write_ds"));
+        assertThat(dataSourcesByRemoveDisabled.get(ExportableConstants.REPLICA_DATA_SOURCE_NAMES), is("read_ds_1"));
     }
     
     private Properties getProperties(final String writeDataSource, final String readDataSources) {


### PR DESCRIPTION
Fixes #16281.

Changes proposed in this pull request:
- ReadwriteSplittingDataSourceRule.getDataSources() need add unit test.
