### PR TITLE
[CI] Unrelated changes not trigger Integration Test

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -20,18 +20,32 @@ name: Integration Test
 on:
   push:
     branches: [ master, dev ]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.txt'
-      - '.*.yaml'
+    paths:
+      - '.github/workflows/**'
+      - '**/src/main/**'
+      - '!examples/**'
+      - '!shardingsphere-distribution/**'
+      - '!shardingsphere-kernel/shardingsphere-data-pipeline/**'
+      - '!shardingsphere-test/**'
+      - 'shardingsphere-test/shardingsphere-integration-test/**'
+      - 'shardingsphere-test/shardingsphere-integration-agent-test/**'
+      - '!*.md'
+      - '!*.txt'
+      - '!.*.yaml'
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - '*.txt'
-      - '.*.yaml'
+    paths:
+      - '.github/workflows/**'
+      - '**/src/main/**'
+      - '!examples/**'
+      - '!shardingsphere-distribution/**'
+      - '!shardingsphere-kernel/shardingsphere-data-pipeline/**'
+      - '!shardingsphere-test/**'
+      - 'shardingsphere-test/shardingsphere-integration-test/**'
+      - 'shardingsphere-test/shardingsphere-integration-agent-test/**'
+      - '!*.md'
+      - '!*.txt'
+      - '!.*.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Purpose:
- Ignore unrelated change in `Integration Test` to speedup CI.

Changes proposed in this pull request:
- Integration Test ignore unrelated changes. `it.yml` is changed, use `paths` to replace `path-ignore`.

Changes trigger Integration Test:
- Files in github workflows folder
- Files in any of `src/main/` folder
- Files in `shardingsphere-test/shardingsphere-integration-test/`
- Files in `shardingsphere-test/shardingsphere-integration-agent-test/`

Other changes will not trigger Integration Test, e.g.:
- Unit tests
- docs/
- examples/
- shardingsphere-distribution/
- data pipeline modules
- shardingsphere-test module except above 2 modules
- Text files: *.md, *.txt

About `paths` syntax, refer to [GitHub Including and excluding paths]( https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths ) for more details.
