### PR TITLE
Use global lock in pipeline simple lock to fix #17228

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/lock/PipelineSimpleLock.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/lock/PipelineSimpleLock.java
@@ -67,7 +67,7 @@ public final class PipelineSimpleLock {
      * @return true if lock got, else false
      */
     public boolean tryLock(final String lockName, final long timeoutMills) {
-        boolean result = lockContext.getOrCreateStandardLock(decorateLockName(lockName)).tryLock(decorateLockName(lockName), timeoutMills);
+        boolean result = lockContext.getOrCreateGlobalLock(lockName).tryLock(decorateLockName(lockName), timeoutMills);
         if (result) {
             lockNameLockedMap.put(lockName, true);
         }
@@ -84,7 +84,7 @@ public final class PipelineSimpleLock {
         log.info("releaseLock, lockName={}", lockName);
         if (lockNameLockedMap.getOrDefault(lockName, false)) {
             lockNameLockedMap.remove(lockName);
-            lockContext.getOrCreateStandardLock(decorateLockName(lockName)).releaseLock(lockName);
+            lockContext.getOrCreateGlobalLock(lockName).releaseLock(lockName);
         }
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/database/watcher/DatabaseAckChangedWatcherTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/database/watcher/DatabaseAckChangedWatcherTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -63,13 +64,13 @@ public final class DatabaseAckChangedWatcherTest {
         DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/database/ack/sharding_db#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.ADDED);
         Optional<GovernanceEvent> addGovernanceEvent = watcher.createGovernanceEvent(addDataChangedEvent);
         assertTrue(addGovernanceEvent.isPresent());
-        assertTrue(addGovernanceEvent.get() instanceof DatabaseAckLockedEvent);
+        assertThat(addGovernanceEvent.get(), instanceOf(DatabaseAckLockedEvent.class));
         assertThat(((DatabaseAckLockedEvent) addGovernanceEvent.get()).getDatabase(), is("sharding_db"));
         assertThat(((DatabaseAckLockedEvent) addGovernanceEvent.get()).getLockedInstance(), is("127.0.0.1@3307"));
         DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/database/ack/sharding_db#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.DELETED);
         Optional<GovernanceEvent> deleteGovernanceEvent = watcher.createGovernanceEvent(deleteDataChangedEvent);
         assertTrue(deleteGovernanceEvent.isPresent());
-        assertTrue(deleteGovernanceEvent.get() instanceof DatabaseAckLockReleasedEvent);
+        assertThat(deleteGovernanceEvent.get(), instanceOf(DatabaseAckLockReleasedEvent.class));
         assertThat(((DatabaseAckLockReleasedEvent) deleteGovernanceEvent.get()).getDatabase(), is("sharding_db"));
         assertThat(((DatabaseAckLockReleasedEvent) deleteGovernanceEvent.get()).getLockedInstance(), is("127.0.0.1@3307"));
         DataChangedEvent updateDataChangedEvent = new DataChangedEvent("/lock/global/database/ack/sharding_db#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.UPDATED);

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/database/watcher/DatabaseLocksChangedWatcherTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/database/watcher/DatabaseLocksChangedWatcherTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -63,12 +64,12 @@ public final class DatabaseLocksChangedWatcherTest {
         DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/database/locks/sharding_db/leases/c_l_0000000", "000000000", DataChangedEvent.Type.ADDED);
         Optional<GovernanceEvent> addGovernanceEvent = watcher.createGovernanceEvent(addDataChangedEvent);
         assertTrue(addGovernanceEvent.isPresent());
-        assertTrue(addGovernanceEvent.get() instanceof DatabaseLockedEvent);
+        assertThat(addGovernanceEvent.get(), instanceOf(DatabaseLockedEvent.class));
         assertThat(((DatabaseLockedEvent) addGovernanceEvent.get()).getDatabase(), is("sharding_db"));
         DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/database/locks/sharding_db/leases/c_l_0000000", "000000000", DataChangedEvent.Type.DELETED);
         Optional<GovernanceEvent> deleteGovernanceEvent = watcher.createGovernanceEvent(deleteDataChangedEvent);
         assertTrue(deleteGovernanceEvent.isPresent());
-        assertTrue(deleteGovernanceEvent.get() instanceof DatabaseLockReleasedEvent);
+        assertThat(deleteGovernanceEvent.get(), instanceOf(DatabaseLockReleasedEvent.class));
         assertThat(((DatabaseLockReleasedEvent) deleteGovernanceEvent.get()).getDatabase(), is("sharding_db"));
         DataChangedEvent updateDataChangedEvent = new DataChangedEvent("/lock/global/database/ack/sharding_db#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.UPDATED);
         Optional<GovernanceEvent> updateGovernanceEvent = watcher.createGovernanceEvent(updateDataChangedEvent);

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/general/watcher/GeneralAckChangedWatcherTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/general/watcher/GeneralAckChangedWatcherTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -63,7 +64,7 @@ public final class GeneralAckChangedWatcherTest {
         DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/general/ack/lock_name#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.ADDED);
         Optional<GovernanceEvent> addGovernanceEvent = watcher.createGovernanceEvent(addDataChangedEvent);
         assertTrue(addGovernanceEvent.isPresent());
-        assertTrue(addGovernanceEvent.get() instanceof GeneralAckLockedEvent);
+        assertThat(addGovernanceEvent.get(), instanceOf(GeneralAckLockedEvent.class));
         assertThat(((GeneralAckLockedEvent) addGovernanceEvent.get()).getLockName(), is("lock_name"));
         assertThat(((GeneralAckLockedEvent) addGovernanceEvent.get()).getLockedInstance(), is("127.0.0.1@3307"));
     }
@@ -73,7 +74,7 @@ public final class GeneralAckChangedWatcherTest {
         DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/general/ack/lock_name#@#127.0.0.1@3307", "127.0.0.1@3307", DataChangedEvent.Type.DELETED);
         Optional<GovernanceEvent> deleteGovernanceEvent = watcher.createGovernanceEvent(deleteDataChangedEvent);
         assertTrue(deleteGovernanceEvent.isPresent());
-        assertTrue(deleteGovernanceEvent.get() instanceof GeneralAckLockReleasedEvent);
+        assertThat(deleteGovernanceEvent.get(), instanceOf(GeneralAckLockReleasedEvent.class));
         assertThat(((GeneralAckLockReleasedEvent) deleteGovernanceEvent.get()).getLockName(), is("lock_name"));
         assertThat(((GeneralAckLockReleasedEvent) deleteGovernanceEvent.get()).getLockedInstance(), is("127.0.0.1@3307"));
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/general/watcher/GeneralLocksChangedWatcherTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/global/general/watcher/GeneralLocksChangedWatcherTest.java
@@ -28,6 +28,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -63,7 +64,7 @@ public final class GeneralLocksChangedWatcherTest {
         DataChangedEvent addDataChangedEvent = new DataChangedEvent("/lock/global/general/locks/lock_name/leases/c_l_0000000", "0000000000", DataChangedEvent.Type.ADDED);
         Optional<GovernanceEvent> addGovernanceEvent = watcher.createGovernanceEvent(addDataChangedEvent);
         assertTrue(addGovernanceEvent.isPresent());
-        assertTrue(addGovernanceEvent.get() instanceof GeneralLockedEvent);
+        assertThat(addGovernanceEvent.get(), instanceOf(GeneralLockedEvent.class));
         assertThat(((GeneralLockedEvent) addGovernanceEvent.get()).getLockName(), is("lock_name"));
     }
     
@@ -72,7 +73,7 @@ public final class GeneralLocksChangedWatcherTest {
         DataChangedEvent deleteDataChangedEvent = new DataChangedEvent("/lock/global/general/locks/lock_name/leases/c_l_0000000", "0000000000", DataChangedEvent.Type.DELETED);
         Optional<GovernanceEvent> deleteGovernanceEvent = watcher.createGovernanceEvent(deleteDataChangedEvent);
         assertTrue(deleteGovernanceEvent.isPresent());
-        assertTrue(deleteGovernanceEvent.get() instanceof GeneralLockReleasedEvent);
+        assertThat(deleteGovernanceEvent.get(), instanceOf(GeneralLockReleasedEvent.class));
         assertThat(((GeneralLockReleasedEvent) deleteGovernanceEvent.get()).getLockName(), is("lock_name"));
     }
     


### PR DESCRIPTION
## Use global lock in pipeline simple lock

Fixes #17228.

Changes proposed in this pull request:
- Use global lock in pipeline simple lock

