### PR TITLE
Add Committer Responsibility in doc

### DIFF
--- a/docs/community/content/contribute/committer.cn.md
+++ b/docs/community/content/contribute/committer.cn.md
@@ -18,6 +18,7 @@ ShardingSphere 社区遵循 [Apache Community’s process](http://community.apac
  - 解答问题；
  - 维护文档和代码示例；
  - 改进流程和工具；
+ - 定期检查 [CI Scheduled Workflow]( https://github.com/apache/shardingsphere/actions/workflows/ci.yml?query=event%3Aschedule ) 是否正常运行；
  - 引导新的参与者融入社区。
 
 ## 日常工作

--- a/docs/community/content/contribute/committer.en.md
+++ b/docs/community/content/contribute/committer.en.md
@@ -18,6 +18,7 @@ After a contributor participates ShardingSphere community actively, PMC and Comm
  - Answer questions;
  - Update documentation and example;
  - Improve processes and tools;
+ - Check whether [CI Scheduled Workflow]( https://github.com/apache/shardingsphere/actions/workflows/ci.yml?query=event%3Aschedule ) works or not periodically;
  - Guide new contributors join community.
 
 


### PR DESCRIPTION

Changes proposed in this pull request:
- Add Committer Responsibility to check whether `CI Scheduled Workflow` works or not. Currently, `windows` and `macos` jobs of `Continuous Integration` are scheduled daily and do not run on pull_request and on push. If there're errors in workflow jobs, we need to fix it.
