### PR TITLE
YamlJdbcConfiguration compatible with url and jdbcUrl

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/check/datasource/PostgreSQLDataSourceChecker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/check/datasource/PostgreSQLDataSourceChecker.java
@@ -18,13 +18,8 @@
 package org.apache.shardingsphere.data.pipeline.postgresql.check.datasource;
 
 import org.apache.shardingsphere.data.pipeline.core.check.datasource.AbstractDataSourceChecker;
-import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobPrepareFailedException;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Collection;
 
 /**
@@ -34,29 +29,6 @@ public class PostgreSQLDataSourceChecker extends AbstractDataSourceChecker {
     
     @Override
     public void checkPrivilege(final Collection<? extends DataSource> dataSources) {
-        try {
-            for (DataSource dataSource : dataSources) {
-                String tableName;
-                try (Connection connection = dataSource.getConnection();
-                     ResultSet resultSet = connection.getMetaData().getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"})) {
-                    if (resultSet.next()) {
-                        tableName = resultSet.getString(3);
-                    } else {
-                        throw new PipelineJobPrepareFailedException("No resultSet find in the source data source.");
-                    }
-                    checkTableExisted(tableName, connection);
-                }
-            }
-        } catch (final SQLException ex) {
-            throw new PipelineJobPrepareFailedException("Data sources privilege check failed.", ex);
-        }
-    }
-    
-    private void checkTableExisted(final String tableName, final Connection connection) throws SQLException {
-        String sql = "SELECT * FROM " + tableName + " LIMIT 1";
-        try (PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-            preparedStatement.executeQuery();
-        }
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/check/datasource/PostgreSQLDataSourceCheckerTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/check/datasource/PostgreSQLDataSourceCheckerTest.java
@@ -17,83 +17,21 @@
 
 package org.apache.shardingsphere.data.pipeline.postgresql.check.datasource;
 
-import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobPrepareFailedException;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.Collection;
-import java.util.LinkedList;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import java.util.Collections;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class PostgreSQLDataSourceCheckerTest {
-
-    private static final String CATALOG = "test";
     
-    @Mock
-    private Connection connection;
+    private final Collection<DataSource> dataSources = Collections.emptyList();
     
-    @Mock
-    private PreparedStatement preparedStatement;
-    
-    @Mock
-    private ResultSet resultSet;
-    
-    @Mock
-    private DatabaseMetaData metaData;
-
-    private Collection<DataSource> dataSources;
-
-    @Before
-    public void setUp() throws SQLException {
-        DataSource dataSource = mock(DataSource.class);
-        Connection connection = mockConnection();
-        when(dataSource.getConnection()).thenReturn(connection);
-        when(metaData.getTables(CATALOG, null, "%", new String[]{"TABLE"})).thenReturn(resultSet);
-        dataSources = new LinkedList<>();
-        dataSources.add(dataSource);
-    }
-
-    private Connection mockConnection() throws SQLException {
-        when(connection.getMetaData()).thenReturn(metaData);
-        when(connection.getCatalog()).thenReturn(CATALOG);
-        when(connection.prepareStatement("SELECT * FROM test LIMIT 1")).thenReturn(preparedStatement);
-        return connection;
-    }
-
     @Test
-    public void assertCheckPrivilege() throws SQLException {
-        when(resultSet.next()).thenReturn(true);
-        when(resultSet.getString(3)).thenReturn("test");
-        PostgreSQLDataSourceChecker dataSourceChecker = new PostgreSQLDataSourceChecker();
-        dataSourceChecker.checkPrivilege(dataSources);
-        verify(preparedStatement).executeQuery();
-    }
-    
-    @Test(expected = PipelineJobPrepareFailedException.class)
-    public void assertCheckPrivilegeWithoutTable() throws SQLException {
-        when(resultSet.next()).thenReturn(false);
-        PostgreSQLDataSourceChecker dataSourceChecker = new PostgreSQLDataSourceChecker();
-        dataSourceChecker.checkPrivilege(dataSources);
-    }
-    
-    @Test(expected = PipelineJobPrepareFailedException.class)
-    public void assertCheckPrivilegeFailure() throws SQLException {
-        when(resultSet.next()).thenReturn(true);
-        when(resultSet.getString(3)).thenReturn("test");
-        when(connection.prepareStatement("SELECT * FROM test LIMIT 1")).thenThrow(new SQLException(""));
+    public void assertCheckPrivilege() {
         PostgreSQLDataSourceChecker dataSourceChecker = new PostgreSQLDataSourceChecker();
         dataSourceChecker.checkPrivilege(dataSources);
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-spi/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfiguration.java
@@ -32,4 +32,13 @@ public final class YamlJdbcConfiguration {
     private String username;
     
     private String password;
+    
+    /**
+     * Set URL. Compatible with <code>jdbcUrl</code> alias.
+     *
+     * @param url JDBC URL
+     */
+    public void setUrl(final String url) {
+        this.jdbcUrl = url;
+    }
 }

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfigurationTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/yaml/YamlJdbcConfigurationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.api.datasource.config.yaml;
+
+import com.google.common.collect.ImmutableMap;
+import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class YamlJdbcConfigurationTest {
+    
+    private static final String JDBC_URL = "jdbc:mysql://127.0.0.1:3306/demo_ds_0?serverTimezone=UTC&useSSL=false";
+    
+    private static final String USERNAME = "root";
+    
+    private static final String PASSWORD = "password";
+    
+    @Test
+    public void assertConstructionWithJdbcUrl() {
+        Map<String, String> dataSourceProps = ImmutableMap.of("jdbcUrl", JDBC_URL, "username", USERNAME, "password", PASSWORD);
+        verifyFields(YamlEngine.unmarshal(YamlEngine.marshal(dataSourceProps), YamlJdbcConfiguration.class));
+    }
+    
+    @Test
+    public void assertConstructionWithUrl() {
+        Map<String, String> dataSourceProps = ImmutableMap.of("url", JDBC_URL, "username", USERNAME, "password", PASSWORD);
+        verifyFields(YamlEngine.unmarshal(YamlEngine.marshal(dataSourceProps), YamlJdbcConfiguration.class));
+    }
+    
+    private void verifyFields(final YamlJdbcConfiguration actual) {
+        assertThat(actual.getJdbcUrl(), is(JDBC_URL));
+        assertThat(actual.getUsername(), is(USERNAME));
+        assertThat(actual.getPassword(), is(PASSWORD));
+    }
+}


### PR DESCRIPTION

Changes proposed in this pull request:
- YamlJdbcConfiguration compatible with url and jdbcUrl
- Remove unnecessary checkTableExisted in checkPrivilege for PostgreSQL. It might need to check `wal_level` later.
