### PR TITLE
fix schema metadata lost when execute alter schema rename to statement

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
@@ -23,13 +23,10 @@ import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContext;
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContextFactory;
 import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationDatabaseMetaData;
-import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationSchemaMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
-import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.event.AlterSchemaEvent;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussAlterSchemaStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterSchemaStatementHandler;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -37,31 +34,39 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Schema refresher for rename schema statement.
+ * Schema refresher for alter schema statement.
  */
-public final class RenameSchemaStatementSchemaRefresher implements MetaDataRefresher<AlterSchemaStatement> {
+public final class AlterSchemaStatementSchemaRefresher implements MetaDataRefresher<AlterSchemaStatement> {
     
     private static final String TYPE = AlterSchemaStatement.class.getName();
     
     @Override
     public void refresh(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                         final Collection<String> logicDataSourceNames, final String schemaName, final AlterSchemaStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
-        Optional<String> renameSchemaName = sqlStatement instanceof PostgreSQLAlterSchemaStatement ? ((PostgreSQLAlterSchemaStatement) sqlStatement).getRenameSchema()
-                : ((OpenGaussAlterSchemaStatement) sqlStatement).getRenameSchema();
+        Optional<String> renameSchemaName = AlterSchemaStatementHandler.getRenameSchema(sqlStatement);
         if (!renameSchemaName.isPresent()) {
             return;
         }
-        Optional<FederationSchemaMetaData> schemaMetadata = database.getSchemaMetadata(sqlStatement.getSchemaName());
-        if (schemaMetadata.isPresent()) {
-            database.remove(sqlStatement.getSchemaName());
-            database.put(renameSchemaName.get(), schemaMetadata.get());
-            optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
-            AlterSchemaEvent event = new AlterSchemaEvent(metaData.getDatabaseName(), sqlStatement.getSchemaName(), renameSchemaName.get(),
-                    new ShardingSphereSchema(metaData.getSchemaByName(sqlStatement.getSchemaName()).getTables()));
-            metaData.getSchemas().remove(sqlStatement.getSchemaName());
-            ShardingSphereEventBus.getInstance().post(event);
-            // TODO Maybe need to refresh tables for SingleTableRule
-        }
+        String actualSchemaName = sqlStatement.getSchemaName();
+        putSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName, renameSchemaName.get());
+        removeSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName);
+        AlterSchemaEvent event = new AlterSchemaEvent(metaData.getDatabaseName(), actualSchemaName, renameSchemaName.get(), metaData.getSchemaByName(renameSchemaName.get()));
+        ShardingSphereEventBus.getInstance().post(event);
+        // TODO Maybe need to refresh tables for SingleTableRule
+    }
+    
+    private void removeSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, 
+                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName) {
+        metaData.getSchemas().remove(schemaName);
+        database.remove(schemaName);
+        optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
+    }
+    
+    private void putSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, 
+                                   final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String renameSchemaName) {
+        metaData.getSchemas().put(renameSchemaName, metaData.getSchemaByName(schemaName));
+        database.getSchemaMetadata(schemaName).ifPresent(optional -> database.put(renameSchemaName, optional));
+        optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.context.refresher.MetaDataRefresher
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.context.refresher.MetaDataRefresher
@@ -26,5 +26,5 @@ org.apache.shardingsphere.infra.context.refresher.type.DropIndexStatementSchemaR
 org.apache.shardingsphere.infra.context.refresher.type.DropSchemaStatementSchemaRefresher
 org.apache.shardingsphere.infra.context.refresher.type.DropTableStatementSchemaRefresher
 org.apache.shardingsphere.infra.context.refresher.type.DropViewStatementSchemaRefresher
-org.apache.shardingsphere.infra.context.refresher.type.RenameSchemaStatementSchemaRefresher
+org.apache.shardingsphere.infra.context.refresher.type.AlterSchemaStatementSchemaRefresher
 org.apache.shardingsphere.infra.context.refresher.type.RenameTableStatementSchemaRefresher

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/metadata/subscriber/SchemaMetaDataRegistrySubscriber.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/metadata/subscriber/SchemaMetaDataRegistrySubscriber.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.metadata.subscriber;
 
 import com.google.common.eventbus.Subscribe;
+import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.metadata.schema.event.AddSchemaEvent;
 import org.apache.shardingsphere.infra.metadata.schema.event.AlterSchemaEvent;
 import org.apache.shardingsphere.infra.metadata.schema.event.DropSchemaEvent;
-import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
-import org.apache.shardingsphere.mode.metadata.persist.service.SchemaMetaDataPersistService;
-import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.metadata.schema.event.SchemaAlteredEvent;
+import org.apache.shardingsphere.mode.metadata.persist.service.SchemaMetaDataPersistService;
+import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
 
 /**
  * Schema meta data registry subscriber.
@@ -66,7 +66,11 @@ public final class SchemaMetaDataRegistrySubscriber {
      */
     @Subscribe
     public void alterSchema(final AlterSchemaEvent event) {
-        persistService.persistTables(event.getDatabaseName(), event.getRenameSchemaName(), event.getSchema());
+        if (event.getSchema().getTables().isEmpty()) {
+            persistService.persistSchema(event.getDatabaseName(), event.getRenameSchemaName());
+        } else {
+            persistService.persistTables(event.getDatabaseName(), event.getRenameSchemaName(), event.getSchema());
+        }
         persistService.deleteSchema(event.getDatabaseName(), event.getSchemaName());
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/metadata/subscriber/SchemaMetaDataRegistrySubscriberTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/metadata/subscriber/SchemaMetaDataRegistrySubscriberTest.java
@@ -33,6 +33,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -79,11 +80,20 @@ public final class SchemaMetaDataRegistrySubscriberTest {
     }
     
     @Test
-    public void assertAlterSchemaEvent() {
-        ShardingSphereSchema schema = new ShardingSphereSchema();
+    public void assertAlterSchemaEventWhenContainsTable() {
+        ShardingSphereSchema schema = new ShardingSphereSchema(Collections.singletonMap("t_order", new TableMetaData()));
         AlterSchemaEvent event = new AlterSchemaEvent("foo_db", "foo_schema", "new_foo_schema", schema);
         schemaMetaDataRegistrySubscriber.alterSchema(event);
         verify(persistService).deleteSchema("foo_db", "foo_schema");
         verify(persistService).persistTables("foo_db", "new_foo_schema", schema);
+    }
+    
+    @Test
+    public void assertAlterSchemaEventWhenNotContainsTable() {
+        ShardingSphereSchema schema = new ShardingSphereSchema();
+        AlterSchemaEvent event = new AlterSchemaEvent("foo_db", "foo_schema", "new_foo_schema", schema);
+        schemaMetaDataRegistrySubscriber.alterSchema(event);
+        verify(persistService).deleteSchema("foo_db", "foo_schema");
+        verify(persistService).persistSchema("foo_db", "new_foo_schema");
     }
 }


### PR DESCRIPTION
Fixes #17208.

Changes proposed in this pull request:
- rename RenameSchemaStatementSchemaRefresher to AlterSchemaStatementSchemaRefresher
- optimize AlterSchemaStatementSchemaRefresher logic
- fix alterSchema logic when event not contains table
