### PR TITLE
Proofread SQLServer DROP LOGIN Statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DCLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/antlr4/imports/sqlserver/DCLStatement.g4
@@ -433,7 +433,7 @@ createLoginForAnalyticsPlatformSystemOptionListClause
     ;
 
 dropLogin
-    : DROP LOGIN
+    : DROP LOGIN ignoredNameIdentifier
     ;
 
 alterLogin

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDCLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerDCLStatementSQLVisitor.java
@@ -332,7 +332,11 @@ public final class SQLServerDCLStatementSQLVisitor extends SQLServerStatementSQL
     
     @Override
     public ASTNode visitDropLogin(final DropLoginContext ctx) {
-        return new SQLServerDropLoginStatement();
+        SQLServerDropLoginStatement result = new SQLServerDropLoginStatement();
+        LoginSegment loginSegment = new LoginSegment(ctx.ignoredNameIdentifier().getStart().getStartIndex(), ctx.ignoredNameIdentifier().getStop().getStopIndex(),
+                (IdentifierValue) visit(ctx.ignoredNameIdentifier()));
+        result.setLoginSegment(loginSegment);
+        return result;
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDropLoginStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/sqlserver/dcl/SQLServerDropLoginStatement.java
@@ -17,7 +17,10 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl;
 
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dcl.LoginSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dcl.DCLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
@@ -26,5 +29,9 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLS
  * SQLServer drop login statement.
  */
 @ToString
+@Getter
+@Setter
 public final class SQLServerDropLoginStatement extends AbstractSQLStatement implements DCLStatement, SQLServerStatement {
+    
+    private LoginSegment loginSegment;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dcl/impl/DropLoginStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dcl/impl/DropLoginStatementAssert.java
@@ -21,7 +21,13 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dcl.SQLServerDropLoginStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dcl.DropLoginStatementTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 /**
  * Drop login statement assert.
@@ -37,5 +43,12 @@ public final class DropLoginStatementAssert {
      * @param expected expected drop login statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SQLServerDropLoginStatement actual, final DropLoginStatementTestCase expected) {
+        if (null != expected.getLogin()) {
+            assertNotNull(assertContext.getText("Actual login should exist."), actual.getLoginSegment());
+            assertThat(assertContext.getText("Login name assertion error: "), actual.getLoginSegment().getLoginName().getValueWithQuoteCharacters(), is(expected.getLogin().getName()));
+            SQLSegmentAssert.assertIs(assertContext, actual.getLoginSegment(), expected.getLogin());
+        } else {
+            assertNull(assertContext.getText("Actual login should not exist."), actual.getLoginSegment());
+        }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dcl/DropLoginStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dcl/DropLoginStatementTestCase.java
@@ -17,10 +17,18 @@
 
 package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dcl;
 
+import lombok.Getter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.login.ExpectedLogin;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlElement;
 
 /**
  * Drop login statement test case.
  */
+@Getter
 public final class DropLoginStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "login")
+    private ExpectedLogin login;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dcl/drop-login.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dcl/drop-login.xml
@@ -17,5 +17,7 @@
   -->
 
 <sql-parser-test-cases>
-    <drop-login sql-case-id="drop_login" />
+    <drop-login sql-case-id="drop_login" >
+        <login name="login1" start-index="11" stop-index="16"/>
+    </drop-login>
 </sql-parser-test-cases>


### PR DESCRIPTION
For #6478 

Changes proposed in this pull request:
- Proofread SQLServer [DROP LOGIN](https://docs.microsoft.com/en-us/sql/t-sql/statements/drop-login-transact-sql?view=sql-server-ver15) statement.
- Assert `DROP LOGIN` statement.
