### PR TITLE
Splitting assertMethod() method in different test cases

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-repository/shardingsphere-standalone-mode-repository-provider/shardingsphere-standalone-mode-repository-h2/src/test/java/org/apache/shardingsphere/mode/repository/standalone/h2/H2RepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-standalone-mode/shardingsphere-standalone-mode-repository/shardingsphere-standalone-mode-repository-provider/shardingsphere-standalone-mode-repository-h2/src/test/java/org/apache/shardingsphere/mode/repository/standalone/h2/H2RepositoryTest.java
@@ -34,14 +34,10 @@ public final class H2RepositoryTest {
     @Test
     public void assertMethod() {
         assertThat(h2Repository.getType(), is("H2"));
-        assertSetProperty();
-        assertPersistAndGet();
-        assertPersistAndGetChildrenKeys();
-        assertDelete();
         h2Repository.close();
     }
-    
-    private void assertSetProperty() {
+
+    public void assertSetProperty() {
         Properties props = new Properties();
         props.setProperty("jdbc_url", "jdbc:h2:~/h2_repository");
         props.setProperty("user", "sa");
@@ -49,23 +45,29 @@ public final class H2RepositoryTest {
         props.setProperty("driver_class", "org.h2.Driver");
         h2Repository.setProps(props);
     }
-    
-    private void assertPersistAndGet() {
+
+    @Test
+    public void assertPersistAndGet() {
+        assertSetProperty();
         h2Repository.persist("/testPath/test1", "test1_content");
         assertThat(h2Repository.get("/testPath/test1"), is("test1_content"));
         h2Repository.persist("/testPath/test1", "modify_content");
         assertThat(h2Repository.get("/testPath/test1"), is("modify_content"));
     }
-    
-    private void assertPersistAndGetChildrenKeys() {
+
+    @Test
+    public void assertPersistAndGetChildrenKeys() {
+        assertSetProperty();
         h2Repository.persist("/testPath/test1", "test1_content");
         h2Repository.persist("/testPath/test2", "test2_content");
         List<String> childrenKeys = h2Repository.getChildrenKeys("/testPath");
         assertThat(childrenKeys.get(0), is("test1"));
         assertThat(childrenKeys.get(1), is("test2"));
     }
-    
-    private void assertDelete() {
+
+    @Test
+    public void assertDelete() {
+        assertSetProperty();
         h2Repository.delete("/testPath");
         assertTrue(StringUtils.isBlank(h2Repository.get("/testPath")));
     }


### PR DESCRIPTION
Fixes #16507.

Changes proposed in this pull request:
- Splitting assertMethod( ) in different test cases as discussed in above issue.
- No code breakage.
- Every thing working fine. 
Let me know if there is any more changes that I can do to make this code more efficient! ;)