### PR TITLE
Modify the wrong ext-lab/ to the correct lab/

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
@@ -17,12 +17,12 @@ weight = 1
 
 ### 使用 MySQL
 
-1. 将 MySQL 的 JDBC 驱动程序复制至目录 `ext-lib/`。
+1. 将 MySQL 的 JDBC 驱动程序复制至目录 `lib/`。
 2. 使用任何 MySQL 的客户端连接。如: `mysql -u root -h 127.0.0.1 -P 3307`。
 
 ### 使用 openGauss
 
-1. 将以 `org.opengauss` 包名为前缀的 openGauss 的 JDBC 驱动程序复制至目录 `ext-lib/`。
+1. 将以 `org.opengauss` 包名为前缀的 openGauss 的 JDBC 驱动程序复制至目录 `lib/`。
 2. 使用任何 openGauss 的客户端连接。如: `gsql -U root -h 127.0.0.1 -p 3307`。
 
 ## 选择元数据持久化仓库
@@ -33,7 +33,7 @@ weight = 1
 
 ### 使用 Etcd
 
-1. 将 Etcd 的客户端驱动程序复制至目录 `ext-lib/`。
+1. 将 Etcd 的客户端驱动程序复制至目录 `lib/`。
 
 ## 使用分布式事务
 
@@ -49,7 +49,7 @@ weight = 1
 3. 在 `META-INF/services` 目录下新建文件 `org.apache.shardingsphere.sharding.spi.ShardingAlgorithm`
 4. 将实现类的绝对路径写入至文件 `org.apache.shardingsphere.sharding.spi.ShardingAlgorithm`
 5. 将上述 Java 文件打包成 jar 包。
-6. 将上述 jar 包拷贝至 ShardingSphere-Proxy 解压后的 `ext-lib/` 目录。
+6. 将上述 jar 包拷贝至 ShardingSphere-Proxy 解压后的 `lib/` 目录。
 7. 将上述自定义算法实现类的 Java 文件引用配置在 YAML 文件中，具体可参考[配置规则](/cn/user-manual/shardingsphere-proxy/yaml-config/)。
 
 ## 注意事项

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
@@ -17,12 +17,12 @@ weight = 1
 
 ### Using MySQL
 
-1. Copy MySQL's JDBC driver to folder `ext-lib/`.
+1. Copy MySQL's JDBC driver to folder `lib/`.
 2. Use any MySQL terminal to connect, such as `mysql -u root -h 127.0.0.1 -P 3307`.
 
 ### Using openGauss
 
-1. Copy openGauss's JDBC driver whose package prefixed with `org.opengauss` to folder `ext-lib/`.
+1. Copy openGauss's JDBC driver whose package prefixed with `org.opengauss` to folder `lib/`.
 2. Use any openGauss terminal to connect, such as `gsql -U root -h 127.0.0.1 -p 3307`.
 
 ## Using metadata persist repository
@@ -33,7 +33,7 @@ Integrated ZooKeeper Curator client by default.
 
 ### Using Etcd
 
-1. Copy Etcd's client driver to folder `ext-lib/`.
+1. Copy Etcd's client driver to folder `lib/`.
 
 ## Using Distributed Transaction
 
@@ -49,7 +49,7 @@ When developer need to use user-defined algorithm, should use the way below to c
 3. Create a new file `org.apache.shardingsphere.sharding.spi.ShardingAlgorithm` in the `META-INF/services` directory.
 4. Absolute path of the implementation class are write to the file `org.apache.shardingsphere.sharding.spi.ShardingAlgorithm`
 5. Package Java file to jar.
-6. Copy jar to ShardingSphere-Proxy's `ext-lib/` folder.
+6. Copy jar to ShardingSphere-Proxy's `lib/` folder.
 7. Configure user-defined Java class into YAML file. Please refer to [Configuration Manual](/en/user-manual/shardingsphere-proxy/yaml-config/) for more details.
 
 ## Notices


### PR DESCRIPTION
Changes proposed in this pull request:
- Modify the wrong ext-lab/ to the correct lab/.

The latest 5.1.0 proxy directory is as follows:

![image](https://user-images.githubusercontent.com/77398366/161540654-b1442ab2-a11b-482c-9902-89474e8b8cd8.png)
