### PR TITLE
Improve scaling job status persistence

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -356,6 +356,8 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
         WorkflowConfiguration workflowConfig = jobConfig.getWorkflowConfig();
         ScalingTaskFinishedEvent taskFinishedEvent = new ScalingTaskFinishedEvent(workflowConfig.getSchemaName(), workflowConfig.getActiveVersion(), workflowConfig.getNewVersion());
         ShardingSphereEventBus.getInstance().post(taskFinishedEvent);
+        // TODO rewrite job status update after job progress structure refactor
+        RuleAlteredJobSchedulerCenter.updateJobStatus(jobId, JobStatus.FINISHED);
         for (int each : repositoryAPI.getShardingItems(jobId)) {
             repositoryAPI.updateShardingJobStatus(jobId, each, JobStatus.FINISHED);
         }
@@ -372,7 +374,7 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
         try {
             new ScalingEnvironmentManager().cleanupTargetTables(getJobConfig(jobConfigPOJO));
         } catch (final SQLException ex) {
-            throw new PipelineJobExecutionException("Reset target table failed for job " + jobId);
+            throw new PipelineJobExecutionException("Reset target table failed for job " + jobId, ex);
         }
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobSchedulerCenter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobSchedulerCenter.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.core.api.GovernanceRepositoryAPI;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
 import org.apache.shardingsphere.infra.executor.kernel.thread.ExecutorThreadFactoryBuilder;
@@ -91,6 +92,23 @@ public final class RuleAlteredJobSchedulerCenter {
      */
     public static boolean existJob(final String jobId) {
         return JOB_SCHEDULER_MAP.containsKey(jobId);
+    }
+    
+    /**
+     * Update job status for all job sharding.
+     *
+     * @param jobId job id
+     * @param jobStatus job status
+     */
+    public static void updateJobStatus(final String jobId, final JobStatus jobStatus) {
+        Map<Integer, RuleAlteredJobScheduler> schedulerMap = JOB_SCHEDULER_MAP.get(jobId);
+        if (null == schedulerMap) {
+            log.info("updateJobStatus, schedulerMap is null, ignore");
+            return;
+        }
+        for (Entry<Integer, RuleAlteredJobScheduler> entry : schedulerMap.entrySet()) {
+            entry.getValue().getJobContext().setStatus(jobStatus);
+        }
     }
     
     private static final class PersistJobContextRunnable implements Runnable {


### PR DESCRIPTION

Changes proposed in this pull request:
- Improve scaling job status persistence. Update local cached job status, persist job status to registry center is scheduled, make sure job status won't be overwritten as old value.
