### PR TITLE
[CI] publish-docker ignore more unrelated changes

### DIFF
--- a/.github/workflows/docker-per-commit.yaml
+++ b/.github/workflows/docker-per-commit.yaml
@@ -20,11 +20,14 @@ on:
   push:
     branches:
       - master
-    paths-ignore:
-      - 'docs/**'
-      - 'examples/**'
-      - 'shardingsphere-test/**'
-      - '*.md'
+    paths:
+      - '**/pom.xml'
+      - '**/src/main/**'
+      - '!examples/**'
+      - '!shardingsphere-distribution/**'
+      - 'shardingsphere-distribution/shardingsphere-proxy-distribution/**'
+      - '!shardingsphere-test/**'
+      - '!*.md'
 
 env:
   HUB: ghcr.io/apache/shardingsphere


### PR DESCRIPTION

Changes proposed in this pull request:
- `docker-per-commit.yaml` is changed, use `paths` to replace `path-ignore`.

Changes trigger publish-docker:
- `pom.xml`
- Files in any of `src/main/` folder, except `examples/`, `shardingsphere-test/` and `shardingsphere-distribution/`
- Files in `shardingsphere-proxy-distribution/`

Already ignored paths before:
- docs/
- examples/
- shardingsphere-test/
- Text files: *.md

Other changes will not trigger publish-docker, e.g.:
- Unit tests
- `shardingsphere-distribution/`, except `shardingsphere-proxy-distribution/`
- github workflows/
