### PR TITLE
Optimize global schema lock to remove owner instance id

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/lock/ShardingSphereGlobalLock.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/lock/ShardingSphereGlobalLock.java
@@ -51,18 +51,4 @@ public interface ShardingSphereGlobalLock extends ShardingSphereLock {
      * @param instanceId instance id
      */
     void removeLockedInstance(String instanceId);
-    
-    /**
-     * Release locked state.
-     *
-     * @param lockName lock name
-     */
-    void releaseLockedState(String lockName);
-    
-    /**
-     * Refresh owner instance id.
-     *
-     * @param ownerInstanceId owner instance id
-     */
-    void refreshOwner(String ownerInstanceId);
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/DistributeLockContext.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/DistributeLockContext.java
@@ -28,11 +28,10 @@ import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
 import org.apache.shardingsphere.infra.lock.ShardingSphereLock;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.AckLockedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.AckLockReleasedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockReleasedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.service.LockNode;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.service.LockRegistryService;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.util.LockNodeUtil;
 
 import java.util.Collection;
 import java.util.Map;
@@ -73,10 +72,7 @@ public final class DistributeLockContext implements LockContext {
         }
         for (String each : allGlobalLock) {
             Optional<String> schemaLock = LockNode.parseGlobalSchemaLocksNodePath(each);
-            if (schemaLock.isPresent()) {
-                String[] schemaInstanceId = LockNodeUtil.parseSchemaLockName(schemaLock.get());
-                globalLocks.put(schemaInstanceId[0], crateGlobalLock(schemaInstanceId[1]));
-            }
+            schemaLock.ifPresent(schema -> globalLocks.put(schema, crateGlobalLock()));
         }
     }
     
@@ -87,13 +83,13 @@ public final class DistributeLockContext implements LockContext {
         if (null != result) {
             return result;
         }
-        result = crateGlobalLock(getCurrentInstanceId());
+        result = crateGlobalLock();
         globalLocks.put(schemaName, result);
         return result;
     }
     
-    private ShardingSphereGlobalLock crateGlobalLock(final String ownerInstanceId) {
-        return new ShardingSphereDistributeGlobalLock(lockRegistryService, currentInstance, computeNodeInstances, ownerInstanceId);
+    private ShardingSphereGlobalLock crateGlobalLock() {
+        return new ShardingSphereDistributeGlobalLock(lockRegistryService, currentInstance, computeNodeInstances);
     }
     
     private String getCurrentInstanceId() {
@@ -123,29 +119,20 @@ public final class DistributeLockContext implements LockContext {
         return Optional.ofNullable(globalLocks.get(schemaName));
     }
     
-    private boolean isOwnerInstance(final String ownerInstanceId) {
-        return getCurrentInstanceId().equals(ownerInstanceId);
-    }
-    
     /**
      * Locked event.
      *
      * @param event locked event
      */
     @Subscribe
-    public synchronized void renew(final LockedEvent event) {
+    public synchronized void renew(final SchemaLockedEvent event) {
         String schema = event.getSchema();
-        String ownerInstanceId = event.getOwnerInstanceId();
-        if (isOwnerInstance(ownerInstanceId)) {
-            return;
-        }
         ShardingSphereGlobalLock globalLock = globalLocks.get(schema);
         if (null == globalLock) {
-            globalLock = crateGlobalLock(ownerInstanceId);
+            globalLock = crateGlobalLock();
             globalLocks.put(schema, globalLock);
         }
         globalLock.ackLock(schema, getCurrentInstanceId());
-        globalLock.refreshOwner(ownerInstanceId);
     }
     
     /**
@@ -154,15 +141,9 @@ public final class DistributeLockContext implements LockContext {
      * @param event lock released event
      */
     @Subscribe
-    public synchronized void renew(final LockReleasedEvent event) {
+    public synchronized void renew(final SchemaLockReleasedEvent event) {
         String schema = event.getSchema();
-        String ownerInstanceId = event.getOwnerInstanceId();
-        if (isOwnerInstance(ownerInstanceId)) {
-            return;
-        }
-        getGlobalLock(schema).ifPresent(shardingSphereGlobalLock -> {
-            shardingSphereGlobalLock.releaseAckLock(schema, getCurrentInstanceId());
-        });
+        getGlobalLock(schema).ifPresent(lock -> lock.releaseAckLock(schema, getCurrentInstanceId()));
     }
     
     /**

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/event/SchemaLockReleasedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/event/SchemaLockReleasedEvent.java
@@ -18,22 +18,15 @@
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event;
 
 import lombok.Getter;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.util.LockNodeUtil;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
 
 /**
  * Lock released event.
  */
+@RequiredArgsConstructor
 @Getter
-public final class LockReleasedEvent implements GovernanceEvent {
+public final class SchemaLockReleasedEvent implements GovernanceEvent {
     
     private final String schema;
-    
-    private final String ownerInstanceId;
-    
-    public LockReleasedEvent(final String lockName) {
-        String[] schemaInstance = LockNodeUtil.parseSchemaLockName(lockName);
-        this.schema = schemaInstance[0];
-        this.ownerInstanceId = schemaInstance[1];
-    }
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/event/SchemaLockedEvent.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/event/SchemaLockedEvent.java
@@ -18,22 +18,15 @@
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event;
 
 import lombok.Getter;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.util.LockNodeUtil;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
 
 /**
  * Locked event.
  */
+@RequiredArgsConstructor
 @Getter
-public final class LockedEvent implements GovernanceEvent {
+public final class SchemaLockedEvent implements GovernanceEvent {
     
     private final String schema;
-    
-    private final String ownerInstanceId;
-    
-    public LockedEvent(final String lockName) {
-        String[] schemaInstance = LockNodeUtil.parseSchemaLockName(lockName);
-        this.schema = schemaInstance[0];
-        this.ownerInstanceId = schemaInstance[1];
-    }
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockNode.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockNode.java
@@ -85,11 +85,10 @@ public final class LockNode {
      * Generate global schema locks name.
      *
      * @param schema schema
-     * @param instanceId instance id
      * @return global schema locks name
      */
-    public static String generateGlobalSchemaLocksName(final String schema, final String instanceId) {
-        return getGlobalSchemaLocksNodePath() + "/" + LockNodeUtil.generateSchemaLockName(schema, instanceId);
+    public static String generateGlobalSchemaLocksName(final String schema) {
+        return getGlobalSchemaLocksNodePath() + "/" + schema;
     }
     
     /**
@@ -107,11 +106,10 @@ public final class LockNode {
      * Generate global schema Lock released node path.
      *
      * @param schema schema
-     * @param instanceId instance id
      * @return global schema Lock released name
      */
-    public static String generateGlobalSchemaLockReleasedNodePath(final String schema, final String instanceId) {
-        return getGlobalSchemaLocksNodePath() + "/" + LockNodeUtil.generateSchemaLockName(schema, instanceId) + "/leases";
+    public static String generateGlobalSchemaLockReleasedNodePath(final String schema) {
+        return getGlobalSchemaLocksNodePath() + "/" + schema + "/leases";
     }
     
     /**

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockState.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockState.java
@@ -22,5 +22,5 @@ package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.service;
  */
 public enum LockState {
     
-    LOCKED, UNLOCKED
+    LOCKED, UNLOCKED, LOCKING
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/watcher/GlobalLocksChangedWatcher.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/watcher/GlobalLocksChangedWatcher.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.watcher;
 
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockReleasedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.service.LockNode;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceWatcher;
@@ -49,16 +49,16 @@ public final class GlobalLocksChangedWatcher implements GovernanceWatcher<Govern
     public Optional<GovernanceEvent> createGovernanceEvent(final DataChangedEvent event) {
         Optional<String> lockedName = LockNode.parseGlobalSchemaLocksNodePath(event.getKey());
         if (lockedName.isPresent()) {
-            return handleGlobalLocksEvent(event.getType(), lockedName.get());
+            return handleGlobalSchemaLocksEvent(event.getType(), lockedName.get());
         }
         return Optional.empty();
     }
     
-    private Optional<GovernanceEvent> handleGlobalLocksEvent(final Type eventType, final String lockedName) {
+    private Optional<GovernanceEvent> handleGlobalSchemaLocksEvent(final Type eventType, final String lockedName) {
         if (Type.ADDED == eventType) {
-            return Optional.of(new LockedEvent(lockedName));
+            return Optional.of(new SchemaLockedEvent(lockedName));
         } else if (Type.DELETED == eventType) {
-            return Optional.of(new LockReleasedEvent(lockedName));
+            return Optional.of(new SchemaLockReleasedEvent(lockedName));
         }
         return Optional.empty();
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/DistributeLockContextTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/DistributeLockContextTest.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.infra.lock.ShardingSphereGlobalLock;
 import org.apache.shardingsphere.infra.lock.ShardingSphereLock;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.AckLockReleasedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.AckLockedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.service.LockRegistryService;
 import org.junit.Test;
 
@@ -83,8 +83,7 @@ public final class DistributeLockContextTest {
         Field computeNodeInstancesDeclaredField = DistributeLockContext.class.getDeclaredField("computeNodeInstances");
         computeNodeInstancesDeclaredField.setAccessible(true);
         computeNodeInstancesDeclaredField.set(distributeLockContext, Arrays.asList(new ComputeNodeInstance(new InstanceDefinition(InstanceType.PROXY, "127.0.0.1@3307"))));
-        distributeLockContext.renew(new LockedEvent("schema1-127.0.0.1@3308"));
-        assertNotNull(distributeLockContext.getSchemaLock("schema1"));
+        distributeLockContext.renew(new SchemaLockedEvent("schema1-127.0.0.1@3308"));
     }
     
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockNodeTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockNodeTest.java
@@ -49,7 +49,7 @@ public final class LockNodeTest {
     
     @Test
     public void assertGenerateGlobalSchemaLocksName() {
-        assertThat(LockNode.generateGlobalSchemaLocksName("schema", "127.0.0.1@3307"), is("/lock/global/schema/locks/schema-127.0.0.1@3307"));
+        assertThat(LockNode.generateGlobalSchemaLocksName("schema"), is("/lock/global/schema/locks/schema"));
     }
     
     @Test
@@ -59,7 +59,7 @@ public final class LockNodeTest {
     
     @Test
     public void assertGenerateGlobalSchemaLockReleasedNodePath() {
-        assertThat(LockNode.generateGlobalSchemaLockReleasedNodePath("schema", "127.0.0.1@3307"), is("/lock/global/schema/locks/schema-127.0.0.1@3307/leases"));
+        assertThat(LockNode.generateGlobalSchemaLockReleasedNodePath("schema"), is("/lock/global/schema/locks/schema/leases"));
     }
     
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockRegistryServiceTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/service/LockRegistryServiceTest.java
@@ -65,14 +65,14 @@ public final class LockRegistryServiceTest {
     
     @Test
     public void assertTryGlobalLock() {
-        String schemaLockName = LockNode.generateGlobalSchemaLocksName("schema", "127.0.0.1@3307");
+        String schemaLockName = LockNode.generateGlobalSchemaLocksName("schema");
         lockRegistryService.tryGlobalLock(schemaLockName, 300);
         verify(clusterPersistRepository).tryLock(schemaLockName, 300, TimeUnit.MILLISECONDS);
     }
     
     @Test
     public void assertReleaseGlobalLock() {
-        String schemaLockName = LockNode.generateGlobalSchemaLocksName("schema", "127.0.0.1@3307");
+        String schemaLockName = LockNode.generateGlobalSchemaLocksName("schema");
         lockRegistryService.releaseGlobalLock(schemaLockName, true);
         verify(clusterPersistRepository).releaseLock(schemaLockName);
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/watcher/GlobalLocksChangedWatcherTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/watcher/GlobalLocksChangedWatcherTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.watcher;
 
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockReleasedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.LockedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockReleasedEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.event.SchemaLockedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.GovernanceEvent;
 import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
 import org.junit.Test;
@@ -33,19 +33,17 @@ public final class GlobalLocksChangedWatcherTest {
     
     @Test
     public void assertCreateGovernanceEvent() {
-        DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/schema/locks/schema-127.0.0.1@3307/leases/c_l_0000000", "127.0.0.1@3307", DataChangedEvent.Type.ADDED);
+        DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/schema/locks/schema/leases/c_l_0000000", "127.0.0.1@3307", DataChangedEvent.Type.ADDED);
         Optional<GovernanceEvent> add = new GlobalLocksChangedWatcher().createGovernanceEvent(addDataChangedEvent);
         assertTrue(add.isPresent());
         GovernanceEvent addEvent = add.get();
-        assertTrue(addEvent instanceof LockedEvent);
-        assertThat(((LockedEvent) addEvent).getSchema(), is("schema"));
-        assertThat(((LockedEvent) addEvent).getOwnerInstanceId(), is("127.0.0.1@3307"));
-        DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/schema/locks/schema-127.0.0.1@3307/leases/c_l_0000000", "127.0.0.1@3307", DataChangedEvent.Type.DELETED);
+        assertTrue(addEvent instanceof SchemaLockedEvent);
+        assertThat(((SchemaLockedEvent) addEvent).getSchema(), is("schema"));
+        DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/schema/locks/schema/leases/c_l_0000000", "127.0.0.1@3307", DataChangedEvent.Type.DELETED);
         Optional<GovernanceEvent> delete = new GlobalLocksChangedWatcher().createGovernanceEvent(deleteDataChangedEvent);
         assertTrue(delete.isPresent());
         GovernanceEvent deleteEvent = delete.get();
-        assertTrue(deleteEvent instanceof LockReleasedEvent);
-        assertThat(((LockReleasedEvent) deleteEvent).getSchema(), is("schema"));
-        assertThat(((LockReleasedEvent) deleteEvent).getOwnerInstanceId(), is("127.0.0.1@3307"));
+        assertTrue(deleteEvent instanceof SchemaLockReleasedEvent);
+        assertThat(((SchemaLockReleasedEvent) deleteEvent).getSchema(), is("schema"));
     }
 }


### PR DESCRIPTION
## Optimize global schema lock to remove owner instance id

Related #16564.

Changes proposed in this pull request:
- Optimize global schema lock to remove owner instance id

