### PR TITLE
Recover ShardingSphereServiceLoader.register in classes which is removed before

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/update/CreateShardingScalingRuleStatementUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/scaling/distsql/handler/update/CreateShardingScalingRuleStatementUpdater.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.scaling.distsql.handler.converter.ShardingScali
 import org.apache.shardingsphere.scaling.distsql.statement.CreateShardingScalingRuleStatement;
 import org.apache.shardingsphere.scaling.distsql.statement.segment.ShardingScalingRuleConfigurationSegment;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPI;
 import org.apache.shardingsphere.spi.type.singleton.TypedSingletonSPIHolder;
 import org.apache.shardingsphere.spi.type.typed.TypedSPI;
@@ -46,6 +47,13 @@ import java.util.Optional;
  * Create sharding scaling rule statement updater.
  */
 public final class CreateShardingScalingRuleStatementUpdater implements RuleDefinitionCreateUpdater<CreateShardingScalingRuleStatement, ShardingRuleConfiguration> {
+    
+    static {
+        ShardingSphereServiceLoader.register(JobRateLimitAlgorithm.class);
+        ShardingSphereServiceLoader.register(PipelineChannelFactory.class);
+        ShardingSphereServiceLoader.register(JobCompletionDetectAlgorithm.class);
+        ShardingSphereServiceLoader.register(DataConsistencyCheckAlgorithm.class);
+    }
     
     private static final TypedSingletonSPIHolder<JobRateLimitAlgorithm> RATE_LIMIT_ALGORITHM_HOLDER = new TypedSingletonSPIHolder<>(JobRateLimitAlgorithm.class, false);
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/loader/TableMetaDataLoaderEngine.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/loader/TableMetaDataLoaderEngine.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.infra.metadata.schema.loader.common.TableMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.schema.loader.spi.DialectTableMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.sql.SQLException;
@@ -43,6 +44,10 @@ import java.util.concurrent.TimeUnit;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class TableMetaDataLoaderEngine {
+    
+    static {
+        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
+    }
     
     private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
             DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/MySQLTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/MySQLTableMetaDataLoaderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.loader.spi.DialectTableMe
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
@@ -39,6 +40,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class MySQLTableMetaDataLoaderTest {
+    
+    static {
+        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
+    }
     
     private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
             DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/OracleTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/OracleTableMetaDataLoaderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.loader.spi.DialectTableMe
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
@@ -72,6 +73,10 @@ public final class OracleTableMetaDataLoaderTest {
     
     private static final String ALL_TAB_COLUMNS_SQL_CONDITION6 = "SELECT OWNER AS TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, DATA_TYPE, COLUMN_ID  FROM ALL_TAB_COLUMNS"
             + " WHERE OWNER = ? AND TABLE_NAME IN ('tbl') ORDER BY COLUMN_ID";
+    
+    static {
+        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
+    }
     
     private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
             DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/SQLServerTableMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/dialect/SQLServerTableMetaDataLoaderTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.metadata.schema.loader.spi.DialectTableMe
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 import org.junit.Test;
 
@@ -39,6 +40,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class SQLServerTableMetaDataLoaderTest {
+    
+    static {
+        ShardingSphereServiceLoader.register(DialectTableMetaDataLoader.class);
+    }
     
     private static final Map<String, DialectTableMetaDataLoader> DIALECT_METADATA_LOADER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(
             DialectTableMetaDataLoader.class, DialectTableMetaDataLoader::getDatabaseType);

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverStateContext.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/state/DriverStateContext.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.driver.state;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.sql.Connection;
@@ -34,6 +35,7 @@ public final class DriverStateContext {
     private static final Map<String, DriverState> STATES;
     
     static {
+        ShardingSphereServiceLoader.register(DriverState.class);
         STATES = SingletonSPIRegistry.getTypedSingletonInstancesMap(DriverState.class);
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -55,6 +55,7 @@ import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
 import org.apache.shardingsphere.scaling.core.job.environment.ScalingEnvironmentManager;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.sql.SQLException;
@@ -75,6 +76,10 @@ import java.util.stream.Stream;
 
 @Slf4j
 public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl implements RuleAlteredJobAPI {
+    
+    static {
+        ShardingSphereServiceLoader.register(DataConsistencyCheckAlgorithm.class);
+    }
     
     private static final Map<String, DataConsistencyCheckAlgorithm> DATA_CONSISTENCY_CHECK_ALGORITHM_MAP = new TreeMap<>(
             SingletonSPIRegistry.getTypedSingletonInstancesMap(DataConsistencyCheckAlgorithm.class));

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreatorFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/datasource/creator/PipelineDataSourceCreatorFactory.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.datasource.creator;
 
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.util.Map;
@@ -25,6 +26,10 @@ import java.util.Map;
  * Pipeline data source creator factory.
  */
 public final class PipelineDataSourceCreatorFactory {
+    
+    static {
+        ShardingSphereServiceLoader.register(PipelineDataSourceCreator.class);
+    }
     
     private static final Map<String, PipelineDataSourceCreator> DATA_SOURCE_CREATOR_MAP = SingletonSPIRegistry.getTypedSingletonInstancesMap(PipelineDataSourceCreator.class);
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/PositionInitializerFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/position/PositionInitializerFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.ingest.position;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.spi.ingest.position.PositionInitializer;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
 import org.apache.shardingsphere.spi.type.singleton.TypedSingletonSPIHolder;
 
@@ -28,6 +29,10 @@ import org.apache.shardingsphere.spi.type.singleton.TypedSingletonSPIHolder;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PositionInitializerFactory {
+    
+    static {
+        ShardingSphereServiceLoader.register(PositionInitializer.class);
+    }
     
     private static final TypedSingletonSPIHolder<PositionInitializer> INITIALIZER_SPI_HOLDER = new TypedSingletonSPIHolder<>(PositionInitializer.class, false);
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/PipelineSQLBuilderFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/PipelineSQLBuilderFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.sqlbuilder;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.spi.sqlbuilder.PipelineSQLBuilder;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.exception.ServiceProviderNotFoundException;
 import org.apache.shardingsphere.spi.type.singleton.TypedSingletonSPIHolder;
 
@@ -28,6 +29,10 @@ import org.apache.shardingsphere.spi.type.singleton.TypedSingletonSPIHolder;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PipelineSQLBuilderFactory {
+    
+    static {
+        ShardingSphereServiceLoader.register(PipelineSQLBuilder.class);
+    }
     
     private static final TypedSingletonSPIHolder<PipelineSQLBuilder> SQL_BUILDER_SPI_HOLDER = new TypedSingletonSPIHolder<>(PipelineSQLBuilder.class, false);
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobPreparer.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobPreparer.java
@@ -39,6 +39,7 @@ import org.apache.shardingsphere.data.pipeline.spi.check.datasource.DataSourceCh
 import org.apache.shardingsphere.data.pipeline.spi.ingest.channel.PipelineChannelFactory;
 import org.apache.shardingsphere.data.pipeline.spi.ingest.position.PositionInitializer;
 import org.apache.shardingsphere.scaling.core.job.check.EnvironmentCheckerFactory;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import javax.sql.DataSource;
@@ -54,6 +55,10 @@ import java.util.Optional;
  */
 @Slf4j
 public final class RuleAlteredJobPreparer {
+    
+    static {
+        ShardingSphereServiceLoader.register(DataSourceChecker.class);
+    }
     
     private static final Map<String, DataSourceChecker> DATA_SOURCE_CHECKER_MAP = SingletonSPIRegistry.getTypedSingletonInstancesMap(DataSourceChecker.class);
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
@@ -55,6 +55,7 @@ import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cache.event.StartScalingEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingReleaseSchemaNameLockEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.required.RequiredSPIRegistry;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
@@ -75,6 +76,10 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public final class RuleAlteredJobWorker {
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleAlteredJobConfigurationPreparer.class);
+    }
     
     private static final RuleAlteredJobWorker INSTANCE = new RuleAlteredJobWorker();
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobWorker.java
@@ -79,6 +79,7 @@ public final class RuleAlteredJobWorker {
     
     static {
         ShardingSphereServiceLoader.register(RuleAlteredJobConfigurationPreparer.class);
+        ShardingSphereServiceLoader.register(RuleAlteredDetector.class);
     }
     
     private static final RuleAlteredJobWorker INSTANCE = new RuleAlteredJobWorker();

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLIncrementalDumper.java
@@ -47,6 +47,7 @@ import org.apache.shardingsphere.data.pipeline.mysql.ingest.client.MySQLClient;
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.column.value.ValueHandler;
 import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeRegistry;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.io.Serializable;
@@ -61,7 +62,11 @@ import java.util.Random;
 @Slf4j
 public final class MySQLIncrementalDumper extends AbstractIncrementalDumper<BinlogPosition> {
     
-    private static final Map<String, ValueHandler> VALUE_HANDLER_MAP;
+    static {
+        ShardingSphereServiceLoader.register(ValueHandler.class);
+    }
+    
+    private static final Map<String, ValueHandler> VALUE_HANDLER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(ValueHandler.class, ValueHandler::getTypeName);
     
     private final BinlogPosition binlogPosition;
     
@@ -72,10 +77,6 @@ public final class MySQLIncrementalDumper extends AbstractIncrementalDumper<Binl
     private final Random random = new SecureRandom();
     
     private final PipelineChannel channel;
-    
-    static {
-        VALUE_HANDLER_MAP = SingletonSPIRegistry.getSingletonInstancesMap(ValueHandler.class, ValueHandler::getTypeName);
-    }
     
     public MySQLIncrementalDumper(final DumperConfiguration dumperConfig, final IngestPosition<BinlogPosition> binlogPosition,
                                   final PipelineChannel channel, final PipelineTableMetaDataLoader metaDataLoader) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobAPIFactory.java
@@ -17,12 +17,17 @@
 
 package org.apache.shardingsphere.data.pipeline.api;
 
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.required.RequiredSPIRegistry;
 
 /**
  * Pipeline job API factory.
  */
 public final class PipelineJobAPIFactory {
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleAlteredJobAPI.class);
+    }
     
     private static final RuleAlteredJobAPI RULE_ALTERED_JOB_API = RequiredSPIRegistry.getRegisteredService(RuleAlteredJobAPI.class);
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/rulealtered/JobConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/config/rulealtered/JobConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.data.pipeline.api.job.JobSubType;
 import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.api.job.RuleAlteredJobId;
 import org.apache.shardingsphere.data.pipeline.spi.rulealtered.RuleAlteredJobConfigurationPreparer;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.required.RequiredSPIRegistry;
 
 import java.util.Collections;
@@ -43,6 +44,10 @@ import java.util.Collections;
 @Slf4j
 // TODO share for totally new scenario
 public final class JobConfiguration {
+    
+    static {
+        ShardingSphereServiceLoader.register(RuleAlteredJobConfigurationPreparer.class);
+    }
     
     private WorkflowConfiguration workflowConfig;
     

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.proxy.backend.config.YamlProxyConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.swapper.YamlProxyConfigurationSwapper;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.version.ShardingSphereProxyVersion;
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.SingletonSPIRegistry;
 
 import java.sql.SQLException;
@@ -44,6 +45,10 @@ import java.util.Map.Entry;
 @RequiredArgsConstructor
 @Slf4j
 public final class BootstrapInitializer {
+    
+    static {
+        ShardingSphereServiceLoader.register(ContextManagerLifecycleListener.class);
+    }
     
     /**
      * Initialize.

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/type/required/RequiredSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/type/required/RequiredSPIRegistry.java
@@ -51,7 +51,6 @@ public final class RequiredSPIRegistry {
     
     private static <T extends RequiredSPI> Collection<T> getRegisteredServices(final Class<T> spiClass) {
         if (SingletonSPI.class.isAssignableFrom(spiClass)) {
-            ShardingSphereServiceLoader.register(spiClass);
             return ShardingSphereServiceLoader.getSingletonServiceInstances(spiClass);
         }
         return ShardingSphereServiceLoader.newServiceInstances(spiClass);

--- a/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/type/singleton/SingletonSPIRegistry.java
+++ b/shardingsphere-spi/src/main/java/org/apache/shardingsphere/spi/type/singleton/SingletonSPIRegistry.java
@@ -43,7 +43,6 @@ public final class SingletonSPIRegistry {
      * @return singleton instances map
      */
     public static <K, T extends SingletonSPI> Map<K, T> getSingletonInstancesMap(final Class<T> singletonSPIClass, final Function<? super T, ? extends K> keyMapper) {
-        ShardingSphereServiceLoader.register(singletonSPIClass);
         Collection<T> instances = ShardingSphereServiceLoader.getSingletonServiceInstances(singletonSPIClass);
         return instances.stream().collect(Collectors.toMap(keyMapper, Function.identity()));
     }

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/type/singleton/SingletonSPIRegistryTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/type/singleton/SingletonSPIRegistryTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.spi.type.singleton;
 
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.fixture.SingletonSPIFixture;
 import org.junit.Test;
 
@@ -27,6 +28,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class SingletonSPIRegistryTest {
+    
+    static {
+        ShardingSphereServiceLoader.register(SingletonSPIFixture.class);
+    }
     
     @Test
     public void assertGetSingletonInstancesMap() {

--- a/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/type/singleton/TypedSingletonSPIHolderTest.java
+++ b/shardingsphere-spi/src/test/java/org/apache/shardingsphere/spi/type/singleton/TypedSingletonSPIHolderTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.spi.type.singleton;
 
+import org.apache.shardingsphere.spi.ShardingSphereServiceLoader;
 import org.apache.shardingsphere.spi.type.singleton.fixture.SingletonSPIFixture;
 import org.junit.Test;
 
@@ -24,6 +25,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class TypedSingletonSPIHolderTest {
+    
+    static {
+        ShardingSphereServiceLoader.register(SingletonSPIFixture.class);
+    }
     
     @Test
     public void assertGetOnTypeCaseSensitiveTrue() {


### PR DESCRIPTION
Purpose:
- Recover `ShardingSphereServiceLoader.register` for later refactoring. Based on discussion with @terrymanu , 1) if users use SingletonSPIRegistry by mistake, `ShardingSphereServiceLoader.register` might be invoked repeatedly, it might hurt performance, 2) singleton should not be SPI interface level, it could be annotation, 3) most SPI should be singleton, auto register might be the default behavior later.

Changes proposed in this pull request:
- Remove `ShardingSphereServiceLoader.register` in `RequiredSPIRegistry` and `SingletonSPIRegistry`
- Recover `ShardingSphereServiceLoader.register` in referenced classes
