### PR TITLE
Rename schema to database in export/import syntax.

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/_index.cn.md
@@ -71,7 +71,7 @@ RAL (Resource & Rule Administration Language) 为 Apache ShardingSphere 的管�
 | REFRESH TABLE METADATA                                                      | 刷新所有表的元数据                                              | REFRESH TABLE METADATA                          |
 | REFRESH TABLE METADATA [tableName / tableName FROM resource resourceName]   | 刷新指定表的元数据                                              | REFRESH TABLE METADATA t_order FROM resource ds_1 |
 | SHOW TABLE METADATA tableName [, tableName] ...                             | 查询表的元数据                                                 | SHOW TABLE METADATA t_order                       |
-| EXPORT SCHEMA CONFIG [FROM schema_name] [, file="file_path"]                | 查询 / 导出 schema 中的资源和规则配置                            | EXPORT SCHEMA CONFIG FROM readwrite_splitting_db  |
+| EXPORT DATABASE CONFIG [FROM database_name] [, file="file_path"]            | 查询 / 导出 database 中的资源和规则配置                          | EXPORT DATABASE CONFIG FROM readwrite_splitting_db |
 | SHOW RULES USED RESOURCE resourceName [from schema]                         | 查询 schema 中使用指定资源的规则                                 | SHOW RULES USED RESOURCE ds_0 FROM schemaName     |
 
 ## 注意事项

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/_index.en.md
@@ -70,7 +70,7 @@ RAL (Resource & Rule Administration Language) responsible for the added-on featu
 | REFRESH TABLE METADATA                                                      | Refresh the metadata of all tables                                                 | REFRESH TABLE METADATA                    |
 | REFRESH TABLE METADATA [tableName / tableName FROM resource resourceName]   | Refresh the metadata of a table                                                    | REFRESH TABLE METADATA t_order FROM resource ds_1  |
 | SHOW TABLE METADATA tableName [, tableName] ...                             | Query table metadata                                                               | SHOW TABLE METADATA t_order                        |
-| EXPORT SCHEMA CONFIG [FROM schema_name] [, file="file_path"]                | Query / export resources and rule configuration in schema                          | EXPORT SCHEMA CONFIG FROM readwrite_splitting_db   |
+| EXPORT DATABASE CONFIG [FROM database_name] [, file="file_path"]            | Query / export resources and rule configuration in database                    | EXPORT DATABASE CONFIG FROM readwrite_splitting_db |
 | SHOW RULES USED RESOURCE resourceName [from schema]                         | Query the rules for using the specified resource in schema                         | SHOW RULES USED RESOURCE ds_0 FROM schemaName  |
 
 ## Notice

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/BaseRule.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/BaseRule.g4
@@ -39,6 +39,10 @@ schemaName
     : IDENTIFIER
     ;
 
+databaseName
+    : IDENTIFIER
+    ;
+
 resourceName
     : IDENTIFIER | STRING
     ;

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/Keyword.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/Keyword.g4
@@ -139,6 +139,10 @@ SCHEMA
     : S C H E M A
     ;
 
+DATABASE
+    : D A T A B A S E
+    ;
+
 SINGLE
     : S I N G L E
     ;

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
@@ -135,12 +135,12 @@ typeName
     : IDENTIFIER
     ;
 
-exportSchemaConfiguration
-    : EXPORT SCHEMA (CONFIGURATION | CONFIG) (FROM schemaName)? (COMMA? FILE EQ filePath)?
+exportDatabaseConfiguration
+    : EXPORT DATABASE (CONFIGURATION | CONFIG) (FROM databaseName)? (COMMA? FILE EQ filePath)?
     ;
 
-importSchemaConfiguration
-    : IMPORT SCHEMA (CONFIGURATION | CONFIG) FILE EQ filePath
+importDatabaseConfiguration
+    : IMPORT DATABASE (CONFIGURATION | CONFIG) FILE EQ filePath
     ;
 
 filePath

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/CommonDistSQLStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/CommonDistSQLStatement.g4
@@ -57,8 +57,8 @@ execute
     | dropTrafficRule
     | createTrafficRule
     | alterTrafficRule
-    | exportSchemaConfiguration
+    | exportDatabaseConfiguration
     | showRulesUsedResource
-    | importSchemaConfiguration
+    | importDatabaseConfiguration
     ) SEMI?
     ;

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/common/CommonDistSQLStatementVisitor.java
@@ -43,8 +43,8 @@ import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementPa
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.DropResourceContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.DropTrafficRuleContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.EnableInstanceContext;
-import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.ExportSchemaConfigurationContext;
-import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.ImportSchemaConfigurationContext;
+import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.ExportDatabaseConfigurationContext;
+import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.ImportDatabaseConfigurationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.InstanceDefinationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.InstanceIdContext;
 import org.apache.shardingsphere.distsql.parser.autogen.CommonDistSQLStatementParser.LabelDefinitionContext;
@@ -83,7 +83,7 @@ import org.apache.shardingsphere.distsql.parser.segment.TrafficRuleSegment;
 import org.apache.shardingsphere.distsql.parser.segment.TransactionProviderSegment;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.hint.ClearHintStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.CountInstanceRulesStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowAuthorityRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceModeStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceStatement;
@@ -100,16 +100,16 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.A
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.CreateTrafficRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.DiscardDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.DropTrafficRuleStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.LabelInstanceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.PrepareDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.RefreshTableMetadataStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.SetInstanceStatusStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.SetVariableStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.UnlabelInstanceStatement;
+import org.apache.shardingsphere.distsql.parser.statement.rdl.alter.AlterDefaultSingleTableRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.alter.AlterResourceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.create.AddResourceStatement;
-import org.apache.shardingsphere.distsql.parser.statement.rdl.alter.AlterDefaultSingleTableRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.create.CreateDefaultSingleTableRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.drop.DropDefaultSingleTableRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.drop.DropResourceStatement;
@@ -128,7 +128,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -468,8 +467,8 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     }
     
     @Override
-    public ASTNode visitExportSchemaConfiguration(final ExportSchemaConfigurationContext ctx) {
-        return new ExportSchemaConfigurationStatement(Objects.nonNull(ctx.schemaName()) ? (SchemaSegment) visit(ctx.schemaName()) : null, Optional.ofNullable(getIdentifierValue(ctx.filePath())));
+    public ASTNode visitExportDatabaseConfiguration(final ExportDatabaseConfigurationContext ctx) {
+        return new ExportDatabaseConfigurationStatement(null == ctx.databaseName() ? null : (SchemaSegment) visit(ctx.databaseName()), Optional.ofNullable(getIdentifierValue(ctx.filePath())));
     }
     
     @Override
@@ -493,8 +492,8 @@ public final class CommonDistSQLStatementVisitor extends CommonDistSQLStatementB
     }
     
     @Override
-    public ASTNode visitImportSchemaConfiguration(final ImportSchemaConfigurationContext ctx) {
-        return new ImportSchemaConfigurationStatement(getIdentifierValue(ctx.filePath()));
+    public ASTNode visitImportDatabaseConfiguration(final ImportDatabaseConfigurationContext ctx) {
+        return new ImportDatabaseConfigurationStatement(getIdentifierValue(ctx.filePath()));
     }
     
     private String getIdentifierValue(final ParseTree context) {

--- a/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/common/queryable/ExportDatabaseConfigurationStatement.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/common/queryable/ExportDatabaseConfigurationStatement.java
@@ -15,20 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.exception;
+package org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable;
 
 import lombok.Getter;
-import org.apache.shardingsphere.infra.distsql.exception.DistSQLException;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.available.FromSchemaAvailable;
+
+import java.util.Optional;
 
 /**
- * Import schema does not exist exception.
+ * Export database configuration statement.
  */
-@Getter
-public final class ImportSchemaNotExistedException extends DistSQLException {
+@RequiredArgsConstructor
+public final class ExportDatabaseConfigurationStatement extends QueryableRALStatement implements FromSchemaAvailable {
     
-    private static final long serialVersionUID = 4803138422791056535L;
+    private final SchemaSegment database;
     
-    public ImportSchemaNotExistedException(final String fileName) {
-        super(1106, String.format("Property `schemaName` in file `%s` is required.", fileName));
+    @Getter
+    private final Optional<String> filePath;
+    
+    @Override
+    public Optional<SchemaSegment> getSchema() {
+        return Optional.ofNullable(database);
     }
 }

--- a/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/common/updatable/ImportDatabaseConfigurationStatement.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/common/updatable/ImportDatabaseConfigurationStatement.java
@@ -15,21 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral;
+package org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 
-import javax.xml.bind.annotation.XmlElement;
+import java.util.Optional;
 
 /**
- * Import schema configuration statement test case.
+ * Import database configuration statement.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ImportSchemaConfigurationStatementTestCase extends SQLParserTestCase {
+public final class ImportDatabaseConfigurationStatement extends UpdatableRALStatement {
     
-    @XmlElement(name = "filePath")
-    private String filePath;
+    private final String filePath;
+    
+    /**
+     * Get file path.
+     * 
+     * @return file path
+     */
+    public Optional<String> getFilePath() {
+        return Optional.ofNullable(filePath);
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/exception/ImportDatabaseNotExistedException.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/exception/ImportDatabaseNotExistedException.java
@@ -15,29 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable;
+package org.apache.shardingsphere.infra.exception;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
-
-import java.util.Optional;
+import org.apache.shardingsphere.infra.distsql.exception.DistSQLException;
 
 /**
- * Import schema configuration statement.
+ * Import database does not exist exception.
  */
-@RequiredArgsConstructor
 @Getter
-public final class ImportSchemaConfigurationStatement extends UpdatableRALStatement {
+public final class ImportDatabaseNotExistedException extends DistSQLException {
     
-    private final String filePath;
+    private static final long serialVersionUID = 4803138422791056535L;
     
-    /**
-     * Get file path.
-     * 
-     * @return file path
-     */
-    public Optional<String> getFilePath() {
-        return Optional.ofNullable(filePath);
+    public ImportDatabaseNotExistedException(final String fileName) {
+        super(1106, String.format("Property `databaseName` in file `%s` is required.", fileName));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/RALBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/RALBackendHandlerFactory.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.advanced.ParseStat
 import org.apache.shardingsphere.distsql.parser.statement.ral.advanced.PreviewStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.HintDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.CountInstanceRulesStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowAuthorityRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceModeStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceStatement;
@@ -42,7 +42,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.A
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.CreateTrafficRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.DiscardDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.DropTrafficRuleStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.LabelInstanceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.PrepareDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.RefreshTableMetadataStatement;
@@ -60,7 +60,7 @@ import org.apache.shardingsphere.proxy.backend.text.distsql.ral.advanced.ParseDi
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.advanced.PreviewDistSQLBackendHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.HintDistSQLBackendHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.CountInstanceRulesHandler;
-import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.ExportSchemaConfigurationHandler;
+import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.ExportDatabaseConfigurationHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.ShowAuthorityRuleHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.ShowInstanceHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable.ShowInstanceModeHandler;
@@ -78,7 +78,7 @@ import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.CreateTrafficRuleHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.DiscardDistSQLHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.DropTrafficRuleHandler;
-import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.ImportSchemaConfigurationHandler;
+import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.ImportDatabaseConfigurationHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.LabelInstanceHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.PrepareDistSQLHandler;
 import org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable.RefreshTableMetadataHandler;
@@ -126,7 +126,7 @@ public final class RALBackendHandlerFactory {
         UPDATABLE_HANDLER_MAP.put(PrepareDistSQLStatement.class.getName(), PrepareDistSQLHandler.class);
         UPDATABLE_HANDLER_MAP.put(ApplyDistSQLStatement.class.getName(), ApplyDistSQLHandler.class);
         UPDATABLE_HANDLER_MAP.put(DiscardDistSQLStatement.class.getName(), DiscardDistSQLHandler.class);
-        UPDATABLE_HANDLER_MAP.put(ImportSchemaConfigurationStatement.class.getName(), ImportSchemaConfigurationHandler.class);
+        UPDATABLE_HANDLER_MAP.put(ImportDatabaseConfigurationStatement.class.getName(), ImportDatabaseConfigurationHandler.class);
     }
     
     private static void initQueryableHandlerMap() {
@@ -140,7 +140,7 @@ public final class RALBackendHandlerFactory {
         QUERYABLE_HANDLER_MAP.put(ShowTableMetadataStatement.class.getName(), ShowTableMetadataHandler.class);
         QUERYABLE_HANDLER_MAP.put(ShowTrafficRulesStatement.class.getName(), ShowTrafficRulesHandler.class);
         QUERYABLE_HANDLER_MAP.put(ShowTransactionRuleStatement.class.getName(), ShowTransactionRuleHandler.class);
-        QUERYABLE_HANDLER_MAP.put(ExportSchemaConfigurationStatement.class.getName(), ExportSchemaConfigurationHandler.class);
+        QUERYABLE_HANDLER_MAP.put(ExportDatabaseConfigurationStatement.class.getName(), ExportDatabaseConfigurationHandler.class);
         QUERYABLE_HANDLER_MAP.put(ParseStatement.class.getName(), ParseDistSQLBackendHandler.class);
         QUERYABLE_HANDLER_MAP.put(PreviewStatement.class.getName(), PreviewDistSQLBackendHandler.class);
         QUERYABLE_HANDLER_MAP.put(FormatStatement.class.getName(), FormatHandler.class);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryabl
 
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.yaml.swapper.DatabaseDiscoveryRuleConfigurationYamlSwapper;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.swapper.EncryptRuleConfigurationYamlSwapper;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
@@ -53,9 +53,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * Export schema configuration handler.
+ * Export database configuration handler.
  */
-public final class ExportSchemaConfigurationHandler extends QueryableRALBackendHandler<ExportSchemaConfigurationStatement, ExportSchemaConfigurationHandler> {
+public final class ExportDatabaseConfigurationHandler extends QueryableRALBackendHandler<ExportDatabaseConfigurationStatement, ExportDatabaseConfigurationHandler> {
     
     private static final String RESULT = "result";
     
@@ -100,7 +100,7 @@ public final class ExportSchemaConfigurationHandler extends QueryableRALBackendH
     }
     
     @Override
-    public ExportSchemaConfigurationHandler init(final HandlerParameter<ExportSchemaConfigurationStatement> parameter) {
+    public ExportDatabaseConfigurationHandler init(final HandlerParameter<ExportDatabaseConfigurationStatement> parameter) {
         connectionSession = parameter.getConnectionSession();
         return super.init(parameter);
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandlerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.queryable;
 
 import com.zaxxer.hikari.HikariDataSource;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class ExportSchemaConfigurationHandlerTest {
+public final class ExportDatabaseConfigurationHandlerTest {
     
     @Before
     public void init() {
@@ -71,8 +71,8 @@ public final class ExportSchemaConfigurationHandlerTest {
     }
     
     @Test
-    public void assertExportSchemaExecutor() throws SQLException {
-        ExportSchemaConfigurationHandler handler = new ExportSchemaConfigurationHandler().init(getParameter(createSqlStatement(), mockConnectionSession()));
+    public void assertExportDatabaseExecutor() throws SQLException {
+        ExportDatabaseConfigurationHandler handler = new ExportDatabaseConfigurationHandler().init(getParameter(createSqlStatement(), mockConnectionSession()));
         handler.execute();
         handler.next();
         List<Object> data = new ArrayList<>(handler.getRowData());
@@ -128,15 +128,15 @@ public final class ExportSchemaConfigurationHandlerTest {
         return result;
     }
     
-    private ExportSchemaConfigurationStatement createSqlStatement() {
-        return new ExportSchemaConfigurationStatement(new SchemaSegment(0, 0, new IdentifierValue("sharding_db")), Optional.empty());
+    private ExportDatabaseConfigurationStatement createSqlStatement() {
+        return new ExportDatabaseConfigurationStatement(new SchemaSegment(0, 0, new IdentifierValue("sharding_db")), Optional.empty());
     }
     
     private ConnectionSession mockConnectionSession() {
         return mock(ConnectionSession.class);
     }
     
-    private HandlerParameter<ExportSchemaConfigurationStatement> getParameter(final ExportSchemaConfigurationStatement statement, final ConnectionSession connectionSession) {
-        return new HandlerParameter<ExportSchemaConfigurationStatement>().setStatement(statement).setConnectionSession(connectionSession);
+    private HandlerParameter<ExportDatabaseConfigurationStatement> getParameter(final ExportDatabaseConfigurationStatement statement, final ConnectionSession connectionSession) {
+        return new HandlerParameter<ExportDatabaseConfigurationStatement>().setStatement(statement).setConnectionSession(connectionSession);
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/ImportDatabaseConfigurationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/updatable/ImportDatabaseConfigurationHandlerTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.text.distsql.ral.common.updatable;
 
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.datasource.props.DataSourcePropertiesValidator;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public final class ImportSchemaConfigurationHandlerTest {
+public final class ImportDatabaseConfigurationHandlerTest {
     
     private final String shardingFilePath = "/conf/import/config-sharding.yaml";
     
@@ -83,7 +83,7 @@ public final class ImportSchemaConfigurationHandlerTest {
     @Mock
     private DatabaseDiscoveryRuleConfigurationImportChecker databaseDiscoveryRuleConfigurationImportChecker;
     
-    private ImportSchemaConfigurationHandler importSchemaConfigurationHandler;
+    private ImportDatabaseConfigurationHandler importDatabaseConfigurationHandler;
     
     private final Map<String, String> featureMap = new HashMap<>();
     
@@ -95,10 +95,10 @@ public final class ImportSchemaConfigurationHandlerTest {
     }
     
     private void init(final String feature) throws Exception {
-        importSchemaConfigurationHandler = new ImportSchemaConfigurationHandler().init(getParameter(createSqlStatement(featureMap.get(feature)), mockConnectionSession()));
-        Field validatorField = importSchemaConfigurationHandler.getClass().getDeclaredField("validator");
+        importDatabaseConfigurationHandler = new ImportDatabaseConfigurationHandler().init(getParameter(createSqlStatement(featureMap.get(feature)), mockConnectionSession()));
+        Field validatorField = importDatabaseConfigurationHandler.getClass().getDeclaredField("validator");
         validatorField.setAccessible(true);
-        validatorField.set(importSchemaConfigurationHandler, validator);
+        validatorField.set(importDatabaseConfigurationHandler, validator);
         ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
         when(contextManager.getMetaDataContexts().getAllDatabaseNames()).thenReturn(Collections.singletonList(feature));
         ShardingSphereMetaData shardingSphereMetaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
@@ -109,44 +109,44 @@ public final class ImportSchemaConfigurationHandlerTest {
     }
     
     @Test
-    public void assertImportSchemaExecutorForSharding() throws Exception {
+    public void assertImportDatabaseExecutorForSharding() throws Exception {
         init(sharding);
-        Field shardingRuleConfigurationImportCheckerField = importSchemaConfigurationHandler.getClass().getDeclaredField("shardingRuleConfigurationImportChecker");
+        Field shardingRuleConfigurationImportCheckerField = importDatabaseConfigurationHandler.getClass().getDeclaredField("shardingRuleConfigurationImportChecker");
         shardingRuleConfigurationImportCheckerField.setAccessible(true);
-        shardingRuleConfigurationImportCheckerField.set(importSchemaConfigurationHandler, shardingRuleConfigurationImportChecker);
+        shardingRuleConfigurationImportCheckerField.set(importDatabaseConfigurationHandler, shardingRuleConfigurationImportChecker);
         Map<String, DataSource> dataSourceMap = ProxyContext.getInstance().getContextManager().getDataSourceMap(sharding);
         assertNotNull(dataSourceMap);
         Collection<RuleConfiguration> ruleConfigurations = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(sharding).getRuleMetaData().getConfigurations();
         assertNotNull(ruleConfigurations);
-        ResponseHeader responseHeader = importSchemaConfigurationHandler.execute();
+        ResponseHeader responseHeader = importDatabaseConfigurationHandler.execute();
         assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
     
     @Test
-    public void assertImportSchemaExecutorForReadwriteSplitting() throws Exception {
+    public void assertImportDatabaseExecutorForReadwriteSplitting() throws Exception {
         init(readwriteSplitting);
-        Field readwriteSplittingRuleConfigurationImportCheckerField = importSchemaConfigurationHandler.getClass().getDeclaredField("readwriteSplittingRuleConfigurationImportChecker");
+        Field readwriteSplittingRuleConfigurationImportCheckerField = importDatabaseConfigurationHandler.getClass().getDeclaredField("readwriteSplittingRuleConfigurationImportChecker");
         readwriteSplittingRuleConfigurationImportCheckerField.setAccessible(true);
-        readwriteSplittingRuleConfigurationImportCheckerField.set(importSchemaConfigurationHandler, readwriteSplittingRuleConfigurationImportChecker);
+        readwriteSplittingRuleConfigurationImportCheckerField.set(importDatabaseConfigurationHandler, readwriteSplittingRuleConfigurationImportChecker);
         Map<String, DataSource> dataSourceMap = ProxyContext.getInstance().getContextManager().getDataSourceMap(readwriteSplitting);
         assertNotNull(dataSourceMap);
         Collection<RuleConfiguration> ruleConfigurations = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(readwriteSplitting).getRuleMetaData().getConfigurations();
         assertNotNull(ruleConfigurations);
-        ResponseHeader responseHeader = importSchemaConfigurationHandler.execute();
+        ResponseHeader responseHeader = importDatabaseConfigurationHandler.execute();
         assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
     
     @Test
-    public void assertImportSchemaExecutorForDatabaseDiscovery() throws Exception {
+    public void assertImportDatabaseExecutorForDatabaseDiscovery() throws Exception {
         init(databaseDiscovery);
-        Field databaseDiscoveryRuleConfigurationImportCheckerField = importSchemaConfigurationHandler.getClass().getDeclaredField("databaseDiscoveryRuleConfigurationImportChecker");
+        Field databaseDiscoveryRuleConfigurationImportCheckerField = importDatabaseConfigurationHandler.getClass().getDeclaredField("databaseDiscoveryRuleConfigurationImportChecker");
         databaseDiscoveryRuleConfigurationImportCheckerField.setAccessible(true);
-        databaseDiscoveryRuleConfigurationImportCheckerField.set(importSchemaConfigurationHandler, databaseDiscoveryRuleConfigurationImportChecker);
+        databaseDiscoveryRuleConfigurationImportCheckerField.set(importDatabaseConfigurationHandler, databaseDiscoveryRuleConfigurationImportChecker);
         Map<String, DataSource> dataSourceMap = ProxyContext.getInstance().getContextManager().getDataSourceMap(databaseDiscovery);
         assertNotNull(dataSourceMap);
         Collection<RuleConfiguration> ruleConfigurations = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(databaseDiscovery).getRuleMetaData().getConfigurations();
         assertNotNull(ruleConfigurations);
-        ResponseHeader responseHeader = importSchemaConfigurationHandler.execute();
+        ResponseHeader responseHeader = importDatabaseConfigurationHandler.execute();
         assertTrue(responseHeader instanceof UpdateResponseHeader);
     }
     
@@ -169,15 +169,15 @@ public final class ImportSchemaConfigurationHandlerTest {
         return result;
     }
     
-    private ImportSchemaConfigurationStatement createSqlStatement(final String importFilePath) {
-        return new ImportSchemaConfigurationStatement(Objects.requireNonNull(ImportSchemaConfigurationHandlerTest.class.getResource(importFilePath)).getPath());
+    private ImportDatabaseConfigurationStatement createSqlStatement(final String importFilePath) {
+        return new ImportDatabaseConfigurationStatement(Objects.requireNonNull(ImportDatabaseConfigurationHandlerTest.class.getResource(importFilePath)).getPath());
     }
     
     private ConnectionSession mockConnectionSession() {
         return mock(ConnectionSession.class);
     }
     
-    private RALBackendHandler.HandlerParameter<ImportSchemaConfigurationStatement> getParameter(final ImportSchemaConfigurationStatement statement, final ConnectionSession connectionSession) {
-        return new RALBackendHandler.HandlerParameter<ImportSchemaConfigurationStatement>().setStatement(statement).setConnectionSession(connectionSession);
+    private RALBackendHandler.HandlerParameter<ImportDatabaseConfigurationStatement> getParameter(final ImportDatabaseConfigurationStatement statement, final ConnectionSession connectionSession) {
+        return new RALBackendHandler.HandlerParameter<ImportDatabaseConfigurationStatement>().setStatement(statement).setConnectionSession(connectionSession);
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/QueryableRALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/QueryableRALStatementAssert.java
@@ -22,7 +22,7 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.advanced.ParseStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.advanced.PreviewStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowAuthorityRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowInstanceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ShowSQLParserRuleStatement;
@@ -34,7 +34,7 @@ import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.Sho
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.advanced.ParseStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.advanced.PreviewStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ExportSchemaConfigurationStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ExportDatabaseConfigurationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ShowAuthorityRuleStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ShowInstanceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ShowReadwriteSplittingReadResourcesStatementAssert;
@@ -44,7 +44,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ShowTransactionRuleStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable.ShowVariableStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportSchemaConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportDatabaseConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ParseStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.PreviewStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowAuthorityRuleStatementTestCase;
@@ -87,8 +87,8 @@ public final class QueryableRALStatementAssert {
             ShowTrafficRulesStatementAssert.assertIs(assertContext, (ShowTrafficRulesStatement) actual, (ShowTrafficRulesStatementTestCase) expected);
         } else if (actual instanceof ShowSQLParserRuleStatement) {
             ShowSQLParserRuleStatementAssert.assertIs(assertContext, (ShowSQLParserRuleStatement) actual, (ShowSQLParserRuleStatementTestCase) expected);
-        } else if (actual instanceof ExportSchemaConfigurationStatement) {
-            ExportSchemaConfigurationStatementAssert.assertIs(assertContext, (ExportSchemaConfigurationStatement) actual, (ExportSchemaConfigurationStatementTestCase) expected);
+        } else if (actual instanceof ExportDatabaseConfigurationStatement) {
+            ExportDatabaseConfigurationStatementAssert.assertIs(assertContext, (ExportDatabaseConfigurationStatement) actual, (ExportDatabaseConfigurationStatementTestCase) expected);
         } else if (actual instanceof PreviewStatement) {
             PreviewStatementAssert.assertIs(assertContext, (PreviewStatement) actual, (PreviewStatementTestCase) expected);
         } else if (actual instanceof ParseStatement) {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/UpdatableRALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/UpdatableRALStatementAssert.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.A
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.AlterTrafficRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.CreateTrafficRuleStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.DropTrafficRuleStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.LabelInstanceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.RefreshTableMetadataStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.SetVariableStatement;
@@ -36,7 +36,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.AlterTrafficRuleStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.CreateTrafficRuleStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.DropTrafficRuleStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.ImportSchemaConfigurationStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.ImportDatabaseConfigurationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.LabelInstanceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.RefreshTableMetadataStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.updatable.SetVariableStatementAssert;
@@ -47,7 +47,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AlterTrafficRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.CreateTrafficRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.DropTrafficRuleStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportSchemaConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportDatabaseConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.LabelInstanceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.RefreshTableMetadataStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.SetVariableStatementTestCase;
@@ -85,8 +85,8 @@ public final class UpdatableRALStatementAssert {
             CreateTrafficRuleStatementAssert.assertIs(assertContext, (CreateTrafficRuleStatement) actual, (CreateTrafficRuleStatementTestCase) expected);
         } else if (actual instanceof AlterTrafficRuleStatement) {
             AlterTrafficRuleStatementAssert.assertIs(assertContext, (AlterTrafficRuleStatement) actual, (AlterTrafficRuleStatementTestCase) expected);
-        } else if (actual instanceof ImportSchemaConfigurationStatement) {
-            ImportSchemaConfigurationStatementAssert.assertIs(assertContext, (ImportSchemaConfigurationStatement) actual, (ImportSchemaConfigurationStatementTestCase) expected);
+        } else if (actual instanceof ImportDatabaseConfigurationStatement) {
+            ImportDatabaseConfigurationStatementAssert.assertIs(assertContext, (ImportDatabaseConfigurationStatement) actual, (ImportDatabaseConfigurationStatementTestCase) expected);
         }
     }
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/common/queryable/ExportDatabaseConfigurationStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/common/queryable/ExportDatabaseConfigurationStatementAssert.java
@@ -17,27 +17,27 @@
 
 package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.common.queryable;
 
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable.ExportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportSchemaConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportDatabaseConfigurationStatementTestCase;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * Export schema configuration statement assert.
+ * Export database configuration statement assert.
  */
-public final class ExportSchemaConfigurationStatementAssert {
+public final class ExportDatabaseConfigurationStatementAssert {
     
     /**
-     * Assert export schema configuration statement is correct with expected parser result.
+     * Assert export database configuration statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual export schema configuration statement statement
-     * @param expected expected export configuration schema statement statement test case
+     * @param actual actual export database configuration statement statement
+     * @param expected expected export configuration database statement statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ExportSchemaConfigurationStatement actual,
-                                final ExportSchemaConfigurationStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ExportDatabaseConfigurationStatement actual,
+                                final ExportDatabaseConfigurationStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/common/updatable/ImportDatabaseConfigurationStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/common/updatable/ImportDatabaseConfigurationStatementAssert.java
@@ -19,9 +19,9 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportSchemaConfigurationStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.common.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportSchemaConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportDatabaseConfigurationStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
@@ -30,20 +30,20 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Import schema configuration statement assert.
+ * Import database configuration statement assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ImportSchemaConfigurationStatementAssert {
+public final class ImportDatabaseConfigurationStatementAssert {
     
     /**
-     * Assert import schema configuration statement is correct with expected parser result.
+     * Assert import database configuration statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual import schema configuration statement statement
-     * @param expected expected import configuration schema statement statement test case
+     * @param actual actual import database configuration statement statement
+     * @param expected expected import configuration database statement statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ImportSchemaConfigurationStatement actual,
-                                final ImportSchemaConfigurationStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ImportDatabaseConfigurationStatement actual,
+                                final ImportDatabaseConfigurationStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -115,6 +115,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSystemStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterTextSearchStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterTriggerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterViewStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AnalyzeStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AssociateStatisticsStatementTestCase;
@@ -144,34 +145,44 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DeclareStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DisassociateStatisticsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DiscardStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropAccessMethodStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropAggregateStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropCastStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropCollationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropConversionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDatabaseLinkStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDatabaseStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDimensionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDirectoryStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropDomainStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropEventTriggerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropExtensionStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropForeignDataWrapperStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropForeignTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropFunctionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropGroupStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropIndexStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropLanguageStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropMaterializedViewStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorClassStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorFamilyStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOwnedStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropPolicyStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropProcedureStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropPublicationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropRoutineStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropRuleStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropPublicationStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropSubscriptionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropSchemaStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropSequenceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropServerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropServiceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropStatisticsStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropSubscriptionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTextSearchStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTriggerStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterTriggerStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropEventTriggerStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTypeStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropViewStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.FlashbackDatabaseStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.FlashbackTableStatementTestCase;
@@ -181,17 +192,6 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.RenameStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.RenameTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.TruncateStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOwnedStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropMaterializedViewStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropCastStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropAggregateStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropCollationStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropForeignDataWrapperStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropTypeStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorClassStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropOperatorFamilyStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.DropAccessMethodStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AlterInstanceStatementTestCase;
@@ -205,8 +205,8 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.CreateTrafficRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.DiscardDistSQLStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.DropTrafficRuleStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportSchemaConfigurationStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportSchemaConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ExportDatabaseConfigurationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ImportDatabaseConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.LabelInstanceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ParseStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.PrepareDistSQLStatementTestCase;
@@ -1217,8 +1217,8 @@ public final class SQLParserTestCases {
     @XmlElement(name = "unlock")
     private final List<UnlockStatementTestCase> unlockStatementTestCases = new LinkedList<>();
     
-    @XmlElement(name = "export-schema-config")
-    private final List<ExportSchemaConfigurationStatementTestCase> exportSchemaConfigurationStatementTestCases = new LinkedList<>();
+    @XmlElement(name = "export-database-config")
+    private final List<ExportDatabaseConfigurationStatementTestCase> exportDatabaseConfigurationStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "show-rules-used-resource")
     private final List<ShowRulesUsedResourceStatementTestCase> showRulesUsedResourceStatementTestCases = new LinkedList<>();
@@ -1244,8 +1244,8 @@ public final class SQLParserTestCases {
     @XmlElement(name = "create-tablespace")
     private final List<CreateTablespaceStatementTestCase> createTablespaceTestCases = new LinkedList<>();
     
-    @XmlElement(name = "import-schema-config")
-    private final List<ImportSchemaConfigurationStatementTestCase> importSchemaConfigurationStatementTestCases = new LinkedList<>();
+    @XmlElement(name = "import-database-config")
+    private final List<ImportDatabaseConfigurationStatementTestCase> importDatabaseConfigurationStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "drop-operator")
     private final List<DropOperatorStatementTestCase> dropOperatorStatementTestCases = new LinkedList<>();
@@ -1578,7 +1578,7 @@ public final class SQLParserTestCases {
         putAll(discardStatementTestCase, result);
         putAll(lockStatementTestCases, result);
         putAll(unlockStatementTestCases, result);
-        putAll(exportSchemaConfigurationStatementTestCases, result);
+        putAll(exportDatabaseConfigurationStatementTestCases, result);
         putAll(showRulesUsedResourceStatementTestCases, result);
         putAll(preparedStatementTestCases, result);
         putAll(showShardingTableRulesUsedAlgorithmStatementTestCases, result);
@@ -1586,7 +1586,7 @@ public final class SQLParserTestCases {
         putAll(setUserStatementTestCases, result);
         putAll(dropShardingAlgorithmStatementTestCases, result);
         putAll(createTablespaceTestCases, result);
-        putAll(importSchemaConfigurationStatementTestCases, result);
+        putAll(importDatabaseConfigurationStatementTestCases, result);
         putAll(dropOwnedStatementTestCases, result);
         putAll(dropOperatorStatementTestCases, result);
         putAll(dropMaterializedViewStatementTestCases, result);

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ExportDatabaseConfigurationStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ExportDatabaseConfigurationStatementTestCase.java
@@ -25,12 +25,12 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import javax.xml.bind.annotation.XmlElement;
 
 /**
- * Export schema configuration statement test case.
+ * Export database configuration statement test case.
  */
 @Getter
 @Setter
-public final class ExportSchemaConfigurationStatementTestCase extends SQLParserTestCase {
+public final class ExportDatabaseConfigurationStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "schema")
-    private ExpectedSchema schema;
+    @XmlElement(name = "database")
+    private ExpectedSchema database;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ImportDatabaseConfigurationStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/ImportDatabaseConfigurationStatementTestCase.java
@@ -15,29 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.distsql.parser.statement.ral.common.queryable;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.SchemaSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.available.FromSchemaAvailable;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
-import java.util.Optional;
+import javax.xml.bind.annotation.XmlElement;
 
 /**
- * Export schema configuration statement.
+ * Import database configuration statement test case.
  */
-@RequiredArgsConstructor
-public final class ExportSchemaConfigurationStatement extends QueryableRALStatement implements FromSchemaAvailable {
+@Getter
+@Setter
+public final class ImportDatabaseConfigurationStatementTestCase extends SQLParserTestCase {
     
-    private final SchemaSegment schema;
-    
-    @Getter
-    private final Optional<String> filePath;
-    
-    @Override
-    public Optional<SchemaSegment> getSchema() {
-        return Optional.ofNullable(schema);
-    }
+    @XmlElement(name = "filePath")
+    private String filePath;
 }

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/common.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/common.xml
@@ -52,9 +52,9 @@
     <drop-traffic-rule sql-case-id="drop-traffic-rule" >
         <rule-name>rule_name</rule-name>
     </drop-traffic-rule>
-    <export-schema-config sql-case-id="export-schema-config">
-        <schema name="schema_name" start-index="26" stop-index="36" />
-    </export-schema-config>
+    <export-database-config sql-case-id="export-database-config">
+        <database name="database_name" start-index="28" stop-index="40" />
+    </export-database-config>
     <create-traffic-rule sql-case-id="create-traffic-rule" >
         <rule name="sql_match_traffic">
             <label>OLTP</label>
@@ -103,7 +103,7 @@
     <discard-distsql sql-case-id="discard-distsql"/>
     <alter-instance sql-case-id="alter-instance-xa-recovery-nodes" instance-id="1.2.3.4@3307"  key="XA_RECOVERY_NODES" value="1.2.3.4@3308"/>
     <alter-instance sql-case-id="alter-instance-xa-recovery-nodes-with-multiple-values" instance-id="1.2.3.4@3307"  key="XA_RECOVERY_NODES" value="1.2.3.4@3308,1.2.3.4@3307"/>
-    <import-schema-config sql-case-id="import-schema-config">
+    <import-database-config sql-case-id="import-database-config">
         <filePath>/yaml/config-sharding.yaml</filePath>
-    </import-schema-config>
+    </import-database-config>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/common.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/common.xml
@@ -42,7 +42,7 @@
     <distsql-case id="alter-sql-parser-rule" value="ALTER SQL_PARSER RULE SQL_COMMENT_PARSE_ENABLE=false,PARSE_TREE_CACHE(INITIAL_CAPACITY=10, MAXIMUM_SIZE=11,CONCURRENCY_LEVEL=1), SQL_STATEMENT_CACHE(INITIAL_CAPACITY=11, MAXIMUM_SIZE=11,CONCURRENCY_LEVEL=100)" />
     <distsql-case id="show-traffic-rules" value="SHOW TRAFFIC RULE rule_name" />
     <distsql-case id="drop-traffic-rule" value="DROP TRAFFIC RULE rule_name" />
-    <distsql-case id="export-schema-config" value="EXPORT SCHEMA CONFIG FROM schema_name" />
+    <distsql-case id="export-database-config" value="EXPORT DATABASE CONFIG FROM database_name" />
     <distsql-case id="create-traffic-rule" value="CREATE TRAFFIC RULE sql_match_traffic (LABELS(OLTP),TRAFFIC_ALGORITHM(TYPE(NAME=SQL_MATCH,PROPERTIES('sql' = 'SELECT * FROM t_order WHERE order_id = ?; UPDATE t_order SET order_id = ?;'))), LOAD_BALANCER(TYPE(NAME=RANDOM, PROPERTIES('key'='value'))) )" />
     <distsql-case id="alter-traffic-rule" value="ALTER TRAFFIC RULE sql_match_traffic (LABELS(OLTP),TRAFFIC_ALGORITHM(TYPE(NAME=SQL_MATCH,PROPERTIES('sql' = 'SELECT * FROM t_order WHERE order_id = ?; UPDATE t_order SET order_id = ?;'))), LOAD_BALANCER(TYPE(NAME=RANDOM, PROPERTIES('key'='value'))) )" />
     <distsql-case id="label-instance" value="LABEL INSTANCE 127.0.0.1@3309 WITH OLAP_1,OLAP_2" />
@@ -54,5 +54,5 @@
     <distsql-case id="discard-distsql" value="DISCARD DISTSQL" />
     <distsql-case id="alter-instance-xa-recovery-nodes" value="ALTER INSTANCE 1.2.3.4@3307 SET XA_RECOVERY_NODES=1.2.3.4@3308" />
     <distsql-case id="alter-instance-xa-recovery-nodes-with-multiple-values" value="ALTER INSTANCE 1.2.3.4@3307 SET XA_RECOVERY_NODES=1.2.3.4@3308,1.2.3.4@3307 " />
-    <distsql-case id="import-schema-config" value="IMPORT SCHEMA CONFIG FILE='/yaml/config-sharding.yaml'" />
+    <distsql-case id="import-database-config" value="IMPORT DATABASE CONFIG FILE='/yaml/config-sharding.yaml'" />
 </sql-cases>


### PR DESCRIPTION
Rename `schema` to `database` in `export/import` syntax.