### PR TITLE
Optimize single table data node loader logic for PostgreSQL multi schema

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
@@ -108,7 +108,7 @@ public final class ShardingTableBroadcastRoutingEngine implements ShardingRouteE
         if (!shardingRuleTableNames.isEmpty()) {
             return shardingRuleTableNames;
         }
-        return sqlStatementContext instanceof IndexAvailable ? getTableNames(metaData, 
+        return sqlStatementContext instanceof IndexAvailable ? getTableNames(metaData,
                 ((IndexAvailable) sqlStatementContext).getIndexes(), sqlStatementContext.getDatabaseType()) : Collections.emptyList();
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/type/broadcast/ShardingTableBroadcastRoutingEngine.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.sharding.route.engine.type.broadcast;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.type.IndexAvailable;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.metadata.schema.util.IndexMetaDataUtil;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
@@ -30,6 +32,7 @@ import org.apache.shardingsphere.sharding.route.engine.type.ShardingRouteEngine;
 import org.apache.shardingsphere.sharding.route.engine.type.complex.ShardingCartesianRoutingEngine;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.IndexSegment;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -105,8 +108,16 @@ public final class ShardingTableBroadcastRoutingEngine implements ShardingRouteE
         if (!shardingRuleTableNames.isEmpty()) {
             return shardingRuleTableNames;
         }
-        return sqlStatementContext instanceof IndexAvailable ? IndexMetaDataUtil.getTableNamesFromMetaData(metaData,
+        return sqlStatementContext instanceof IndexAvailable ? getTableNames(metaData, 
                 ((IndexAvailable) sqlStatementContext).getIndexes(), sqlStatementContext.getDatabaseType()) : Collections.emptyList();
+    }
+    
+    private Collection<String> getTableNames(final ShardingSphereMetaData metaData, final Collection<IndexSegment> indexes, final DatabaseType databaseType) {
+        Collection<String> result = new LinkedList<>();
+        for (QualifiedTable each : IndexMetaDataUtil.getTableNamesFromMetaData(metaData, indexes, databaseType)) {
+            result.add(each.getTableName());
+        }
+        return result;
     }
     
     private Collection<RouteUnit> getBroadcastTableRouteUnits(final ShardingRule shardingRule, final String broadcastTableName) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
@@ -20,10 +20,9 @@ package org.apache.shardingsphere.sharding.route.engine.fixture;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.parser.rule.SQLParserRule;
-import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.HintShardingStrategyConfiguration;
@@ -246,11 +245,7 @@ public abstract class AbstractRoutingEngineTest {
     protected SingleTableRule createAllSingleTableRule(final Collection<ShardingSphereRule> rules) {
         Map<String, DataSource> dataSourceMap = createDataSourceMapWithMain();
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap, rules, new ConfigurationProperties(new Properties()));
-        singleTableRule.put("t_category", dataSourceMap.keySet().iterator().next());
+        singleTableRule.put(dataSourceMap.keySet().iterator().next(), DefaultSchema.LOGIC_NAME, "t_category");
         return singleTableRule;
-    }
-    
-    protected SQLParserRule createDefaultSQLParserRule() {
-        return new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build());
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/fixture/AbstractRoutingEngineTest.java
@@ -242,10 +242,17 @@ public abstract class AbstractRoutingEngineTest {
         return result;
     }
     
-    protected SingleTableRule createAllSingleTableRule(final Collection<ShardingSphereRule> rules) {
+    /**
+     * Create single table rule.
+     * 
+     * @param rules rules
+     * @return single table rule
+     */
+    protected SingleTableRule createSingleTableRule(final Collection<ShardingSphereRule> rules) {
         Map<String, DataSource> dataSourceMap = createDataSourceMapWithMain();
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap, rules, new ConfigurationProperties(new Properties()));
-        singleTableRule.put(dataSourceMap.keySet().iterator().next(), DefaultSchema.LOGIC_NAME, "t_category");
-        return singleTableRule;
+        SingleTableRule result = new SingleTableRule(new SingleTableRuleConfiguration(),
+                DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap, rules, new ConfigurationProperties(new Properties()));
+        result.put(dataSourceMap.keySet().iterator().next(), DefaultSchema.LOGIC_NAME, "t_category");
+        return result;
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/AbstractSQLRouteTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/type/standard/AbstractSQLRouteTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractSQLRouteTest extends AbstractRoutingEngineTest {
     
     protected final RouteContext assertRoute(final String sql, final List<Object> parameters, final int routeUnitSize) {
         ShardingRule shardingRule = createAllShardingRule();
-        SingleTableRule singleTableRule = createAllSingleTableRule(Collections.singletonList(shardingRule));
+        SingleTableRule singleTableRule = createSingleTableRule(Collections.singletonList(shardingRule));
         Map<String, ShardingSphereSchema> schemas = buildSchemas();
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
         SQLStatementParserEngine sqlStatementParserEngine = new SQLStatementParserEngine("MySQL",

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/QualifiedTable.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/QualifiedTable.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.schema;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Qualified table.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class QualifiedTable {
+    
+    private final String schemaName;
+    
+    private final String tableName;
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
@@ -91,7 +91,7 @@ public class IndexMetaDataUtil {
         String schemaName = databaseType.getDefaultSchema(metaData.getDatabaseName());
         for (IndexSegment each : indexes) {
             String actualSchemaName = each.getOwner().map(optional -> optional.getIdentifier().getValue()).orElse(schemaName);
-            findLogicTableNameFromMetaData(metaData.getSchemaByName(actualSchemaName), 
+            findLogicTableNameFromMetaData(metaData.getSchemaByName(actualSchemaName),
                     each.getIndexName().getIdentifier().getValue()).ifPresent(optional -> result.add(createQualifiedTable(actualSchemaName, optional)));
         }
         return result;

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtil.java
@@ -92,13 +92,9 @@ public class IndexMetaDataUtil {
         for (IndexSegment each : indexes) {
             String actualSchemaName = each.getOwner().map(optional -> optional.getIdentifier().getValue()).orElse(schemaName);
             findLogicTableNameFromMetaData(metaData.getSchemaByName(actualSchemaName),
-                    each.getIndexName().getIdentifier().getValue()).ifPresent(optional -> result.add(createQualifiedTable(actualSchemaName, optional)));
+                    each.getIndexName().getIdentifier().getValue()).ifPresent(optional -> result.add(new QualifiedTable(actualSchemaName, optional)));
         }
         return result;
-    }
-    
-    private static QualifiedTable createQualifiedTable(final String schemaName, final String tableName) {
-        return new QualifiedTable(schemaName, tableName);
     }
     
     private static Optional<String> findLogicTableNameFromMetaData(final ShardingSphereSchema schema, final String logicIndexName) {

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
@@ -30,23 +30,26 @@ public interface MutableDataNodeRule extends ShardingSphereRule {
     /**
      * Add data node.
      *
-     * @param tableName table name
      * @param dataSourceName data source name
+     * @param schemaName schema name
+     * @param tableName table name
      */
-    void put(String tableName, String dataSourceName);
+    void put(String dataSourceName, String schemaName, String tableName);
     
     /**
      * Remove data node.
      *
+     * @param schemaName schema name
      * @param tableName table name
      */
-    void remove(String tableName);
+    void remove(String schemaName, String tableName);
     
     /**
-     * Find single data node by table name.
+     * Find single data node.
      *
+     * @param schemaName schema name
      * @param tableName table name
      * @return single table data node
      */
-    Optional<DataNode> findSingleTableDataNode(String tableName);
+    Optional<DataNode> findSingleTableDataNode(String schemaName, String tableName);
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/common/SchemaMetaDataLoaderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/loader/common/SchemaMetaDataLoaderTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.metadata.schema.loader.common;
 
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.junit.Before;
 import org.junit.Test;
@@ -58,6 +59,7 @@ public final class SchemaMetaDataLoaderTest {
     
     @Test
     public void assertLoadSchemaTableNames() throws SQLException {
-        assertThat(SchemaMetaDataLoader.loadSchemaTableNames(new PostgreSQLDatabaseType(), dataSource), is(Collections.singletonMap("public", Collections.singletonList("tbl"))));
+        assertThat(SchemaMetaDataLoader.loadSchemaTableNames(DefaultSchema.LOGIC_NAME,
+                new PostgreSQLDatabaseType(), dataSource), is(Collections.singletonMap("public", Collections.singletonList("tbl"))));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtilTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/schema/util/IndexMetaDataUtilTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.resource.ShardingSphereResource;
 import org.apache.shardingsphere.infra.metadata.rule.ShardingSphereRuleMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
@@ -33,6 +34,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.Identifi
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +84,10 @@ public final class IndexMetaDataUtilTest {
     @Test
     public void assertGetTableNamesFromMetaData() {
         IndexSegment indexSegment = new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue(INDEX_NAME)));
-        assertThat(IndexMetaDataUtil.getTableNamesFromMetaData(buildMetaData(), Lists.newArrayList(indexSegment), new MySQLDatabaseType()), is(Collections.singletonList(TABLE_NAME)));
+        Collection<QualifiedTable> actual = IndexMetaDataUtil.getTableNamesFromMetaData(buildMetaData(), Lists.newArrayList(indexSegment), new MySQLDatabaseType());
+        assertThat(actual.size(), is(1));
+        assertThat(actual.iterator().next().getSchemaName(), is(DefaultSchema.LOGIC_NAME));
+        assertThat(actual.iterator().next().getTableName(), is(TABLE_NAME));
     }
     
     private ShardingSphereMetaData buildMetaData() {

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
@@ -67,7 +67,7 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
     private void removeTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String tableName) {
         metaData.getSchemaByName(schemaName).remove(tableName);
-        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(tableName));
+        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, tableName));
         database.remove(schemaName, tableName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
@@ -75,7 +75,7 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String tableName, final ConfigurationProperties props) throws SQLException {
         if (!containsInDataNodeContainedRule(tableName, metaData)) {
-            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(tableName, logicDataSourceNames.iterator().next()));
+            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 metaData.getResource().getDatabaseType(), metaData.getResource().getDataSources(), metaData.getRuleMetaData().getRules(), props, schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
@@ -70,7 +70,7 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
     private void removeTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String viewName) {
         metaData.getSchemaByName(schemaName).remove(viewName);
-        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(viewName));
+        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, viewName));
         database.remove(schemaName, viewName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
@@ -78,7 +78,7 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String viewName, final ConfigurationProperties props) throws SQLException {
         if (!containsInDataNodeContainedRule(viewName, metaData)) {
-            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(viewName, logicDataSourceNames.iterator().next()));
+            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, viewName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 metaData.getResource().getDatabaseType(), metaData.getResource().getDataSources(), metaData.getRuleMetaData().getRules(), props, schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -51,7 +51,7 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
                         final Collection<String> logicDataSourceNames, final String schemaName, final CreateTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
         if (!containsInDataNodeContainedRule(tableName, metaData)) {
-            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(tableName, logicDataSourceNames.iterator().next()));
+            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 metaData.getResource().getDatabaseType(), metaData.getResource().getDataSources(), metaData.getRuleMetaData().getRules(), props, schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -51,7 +51,7 @@ public final class CreateViewStatementSchemaRefresher implements MetaDataRefresh
                         final Collection<String> logicDataSourceNames, final String schemaName, final CreateViewStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         String viewName = sqlStatement.getView().getTableName().getIdentifier().getValue();
         if (!containsInDataNodeContainedRule(viewName, metaData)) {
-            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(viewName, logicDataSourceNames.iterator().next()));
+            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, viewName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 metaData.getResource().getDatabaseType(), metaData.getResource().getDataSources(), metaData.getRuleMetaData().getRules(), props, schemaName);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropIndexStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropIndexStatementSchemaRefresher.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContext;
 import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationDatabaseMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.metadata.schema.event.SchemaAlteredEvent;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.util.IndexMetaDataUtil;
@@ -64,8 +65,8 @@ public final class DropIndexStatementSchemaRefresher implements MetaDataRefreshe
         if (simpleTableSegment.isPresent()) {
             return Optional.of(simpleTableSegment.get().getTableName().getIdentifier().getValue());
         }
-        Collection<String> tableNames = IndexMetaDataUtil.getTableNamesFromMetaData(metaData, indexSegments, metaData.getResource().getDatabaseType());
-        return tableNames.isEmpty() ? Optional.empty() : Optional.of(tableNames.iterator().next());
+        Collection<QualifiedTable> tableNames = IndexMetaDataUtil.getTableNamesFromMetaData(metaData, indexSegments, metaData.getResource().getDatabaseType());
+        return tableNames.isEmpty() ? Optional.empty() : Optional.of(tableNames.iterator().next().getTableName());
     }
     
     private void post(final String databaseName, final String schemaName, final TableMetaData tableMetaData) {

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
@@ -52,14 +52,14 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
         });
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getTables()) {
-            removeSegment(rules, each);
+            removeSegment(rules, each, schemaName);
         }
         ShardingSphereEventBus.getInstance().post(event);
     }
     
-    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment) {
+    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
         for (MutableDataNodeRule each : rules) {
-            each.remove(tobeRemovedSegment.getTableName().getIdentifier().getValue());
+            each.remove(schemaName, tobeRemovedSegment.getTableName().getIdentifier().getValue());
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
@@ -49,14 +49,14 @@ public final class DropViewStatementSchemaRefresher implements MetaDataRefresher
         });
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getViews()) {
-            removeSegment(rules, each);
+            removeSegment(rules, each, schemaName);
         }
         ShardingSphereEventBus.getInstance().post(event);
     }
     
-    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment) {
+    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
         for (MutableDataNodeRule each : rules) {
-            each.remove(tobeRemovedSegment.getTableName().getIdentifier().getValue());
+            each.remove(schemaName, tobeRemovedSegment.getTableName().getIdentifier().getValue());
         }
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
@@ -65,7 +65,7 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
     private void removeTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String tableName) {
         metaData.getSchemaByName(schemaName).remove(tableName);
-        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(tableName));
+        metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, tableName));
         database.remove(schemaName, tableName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
@@ -73,7 +73,7 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String tableName, final ConfigurationProperties props) throws SQLException {
         if (!containsInDataNodeContainedRule(tableName, metaData)) {
-            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(tableName, logicDataSourceNames.iterator().next()));
+            metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
                 metaData.getResource().getDatabaseType(), metaData.getResource().getDataSources(), metaData.getRuleMetaData().getRules(), props, schemaName);

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoader.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoader.java
@@ -46,19 +46,20 @@ public final class SingleTableDataNodeLoader {
     
     /**
      * Load single table data nodes.
-     * 
+     *
+     * @param databaseName database name
      * @param databaseType database type
      * @param dataSourceMap data source map
      * @param excludedTables excluded tables
      * @param props configuration properties
      * @return single table data node map
      */
-    public static Map<String, Collection<DataNode>> load(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap,
+    public static Map<String, Collection<DataNode>> load(final String databaseName, final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap,
                                                          final Collection<String> excludedTables, final ConfigurationProperties props) {
         Map<String, Collection<DataNode>> result = new ConcurrentHashMap<>();
         boolean checkDuplicateTable = props.getValue(ConfigurationPropertyKey.CHECK_DUPLICATE_TABLE_ENABLED);
         for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
-            Map<String, Collection<DataNode>> dataNodeMap = load(databaseType, entry.getKey(), entry.getValue(), excludedTables);
+            Map<String, Collection<DataNode>> dataNodeMap = load(databaseName, databaseType, entry.getKey(), entry.getValue(), excludedTables);
             for (String each : dataNodeMap.keySet()) {
                 Collection<DataNode> addedDataNodes = dataNodeMap.get(each);
                 Collection<DataNode> existDataNodes = result.getOrDefault(each.toLowerCase(), new LinkedHashSet<>(addedDataNodes.size(), 1));
@@ -72,8 +73,9 @@ public final class SingleTableDataNodeLoader {
         return result;
     }
     
-    private static Map<String, Collection<DataNode>> load(final DatabaseType databaseType, final String dataSourceName, final DataSource dataSource, final Collection<String> excludedTables) {
-        Map<String, Collection<String>> schemaTableNames = loadSchemaTableNames(databaseType, dataSource);
+    private static Map<String, Collection<DataNode>> load(final String databaseName, final DatabaseType databaseType, final String dataSourceName,
+                                                          final DataSource dataSource, final Collection<String> excludedTables) {
+        Map<String, Collection<String>> schemaTableNames = loadSchemaTableNames(databaseName, databaseType, dataSource);
         Map<String, Collection<DataNode>> result = new LinkedHashMap<>();
         for (Entry<String, Collection<String>> entry : schemaTableNames.entrySet()) {
             for (String each : entry.getValue()) {
@@ -100,9 +102,9 @@ public final class SingleTableDataNodeLoader {
         return false;
     }
     
-    private static Map<String, Collection<String>> loadSchemaTableNames(final DatabaseType databaseType, final DataSource dataSource) {
+    private static Map<String, Collection<String>> loadSchemaTableNames(final String databaseName, final DatabaseType databaseType, final DataSource dataSource) {
         try {
-            return SchemaMetaDataLoader.loadSchemaTableNames(databaseType, dataSource);
+            return SchemaMetaDataLoader.loadSchemaTableNames(databaseName, databaseType, dataSource);
         } catch (final SQLException ex) {
             throw new ShardingSphereConfigurationException("Can not load table: %s", ex.getMessage());
         }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngine.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngine.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.singletable.route;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
+import org.apache.shardingsphere.infra.metadata.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteMapper;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
@@ -46,7 +47,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public final class SingleTableRouteEngine {
     
-    private final Collection<String> singleTableNames;
+    private final Collection<QualifiedTable> singleTableNames;
     
     private final SQLStatement sqlStatement;
     
@@ -80,7 +81,7 @@ public final class SingleTableRouteEngine {
     
     private void route0(final RouteContext routeContext, final SingleTableRule rule) {
         if (isDDLTableStatement() || rule.isAllTablesInSameDataSource(routeContext, singleTableNames)) {
-            Collection<String> existSingleTables = rule.getSingleTableNames(singleTableNames);
+            Collection<QualifiedTable> existSingleTables = rule.getSingleTableNames(singleTableNames);
             if (!existSingleTables.isEmpty()) {
                 fillRouteContext(rule, routeContext, existSingleTables);
             } else {
@@ -112,23 +113,24 @@ public final class SingleTableRouteEngine {
     private RouteUnit getRandomRouteUnit(final SingleTableRule singleTableRule) {
         Collection<String> dataSourceNames = singleTableRule.getDataSourceNames();
         String dataSource = new ArrayList<>(dataSourceNames).get(ThreadLocalRandom.current().nextInt(dataSourceNames.size()));
-        String table = singleTableNames.iterator().next();
+        String table = singleTableNames.iterator().next().getTableName();
         return new RouteUnit(new RouteMapper(dataSource, dataSource), Collections.singleton(new RouteMapper(table, table)));
     }
     
     private RouteUnit getDefaultRouteUnit(final String dataSource) {
-        String table = singleTableNames.iterator().next();
+        String table = singleTableNames.iterator().next().getTableName();
         return new RouteUnit(new RouteMapper(dataSource, dataSource), Collections.singleton(new RouteMapper(table, table)));
     }
     
-    private void fillRouteContext(final SingleTableRule singleTableRule, final RouteContext routeContext, final Collection<String> logicTables) {
-        for (String each : logicTables) {
-            Optional<DataNode> dataNode = singleTableRule.findSingleTableDataNode(each);
+    private void fillRouteContext(final SingleTableRule singleTableRule, final RouteContext routeContext, final Collection<QualifiedTable> logicTables) {
+        for (QualifiedTable each : logicTables) {
+            String tableName = each.getTableName();
+            Optional<DataNode> dataNode = singleTableRule.findSingleTableDataNode(each.getSchemaName(), tableName);
             if (!dataNode.isPresent()) {
                 throw new ShardingSphereException("`%s` single table does not exist.", each);
             }
             String dataSource = dataNode.get().getDataSourceName();
-            routeContext.putRouteUnit(new RouteMapper(dataSource, dataSource), Collections.singletonList(new RouteMapper(each, each)));
+            routeContext.putRouteUnit(new RouteMapper(dataSource, dataSource), Collections.singletonList(new RouteMapper(tableName, tableName)));
         }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouter.java
@@ -69,7 +69,7 @@ public final class SingleTableSQLRouter implements SQLRouter<SingleTableRule> {
         new SingleTableRouteEngine(singleTableNames, sqlStatementContext.getSqlStatement()).route(routeContext, rule);
     }
     
-    private Collection<QualifiedTable> getSingleTableNames(final SQLStatementContext<?> sqlStatementContext, final ShardingSphereMetaData metaData, 
+    private Collection<QualifiedTable> getSingleTableNames(final SQLStatementContext<?> sqlStatementContext, final ShardingSphereMetaData metaData,
                                                            final SingleTableRule rule, final RouteContext routeContext) {
         Collection<QualifiedTable> result = getQualifiedTables(metaData, sqlStatementContext.getTablesContext().getTables(), sqlStatementContext.getDatabaseType());
         if (result.isEmpty() && sqlStatementContext instanceof IndexAvailable) {

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -171,7 +171,7 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     
     private boolean containsDataNode(final QualifiedTable qualifiedTable, final Collection<DataNode> dataNodes) {
         for (DataNode each : dataNodes) {
-            if (null != qualifiedTable.getSchemaName() && qualifiedTable.getSchemaName().equalsIgnoreCase(each.getSchemaName())) {
+            if (qualifiedTable.getSchemaName().equalsIgnoreCase(each.getSchemaName())) {
                 return true;
             }
         }
@@ -202,7 +202,7 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     public Optional<DataNode> findSingleTableDataNode(final String schemaName, final String tableName) {
         Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(tableName.toLowerCase(), new LinkedHashSet<>());
         for (DataNode each : dataNodes) {
-            if (null != schemaName && schemaName.equalsIgnoreCase(each.getSchemaName())) {
+            if (schemaName.equalsIgnoreCase(each.getSchemaName())) {
                 return Optional.of(each);
             }
         }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.distsql.constant.ExportableConstants;
+import org.apache.shardingsphere.infra.metadata.schema.QualifiedTable;
 import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -100,10 +102,10 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
      * @param singleTableNames single table names
      * @return whether single tables are in same data source or not
      */
-    public boolean isSingleTablesInSameDataSource(final Collection<String> singleTableNames) {
+    public boolean isSingleTablesInSameDataSource(final Collection<QualifiedTable> singleTableNames) {
         String firstFoundDataSourceName = null;
-        for (String each : singleTableNames) {
-            Optional<DataNode> dataNode = findSingleTableDataNode(each);
+        for (QualifiedTable each : singleTableNames) {
+            Optional<DataNode> dataNode = findSingleTableDataNode(each.getSchemaName(), each.getTableName());
             if (!dataNode.isPresent()) {
                 continue;
             }
@@ -125,11 +127,12 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
      * @param singleTableNames single table names
      * @return whether all tables are in same data source or not
      */
-    public boolean isAllTablesInSameDataSource(final RouteContext routeContext, final Collection<String> singleTableNames) {
+    public boolean isAllTablesInSameDataSource(final RouteContext routeContext, final Collection<QualifiedTable> singleTableNames) {
         if (!isSingleTablesInSameDataSource(singleTableNames)) {
             return false;
         }
-        Optional<DataNode> dataNode = findSingleTableDataNode(singleTableNames.iterator().next());
+        QualifiedTable sampleTable = singleTableNames.iterator().next();
+        Optional<DataNode> dataNode = findSingleTableDataNode(sampleTable.getSchemaName(), sampleTable.getTableName());
         if (dataNode.isPresent()) {
             for (RouteUnit each : routeContext.getRouteUnits()) {
                 if (!each.getDataSourceMapper().getLogicName().equals(dataNode.get().getDataSourceName())) {
@@ -152,46 +155,63 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     /**
      * Get single table names.
      *
-     * @param tableNames table names
+     * @param qualifiedTables qualified tables
      * @return single table names
      */
-    public Collection<String> getSingleTableNames(final Collection<String> tableNames) {
-        Collection<String> result = new LinkedList<>();
-        for (String each : tableNames) {
-            if (singleTableDataNodes.containsKey(each.toLowerCase())) {
+    public Collection<QualifiedTable> getSingleTableNames(final Collection<QualifiedTable> qualifiedTables) {
+        Collection<QualifiedTable> result = new LinkedList<>();
+        for (QualifiedTable each : qualifiedTables) {
+            Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(each.getTableName(), new LinkedList<>());
+            if (!dataNodes.isEmpty() && containsDataNode(each, dataNodes)) {
                 result.add(each);
             }
         }
         return result;
     }
     
+    private boolean containsDataNode(final QualifiedTable qualifiedTable, final Collection<DataNode> dataNodes) {
+        for (DataNode each : dataNodes) {
+            if (qualifiedTable.getTableName().equalsIgnoreCase(each.getTableName()) && qualifiedTable.getSchemaName().equalsIgnoreCase(each.getSchemaName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+    
     @Override
-    public void put(final String tableName, final String dataSourceName) {
+    public void put(final String dataSourceName, final String schemaName, final String tableName) {
         if (dataSourceNames.contains(dataSourceName)) {
-            singleTableDataNodes.put(tableName.toLowerCase(), Collections.singletonList(new DataNode(dataSourceName, tableName)));
+            Collection<DataNode> dataNodes = singleTableDataNodes.computeIfAbsent(tableName, key -> new LinkedHashSet<>());
+            DataNode dataNode = new DataNode(dataSourceName, tableName);
+            dataNode.setSchemaName(schemaName);
+            dataNodes.add(dataNode);
             tableNames.put(tableName.toLowerCase(), tableName);
         }
     }
     
     @Override
-    public void remove(final String tableName) {
-        singleTableDataNodes.remove(tableName.toLowerCase());
-        tableNames.remove(tableName.toLowerCase());
+    public void remove(final String schemaName, final String tableName) {
+        Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(tableName, new LinkedHashSet<>());
+        dataNodes.removeIf(each -> schemaName.equalsIgnoreCase(each.getSchemaName()));
+        if (dataNodes.isEmpty()) {
+            tableNames.remove(tableName.toLowerCase());
+        }
+    }
+    
+    @Override
+    public Optional<DataNode> findSingleTableDataNode(final String schemaName, final String tableName) {
+        Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(tableName.toLowerCase(), new LinkedHashSet<>());
+        for (DataNode each : dataNodes) {
+            if (schemaName.equalsIgnoreCase(each.getSchemaName())) {
+                return Optional.of(each);
+            }
+        }
+        return Optional.empty();
     }
     
     private Collection<String> getExcludedTables(final Collection<ShardingSphereRule> rules) {
         return rules.stream().filter(each -> each instanceof DataNodeContainedRule)
                 .flatMap(each -> ((DataNodeContainedRule) each).getAllTables().stream()).collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
-    }
-    
-    /**
-     * Find single table data node.
-     * 
-     * @param tableName table name
-     * @return data node
-     */
-    public Optional<DataNode> findSingleTableDataNode(final String tableName) {
-        return Optional.ofNullable(singleTableDataNodes.get(tableName.toLowerCase())).map(optional -> optional.iterator().next());
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -64,11 +64,11 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     
     private final Map<String, String> tableNames;
     
-    public SingleTableRule(final SingleTableRuleConfiguration config, final DatabaseType databaseType,
+    public SingleTableRule(final SingleTableRuleConfiguration config, final String databaseName, final DatabaseType databaseType,
                            final Map<String, DataSource> dataSourceMap, final Collection<ShardingSphereRule> builtRules, final ConfigurationProperties props) {
         Map<String, DataSource> aggregateDataSourceMap = getAggregateDataSourceMap(dataSourceMap, builtRules);
         dataSourceNames = aggregateDataSourceMap.keySet();
-        singleTableDataNodes = SingleTableDataNodeLoader.load(databaseType, aggregateDataSourceMap, getExcludedTables(builtRules), props);
+        singleTableDataNodes = SingleTableDataNodeLoader.load(databaseName, databaseType, aggregateDataSourceMap, getExcludedTables(builtRules), props);
         tableNames = singleTableDataNodes.entrySet().stream().collect(Collectors.toConcurrentMap(Entry::getKey, entry -> entry.getValue().iterator().next().getTableName()));
         config.getDefaultDataSource().ifPresent(optional -> defaultDataSource = optional);
     }
@@ -171,7 +171,7 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     
     private boolean containsDataNode(final QualifiedTable qualifiedTable, final Collection<DataNode> dataNodes) {
         for (DataNode each : dataNodes) {
-            if (qualifiedTable.getTableName().equalsIgnoreCase(each.getTableName()) && qualifiedTable.getSchemaName().equalsIgnoreCase(each.getSchemaName())) {
+            if (null != qualifiedTable.getSchemaName() && qualifiedTable.getSchemaName().equalsIgnoreCase(each.getSchemaName())) {
                 return true;
             }
         }
@@ -202,7 +202,7 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     public Optional<DataNode> findSingleTableDataNode(final String schemaName, final String tableName) {
         Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(tableName.toLowerCase(), new LinkedHashSet<>());
         for (DataNode each : dataNodes) {
-            if (schemaName.equalsIgnoreCase(each.getSchemaName())) {
+            if (null != schemaName && schemaName.equalsIgnoreCase(each.getSchemaName())) {
                 return Optional.of(each);
             }
         }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/builder/SingleTableRuleBuilder.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/builder/SingleTableRuleBuilder.java
@@ -37,7 +37,7 @@ public final class SingleTableRuleBuilder implements SchemaRuleBuilder<SingleTab
     @Override
     public SingleTableRule build(final SingleTableRuleConfiguration config, final String databaseName,
                                  final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> builtRules, final ConfigurationProperties props) {
-        return new SingleTableRule(config, DatabaseTypeRecognizer.getDatabaseType(dataSources.values()), dataSources, builtRules, props);
+        return new SingleTableRule(config, databaseName, DatabaseTypeRecognizer.getDatabaseType(dataSources.values()), dataSources, builtRules, props);
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoaderTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoaderTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.singletable.datanode;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.junit.Before;
@@ -86,7 +87,7 @@ public final class SingleTableDataNodeLoaderTest {
     @Test
     public void assertLoad() {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
-        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), props);
+        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load("databaseName", mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), props);
         assertTrue(dataNodeMap.containsKey("employee"));
         assertTrue(dataNodeMap.containsKey("dept"));
         assertTrue(dataNodeMap.containsKey("salary"));
@@ -105,7 +106,7 @@ public final class SingleTableDataNodeLoaderTest {
     public void assertLoadWithExcludeTables() {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
         Collection<String> excludedTables = Arrays.asList("salary", "employee", "student");
-        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(mock(DatabaseType.class), dataSourceMap, excludedTables, props);
+        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap, excludedTables, props);
         assertFalse(dataNodeMap.containsKey("employee"));
         assertFalse(dataNodeMap.containsKey("salary"));
         assertFalse(dataNodeMap.containsKey("student"));
@@ -121,7 +122,7 @@ public final class SingleTableDataNodeLoaderTest {
     public void assertLoadWithCheckOption() {
         Properties props = new Properties();
         props.setProperty(ConfigurationPropertyKey.CHECK_DUPLICATE_TABLE_ENABLED.getKey(), Boolean.TRUE.toString());
-        SingleTableDataNodeLoader.load(mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), new ConfigurationProperties(props));
+        SingleTableDataNodeLoader.load(DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), new ConfigurationProperties(props));
     }
     
     @Test
@@ -129,7 +130,8 @@ public final class SingleTableDataNodeLoaderTest {
         Properties props = new Properties();
         props.setProperty(ConfigurationPropertyKey.CHECK_DUPLICATE_TABLE_ENABLED.getKey(), Boolean.TRUE.toString());
         Collection<String> excludedTables = Arrays.asList("salary", "employee", "student");
-        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(mock(DatabaseType.class), dataSourceMap, excludedTables, new ConfigurationProperties(props));
+        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(
+                DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap, excludedTables, new ConfigurationProperties(props));
         assertFalse(dataNodeMap.containsKey("employee"));
         assertFalse(dataNodeMap.containsKey("salary"));
         assertFalse(dataNodeMap.containsKey("student"));

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoaderTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/datanode/SingleTableDataNodeLoaderTest.java
@@ -87,7 +87,7 @@ public final class SingleTableDataNodeLoaderTest {
     @Test
     public void assertLoad() {
         ConfigurationProperties props = new ConfigurationProperties(new Properties());
-        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load("databaseName", mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), props);
+        Map<String, Collection<DataNode>> dataNodeMap = SingleTableDataNodeLoader.load(DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap, Collections.emptyList(), props);
         assertTrue(dataNodeMap.containsKey("employee"));
         assertTrue(dataNodeMap.containsKey("dept"));
         assertTrue(dataNodeMap.containsKey("salary"));

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/metadata/SingleTableSchemaBuilderTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/metadata/SingleTableSchemaBuilderTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.singletable.metadata;
 
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.schema.builder.SchemaBuilderMaterials;
 import org.apache.shardingsphere.infra.metadata.schema.builder.TableMetaDataBuilder;
@@ -77,7 +78,7 @@ public final class SingleTableSchemaBuilderTest {
         Collection<ShardingSphereRule> rules = Collections.singletonList(mockSingleTableRuleLoad(connection));
         mockSQLLoad(connection);
         Map<String, SchemaMetaData> actual = TableMetaDataBuilder.load(Arrays.asList(singleTableNames),
-                new SchemaBuilderMaterials(databaseType, Collections.singletonMap("logic_db", dataSource), rules, props, "sharding_db"));
+                new SchemaBuilderMaterials(databaseType, Collections.singletonMap(DefaultSchema.LOGIC_NAME, dataSource), rules, props, DefaultSchema.LOGIC_NAME));
         assertThat(actual.size(), is(1));
         assertThat(actual.values().iterator().next().getTables().size(), is(2));
         assertActualOfSingleTables(actual.values().iterator().next().getTables().values());
@@ -115,7 +116,7 @@ public final class SingleTableSchemaBuilderTest {
         when(connection.getMetaData().getTables(any(), any(), eq(null), any())).thenReturn(resultSet);
         when(resultSet.next()).thenReturn(true, true, true, true, true, true, false);
         when(resultSet.getString(TABLE_NAME)).thenReturn(singleTableNames[0], singleTableNames[1]);
-        return new SingleTableRule(new SingleTableRuleConfiguration(), databaseType, Collections.singletonMap("logic_db", dataSource),
+        return new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, databaseType, Collections.singletonMap("logic_db", dataSource),
                 Collections.emptyList(), new ConfigurationProperties(new Properties()));
     }
     

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/metadata/SingleTableSchemaMetaDataBuilderTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/metadata/SingleTableSchemaMetaDataBuilderTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.singletable.metadata;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.schema.builder.RuleBasedSchemaMetaDataBuilderFactory;
 import org.apache.shardingsphere.infra.metadata.schema.builder.SchemaBuilderMaterials;
@@ -75,7 +76,7 @@ public final class SingleTableSchemaMetaDataBuilderTest {
         Connection connection = mock(Connection.class, RETURNS_DEEP_STUBS);
         when(dataSource.getConnection()).thenReturn(connection);
         mockSingleTableLoad(connection);
-        singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), databaseType,
+        singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, databaseType,
                 Collections.singletonMap("ds", dataSource), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         when(databaseType.formatTableNamePattern("tbl")).thenReturn("tbl");
         mockTableIsExist(connection);

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngineTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngineTest.java
@@ -55,8 +55,8 @@ public final class SingleTableRouteEngineTest {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), null);
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0", "t_order")));
-        singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(createDataNode("ds_0", "t_order_item")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(mockDataNode("ds_0", "t_order")));
+        singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(mockDataNode("ds_0", "t_order_item")));
         RouteContext routeContext = new RouteContext();
         singleTableRouteEngine.route(routeContext, singleTableRule);
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
@@ -73,7 +73,7 @@ public final class SingleTableRouteEngineTest {
         assertFalse(routeContext.isFederated());
     }
     
-    private DataNode createDataNode(final String dataSourceName, final String tableName) {
+    private DataNode mockDataNode(final String dataSourceName, final String tableName) {
         DataNode result = new DataNode(dataSourceName, tableName);
         result.setSchemaName(DefaultSchema.LOGIC_NAME);
         return result;
@@ -88,8 +88,8 @@ public final class SingleTableRouteEngineTest {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), null);
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(getDataNode()));
-        singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(createDataNode("ds_1", "t_order_item")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(mockDataNode("ds_0", "t_order")));
+        singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(mockDataNode("ds_1", "t_order_item")));
         RouteContext routeContext = new RouteContext();
         singleTableRouteEngine.route(routeContext, singleTableRule);
         List<RouteUnit> routeUnits = new ArrayList<>(routeContext.getRouteUnits());
@@ -105,10 +105,6 @@ public final class SingleTableRouteEngineTest {
         assertThat(tableMapper1.getActualName(), is("t_order_item"));
         assertThat(tableMapper1.getLogicName(), is("t_order_item"));
         assertTrue(routeContext.isFederated());
-    }
-    
-    private DataNode getDataNode() {
-        return createDataNode("ds_0", "t_order");
     }
     
     @Test

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngineTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableRouteEngineTest.java
@@ -53,7 +53,7 @@ public final class SingleTableRouteEngineTest {
     @Test
     public void assertRouteInSameDataSource() {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), null);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0", "t_order")));
         singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(createDataNode("ds_0", "t_order_item")));
@@ -86,7 +86,7 @@ public final class SingleTableRouteEngineTest {
     @Test
     public void assertRouteInDifferentDataSource() {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), null);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(getDataNode()));
         singleTableRule.getSingleTableDataNodes().put("t_order_item", Collections.singletonList(createDataNode("ds_1", "t_order_item")));
@@ -114,7 +114,7 @@ public final class SingleTableRouteEngineTest {
     @Test
     public void assertRouteWithoutSingleTableRule() {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), new MySQLCreateTableStatement());
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         RouteContext routeContext = new RouteContext();
         singleTableRouteEngine.route(routeContext, singleTableRule);
@@ -130,7 +130,7 @@ public final class SingleTableRouteEngineTest {
     @Test
     public void assertRouteWithDefaultSingleTableRule() {
         SingleTableRouteEngine singleTableRouteEngine = new SingleTableRouteEngine(mockQualifiedTables(), new MySQLCreateTableStatement());
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration("ds_0"), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration("ds_0"), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
         RouteContext routeContext = new RouteContext();
         singleTableRouteEngine.route(routeContext, singleTableRule);

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.binder.LogicSQL;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.ddl.CreateTableStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
@@ -57,9 +58,9 @@ public final class SingleTableSQLRouterTest {
     
     @Test
     public void assertCreateRouteContextWithSingleDataSource() {
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createSingleDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("ds_0", "t_order")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0")));
         ShardingSphereMetaData metaData = mockSingleDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -72,9 +73,9 @@ public final class SingleTableSQLRouterTest {
     
     @Test
     public void assertCreateRouteContextWithReadwriteSplittingDataSource() {
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createReadwriteSplittingDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("write_ds", "t_order")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("write_ds")));
         ShardingSphereMetaData metaData = mockReadwriteSplittingDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -87,9 +88,9 @@ public final class SingleTableSQLRouterTest {
     
     @Test
     public void assertCreateRouteContextWithMultiDataSource() {
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class),
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createMultiDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(new DataNode("ds_0", "t_order")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0")));
         ShardingSphereMetaData metaData = mockMultiDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -101,6 +102,12 @@ public final class SingleTableSQLRouterTest {
         assertThat(tableMapper.getActualName(), is("t_order"));
         assertThat(tableMapper.getLogicName(), is("t_order"));
         assertFalse(actual.isFederated());
+    }
+    
+    private DataNode createDataNode(final String dataSourceName) {
+        DataNode result = new DataNode(dataSourceName, "t_order");
+        result.setSchemaName(DefaultSchema.LOGIC_NAME);
+        return result;
     }
     
     private ShardingSphereMetaData mockSingleDataSourceMetaData() {
@@ -125,6 +132,7 @@ public final class SingleTableSQLRouterTest {
         dataSourceMap.put("ds_0", mock(DataSource.class, RETURNS_DEEP_STUBS));
         dataSourceMap.put("ds_1", mock(DataSource.class, RETURNS_DEEP_STUBS));
         when(result.getResource().getDataSources()).thenReturn(dataSourceMap);
+        when(result.getDatabaseName()).thenReturn(DefaultSchema.LOGIC_NAME);
         return result;
     }
     

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/route/SingleTableSQLRouterTest.java
@@ -60,7 +60,7 @@ public final class SingleTableSQLRouterTest {
     public void assertCreateRouteContextWithSingleDataSource() {
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createSingleDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(mockDataNode("ds_0")));
         ShardingSphereMetaData metaData = mockSingleDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -75,7 +75,7 @@ public final class SingleTableSQLRouterTest {
     public void assertCreateRouteContextWithReadwriteSplittingDataSource() {
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createReadwriteSplittingDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("write_ds")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(mockDataNode("write_ds")));
         ShardingSphereMetaData metaData = mockReadwriteSplittingDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -90,7 +90,7 @@ public final class SingleTableSQLRouterTest {
     public void assertCreateRouteContextWithMultiDataSource() {
         SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class),
                 createMultiDataSourceMap(), Collections.emptyList(), new ConfigurationProperties(new Properties()));
-        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(createDataNode("ds_0")));
+        singleTableRule.getSingleTableDataNodes().put("t_order", Collections.singletonList(mockDataNode("ds_0")));
         ShardingSphereMetaData metaData = mockMultiDataSourceMetaData();
         RouteContext actual = new SingleTableSQLRouter().createRouteContext(createLogicSQL(), metaData, singleTableRule, new ConfigurationProperties(new Properties()));
         List<RouteUnit> routeUnits = new ArrayList<>(actual.getRouteUnits());
@@ -104,7 +104,7 @@ public final class SingleTableSQLRouterTest {
         assertFalse(actual.isFederated());
     }
     
-    private DataNode createDataNode(final String dataSourceName) {
+    private DataNode mockDataNode(final String dataSourceName) {
         DataNode result = new DataNode(dataSourceName, "t_order");
         result.setSchemaName(DefaultSchema.LOGIC_NAME);
         return result;

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/test/java/org/apache/shardingsphere/singletable/rule/SingleTableRuleTest.java
@@ -59,8 +59,6 @@ public final class SingleTableRuleTest {
     
     private static final String TABLE_NAME = "TABLE_NAME";
     
-    private static final String TABLE_SCHEME = "TABLE_SCHEM";
-    
     private Map<String, DataSource> dataSourceMap;
     
     @Before
@@ -73,21 +71,12 @@ public final class SingleTableRuleTest {
     private DataSource mockDataSource(final String dataSourceName, final List<String> tableNames) throws SQLException {
         DataSource result = mock(DataSource.class, RETURNS_DEEP_STUBS);
         when(result.getConnection().getCatalog()).thenReturn(dataSourceName);
-        ResultSet tableResultSet = mockTableResultSet(tableNames);
-        when(result.getConnection().getMetaData().getTables(dataSourceName, DefaultSchema.LOGIC_NAME, null, new String[]{TABLE_TYPE, VIEW_TYPE})).thenReturn(tableResultSet);
-        ResultSet schemaResultSet = mockSchemaResultSet();
-        when(result.getConnection().getMetaData().getSchemas()).thenReturn(schemaResultSet);
+        ResultSet resultSet = mockResultSet(tableNames);
+        when(result.getConnection().getMetaData().getTables(dataSourceName, null, null, new String[]{TABLE_TYPE, VIEW_TYPE})).thenReturn(resultSet);
         return result;
     }
     
-    private ResultSet mockSchemaResultSet() throws SQLException {
-        ResultSet result = mock(ResultSet.class);
-        when(result.next()).thenReturn(true, false);
-        when(result.getString(TABLE_SCHEME)).thenReturn(DefaultSchema.LOGIC_NAME);
-        return result;
-    }
-    
-    private ResultSet mockTableResultSet(final List<String> tableNames) throws SQLException {
+    private ResultSet mockResultSet(final List<String> tableNames) throws SQLException {
         ResultSet result = mock(ResultSet.class);
         Collection<Boolean> nextResults = tableNames.stream().map(each -> true).collect(Collectors.toList());
         nextResults.add(false);
@@ -102,7 +91,7 @@ public final class SingleTableRuleTest {
     public void assertGetSingleTableDataNodes() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         when(dataNodeContainedRule.getAllTables()).thenReturn(Arrays.asList("t_order", "t_order_0", "t_order_1"));
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Map<String, Collection<DataNode>> actual = singleTableRule.getSingleTableDataNodes();
         assertThat(actual.size(), is(2));
@@ -114,7 +103,7 @@ public final class SingleTableRuleTest {
     public void assertGetSingleTableDataNodesWithUpperCase() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         when(dataNodeContainedRule.getAllTables()).thenReturn(Arrays.asList("T_ORDER", "T_ORDER_0", "T_ORDER_1"));
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Map<String, Collection<DataNode>> actual = singleTableRule.getSingleTableDataNodes();
         assertThat(actual.size(), is(2));
@@ -125,7 +114,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertFindSingleTableDataNode() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Optional<DataNode> actual = singleTableRule.findSingleTableDataNode(DefaultSchema.LOGIC_NAME, "employee");
         assertTrue(actual.isPresent());
@@ -136,7 +125,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertFindSingleTableDataNodeWithUpperCase() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Optional<DataNode> actual = singleTableRule.findSingleTableDataNode(DefaultSchema.LOGIC_NAME, "EMPLOYEE");
         assertTrue(actual.isPresent());
@@ -147,7 +136,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertIsSingleTablesInSameDataSource() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Collection<QualifiedTable> singleTableNames = new LinkedList<>();
         singleTableNames.add(new QualifiedTable(DefaultSchema.LOGIC_NAME, "employee"));
@@ -164,7 +153,7 @@ public final class SingleTableRuleTest {
         RouteContext routeContext = new RouteContext();
         routeContext.putRouteUnit(dataSourceMapper, tableMappers);
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         assertTrue(singleTableRule.isAllTablesInSameDataSource(routeContext, singleTableNames));
     }
@@ -174,7 +163,7 @@ public final class SingleTableRuleTest {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         SingleTableRuleConfiguration singleTableRuleConfig = new SingleTableRuleConfiguration();
         singleTableRuleConfig.setDefaultDataSource("ds_0");
-        SingleTableRule singleTableRule = new SingleTableRule(singleTableRuleConfig, mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(singleTableRuleConfig, DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         assertTrue(singleTableRule.getDefaultDataSource().isPresent());
         assertThat(singleTableRule.getDefaultDataSource().get(), is("ds_0"));
@@ -183,7 +172,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertGetSingleTableNames() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Collection<QualifiedTable> tableNames = new LinkedList<>();
         tableNames.add(new QualifiedTable(DefaultSchema.LOGIC_NAME, "employee"));
@@ -194,7 +183,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertPut() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         String tableName = "teacher";
         String dataSourceName = "ds_0";
@@ -213,7 +202,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertRemove() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         String tableName = "employee";
         singleTableRule.remove(DefaultSchema.LOGIC_NAME, tableName);
@@ -228,7 +217,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertGetAllDataNodes() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         assertTrue(singleTableRule.getAllDataNodes().containsKey("employee"));
         assertTrue(singleTableRule.getAllDataNodes().containsKey("student"));
@@ -239,7 +228,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertGetDataNodesByTableName() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         Collection<DataNode> actual = singleTableRule.getDataNodesByTableName("EMPLOYEE");
         assertThat(actual.size(), is(1));
@@ -251,7 +240,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertFindFirstActualTable() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         String logicTable = "employee";
         assertFalse(singleTableRule.findFirstActualTable(logicTable).isPresent());
@@ -260,7 +249,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertIsNeedAccumulate() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         assertFalse(singleTableRule.isNeedAccumulate(Collections.emptyList()));
     }
@@ -268,7 +257,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertFindLogicTableByActualTable() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         String actualTable = "student";
         assertFalse(singleTableRule.findLogicTableByActualTable(actualTable).isPresent());
@@ -277,7 +266,7 @@ public final class SingleTableRuleTest {
     @Test
     public void assertFindActualTableByCatalog() {
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
-        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), mock(DatabaseType.class), dataSourceMap,
+        SingleTableRule singleTableRule = new SingleTableRule(new SingleTableRuleConfiguration(), DefaultSchema.LOGIC_NAME, mock(DatabaseType.class), dataSourceMap,
                 Collections.singletonList(dataNodeContainedRule), new ConfigurationProperties(new Properties()));
         String catalog = "employee";
         String logicTable = "t_order_0";

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
@@ -71,24 +71,24 @@ public final class EncryptSQLRewriterParameterizedTest extends AbstractSQLRewrit
     }
     
     @Override
-    protected Map<String, ShardingSphereSchema> mockSchemas(final String databaseName) {
+    protected Map<String, ShardingSphereSchema> mockSchemas(final String schemaName) {
         ShardingSphereSchema result = mock(ShardingSphereSchema.class);
         when(result.getAllColumnNames("t_account")).thenReturn(Arrays.asList("account_id", "certificate_number", "password", "amount", "status"));
         when(result.getAllColumnNames("t_account_bak")).thenReturn(Arrays.asList("account_id", "certificate_number", "password", "amount", "status"));
         when(result.getAllColumnNames("t_account_detail")).thenReturn(Arrays.asList("account_id", "certificate_number", "password", "amount", "status"));
         when(result.getAllColumnNames("t_order")).thenReturn(Arrays.asList("ORDER_ID", "USER_ID", "CONTENT"));
         when(result.get("t_order")).thenReturn(new TableMetaData("t_order", Collections.emptyList(), Collections.emptyList(), Collections.emptyList()));
-        return Collections.singletonMap(databaseName, result);
+        return Collections.singletonMap(schemaName, result);
     }
     
     @Override
-    protected void mockRules(final Collection<ShardingSphereRule> rules) {
+    protected void mockRules(final Collection<ShardingSphereRule> rules, final String schemaName) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().put("encrypt_ds", "public", "t_account");
-            singleTableRule.get().put("encrypt_ds", "public", "t_account_bak");
-            singleTableRule.get().put("encrypt_ds", "public", "t_account_detail");
-            singleTableRule.get().put("encrypt_ds", "public", "t_order");
+            singleTableRule.get().put("encrypt_ds", schemaName, "t_account");
+            singleTableRule.get().put("encrypt_ds", schemaName, "t_account_bak");
+            singleTableRule.get().put("encrypt_ds", schemaName, "t_account_detail");
+            singleTableRule.get().put("encrypt_ds", schemaName, "t_order");
         }
     }
     

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized.scenario;
 
 import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -85,10 +86,10 @@ public final class EncryptSQLRewriterParameterizedTest extends AbstractSQLRewrit
     protected void mockRules(final Collection<ShardingSphereRule> rules) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().put("t_account", "encrypt_ds");
-            singleTableRule.get().put("t_account_bak", "encrypt_ds");
-            singleTableRule.get().put("t_account_detail", "encrypt_ds");
-            singleTableRule.get().put("t_order", "encrypt_ds");
+            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account");
+            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account_bak");
+            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account_detail");
+            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_order");
         }
     }
     

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/EncryptSQLRewriterParameterizedTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized.scenario;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -86,10 +85,10 @@ public final class EncryptSQLRewriterParameterizedTest extends AbstractSQLRewrit
     protected void mockRules(final Collection<ShardingSphereRule> rules) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account");
-            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account_bak");
-            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_account_detail");
-            singleTableRule.get().put("encrypt_ds", DefaultSchema.LOGIC_NAME, "t_order");
+            singleTableRule.get().put("encrypt_ds", "public", "t_account");
+            singleTableRule.get().put("encrypt_ds", "public", "t_account_bak");
+            singleTableRule.get().put("encrypt_ds", "public", "t_account_detail");
+            singleTableRule.get().put("encrypt_ds", "public", "t_order");
         }
     }
     

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/MixSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/MixSQLRewriterParameterizedTest.java
@@ -68,7 +68,7 @@ public final class MixSQLRewriterParameterizedTest extends AbstractSQLRewriterPa
     }
     
     @Override
-    protected Map<String, ShardingSphereSchema> mockSchemas(final String databaseName) {
+    protected Map<String, ShardingSphereSchema> mockSchemas(final String schemaName) {
         ShardingSphereSchema result = mock(ShardingSphereSchema.class);
         when(result.getAllTableNames()).thenReturn(Arrays.asList("t_account", "t_account_bak", "t_account_detail"));
         TableMetaData accountTableMetaData = mock(TableMetaData.class);
@@ -85,11 +85,11 @@ public final class MixSQLRewriterParameterizedTest extends AbstractSQLRewriterPa
         when(result.get("t_account_detail")).thenReturn(mock(TableMetaData.class));
         when(result.getAllColumnNames("t_account")).thenReturn(Arrays.asList("account_id", "password", "amount", "status"));
         when(result.getAllColumnNames("t_account_bak")).thenReturn(Arrays.asList("account_id", "password", "amount", "status"));
-        return Collections.singletonMap(databaseName, result);
+        return Collections.singletonMap(schemaName, result);
     }
     
     @Override
-    protected void mockRules(final Collection<ShardingSphereRule> rules) {
+    protected void mockRules(final Collection<ShardingSphereRule> rules, final String schemaName) {
     }
     
     @Override

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized.scenario;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
@@ -72,16 +71,16 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
     }
     
     @Override
-    protected void mockRules(final Collection<ShardingSphereRule> rules) {
+    protected void mockRules(final Collection<ShardingSphereRule> rules, final String schemaName) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().put("db", DefaultSchema.LOGIC_NAME, "t_single");
-            singleTableRule.get().put("db", DefaultSchema.LOGIC_NAME, "t_single_extend");
+            singleTableRule.get().put("db", schemaName, "t_single");
+            singleTableRule.get().put("db", schemaName, "t_single_extend");
         }
     }
     
     @Override
-    protected Map<String, ShardingSphereSchema> mockSchemas(final String databaseName) {
+    protected Map<String, ShardingSphereSchema> mockSchemas(final String schemaName) {
         ShardingSphereSchema result = mock(ShardingSphereSchema.class);
         when(result.getAllTableNames()).thenReturn(Arrays.asList("t_account", "t_account_detail"));
         TableMetaData accountTableMetaData = mock(TableMetaData.class);
@@ -97,7 +96,7 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
         when(result.getAllColumnNames("t_user")).thenReturn(new ArrayList<>(Arrays.asList("id", "content")));
         when(result.getAllColumnNames("t_user_extend")).thenReturn(new ArrayList<>(Arrays.asList("user_id", "content")));
         when(result.containsColumn("t_account", "account_id")).thenReturn(true);
-        return Collections.singletonMap(databaseName, result);
+        return Collections.singletonMap(schemaName, result);
     }
     
     private Map<String, ColumnMetaData> createColumnMetaDataMap() {

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/java/org/apache/shardingsphere/sharding/rewrite/parameterized/scenario/ShardingSQLRewriterParameterizedTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sharding.rewrite.parameterized.scenario;
 
 import com.google.common.base.Preconditions;
+import org.apache.shardingsphere.infra.database.DefaultSchema;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.model.IndexMetaData;
@@ -74,8 +75,8 @@ public final class ShardingSQLRewriterParameterizedTest extends AbstractSQLRewri
     protected void mockRules(final Collection<ShardingSphereRule> rules) {
         Optional<SingleTableRule> singleTableRule = rules.stream().filter(each -> each instanceof SingleTableRule).map(each -> (SingleTableRule) each).findFirst();
         if (singleTableRule.isPresent()) {
-            singleTableRule.get().put("t_single", "db");
-            singleTableRule.get().put("t_single_extend", "db");
+            singleTableRule.get().put("db", DefaultSchema.LOGIC_NAME, "t_single");
+            singleTableRule.get().put("db", DefaultSchema.LOGIC_NAME, "t_single_extend");
         }
     }
     


### PR DESCRIPTION
Ref #14004.

Changes proposed in this pull request:
- optimize single table data node loader logic for PostgreSQL multi schema
- refactor MutableDataNodeRule interface
- add QualifiedTable class to describe table info
- modify unit test
