### PR TITLE
Disable Spring Boot banner in unit tests

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-spring/shardingsphere-db-discovery-spring-boot-starter/src/test/resources/application-database-discovery.properties
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-spring/shardingsphere-db-discovery-spring-boot-starter/src/test/resources/application-database-discovery.properties
@@ -24,3 +24,4 @@ spring.shardingsphere.rules.database-discovery.discovery-heartbeats.mgr-heartbea
 spring.shardingsphere.rules.database-discovery.discovery-types.mgr.type=MySQL.MGR
 spring.shardingsphere.rules.database-discovery.discovery-types.mgr.props.group-name=92504d5b-6dec-11e8-91ea-246e9612aaf1
 
+spring.main.banner-mode=off

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-spring/shardingsphere-encrypt-spring-boot-starter/src/test/resources/application-encrypt.properties
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-spring/shardingsphere-encrypt-spring-boot-starter/src/test/resources/application-encrypt.properties
@@ -29,3 +29,5 @@ spring.shardingsphere.rules.encrypt.tables.t_order.columns.credit_card.cipher-co
 spring.shardingsphere.rules.encrypt.tables.t_order.columns.credit_card.plain-column=credit_card_plain
 spring.shardingsphere.rules.encrypt.tables.t_order.columns.credit_card.assisted-query-column=credit_card_assisted_query
 spring.shardingsphere.rules.encrypt.tables.t_order.columns.credit_card.encryptor-name=md5Encryptor
+
+spring.main.banner-mode=off

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-spring/shardingsphere-readwrite-splitting-spring-boot-starter/src/test/resources/application-readwrite-splitting.properties
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-spring/shardingsphere-readwrite-splitting-spring-boot-starter/src/test/resources/application-readwrite-splitting.properties
@@ -21,3 +21,5 @@ spring.shardingsphere.rules.readwrite-splitting.data-sources.readwrite_ds.type=S
 spring.shardingsphere.rules.readwrite-splitting.data-sources.readwrite_ds.props.write-data-source-name=write_ds
 spring.shardingsphere.rules.readwrite-splitting.data-sources.readwrite_ds.props.read-data-source-names=read_ds_0,read_ds_1
 spring.shardingsphere.rules.readwrite-splitting.data-sources.readwrite_ds.load-balancer-name=random
+
+spring.main.banner-mode=off

--- a/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-default.yml
+++ b/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-default.yml
@@ -30,3 +30,5 @@ spring:
             props:
               shadow: true
               foo: bar
+  main:
+    banner-mode: 'off'

--- a/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-properties.properties
+++ b/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-properties.properties
@@ -33,3 +33,5 @@ spring.shardingsphere.rules.shadow.shadow-algorithms.user-id-match-algorithm.pro
 spring.shardingsphere.rules.shadow.shadow-algorithms.simple-hint-algorithm.type=SIMPLE_HINT
 spring.shardingsphere.rules.shadow.shadow-algorithms.simple-hint-algorithm.props.shadow=true
 spring.shardingsphere.rules.shadow.shadow-algorithms.simple-hint-algorithm.props.foo=bar
+
+spring.main.banner-mode=off

--- a/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-yml.yml
+++ b/shardingsphere-features/shardingsphere-shadow/shardingsphere-shadow-spring/shardingsphere-shadow-spring-boot-starter/src/test/resources/application-shadow-yml.yml
@@ -55,3 +55,5 @@ spring:
             props:
               shadow: true
               foo: bar
+  main:
+    banner-mode: 'off'

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-spring/shardingsphere-sharding-spring-boot-starter/src/test/resources/application-sharding.properties
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-spring/shardingsphere-sharding-spring-boot-starter/src/test/resources/application-sharding.properties
@@ -53,3 +53,5 @@ spring.shardingsphere.rules.sharding.auto-tables.t_order_auto.sharding-strategy.
 
 spring.shardingsphere.rules.sharding.binding-tables[0]=t_order,t_order_item
 spring.shardingsphere.rules.sharding.broadcast-tables=t_config
+
+spring.main.banner-mode=off

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/resources/application-jndi.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/resources/application-jndi.properties
@@ -18,3 +18,5 @@
 spring.shardingsphere.datasource.names=ds0,ds1
 spring.shardingsphere.datasource.ds0.jndi-name=java:comp/env/jdbc/ds0
 spring.shardingsphere.datasource.ds1.jndi-name=jdbc/ds1
+
+spring.main.banner-mode=off

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/resources/application.properties
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/resources/application.properties
@@ -86,3 +86,5 @@ spring.shardingsphere.rules.sql-parser.sql-statement-cache.concurrency-level=4
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.maximum-size=1024
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.initial-capacity=1024
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.concurrency-level=4
+
+spring.main.banner-mode=off

--- a/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-spring/shardingsphere-parser-spring-boot-starter/src/test/resources/application-sql-parser.properties
+++ b/shardingsphere-kernel/shardingsphere-parser/shardingsphere-parser-spring/shardingsphere-parser-spring-boot-starter/src/test/resources/application-sql-parser.properties
@@ -23,3 +23,5 @@ spring.shardingsphere.rules.sql-parser.sql-statement-cache.concurrency-level=4
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.initial-capacity=1024
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.maximum-size=1024
 spring.shardingsphere.rules.sql-parser.parse-tree-cache.concurrency-level=4
+
+spring.main.banner-mode=off


### PR DESCRIPTION
This can reduce redundant output in build logs.

https://github.com/apache/shardingsphere/runs/6170731543?check_suite_focus=true#step:6:10435