### PR TITLE
Support postgresql alter/drop index statement with qualified name

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.type.IndexAvailable;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.schema.util.IndexMetaDataUtil;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
@@ -29,12 +30,10 @@ import org.apache.shardingsphere.sharding.route.engine.type.ShardingRouteEngine;
 import org.apache.shardingsphere.sharding.route.engine.type.complex.ShardingCartesianRoutingEngine;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -106,24 +105,7 @@ public final class ShardingTableBroadcastRoutingEngine implements ShardingRouteE
         if (!shardingRuleTableNames.isEmpty()) {
             return shardingRuleTableNames;
         }
-        return sqlStatementContext instanceof IndexAvailable ? getTableNamesFromMetaData(((IndexAvailable) sqlStatementContext).getIndexes()) : Collections.emptyList();
-    }
-    
-    private Collection<String> getTableNamesFromMetaData(final Collection<IndexSegment> indexes) {
-        Collection<String> result = new LinkedList<>();
-        for (IndexSegment each : indexes) {
-            findLogicTableNameFromMetaData(each.getIdentifier().getValue()).ifPresent(result::add);
-        }
-        return result;
-    }
-    
-    private Optional<String> findLogicTableNameFromMetaData(final String logicIndexName) {
-        for (String each : schema.getAllTableNames()) {
-            if (schema.get(each).getIndexes().containsKey(logicIndexName)) {
-                return Optional.of(each);
-            }
-        }
-        return Optional.empty();
+        return sqlStatementContext instanceof IndexAvailable ? IndexMetaDataUtil.getTableNamesFromMetaData(schema, ((IndexAvailable) sqlStatementContext).getIndexes()) : Collections.emptyList();
     }
     
     private Collection<RouteUnit> getBroadcastTableRouteUnits(final ShardingRule shardingRule, final String broadcastTableName) {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
@@ -20,9 +20,13 @@ package org.apache.shardingsphere.infra.metadata.schema.util;
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Optional;
 
 /**
  * Index meta data utility class.
@@ -69,5 +73,29 @@ public class IndexMetaDataUtil {
             builder.append(each.getIdentifier().getValue()).append(UNDERLINE);
         }
         return builder.append(GENERATED_LOGIC_INDEX_NAME_SUFFIX).toString();
+    }
+    
+    /**
+     * Get table names from metadata.
+     *
+     * @param schema schema
+     * @param indexes indexes
+     * @return table names
+     */
+    public static Collection<String> getTableNamesFromMetaData(final ShardingSphereSchema schema, final Collection<IndexSegment> indexes) {
+        Collection<String> result = new LinkedList<>();
+        for (IndexSegment each : indexes) {
+            findLogicTableNameFromMetaData(schema, each.getIdentifier().getValue()).ifPresent(result::add);
+        }
+        return result;
+    }
+    
+    private static Optional<String> findLogicTableNameFromMetaData(final ShardingSphereSchema schema, final String logicIndexName) {
+        for (String each : schema.getAllTableNames()) {
+            if (schema.get(each).getIndexes().containsKey(logicIndexName)) {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
@@ -21,22 +21,22 @@ import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
-import org.apache.shardingsphere.infra.binder.type.TableAvailable;
+import org.apache.shardingsphere.infra.binder.type.IndexAvailable;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.schema.util.IndexMetaDataUtil;
 import org.apache.shardingsphere.infra.route.SQLRouter;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.singletable.constant.SingleTableOrder;
 import org.apache.shardingsphere.singletable.rule.SingleTableRule;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTableStatement;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 
 /**
  * Single table SQL router.
@@ -51,13 +51,14 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
             String actualDataSource = metaData.getResource().getDataSources().keySet().iterator().next();
             result.getRouteUnits().add(new RouteUnit(new RouteMapper(logicDataSource, actualDataSource), Collections.emptyList()));
         } else {
-            route(logicSQL.getSqlStatementContext(), rule, result, props);
+            route(logicSQL.getSqlStatementContext(), metaData.getDefaultSchema(), rule, props, result);
         }
         return result;
     }
     
-    private void route(final SQLStatementContext<?> sqlStatementContext, final SingleTableRule rule, final RouteContext routeContext, final ConfigurationProperties props) {
-        Collection<String> singleTableNames = getSingleTableNames(sqlStatementContext, rule, routeContext);
+    private void route(final SQLStatementContext<?> sqlStatementContext, final ShardingSphereSchema schema, final SingleTableRule rule, 
+                       final ConfigurationProperties props, final RouteContext routeContext) {
+        Collection<String> singleTableNames = getSingleTableNames(sqlStatementContext, schema, rule, routeContext);
         if (singleTableNames.isEmpty()) {
             return;
         }
@@ -65,17 +66,11 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
         new SingleTableRouteEngine(singleTableNames, sqlStatementContext.getSqlStatement()).route(routeContext, rule);
     }
     
-    private Collection<String> getSingleTableNames(final SQLStatementContext<?> sqlStatementContext, final SingleTableRule rule, final RouteContext routeContext) {
-        Collection<String> result;
-        if (sqlStatementContext instanceof TableAvailable) {
-            Collection<SimpleTableSegment> allTables = ((TableAvailable) sqlStatementContext).getAllTables();
-            result = new HashSet<>(allTables.size(), 1);
-            for (SimpleTableSegment each : allTables) {
-                String value = each.getTableName().getIdentifier().getValue();
-                result.add(value);
-            }
-        } else {
-            result = sqlStatementContext.getTablesContext().getTableNames();
+    private Collection<String> getSingleTableNames(final SQLStatementContext<?> sqlStatementContext, final ShardingSphereSchema schema, 
+                                                   final SingleTableRule rule, final RouteContext routeContext) {
+        Collection<String> result = sqlStatementContext.getTablesContext().getTableNames();
+        if (result.isEmpty() && sqlStatementContext instanceof IndexAvailable) {
+            result = IndexMetaDataUtil.getTableNamesFromMetaData(schema, ((IndexAvailable) sqlStatementContext).getIndexes());
         }
         return routeContext.getRouteUnits().isEmpty() && sqlStatementContext.getSqlStatement() instanceof CreateTableStatement ? result : rule.getSingleTableNames(result); 
     }
@@ -92,7 +87,7 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
     @Override
     public void decorateRouteContext(final RouteContext routeContext, final LogicSQL logicSQL, final ShardingSphereMetaData metaData,
                                      final SingleTableRule rule, final ConfigurationProperties props) {
-        route(logicSQL.getSqlStatementContext(), rule, routeContext, props);
+        route(logicSQL.getSqlStatementContext(), metaData.getDefaultSchema(), rule, props, routeContext);
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DDLStatement.g4
@@ -149,7 +149,7 @@ alterTable
     ;
 
 alterIndex
-    : ALTER INDEX (existClause? | ALL IN TABLESPACE) indexName alterIndexDefinitionClause
+    : ALTER INDEX (existClause? | ALL IN TABLESPACE) qualifiedName alterIndexDefinitionClause
     ;
 
 dropTable
@@ -161,7 +161,7 @@ dropTableOpt
     ;
 
 dropIndex
-    : DROP INDEX concurrentlyClause existClause? indexNames dropIndexOpt?
+    : DROP INDEX concurrentlyClause existClause? qualifiedNameList dropIndexOpt?
     ;
 
 dropIndexOpt

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
@@ -213,10 +213,6 @@ qualifiedNameList
     | qualifiedNameList COMMA_ qualifiedName
     ;
 
-qualifiedName
-    : colId | colId indirection
-    ;
-
 selectLimit
     : limitClause offsetClause
     | offsetClause limitClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -155,7 +155,7 @@ alterTable
     ;
 
 alterIndex
-    : ALTER INDEX (existClause? | ALL IN TABLESPACE) indexName alterIndexDefinitionClause
+    : ALTER INDEX (existClause? | ALL IN TABLESPACE) qualifiedName alterIndexDefinitionClause
     ;
 
 dropTable
@@ -167,7 +167,7 @@ dropTableOpt
     ;
 
 dropIndex
-    : DROP INDEX concurrentlyClause existClause? indexNames dropIndexOpt?
+    : DROP INDEX concurrentlyClause existClause? qualifiedNameList dropIndexOpt?
     ;
 
 dropIndexOpt

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
@@ -215,10 +215,6 @@ qualifiedNameList
     | qualifiedNameList COMMA_ qualifiedName
     ;
 
-qualifiedName
-    : colId | colId indirection
-    ;
-
 selectLimit
     : limitClause offsetClause
     | offsetClause limitClause

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -527,10 +527,16 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitAlterIndex(final AlterIndexContext ctx) {
         PostgreSQLAlterIndexStatement result = new PostgreSQLAlterIndexStatement();
-        result.setIndex((IndexSegment) visit(ctx.indexName()));
+        result.setIndex(createIndexSegment((SimpleTableSegment) visit(ctx.qualifiedName())));
         if (null != ctx.alterIndexDefinitionClause().renameIndexSpecification()) {
             result.setRenameIndex((IndexSegment) visit(ctx.alterIndexDefinitionClause().renameIndexSpecification().indexName()));
         }
+        return result;
+    }
+    
+    private IndexSegment createIndexSegment(final SimpleTableSegment tableSegment) {
+        IndexSegment result = new IndexSegment(tableSegment.getStartIndex(), tableSegment.getStopIndex(), tableSegment.getTableName().getIdentifier());
+        tableSegment.getOwner().ifPresent(result::setOwner);
         return result;
     }
     
@@ -538,8 +544,16 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitDropIndex(final DropIndexContext ctx) {
         PostgreSQLDropIndexStatement result = new PostgreSQLDropIndexStatement();
-        result.getIndexes().addAll(((CollectionValue<IndexSegment>) visit(ctx.indexNames())).getValue());
+        result.getIndexes().addAll(createIndexSegments(((CollectionValue<SimpleTableSegment>) visit(ctx.qualifiedNameList())).getValue()));
         result.setContainsExistClause(null != ctx.existClause());
+        return result;
+    }
+    
+    private Collection<IndexSegment> createIndexSegments(final Collection<SimpleTableSegment> tableSegments) {
+        Collection<IndexSegment> result = new LinkedList<>();
+        for (SimpleTableSegment each : tableSegments) {
+            result.add(createIndexSegment(each));
+        }
         return result;
     }
     

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-index.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-index.xml
@@ -79,5 +79,6 @@
     </alter-index>
     
     <alter-index sql-case-id="alter_index_alter_column" />
+    <alter-index sql-case-id="alter_index_with_schema" />
     <alter-index sql-case-id="alter_index_set_tablespace" />
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-index.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/drop-index.xml
@@ -44,6 +44,7 @@
     
     <drop-index sql-case-id="drop_index_with_double_quota" />
     <drop-index sql-case-id="drop_index_concurrently" />
+    <drop-index sql-case-id="drop_index_with_schema" />
     
     <drop-index sql-case-id="drop_index_with_bracket">
         <table name="t_order" start-delimiter="[" end-delimiter="]" start-index="28" stop-index="36" />

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-index.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-index.xml
@@ -36,4 +36,5 @@
     <sql-case id="alter_index_with_reorganize" value="ALTER INDEX order_index ON t_order REORGANIZE WITH (COMPRESS_ALL_ROW_GROUPS = ON)" db-types="SQLServer" />
     <sql-case id="alter_index_set_tablespace" value="ALTER INDEX distributors SET TABLESPACE fasttablespace" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_index_alter_column" value="ALTER INDEX t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss"/>
+    <sql-case id="alter_index_with_schema" value="ALTER INDEX public.t_order_idx ALTER COLUMN 3 SET STATISTICS 1000" db-types="PostgreSQL,openGauss"/>
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-index.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/drop-index.xml
@@ -29,6 +29,7 @@
     <sql-case id="drop_index_with_quota" value="DROP INDEX &quot;order_index&quot; ON &quot;t_order&quot;" db-types="Oracle" />
     <sql-case id="drop_index_with_double_quota" value="DROP INDEX &quot;order_index&quot;" db-types="PostgreSQL,openGauss" />
     <sql-case id="drop_index_concurrently" value="DROP INDEX CONCURRENTLY order_index" db-types="PostgreSQL,openGauss" />
+    <sql-case id="drop_index_with_schema" value="DROP INDEX public.order_index" db-types="PostgreSQL,openGauss" />
     <sql-case id="drop_index_with_bracket" value="DROP INDEX [order_index] ON [t_order]" db-types="SQLServer" />
     <sql-case id="drop_index_if_exists_on_table" value="DROP INDEX IF EXISTS order_index ON t_order" db-types="SQLServer" />
     <sql-case id="drop_index_with_online_force_invalidation" value="DROP INDEX order_index ONLINE FORCE DEFERRED INVALIDATION" db-types="Oracle" />


### PR DESCRIPTION
Fixes #16634.

Changes proposed in this pull request:
- optimize alter/drop index g4 grammar and modify visitor logic
- add sql parse test case
- extract common logic of `getTableNamesFromMetaData` method
- refactor DropIndexStatementSchemaRefresher

