### PR TITLE
Recover log.isDebugEnabled() for now

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-core/src/main/java/org/apache/shardingsphere/db/protocol/codec/PacketCodec.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-core/src/main/java/org/apache/shardingsphere/db/protocol/codec/PacketCodec.java
@@ -42,7 +42,9 @@ public final class PacketCodec extends ByteToMessageCodec<DatabasePacket<?>> {
         if (!databasePacketCodecEngine.isValidHeader(readableBytes)) {
             return;
         }
-        log.debug("Read from client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(in));
+        if (log.isDebugEnabled()) {
+            log.debug("Read from client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(in));
+        }
         databasePacketCodecEngine.decode(context, in, out);
     }
     
@@ -50,6 +52,8 @@ public final class PacketCodec extends ByteToMessageCodec<DatabasePacket<?>> {
     @Override
     protected void encode(final ChannelHandlerContext context, final DatabasePacket<?> message, final ByteBuf out) {
         databasePacketCodecEngine.encode(context, message, out);
-        log.debug("Write to client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(out));
+        if (log.isDebugEnabled()) {
+            log.debug("Write to client {} :\n{}", context.channel().id().asShortText(), ByteBufUtil.prettyHexDump(out));
+        }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoder.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoder.java
@@ -102,7 +102,9 @@ public final class MySQLBinlogEventPacketDecoder extends ByteToMessageDecoder {
             String sqlState = payload.readStringFix(5);
             throw new RuntimeException(String.format("Decode binlog event failed, errorCode: %d, sqlState: %s, errorMessage: %s", errorNo, sqlState, payload.readStringEOF()));
         } else if (0 != statusCode) {
-            log.debug("Illegal binlog status code {}, remaining packet \n{}", statusCode, readRemainPacket(payload));
+            if (log.isDebugEnabled()) {
+                log.debug("Illegal binlog status code {}, remaining packet \n{}", statusCode, readRemainPacket(payload));
+            }
         }
     }
     


### PR DESCRIPTION
Related to #16779.

Changes proposed in this pull request:
- Recover log.isDebugEnabled() for now. Since ByteBufUtil.prettyHexDump(out) and readRemainPacket(payload) will be calculated and might reduce performance.

We could try lazy evaluation later, it need some investigation then.
