### PR TITLE
[CI] Resolve maven dependencies version range before mvn install to speedup spring downloading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Maven resolve ranges
-        run: ./mvnw versions:resolve-ranges -ntp
+        run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -169,7 +169,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Maven resolve ranges
-        run: ./mvnw versions:resolve-ranges -ntp
+        run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
             maven_args: "-Dmaven.javadoc.skip=true -Drat.skip=true -Djacoco.skip=true"
           }
     steps:
+      - uses: actions/checkout@v2
+      - name: Maven resolve ranges
+        run: ./mvnw versions:resolve-ranges -ntp
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -117,7 +120,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java.version }}
         uses: actions/setup-java@v2
         with:
@@ -165,6 +167,9 @@ jobs:
     name: shardingsphere example generator
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - name: Maven resolve ranges
+        run: ./mvnw versions:resolve-ranges -ntp
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -172,7 +177,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Maven resolve ranges
-        run: ./mvnw versions:resolve-ranges -ntp
+        run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -198,7 +198,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Maven resolve ranges
-        run: ./mvnw versions:resolve-ranges -ntp
+        run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -63,6 +63,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
+      - name: Maven resolve ranges
+        run: ./mvnw versions:resolve-ranges -ntp
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -194,6 +196,9 @@ jobs:
     name: Agent Metrics & OpenTelemetry
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - name: Maven resolve ranges
+        run: ./mvnw versions:resolve-ranges -ntp
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -201,7 +206,6 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
Fixes #14878.

Purpose:
- Speedup spring downloading in GitHub CI maven building

Changes proposed in this pull request:
- `ci.yml` and `it.yml` are changed, run `./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'` before `Cache Maven Repos`. So there's no `xxx.BUILD-SNAPSHOT` dependencies will be tried to download.
