### PR TITLE
In-memory RuleConfiguration not change when scaling job not finished.

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/preprocess/AlterShardingTableRuleStatementPreprocessor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/preprocess/AlterShardingTableRuleStatementPreprocessor.java
@@ -29,16 +29,16 @@ public final class AlterShardingTableRuleStatementPreprocessor implements RuleDe
     @Override
     public ShardingRuleConfiguration preprocess(final ShardingRuleConfiguration currentRuleConfig, final ShardingRuleConfiguration toBeAlteredRuleConfig) {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
-        result.setShardingAlgorithms(currentRuleConfig.getShardingAlgorithms());
-        result.setAutoTables(currentRuleConfig.getAutoTables());
+        result.setShardingAlgorithms(toBeAlteredRuleConfig.getShardingAlgorithms());
+        result.setAutoTables(toBeAlteredRuleConfig.getAutoTables());
         result.setDefaultShardingColumn(currentRuleConfig.getDefaultShardingColumn());
         result.setDefaultTableShardingStrategy(currentRuleConfig.getDefaultTableShardingStrategy());
         result.setBindingTableGroups(currentRuleConfig.getBindingTableGroups());
         result.setDefaultDatabaseShardingStrategy(currentRuleConfig.getDefaultDatabaseShardingStrategy());
-        result.setTables(currentRuleConfig.getTables());
+        result.setTables(toBeAlteredRuleConfig.getTables());
         result.setBroadcastTables(currentRuleConfig.getBroadcastTables());
         result.setDefaultKeyGenerateStrategy(currentRuleConfig.getDefaultKeyGenerateStrategy());
-        result.setKeyGenerators(currentRuleConfig.getKeyGenerators());
+        result.setKeyGenerators(toBeAlteredRuleConfig.getKeyGenerators());
         result.setScalingName(currentRuleConfig.getScalingName());
         result.setScaling(currentRuleConfig.getScaling());
         return result;

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/RuleDefinitionBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/rdl/rule/RuleDefinitionBackendHandler.java
@@ -169,7 +169,6 @@ public final class RuleDefinitionBackendHandler<T extends RuleDefinitionStatemen
                                                                          final RuleDefinitionAlterPreprocessor preprocessor) {
         RuleConfiguration toBeAlteredRuleConfig = updater.buildToBeAlteredRuleConfiguration(sqlStatement);
         RuleConfiguration alteredRuleConfig = preprocessor.preprocess(currentRuleConfig, toBeAlteredRuleConfig);
-        updater.updateCurrentRuleConfiguration(alteredRuleConfig, toBeAlteredRuleConfig);
         Collection<RuleConfiguration> result = new LinkedList<>(shardingSphereMetaData.getRuleMetaData().getConfigurations());
         result.remove(currentRuleConfig);
         result.add(alteredRuleConfig);


### PR DESCRIPTION
Fixes #16924 , #17045 


```
mysql> SHOW SHARDING TABLE RULE t_order \G;
*************************** 1. row ***************************
                            table: t_order
                actual_data_nodes: ds_${0..1}.t_order_${0..1}
              actual_data_sources:
           database_strategy_type: INLINE
         database_sharding_column: user_id
 database_sharding_algorithm_type: INLINE
database_sharding_algorithm_props: algorithm-expression=ds_${user_id % 2}
              table_strategy_type: INLINE
            table_sharding_column: order_id
    table_sharding_algorithm_type: INLINE
   table_sharding_algorithm_props: algorithm-expression=t_order_${order_id % 2}
              key_generate_column: order_id
               key_generator_type: SNOWFLAKE
              key_generator_props:
1 row in set (0.00 sec)

ERROR:
No query specified

mysql>
mysql>
mysql>
mysql>
mysql> ALTER SHARDING TABLE RULE t_order(
    ->    RESOURCES(ds_2,ds_3,ds_4),
    ->    SHARDING_COLUMN=order_id,
    ->    TYPE(NAME=hash_mod,PROPERTIES("sharding-count"=6)),
    ->    KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME=snowflake))
    ->    ), t_order_item(
    ->    RESOURCES(ds_2,ds_3,ds_4),
    ->    SHARDING_COLUMN=order_id,
    ->    TYPE(NAME=hash_mod,PROPERTIES("sharding-count"=6)),
    ->    KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME=snowflake))
    ->    );
Query OK, 0 rows affected (3.50 sec)

mysql> SHOW SHARDING TABLE RULE t_order \G;
*************************** 1. row ***************************
                            table: t_order
                actual_data_nodes: ds_${0..1}.t_order_${0..1}
              actual_data_sources:
           database_strategy_type: INLINE
         database_sharding_column: user_id
 database_sharding_algorithm_type: INLINE
database_sharding_algorithm_props: algorithm-expression=ds_${user_id % 2}
              table_strategy_type: INLINE
            table_sharding_column: order_id
    table_sharding_algorithm_type: INLINE
   table_sharding_algorithm_props: algorithm-expression=t_order_${order_id % 2}
              key_generate_column: order_id
               key_generator_type: SNOWFLAKE
              key_generator_props:
1 row in set (0.01 sec)
```