### PR TITLE
add unit test `SchemaMetaDataNode.getMetaDataNodePath()`

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/node/SchemaMetaDataNodeTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/node/SchemaMetaDataNodeTest.java
@@ -102,7 +102,7 @@ public class SchemaMetaDataNodeTest {
 
     @Test
     public void assertGetMetaDataNodePath() {
-        assertThat(SchemaMetaDataNode.getMetaDataNodePath(), is("/metdata"));
+        assertThat(SchemaMetaDataNode.getMetaDataNodePath(), is("/metadata"));
     }
 
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/node/SchemaMetaDataNodeTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/metadata/persist/node/SchemaMetaDataNodeTest.java
@@ -101,6 +101,11 @@ public class SchemaMetaDataNodeTest {
     }
 
     @Test
+    public void assertGetMetaDataNodePath() {
+        assertThat(SchemaMetaDataNode.getMetaDataNodePath(), is("/metdata"));
+    }
+
+    @Test
     public void assertGetMetaDataDataSourcePath() {
         assertThat(SchemaMetaDataNode.getMetaDataDataSourcePath(DefaultSchema.LOGIC_NAME, "0"), is("/metadata/logic_db/logic_db/versions/0/dataSources"));
     }


### PR DESCRIPTION
Fixes #16543 .

Changes proposed in this pull request:
- adds unit test for `SchemaMetaDataNode.getMetaDataNodePath()`
