### PR TITLE
Optimize RoundRobinReplicaLoadBalanceAlgorithm and RoundRobinTrafficLoadBalanceAlgorithm logic

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithm.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.readwritesplitting.spi.ReplicaLoadBalanceAlgori
 
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -31,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class RoundRobinReplicaLoadBalanceAlgorithm implements ReplicaLoadBalanceAlgorithm {
     
-    private static final ConcurrentHashMap<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
+    private final AtomicInteger count = new AtomicInteger(0);
     
     @Getter
     @Setter
@@ -39,10 +38,8 @@ public final class RoundRobinReplicaLoadBalanceAlgorithm implements ReplicaLoadB
     
     @Override
     public String getDataSource(final String name, final String writeDataSourceName, final List<String> readDataSourceNames) {
-        AtomicInteger count = COUNTS.containsKey(name) ? COUNTS.get(name) : new AtomicInteger(0);
-        COUNTS.putIfAbsent(name, count);
         count.compareAndSet(readDataSourceNames.size(), 0);
-        return readDataSourceNames.get(Math.abs(count.getAndIncrement()) % readDataSourceNames.size());
+        return readDataSourceNames.get(count.getAndIncrement());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithm.java
@@ -38,8 +38,7 @@ public final class RoundRobinReplicaLoadBalanceAlgorithm implements ReplicaLoadB
     
     @Override
     public String getDataSource(final String name, final String writeDataSourceName, final List<String> readDataSourceNames) {
-        count.compareAndSet(readDataSourceNames.size(), 0);
-        return readDataSourceNames.get(count.getAndIncrement());
+        return readDataSourceNames.get(Math.abs(count.getAndIncrement()) % readDataSourceNames.size());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/algorithm/loadbalance/RoundRobinReplicaLoadBalanceAlgorithmTest.java
@@ -17,35 +17,22 @@
 
 package org.apache.shardingsphere.readwritesplitting.algorithm.loadbalance;
 
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class RoundRobinReplicaLoadBalanceAlgorithmTest {
     
-    private final RoundRobinReplicaLoadBalanceAlgorithm roundRobinReplicaLoadBalanceAlgorithm = new RoundRobinReplicaLoadBalanceAlgorithm();
-    
-    @Before
-    @After
-    public void reset() throws NoSuchFieldException, IllegalAccessException {
-        Field field = RoundRobinReplicaLoadBalanceAlgorithm.class.getDeclaredField("COUNTS");
-        field.setAccessible(true);
-        ((ConcurrentHashMap<?, ?>) field.get(RoundRobinReplicaLoadBalanceAlgorithm.class)).clear();
-    }
-    
     @Test
     public void assertGetDataSource() {
         String writeDataSourceName = "test_write_ds";
         String readDataSourceName1 = "test_read_ds_1";
         String readDataSourceName2 = "test_read_ds_2";
+        RoundRobinReplicaLoadBalanceAlgorithm roundRobinReplicaLoadBalanceAlgorithm = new RoundRobinReplicaLoadBalanceAlgorithm();
         List<String> readDataSourceNames = Arrays.asList(readDataSourceName1, readDataSourceName2);
         assertThat(roundRobinReplicaLoadBalanceAlgorithm.getDataSource("ds", writeDataSourceName, readDataSourceNames), is(readDataSourceName1));
         assertThat(roundRobinReplicaLoadBalanceAlgorithm.getDataSource("ds", writeDataSourceName, readDataSourceNames), is(readDataSourceName2));

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
@@ -32,8 +32,7 @@ public final class RoundRobinTrafficLoadBalanceAlgorithm implements TrafficLoadB
     
     @Override
     public InstanceId getInstanceId(final String name, final List<InstanceId> instanceIds) {
-        count.compareAndSet(instanceIds.size(), 0);
-        return instanceIds.get(count.getAndIncrement());
+        return instanceIds.get(Math.abs(count.getAndIncrement()) % instanceIds.size());
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/main/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithm.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.infra.instance.definition.InstanceId;
 import org.apache.shardingsphere.traffic.spi.TrafficLoadBalanceAlgorithm;
 
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -29,14 +28,12 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class RoundRobinTrafficLoadBalanceAlgorithm implements TrafficLoadBalanceAlgorithm {
     
-    private static final ConcurrentHashMap<String, AtomicInteger> COUNTS = new ConcurrentHashMap<>();
+    private final AtomicInteger count = new AtomicInteger(0);
     
     @Override
     public InstanceId getInstanceId(final String name, final List<InstanceId> instanceIds) {
-        AtomicInteger count = COUNTS.containsKey(name) ? COUNTS.get(name) : new AtomicInteger(0);
-        COUNTS.putIfAbsent(name, count);
         count.compareAndSet(instanceIds.size(), 0);
-        return instanceIds.get(Math.abs(count.getAndIncrement()) % instanceIds.size());
+        return instanceIds.get(count.getAndIncrement());
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
+++ b/shardingsphere-kernel/shardingsphere-traffic/shardingsphere-traffic-core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
@@ -18,27 +18,15 @@
 package org.apache.shardingsphere.traffic.algorithm.loadbalance;
 
 import org.apache.shardingsphere.infra.instance.definition.InstanceId;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public final class RoundRobinTrafficLoadBalanceAlgorithmTest {
-    
-    @Before
-    @After
-    public void reset() throws NoSuchFieldException, IllegalAccessException {
-        Field field = RoundRobinTrafficLoadBalanceAlgorithm.class.getDeclaredField("COUNTS");
-        field.setAccessible(true);
-        ((ConcurrentHashMap<?, ?>) field.get(RoundRobinTrafficLoadBalanceAlgorithm.class)).clear();
-    }
     
     @Test
     public void assertGetInstanceId() {


### PR DESCRIPTION
Fixes #17419.

Changes proposed in this pull request:
- optimize RoundRobinReplicaLoadBalanceAlgorithm and RoundRobinTrafficLoadBalanceAlgorithm logic
- modify unit test

Following is the performance test result:

```
Before: 
Benchmark                                                          Mode  Cnt     Score     Error   Units
RoundRobinTrafficLoadBalanceAlgorithmBenchmark.testGetInstanceId  thrpt    5  6273.145 ± 514.960  ops/ms

After: 
Benchmark                                                          Mode  Cnt      Score      Error   Units
RoundRobinTrafficLoadBalanceAlgorithmBenchmark.testGetInstanceId  thrpt    5  37077.727 ± 3498.619  ops/ms
```

Source code:

```java
/**
 * Round-robin traffic load balance algorithm benchmark.
 */
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@Fork(1)
@Threads(5)
@Warmup(iterations = 5, time = 5)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class RoundRobinTrafficLoadBalanceAlgorithmBenchmark {
    
    private RoundRobinTrafficLoadBalanceAlgorithm loadBalanceAlgorithm;
    
    private List<InstanceId> instanceIds;
    
    @Setup(Level.Trial)
    public void setUp() {
        loadBalanceAlgorithm = new RoundRobinTrafficLoadBalanceAlgorithm();
        InstanceId instanceId1 = new InstanceId("127.0.0.1@3307");
        InstanceId instanceId2 = new InstanceId("127.0.0.1@3308");
        instanceIds = Arrays.asList(instanceId1, instanceId2);
    }
    
    @Benchmark
    public void testGetInstanceId() {
        loadBalanceAlgorithm.getInstanceId("traffic", instanceIds);
    }
}
```