### PR TITLE
Support for configuring Props of primitive types

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/keygen/CosIdKeyGenerateAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/keygen/CosIdKeyGenerateAlgorithm.java
@@ -46,7 +46,7 @@ public final class CosIdKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     public void init(final Properties props) {
         this.props = props;
         lazyIdGenerator = new LazyIdGenerator(props.getProperty(CosIdAlgorithmConstants.ID_NAME_KEY, IdGeneratorProvider.SHARE));
-        asString = Boolean.parseBoolean(props.getProperty(AS_STRING_KEY, Boolean.FALSE.toString()));
+        asString = Boolean.parseBoolean(props.getOrDefault(AS_STRING_KEY, Boolean.FALSE.toString()).toString());
         lazyIdGenerator.tryGet(false);
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/keygen/CosIdSnowflakeKeyGenerateAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/keygen/CosIdSnowflakeKeyGenerateAlgorithm.java
@@ -72,11 +72,11 @@ public final class CosIdSnowflakeKeyGenerateAlgorithm implements KeyGenerateAlgo
     }
     
     private boolean getAsString(final Properties props) {
-        return Boolean.parseBoolean(props.getProperty(AS_STRING_KEY, Boolean.FALSE.toString()));
+        return Boolean.parseBoolean(props.getOrDefault(AS_STRING_KEY, Boolean.FALSE.toString()).toString());
     }
     
     private long getEpoch(final Properties props) {
-        return Long.parseLong(props.getProperty(EPOCH_KEY, DEFAULT_EPOCH + ""));
+        return Long.parseLong(props.getOrDefault(EPOCH_KEY, DEFAULT_EPOCH).toString());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/interval/AbstractCosIdIntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/interval/AbstractCosIdIntervalShardingAlgorithm.java
@@ -88,7 +88,7 @@ public abstract class AbstractCosIdIntervalShardingAlgorithm<T extends Comparabl
     
     private String getRequiredValue(final Properties props, final String key) {
         Preconditions.checkArgument(props.containsKey(key), "%s can not be null.", key);
-        return props.getProperty(key);
+        return props.get(key).toString();
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/interval/CosIdSnowflakeIntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/interval/CosIdSnowflakeIntervalShardingAlgorithm.java
@@ -46,7 +46,7 @@ public final class CosIdSnowflakeIntervalShardingAlgorithm extends AbstractCosId
     }
     
     private SnowflakeIdStateParser getSnowflakeIdStateParser(final Properties props) {
-        long epoch = Long.parseLong(props.getProperty(EPOCH_KEY, CosIdSnowflakeKeyGenerateAlgorithm.DEFAULT_EPOCH + ""));
+        long epoch = Long.parseLong(props.getOrDefault(EPOCH_KEY, CosIdSnowflakeKeyGenerateAlgorithm.DEFAULT_EPOCH).toString());
         return new MillisecondSnowflakeIdStateParser(
                 epoch, MillisecondSnowflakeId.DEFAULT_TIMESTAMP_BIT, MillisecondSnowflakeId.DEFAULT_MACHINE_BIT, MillisecondSnowflakeId.DEFAULT_SEQUENCE_BIT, getZoneId());
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/mod/CosIdModShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-plugin/shardingsphere-sharding-cosid/src/main/java/org/apache/shardingsphere/sharding/cosid/algorithm/sharding/mod/CosIdModShardingAlgorithm.java
@@ -53,7 +53,7 @@ public final class CosIdModShardingAlgorithm<T extends Number & Comparable<T>> i
     
     private String getRequiredValue(final Properties props, final String key) {
         Preconditions.checkArgument(props.containsKey(key), "%s can not be null.", key);
-        return props.getProperty(key);
+        return props.get(key).toString();
     }
     
     @Override


### PR DESCRIPTION
When I checked the latest `shardingsphere-sharding-cosid` module code found the last PR (https://github.com/apache/shardingsphere/pull/17352) has been lost.

Related: 
- https://github.com/apache/shardingsphere/pull/17160
- https://github.com/apache/shardingsphere/pull/17352
- https://github.com/apache/shardingsphere/issues/17159


Changes proposed in this pull request:
- Support for configuring Props of primitive types.