### PR TITLE
Remove use of SimpleDateFormat in IntervalShardingAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -27,8 +27,8 @@ import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingV
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -162,7 +162,7 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
             return ((LocalDateTime) endpoint).format(dateTimeFormatter);
         }
         if (endpoint instanceof Date) {
-            return new SimpleDateFormat(getDateTimePattern()).format(endpoint);
+            return ((Date) endpoint).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().format(dateTimeFormatter);
         }
         return endpoint.toString();
     }


### PR DESCRIPTION
Fixes #16740.

Changes proposed in this pull request:
- Using `java.text.SimpleDateFormat` is thread-unsafe and should be avoided.
- In addition, the `this.getDateTimePattern()` method is called here, bypassing the `this.init()` of the algorithm class, which means that when the rule is updated, the result obtained by the `getDateTimePattern()` method may be the same as `private DateTimeFormatter dateTimeFormatter` property inconsistency corner case.
