### PR TITLE
Improve performance about large tables loaded.

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/TableMetaDataBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/TableMetaDataBuilder.java
@@ -58,19 +58,14 @@ public final class TableMetaDataBuilder {
             if (entry.getKey() instanceof TableContainedRule) {
                 TableContainedRule rule = (TableContainedRule) entry.getKey();
                 RuleBasedTableMetaDataBuilder<TableContainedRule> builder = entry.getValue();
-                Collection<String> needLoadTables = getNeedLoadTables(tableNames, tableMetaDataMap, rule);
+                Collection<String> ruleTables = rule.getTables();
+                Collection<String> needLoadTables = tableNames.stream().filter(ruleTables::contains).filter(each -> !tableMetaDataMap.containsKey(each)).collect(Collectors.toList());
                 if (!needLoadTables.isEmpty()) {
                     tableMetaDataMap.putAll(builder.load(needLoadTables, rule, materials));
                 }
             }
         }
         return decorate(tableMetaDataMap, materials);
-    }
-    
-    private static Collection<String> getNeedLoadTables(final Collection<String> tableNames, final Map<String, TableMetaData> tableMetaDataMap, final TableContainedRule rule) {
-        Collection<String> ruleTables = rule.getTables();
-        return tableNames.stream().filter(ruleTables::contains)
-                .filter(each -> !tableMetaDataMap.containsKey(each)).collect(Collectors.toList());
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/TableMetaDataBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/builder/TableMetaDataBuilder.java
@@ -58,14 +58,19 @@ public final class TableMetaDataBuilder {
             if (entry.getKey() instanceof TableContainedRule) {
                 TableContainedRule rule = (TableContainedRule) entry.getKey();
                 RuleBasedTableMetaDataBuilder<TableContainedRule> builder = entry.getValue();
-                Collection<String> needLoadTables = tableNames.stream().filter(each -> rule.getTables().contains(each))
-                        .filter(each -> !tableMetaDataMap.containsKey(each)).collect(Collectors.toList());
+                Collection<String> needLoadTables = getNeedLoadTables(tableNames, tableMetaDataMap, rule);
                 if (!needLoadTables.isEmpty()) {
                     tableMetaDataMap.putAll(builder.load(needLoadTables, rule, materials));
                 }
             }
         }
         return decorate(tableMetaDataMap, materials);
+    }
+    
+    private static Collection<String> getNeedLoadTables(final Collection<String> tableNames, final Map<String, TableMetaData> tableMetaDataMap, final TableContainedRule rule) {
+        Collection<String> ruleTables = rule.getTables();
+        return tableNames.stream().filter(ruleTables::contains)
+                .filter(each -> !tableMetaDataMap.containsKey(each)).collect(Collectors.toList());
     }
     
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/metadata/SingleTableMetaDataBuilder.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/metadata/SingleTableMetaDataBuilder.java
@@ -46,7 +46,8 @@ public final class SingleTableMetaDataBuilder implements RuleBasedTableMetaDataB
     @Override
     public Map<String, TableMetaData> load(final Collection<String> tableNames, final SingleTableRule rule, final SchemaBuilderMaterials materials)
             throws SQLException {
-        Collection<String> needLoadTables = tableNames.stream().filter(each -> rule.getTables().contains(each)).collect(Collectors.toSet());
+        Collection<String> ruleTables = rule.getTables();
+        Collection<String> needLoadTables = tableNames.stream().filter(ruleTables::contains).collect(Collectors.toSet());
         if (needLoadTables.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -61,14 +62,15 @@ public final class SingleTableMetaDataBuilder implements RuleBasedTableMetaDataB
     @Override
     public Map<String, TableMetaData> decorate(final Map<String, TableMetaData> tableMetaDataMap, final SingleTableRule rule, final SchemaBuilderMaterials materials) {
         Map<String, TableMetaData> result = new LinkedHashMap<>();
+        Collection<String> ruleTables = rule.getTables();
         for (Entry<String, TableMetaData> entry : tableMetaDataMap.entrySet()) {
-            result.put(entry.getKey(), decorate(entry.getKey(), entry.getValue(), rule));
+            result.put(entry.getKey(), ruleTables.contains(entry.getKey()) ? decorate(entry.getKey(), entry.getValue()) : entry.getValue());
         }
         return result;
     }
     
-    private TableMetaData decorate(final String tableName, final TableMetaData tableMetaData, final SingleTableRule rule) {
-        return rule.getTables().contains(tableName) ? new TableMetaData(tableName, tableMetaData.getColumns().values(), getIndex(tableMetaData), getConstraint(tableMetaData)) : tableMetaData;
+    private TableMetaData decorate(final String tableName, final TableMetaData tableMetaData) {
+        return new TableMetaData(tableName, tableMetaData.getColumns().values(), getIndex(tableMetaData), getConstraint(tableMetaData));
     }
     
     private Collection<IndexMetaData> getIndex(final TableMetaData tableMetaData) {

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -37,6 +37,7 @@ import javax.sql.DataSource;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -224,12 +225,12 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     
     @Override
     public Collection<String> getAllTables() {
-        return tableNames.values();
+        return new HashSet<>(tableNames.values());
     }
     
     @Override
     public Collection<String> getTables() {
-        return tableNames.values();
+        return new HashSet<>(tableNames.values());
     }
     
     @Override


### PR DESCRIPTION
Fixes #16753.
Ref to #16880.
Changes proposed in this pull request:
- Avoid calling the concurrentHashMap.values() method in a loop.
- use hash set to replace concurrentHashMap.values().

## performance
after: 20w single table(simple table) one datasource -> 120 s 
before: >20 min
## before.
![image](https://user-images.githubusercontent.com/86938616/163914436-b1bdaf5c-afe9-4a7f-9f43-6a8792a95be6.png)
## after
![image](https://user-images.githubusercontent.com/86938616/163914537-da40549b-6f7b-4c58-b0ca-b88f1bf50eaf.png)
