### PR TITLE
Refresh single table data node when execute alter/drop schema statement

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/rule/identifier/type/MutableDataNodeRule.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.infra.rule.identifier.type;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -43,6 +44,14 @@ public interface MutableDataNodeRule extends ShardingSphereRule {
      * @param tableName table name
      */
     void remove(String schemaName, String tableName);
+    
+    /**
+     * Remove data node.
+     *
+     * @param schemaNames schema name collection
+     * @param tableName table name
+     */
+    void remove(Collection<String> schemaNames, String tableName);
     
     /**
      * Find single data node.

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
@@ -60,7 +60,7 @@ public final class AlterSchemaStatementSchemaRefresher implements MetaDataRefres
     private void removeSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
                                       final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName) {
         ShardingSphereSchema schema = metaData.getSchemas().remove(schemaName);
-        database.remove(schemaName);
+        database.removeSchemaMetadata(schemaName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (String each : schema.getAllTableNames()) {
@@ -78,7 +78,7 @@ public final class AlterSchemaStatementSchemaRefresher implements MetaDataRefres
                                    final String schemaName, final String renameSchemaName, final Collection<String> logicDataSourceNames) {
         ShardingSphereSchema schema = metaData.getSchemaByName(schemaName);
         metaData.getSchemas().put(renameSchemaName, schema);
-        database.getSchemaMetadata(schemaName).ifPresent(optional -> database.put(renameSchemaName, optional));
+        database.getSchemaMetadata(schemaName).ifPresent(optional -> database.putSchemaMetadata(renameSchemaName, optional));
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (String each : schema.getAllTableNames()) {

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
@@ -24,7 +24,10 @@ import org.apache.shardingsphere.infra.federation.optimizer.context.planner.Opti
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContextFactory;
 import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationDatabaseMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.event.AlterSchemaEvent;
+import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
+import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterSchemaStatementHandler;
 
@@ -48,25 +51,53 @@ public final class AlterSchemaStatementSchemaRefresher implements MetaDataRefres
             return;
         }
         String actualSchemaName = sqlStatement.getSchemaName();
-        putSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName, renameSchemaName.get());
+        putSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName, renameSchemaName.get(), logicDataSourceNames);
         removeSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName);
         AlterSchemaEvent event = new AlterSchemaEvent(metaData.getDatabaseName(), actualSchemaName, renameSchemaName.get(), metaData.getSchemaByName(renameSchemaName.get()));
         ShardingSphereEventBus.getInstance().post(event);
-        // TODO Maybe need to refresh tables for SingleTableRule
     }
     
     private void removeSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
                                       final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName) {
-        metaData.getSchemas().remove(schemaName);
+        ShardingSphereSchema schema = metaData.getSchemas().remove(schemaName);
         database.remove(schemaName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
+        Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
+        for (String each : schema.getAllTableNames()) {
+            removeDataNode(rules, schemaName, each);
+        }
     }
     
-    private void putSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database,
-                                   final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String renameSchemaName) {
-        metaData.getSchemas().put(renameSchemaName, metaData.getSchemaByName(schemaName));
+    private void removeDataNode(final Collection<MutableDataNodeRule> rules, final String schemaName, final String tableName) {
+        for (MutableDataNodeRule each : rules) {
+            each.remove(schemaName, tableName);
+        }
+    }
+    
+    private void putSchemaMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners, 
+                                   final String schemaName, final String renameSchemaName, final Collection<String> logicDataSourceNames) {
+        ShardingSphereSchema schema = metaData.getSchemaByName(schemaName);
+        metaData.getSchemas().put(renameSchemaName, schema);
         database.getSchemaMetadata(schemaName).ifPresent(optional -> database.put(renameSchemaName, optional));
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
+        Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
+        for (String each : schema.getAllTableNames()) {
+            if (containsInImmutableDataNodeContainedRule(each, metaData)) {
+                continue;
+            }
+            putDataNode(rules, logicDataSourceNames.iterator().next(), renameSchemaName, each);
+        }
+    }
+    
+    private void putDataNode(final Collection<MutableDataNodeRule> rules, final String dataSourceName, final String schemaName, final String tableName) {
+        for (MutableDataNodeRule each : rules) {
+            each.put(dataSourceName, schemaName, tableName);
+        }
+    }
+    
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
@@ -74,7 +74,7 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
     
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String tableName, final ConfigurationProperties props) throws SQLException {
-        if (!containsInDataNodeContainedRule(tableName, metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(tableName, metaData)) {
             metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
@@ -88,8 +88,9 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
         });
     }
     
-    private boolean containsInDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
-        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterTableStatementSchemaRefresher.java
@@ -68,7 +68,7 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String tableName) {
         metaData.getSchemaByName(schemaName).remove(tableName);
         metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, tableName));
-        database.remove(schemaName, tableName);
+        database.removeTableMetadata(schemaName, tableName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
     
@@ -83,7 +83,7 @@ public final class AlterTableStatementSchemaRefresher implements MetaDataRefresh
         Optional<TableMetaData> actualTableMetaData = Optional.ofNullable(metaDataMap.get(schemaName)).map(optional -> optional.getTables().get(tableName));
         actualTableMetaData.ifPresent(optional -> {
             metaData.getSchemaByName(schemaName).put(tableName, optional);
-            database.put(schemaName, optional);
+            database.putTableMetadata(schemaName, optional);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         });
     }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
@@ -77,7 +77,7 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
     
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String viewName, final ConfigurationProperties props) throws SQLException {
-        if (!containsInDataNodeContainedRule(viewName, metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(viewName, metaData)) {
             metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, viewName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
@@ -91,8 +91,9 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
         });
     }
     
-    private boolean containsInDataNodeContainedRule(final String viewName, final ShardingSphereMetaData metaData) {
-        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(viewName));
+    private boolean containsInImmutableDataNodeContainedRule(final String viewName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(viewName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterViewStatementSchemaRefresher.java
@@ -71,7 +71,7 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String viewName) {
         metaData.getSchemaByName(schemaName).remove(viewName);
         metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, viewName));
-        database.remove(schemaName, viewName);
+        database.removeTableMetadata(schemaName, viewName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
     
@@ -86,7 +86,7 @@ public final class AlterViewStatementSchemaRefresher implements MetaDataRefreshe
         Optional<TableMetaData> actualViewMetaData = Optional.ofNullable(metaDataMap.get(schemaName)).map(optional -> optional.getTables().get(viewName));
         actualViewMetaData.ifPresent(optional -> {
             metaData.getSchemaByName(schemaName).put(viewName, optional);
-            database.put(schemaName, optional);
+            database.putTableMetadata(schemaName, optional);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         });
     }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateSchemaStatementSchemaRefresher.java
@@ -23,15 +23,16 @@ import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContext;
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContextFactory;
 import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationDatabaseMetaData;
+import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationSchemaMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.event.AddSchemaEvent;
-import org.apache.shardingsphere.infra.metadata.schema.model.TableMetaData;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateSchemaStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateSchemaStatementHandler;
 
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -50,7 +51,7 @@ public final class CreateSchemaStatementSchemaRefresher implements MetaDataRefre
             return;
         }
         metaData.getSchemas().put(schema.get(), new ShardingSphereSchema());
-        database.put(schema.get(), new TableMetaData());
+        database.putSchemaMetadata(schema.get(), new FederationSchemaMetaData(schema.get(), new LinkedHashMap<>()));
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         AddSchemaEvent event = new AddSchemaEvent(metaData.getDatabaseName(), schema.get());
         ShardingSphereEventBus.getInstance().post(event);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -50,7 +50,7 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
     public void refresh(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                         final Collection<String> logicDataSourceNames, final String schemaName, final CreateTableStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         String tableName = sqlStatement.getTable().getTableName().getIdentifier().getValue();
-        if (!containsInDataNodeContainedRule(tableName, metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(tableName, metaData)) {
             metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
@@ -67,8 +67,9 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
         });
     }
     
-    private boolean containsInDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
-        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateTableStatementSchemaRefresher.java
@@ -59,7 +59,7 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
         Optional<TableMetaData> actualTableMetaData = Optional.ofNullable(metaDataMap.get(schemaName)).map(optional -> optional.getTables().get(tableName));
         actualTableMetaData.ifPresent(optional -> {
             metaData.getSchemaByName(schemaName).put(tableName, optional);
-            database.put(schemaName, optional);
+            database.putTableMetadata(schemaName, optional);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
             SchemaAlteredEvent event = new SchemaAlteredEvent(metaData.getDatabaseName(), schemaName);
             event.getAlteredTables().add(optional);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -59,7 +59,7 @@ public final class CreateViewStatementSchemaRefresher implements MetaDataRefresh
         Optional<TableMetaData> actualViewMetaData = Optional.ofNullable(metaDataMap.get(schemaName)).map(optional -> optional.getTables().get(viewName));
         actualViewMetaData.ifPresent(optional -> {
             metaData.getSchemaByName(schemaName).put(viewName, optional);
-            database.put(schemaName, optional);
+            database.putTableMetadata(schemaName, optional);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
             SchemaAlteredEvent event = new SchemaAlteredEvent(metaData.getDatabaseName(), schemaName);
             event.getAlteredTables().add(optional);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/CreateViewStatementSchemaRefresher.java
@@ -50,7 +50,7 @@ public final class CreateViewStatementSchemaRefresher implements MetaDataRefresh
     public void refresh(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                         final Collection<String> logicDataSourceNames, final String schemaName, final CreateViewStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
         String viewName = sqlStatement.getView().getTableName().getIdentifier().getValue();
-        if (!containsInDataNodeContainedRule(viewName, metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(viewName, metaData)) {
             metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, viewName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
@@ -67,8 +67,9 @@ public final class CreateViewStatementSchemaRefresher implements MetaDataRefresh
         });
     }
     
-    private boolean containsInDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
-        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropSchemaStatementSchemaRefresher.java
@@ -50,7 +50,7 @@ public final class DropSchemaStatementSchemaRefresher implements MetaDataRefresh
             ShardingSphereSchema schema = metaData.getSchemas().remove(each);
             tobeRemovedTables.addAll(schema.getAllTableNames());
             tobeRemovedSchemas.add(each.toLowerCase());
-            database.remove(each);
+            database.removeSchemaMetadata(each);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         });
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropSchemaStatementSchemaRefresher.java
@@ -24,11 +24,14 @@ import org.apache.shardingsphere.infra.federation.optimizer.context.planner.Opti
 import org.apache.shardingsphere.infra.federation.optimizer.context.planner.OptimizerPlannerContextFactory;
 import org.apache.shardingsphere.infra.federation.optimizer.metadata.FederationDatabaseMetaData;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.schema.event.DropSchemaEvent;
+import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropSchemaStatement;
 
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 /**
@@ -41,13 +44,26 @@ public final class DropSchemaStatementSchemaRefresher implements MetaDataRefresh
     @Override
     public void refresh(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                         final Collection<String> logicDataSourceNames, final String schemaName, final DropSchemaStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
+        Collection<String> tobeRemovedTables = new LinkedHashSet<>();
+        Collection<String> tobeRemovedSchemas = new LinkedHashSet<>();
         sqlStatement.getSchemaNames().forEach(each -> {
-            metaData.getSchemas().remove(each);
+            ShardingSphereSchema schema = metaData.getSchemas().remove(each);
+            tobeRemovedTables.addAll(schema.getAllTableNames());
+            tobeRemovedSchemas.add(each.toLowerCase());
             database.remove(each);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         });
-        // TODO remove tables for SingleTableRule
+        Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
+        for (String each : tobeRemovedTables) {
+            removeDataNode(rules, each, tobeRemovedSchemas);
+        }
         ShardingSphereEventBus.getInstance().post(new DropSchemaEvent(metaData.getDatabaseName(), sqlStatement.getSchemaNames()));
+    }
+    
+    private void removeDataNode(final Collection<MutableDataNodeRule> rules, final String tobeRemovedTable, final Collection<String> schemaNames) {
+        for (MutableDataNodeRule each : rules) {
+            each.remove(schemaNames, tobeRemovedTable);
+        }
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
@@ -46,7 +46,7 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
         SchemaAlteredEvent event = new SchemaAlteredEvent(metaData.getDatabaseName(), schemaName);
         sqlStatement.getTables().forEach(each -> {
             metaData.getSchemaByName(schemaName).remove(each.getTableName().getIdentifier().getValue());
-            database.remove(schemaName, each.getTableName().getIdentifier().getValue());
+            database.removeTableMetadata(schemaName, each.getTableName().getIdentifier().getValue());
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
             event.getDroppedTables().add(each.getTableName().getIdentifier().getValue());
         });

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropTableStatementSchemaRefresher.java
@@ -52,12 +52,12 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
         });
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getTables()) {
-            removeSegment(rules, each, schemaName);
+            removeDataNode(rules, each, schemaName);
         }
         ShardingSphereEventBus.getInstance().post(event);
     }
     
-    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
+    private void removeDataNode(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
         for (MutableDataNodeRule each : rules) {
             each.remove(schemaName, tobeRemovedSegment.getTableName().getIdentifier().getValue());
         }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/DropViewStatementSchemaRefresher.java
@@ -49,12 +49,12 @@ public final class DropViewStatementSchemaRefresher implements MetaDataRefresher
         });
         Collection<MutableDataNodeRule> rules = metaData.getRuleMetaData().findRules(MutableDataNodeRule.class);
         for (SimpleTableSegment each : sqlStatement.getViews()) {
-            removeSegment(rules, each, schemaName);
+            removeDataNode(rules, each, schemaName);
         }
         ShardingSphereEventBus.getInstance().post(event);
     }
     
-    private void removeSegment(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
+    private void removeDataNode(final Collection<MutableDataNodeRule> rules, final SimpleTableSegment tobeRemovedSegment, final String schemaName) {
         for (MutableDataNodeRule each : rules) {
             each.remove(schemaName, tobeRemovedSegment.getTableName().getIdentifier().getValue());
         }

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
@@ -72,7 +72,7 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
     
     private void putTableMetaData(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                                   final Collection<String> logicDataSourceNames, final String schemaName, final String tableName, final ConfigurationProperties props) throws SQLException {
-        if (!containsInDataNodeContainedRule(tableName, metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(tableName, metaData)) {
             metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.put(logicDataSourceNames.iterator().next(), schemaName, tableName));
         }
         SchemaBuilderMaterials materials = new SchemaBuilderMaterials(
@@ -86,8 +86,9 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
         });
     }
     
-    private boolean containsInDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
-        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData metaData) {
+        return metaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/RenameTableStatementSchemaRefresher.java
@@ -66,7 +66,7 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
                                      final Map<String, OptimizerPlannerContext> optimizerPlanners, final String schemaName, final String tableName) {
         metaData.getSchemaByName(schemaName).remove(tableName);
         metaData.getRuleMetaData().findRules(MutableDataNodeRule.class).forEach(each -> each.remove(schemaName, tableName));
-        database.remove(schemaName, tableName);
+        database.removeTableMetadata(schemaName, tableName);
         optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
     }
     
@@ -81,7 +81,7 @@ public final class RenameTableStatementSchemaRefresher implements MetaDataRefres
         Optional<TableMetaData> actualTableMetaData = Optional.ofNullable(metaDataMap.get(schemaName)).map(optional -> optional.getTables().get(tableName));
         actualTableMetaData.ifPresent(optional -> {
             metaData.getSchemaByName(schemaName).put(tableName, optional);
-            database.put(schemaName, optional);
+            database.putTableMetadata(schemaName, optional);
             optimizerPlanners.put(database.getName(), OptimizerPlannerContextFactory.create(database));
         });
     }

--- a/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/metadata/FederationDatabaseMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/metadata/FederationDatabaseMetaData.java
@@ -51,23 +51,39 @@ public final class FederationDatabaseMetaData {
      * @param schemaName schema name
      * @param schemaMetaData schema metadata
      */
-    public void put(final String schemaName, final FederationSchemaMetaData schemaMetaData) {
-        schemas.put(schemaName, schemaMetaData);
+    public void putSchemaMetadata(final String schemaName, final FederationSchemaMetaData schemaMetaData) {
+        schemas.put(schemaName.toLowerCase(), schemaMetaData);
     }
     
     /**
-     * Add table meta data.
+     * Put table meta data.
      *
      * @param schemaName schema name
-     * @param metaData table meta data to be updated
+     * @param tableMetaData table meta data
      */
-    public void put(final String schemaName, final TableMetaData metaData) {
-        if (schemas.containsKey(schemaName)) {
-            schemas.get(schemaName).put(metaData);
-        } else {
-            Map<String, TableMetaData> tableMetaData = new LinkedHashMap<>();
-            tableMetaData.put(schemaName, metaData);
-            schemas.put(schemaName, new FederationSchemaMetaData(schemaName, tableMetaData));
+    public void putTableMetadata(final String schemaName, final TableMetaData tableMetaData) {
+        FederationSchemaMetaData schemaMetaData = schemas.computeIfAbsent(schemaName.toLowerCase(), key -> new FederationSchemaMetaData(schemaName, new LinkedHashMap<>()));
+        schemaMetaData.put(tableMetaData);
+    }
+    
+    /**
+     * Remove schema meta data.
+     *
+     * @param schemaName schema name
+     */
+    public void removeSchemaMetadata(final String schemaName) {
+        schemas.remove(schemaName.toLowerCase());
+    }
+    
+    /**
+     * Remove table meta data.
+     *
+     * @param schemaName schema name
+     * @param tableName table name
+     */
+    public void removeTableMetadata(final String schemaName, final String tableName) {
+        if (schemas.containsKey(schemaName.toLowerCase())) {
+            schemas.get(schemaName.toLowerCase()).remove(tableName.toLowerCase());
         }
     }
     
@@ -80,26 +96,5 @@ public final class FederationDatabaseMetaData {
      */
     public Optional<FederationSchemaMetaData> getSchemaMetadata(final String schemaName) {
         return Optional.of(schemas.get(schemaName));
-    }
-    
-    /**
-     * Remove table meta data.
-     *
-     * @param schemaName schema name
-     */
-    public void remove(final String schemaName) {
-        schemas.remove(schemaName);
-    }
-    
-    /**
-     * Remove table meta data.
-     *
-     * @param schemaName schema name
-     * @param tableName table name to be removed
-     */
-    public void remove(final String schemaName, final String tableName) {
-        if (schemas.containsKey(schemaName)) {
-            schemas.get(schemaName).remove(tableName);
-        }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/rule/SingleTableRule.java
@@ -181,7 +181,7 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     @Override
     public void put(final String dataSourceName, final String schemaName, final String tableName) {
         if (dataSourceNames.contains(dataSourceName)) {
-            Collection<DataNode> dataNodes = singleTableDataNodes.computeIfAbsent(tableName, key -> new LinkedHashSet<>());
+            Collection<DataNode> dataNodes = singleTableDataNodes.computeIfAbsent(tableName.toLowerCase(), key -> new LinkedHashSet<>());
             DataNode dataNode = new DataNode(dataSourceName, tableName);
             dataNode.setSchemaName(schemaName);
             dataNodes.add(dataNode);
@@ -191,9 +191,18 @@ public final class SingleTableRule implements SchemaRule, DataNodeContainedRule,
     
     @Override
     public void remove(final String schemaName, final String tableName) {
-        Collection<DataNode> dataNodes = singleTableDataNodes.getOrDefault(tableName, new LinkedHashSet<>());
-        dataNodes.removeIf(each -> schemaName.equalsIgnoreCase(each.getSchemaName()));
+        remove(Collections.singleton(schemaName.toLowerCase()), tableName);
+    }
+    
+    @Override
+    public void remove(final Collection<String> schemaNames, final String tableName) {
+        if (!singleTableDataNodes.containsKey(tableName.toLowerCase())) {
+            return;
+        }
+        Collection<DataNode> dataNodes = singleTableDataNodes.get(tableName.toLowerCase());
+        dataNodes.removeIf(each -> schemaNames.contains(each.getSchemaName().toLowerCase()));
         if (dataNodes.isEmpty()) {
+            singleTableDataNodes.remove(tableName.toLowerCase());
             tableNames.remove(tableName.toLowerCase());
         }
     }

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -157,7 +157,7 @@ public final class ContextManager implements AutoCloseable {
             return;
         }
         FederationDatabaseMetaData databaseMetaData = metaDataContexts.getOptimizerContext().getFederationMetaData().getDatabases().get(databaseName);
-        databaseMetaData.put(schemaName, new TableMetaData());
+        databaseMetaData.putTableMetadata(schemaName, new TableMetaData());
         metaDataContexts.getOptimizerContext().getPlannerContexts().put(databaseName, OptimizerPlannerContextFactory.create(databaseMetaData));
         metaDataContexts.getMetaDataMap().get(databaseName).getSchemas().put(schemaName, new ShardingSphereSchema());
     }
@@ -209,7 +209,7 @@ public final class ContextManager implements AutoCloseable {
         alterSingleTableDataNodes(databaseName, metaData, changedTableMetaData);
         FederationDatabaseMetaData databaseMetaData = metaDataContexts.getOptimizerContext().getFederationMetaData().getDatabases().get(databaseName);
         metaData.getSchemaByName(schemaName).put(changedTableMetaData.getName(), changedTableMetaData);
-        databaseMetaData.put(schemaName, changedTableMetaData);
+        databaseMetaData.putTableMetadata(schemaName, changedTableMetaData);
         metaDataContexts.getOptimizerContext().getPlannerContexts().put(databaseName, OptimizerPlannerContextFactory.create(databaseMetaData));
     }
     
@@ -230,7 +230,7 @@ public final class ContextManager implements AutoCloseable {
         if (null != metaDataContexts.getMetaData(databaseName).getSchemaByName(schemaName)) {
             metaDataContexts.getMetaData(databaseName).getSchemaByName(schemaName).remove(deletedTable);
             FederationDatabaseMetaData databaseMetaData = metaDataContexts.getOptimizerContext().getFederationMetaData().getDatabases().get(databaseName);
-            databaseMetaData.remove(schemaName, deletedTable);
+            databaseMetaData.removeTableMetadata(schemaName, deletedTable);
             metaDataContexts.getOptimizerContext().getPlannerContexts().put(databaseName, OptimizerPlannerContextFactory.create(databaseMetaData));
         }
     }
@@ -269,7 +269,7 @@ public final class ContextManager implements AutoCloseable {
             return;
         }
         FederationDatabaseMetaData databaseMetaData = metaDataContexts.getOptimizerContext().getFederationMetaData().getDatabases().get(databaseName);
-        databaseMetaData.remove(schemaName);
+        databaseMetaData.removeSchemaMetadata(schemaName);
         metaData.getSchemas().remove(schemaName);
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -48,6 +48,7 @@ import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.builder.global.GlobalRulesBuilder;
 import org.apache.shardingsphere.infra.rule.builder.schema.SchemaRulesBuilder;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
+import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
 import org.apache.shardingsphere.mode.metadata.MetaDataContextsBuilder;
 import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
@@ -213,7 +214,7 @@ public final class ContextManager implements AutoCloseable {
     }
     
     private void alterSingleTableDataNodes(final String databaseName, final ShardingSphereMetaData metaData, final TableMetaData changedTableMetaData) {
-        if (!containsInDataNodeContainedRule(changedTableMetaData.getName(), metaData)) {
+        if (!containsInImmutableDataNodeContainedRule(changedTableMetaData.getName(), metaData)) {
             refreshRules(databaseName, metaData);
         }
     }
@@ -234,8 +235,9 @@ public final class ContextManager implements AutoCloseable {
         }
     }
     
-    private boolean containsInDataNodeContainedRule(final String tableName, final ShardingSphereMetaData schemaMetaData) {
-        return schemaMetaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream().anyMatch(each -> each.getAllTables().contains(tableName));
+    private boolean containsInImmutableDataNodeContainedRule(final String tableName, final ShardingSphereMetaData schemaMetaData) {
+        return schemaMetaData.getRuleMetaData().findRules(DataNodeContainedRule.class).stream()
+                .filter(each -> !(each instanceof MutableDataNodeRule)).anyMatch(each -> each.getAllTables().contains(tableName));
     }
     
     /**


### PR DESCRIPTION
Ref #14004.

Changes proposed in this pull request:
- refresh single table data node when execute alter/drop schema statement
- refactor FederationDatabaseMetaData logic
