### PR TITLE
Fix create, alter and drop schema statements wrong parse result with quotes

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
+++ b/shardingsphere-infra/shardingsphere-infra-context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/AlterSchemaStatementSchemaRefresher.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.metadata.schema.event.AlterSchemaEvent;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataNodeContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.AlterSchemaStatementHandler;
 
 import java.sql.SQLException;
@@ -46,14 +47,14 @@ public final class AlterSchemaStatementSchemaRefresher implements MetaDataRefres
     @Override
     public void refresh(final ShardingSphereMetaData metaData, final FederationDatabaseMetaData database, final Map<String, OptimizerPlannerContext> optimizerPlanners,
                         final Collection<String> logicDataSourceNames, final String schemaName, final AlterSchemaStatement sqlStatement, final ConfigurationProperties props) throws SQLException {
-        Optional<String> renameSchemaName = AlterSchemaStatementHandler.getRenameSchema(sqlStatement);
+        Optional<IdentifierValue> renameSchemaName = AlterSchemaStatementHandler.getRenameSchema(sqlStatement);
         if (!renameSchemaName.isPresent()) {
             return;
         }
-        String actualSchemaName = sqlStatement.getSchemaName();
-        putSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName, renameSchemaName.get(), logicDataSourceNames);
+        String actualSchemaName = sqlStatement.getSchemaName().getValue();
+        putSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName, renameSchemaName.get().getValue(), logicDataSourceNames);
         removeSchemaMetaData(metaData, database, optimizerPlanners, actualSchemaName);
-        AlterSchemaEvent event = new AlterSchemaEvent(metaData.getDatabaseName(), actualSchemaName, renameSchemaName.get(), metaData.getSchemaByName(renameSchemaName.get()));
+        AlterSchemaEvent event = new AlterSchemaEvent(metaData.getDatabaseName(), actualSchemaName, renameSchemaName.get().getValue(), metaData.getSchemaByName(renameSchemaName.get().getValue()));
         ShardingSphereEventBus.getInstance().post(event);
     }
     

--- a/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidator.java
+++ b/shardingsphere-kernel/shardingsphere-single-table/shardingsphere-single-table-core/src/main/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidator.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.metadata.schema.ShardingSphereSchema;
 import org.apache.shardingsphere.singletable.route.validator.SingleTableMetadataValidator;
 import org.apache.shardingsphere.singletable.rule.SingleTableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.DropSchemaStatementHandler;
 
 /**
@@ -34,13 +35,14 @@ public final class SingleTableDropSchemaMetadataValidator implements SingleTable
     @Override
     public void validate(final SingleTableRule rule, final SQLStatementContext<DropSchemaStatement> sqlStatementContext, final ShardingSphereMetaData metaData) {
         boolean containsCascade = DropSchemaStatementHandler.isContainsCascade(sqlStatementContext.getSqlStatement());
-        for (String each : sqlStatementContext.getSqlStatement().getSchemaNames()) {
-            ShardingSphereSchema schema = metaData.getSchemaByName(each);
+        for (IdentifierValue each : sqlStatementContext.getSqlStatement().getSchemaNames()) {
+            String schemaName = each.getValue();
+            ShardingSphereSchema schema = metaData.getSchemaByName(schemaName);
             if (null == schema) {
-                throw new ShardingSphereException("Schema %s does not exist.", each);
+                throw new ShardingSphereException("Schema %s does not exist.", schemaName);
             }
             if (!containsCascade && !schema.getAllTableNames().isEmpty()) {
-                throw new ShardingSphereException("Can not drop schema %s because it contains tables.", each);
+                throw new ShardingSphereException("Can not drop schema %s because it contains tables.", schemaName);
             }
         }
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
@@ -695,11 +695,10 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     public ASTNode visitCreateSchema(final CreateSchemaContext ctx) {
         OpenGaussCreateSchemaStatement result = new OpenGaussCreateSchemaStatement();
         if (null != ctx.createSchemaClauses().colId()) {
-            result.setSchemaName(ctx.createSchemaClauses().colId().getText());
+            result.setSchemaName(new IdentifierValue(ctx.createSchemaClauses().colId().getText()));
         }
         if (null != ctx.createSchemaClauses().roleSpec() && null != ctx.createSchemaClauses().roleSpec().identifier()) {
-            IdentifierValue username = (IdentifierValue) visit(ctx.createSchemaClauses().roleSpec().identifier());
-            result.setUsername(username.getValue());
+            result.setUsername((IdentifierValue) visit(ctx.createSchemaClauses().roleSpec().identifier()));
         }
         return result;
     }
@@ -707,9 +706,9 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     @Override
     public ASTNode visitAlterSchema(final AlterSchemaContext ctx) {
         OpenGaussAlterSchemaStatement result = new OpenGaussAlterSchemaStatement();
-        result.setSchemaName(((IdentifierValue) visit(ctx.name().get(0))).getValue());
+        result.setSchemaName((IdentifierValue) visit(ctx.name().get(0)));
         if (ctx.name().size() > 1) {
-            result.setRenameSchema(((IdentifierValue) visit(ctx.name().get(1))).getValue());
+            result.setRenameSchema((IdentifierValue) visit(ctx.name().get(1)));
         }
         return result;
     }
@@ -718,7 +717,7 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     @Override
     public ASTNode visitDropSchema(final DropSchemaContext ctx) {
         OpenGaussDropSchemaStatement result = new OpenGaussDropSchemaStatement();
-        result.getSchemaNames().addAll(((CollectionValue<String>) visit(ctx.nameList())).getValue());
+        result.getSchemaNames().addAll(((CollectionValue<IdentifierValue>) visit(ctx.nameList())).getValue());
         result.setContainsCascade(null != ctx.dropBehavior() && null != ctx.dropBehavior().CASCADE());
         return result;
     }
@@ -726,12 +725,12 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitNameList(final NameListContext ctx) {
-        CollectionValue<String> result = new CollectionValue<>();
+        CollectionValue<IdentifierValue> result = new CollectionValue<>();
         if (null != ctx.nameList()) {
-            result.combine((CollectionValue<String>) visit(ctx.nameList()));
+            result.combine((CollectionValue<IdentifierValue>) visit(ctx.nameList()));
         }
         if (null != ctx.name()) {
-            result.getValue().add(((IdentifierValue) visit(ctx.name())).getValue());
+            result.getValue().add((IdentifierValue) visit(ctx.name()));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -807,11 +807,10 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     public ASTNode visitCreateSchema(final CreateSchemaContext ctx) {
         PostgreSQLCreateSchemaStatement result = new PostgreSQLCreateSchemaStatement();
         if (null != ctx.createSchemaClauses().colId()) {
-            result.setSchemaName(ctx.createSchemaClauses().colId().getText());
+            result.setSchemaName(new IdentifierValue(ctx.createSchemaClauses().colId().getText()));
         }
         if (null != ctx.createSchemaClauses().roleSpec() && null != ctx.createSchemaClauses().roleSpec().identifier()) {
-            IdentifierValue username = (IdentifierValue) visit(ctx.createSchemaClauses().roleSpec().identifier());
-            result.setUsername(username.getValue());
+            result.setUsername((IdentifierValue) visit(ctx.createSchemaClauses().roleSpec().identifier()));
         }
         return result;
     }
@@ -819,9 +818,9 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitAlterSchema(final AlterSchemaContext ctx) {
         PostgreSQLAlterSchemaStatement result = new PostgreSQLAlterSchemaStatement();
-        result.setSchemaName(((IdentifierValue) visit(ctx.name().get(0))).getValue());
+        result.setSchemaName((IdentifierValue) visit(ctx.name().get(0)));
         if (ctx.name().size() > 1) {
-            result.setRenameSchema(((IdentifierValue) visit(ctx.name().get(1))).getValue());
+            result.setRenameSchema((IdentifierValue) visit(ctx.name().get(1)));
         }
         return result;
     }
@@ -830,7 +829,7 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitDropSchema(final DropSchemaContext ctx) {
         PostgreSQLDropSchemaStatement result = new PostgreSQLDropSchemaStatement();
-        result.getSchemaNames().addAll(((CollectionValue<String>) visit(ctx.nameList())).getValue());
+        result.getSchemaNames().addAll(((CollectionValue<IdentifierValue>) visit(ctx.nameList())).getValue());
         result.setContainsCascade(null != ctx.dropBehavior() && null != ctx.dropBehavior().CASCADE());
         return result;
     }
@@ -838,12 +837,12 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitNameList(final NameListContext ctx) {
-        CollectionValue<String> result = new CollectionValue<>();
+        CollectionValue<IdentifierValue> result = new CollectionValue<>();
         if (null != ctx.nameList()) {
-            result.combine((CollectionValue<String>) visit(ctx.nameList()));
+            result.combine((CollectionValue<IdentifierValue>) visit(ctx.nameList()));
         }
         if (null != ctx.name()) {
-            result.getValue().add(((IdentifierValue) visit(ctx.name())).getValue());
+            result.getValue().add((IdentifierValue) visit(ctx.name()));
         }
         return result;
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 /**
  * Alter schema statement.
@@ -30,5 +31,5 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStat
 @ToString
 public abstract class AlterSchemaStatement extends AbstractSQLStatement implements DDLStatement {
     
-    private String schemaName;
+    private IdentifierValue schemaName;
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/CreateSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 import java.util.Optional;
 
@@ -32,14 +33,14 @@ import java.util.Optional;
 @ToString
 public abstract class CreateSchemaStatement extends AbstractSQLStatement implements DDLStatement {
     
-    private String schemaName;
+    private IdentifierValue schemaName;
     
     /**
      * Get schema name.
      * 
      * @return schema name
      */
-    public Optional<String> getSchemaName() {
+    public Optional<IdentifierValue> getSchemaName() {
         return Optional.ofNullable(schemaName);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/DropSchemaStatement.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.common.statement.ddl;
 import lombok.Getter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -31,5 +32,5 @@ import java.util.LinkedList;
 @ToString
 public abstract class DropSchemaStatement extends AbstractSQLStatement implements DDLStatement {
     
-    private final Collection<String> schemaNames = new LinkedList<>();
+    private final Collection<IdentifierValue> schemaNames = new LinkedList<>();
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/AlterSchemaStatementHandler.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/AlterSchemaStatementHandler.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussAlterSchemaStatement;
@@ -40,7 +41,7 @@ public final class AlterSchemaStatementHandler implements SQLStatementHandler {
      * @param alterSchemaStatement alter schema statement
      * @return rename schema
      */
-    public static Optional<String> getRenameSchema(final AlterSchemaStatement alterSchemaStatement) {
+    public static Optional<IdentifierValue> getRenameSchema(final AlterSchemaStatement alterSchemaStatement) {
         if (alterSchemaStatement instanceof PostgreSQLStatement) {
             return ((PostgreSQLAlterSchemaStatement) alterSchemaStatement).getRenameSchema();
         }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateSchemaStatementHandler.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateSchemaStatementHandler.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateSchemaStatement;
@@ -40,7 +41,7 @@ public final class CreateSchemaStatementHandler implements SQLStatementHandler {
      * @param createSchemaStatement create schema statement
      * @return username
      */
-    public static Optional<String> getUsername(final CreateSchemaStatement createSchemaStatement) {
+    public static Optional<IdentifierValue> getUsername(final CreateSchemaStatement createSchemaStatement) {
         if (createSchemaStatement instanceof PostgreSQLStatement) {
             return ((PostgreSQLCreateSchemaStatement) createSchemaStatement).getUsername();
         }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussAlterSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 
 import java.util.Optional;
@@ -33,14 +34,14 @@ import java.util.Optional;
 @ToString
 public final class OpenGaussAlterSchemaStatement extends AlterSchemaStatement implements OpenGaussStatement {
     
-    private String renameSchema;
+    private IdentifierValue renameSchema;
     
     /**
      * Get rename schema.
      * 
      * @return rename schema
      */
-    public Optional<String> getRenameSchema() {
+    public Optional<IdentifierValue> getRenameSchema() {
         return Optional.ofNullable(renameSchema);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 
 import java.util.Optional;
@@ -33,14 +34,14 @@ import java.util.Optional;
 @ToString
 public final class OpenGaussCreateSchemaStatement extends CreateSchemaStatement implements OpenGaussStatement {
     
-    private String username;
+    private IdentifierValue username;
     
     /**
      * Get username.
      *
      * @return username
      */
-    public Optional<String> getUsername() {
+    public Optional<IdentifierValue> getUsername() {
         return Optional.ofNullable(username);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
 
 import java.util.Optional;
@@ -33,14 +34,14 @@ import java.util.Optional;
 @ToString
 public final class PostgreSQLAlterSchemaStatement extends AlterSchemaStatement implements PostgreSQLStatement {
     
-    private String renameSchema;
+    private IdentifierValue renameSchema;
     
     /**
      * Get rename schema.
      *
      * @return rename schema
      */
-    public Optional<String> getRenameSchema() {
+    public Optional<IdentifierValue> getRenameSchema() {
         return Optional.ofNullable(renameSchema);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLCreateSchemaStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLCreateSchemaStatement.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateSchemaStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
 
 import java.util.Optional;
@@ -33,14 +34,14 @@ import java.util.Optional;
 @ToString
 public final class PostgreSQLCreateSchemaStatement extends CreateSchemaStatement implements PostgreSQLStatement {
     
-    private String username;
+    private IdentifierValue username;
     
     /**
      * Get username.
      *
      * @return username
      */
-    public Optional<String> getUsername() {
+    public Optional<IdentifierValue> getUsername() {
         return Optional.ofNullable(username);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/AlterSchemaStatementHandlerTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/AlterSchemaStatementHandlerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussAlterSchemaStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterSchemaStatement;
 import org.junit.Test;
@@ -32,18 +33,18 @@ public final class AlterSchemaStatementHandlerTest {
     @Test
     public void assertGetUsernameForPostgreSQL() {
         PostgreSQLAlterSchemaStatement alterSchemaStatement = new PostgreSQLAlterSchemaStatement();
-        alterSchemaStatement.setRenameSchema("new_schema");
-        Optional<String> actual = AlterSchemaStatementHandler.getRenameSchema(alterSchemaStatement);
+        alterSchemaStatement.setRenameSchema(new IdentifierValue("new_schema"));
+        Optional<IdentifierValue> actual = AlterSchemaStatementHandler.getRenameSchema(alterSchemaStatement);
         assertTrue(actual.isPresent());
-        assertThat(actual.get(), is("new_schema"));
+        assertThat(actual.get().getValue(), is("new_schema"));
     }
     
     @Test
     public void assertGetUsernameForOpenGauss() {
         OpenGaussAlterSchemaStatement alterSchemaStatement = new OpenGaussAlterSchemaStatement();
-        alterSchemaStatement.setRenameSchema("new_schema");
-        Optional<String> actual = AlterSchemaStatementHandler.getRenameSchema(alterSchemaStatement);
+        alterSchemaStatement.setRenameSchema(new IdentifierValue("new_schema"));
+        Optional<IdentifierValue> actual = AlterSchemaStatementHandler.getRenameSchema(alterSchemaStatement);
         assertTrue(actual.isPresent());
-        assertThat(actual.get(), is("new_schema"));
+        assertThat(actual.get().getValue(), is("new_schema"));
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateSchemaStatementHandlerTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateSchemaStatementHandlerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateSchemaStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLCreateSchemaStatement;
 import org.junit.Test;
@@ -32,18 +33,18 @@ public final class CreateSchemaStatementHandlerTest {
     @Test
     public void assertGetUsernameForPostgreSQL() {
         PostgreSQLCreateSchemaStatement createSchemaStatement = new PostgreSQLCreateSchemaStatement();
-        createSchemaStatement.setUsername("root");
-        Optional<String> actual = CreateSchemaStatementHandler.getUsername(createSchemaStatement);
+        createSchemaStatement.setUsername(new IdentifierValue("root"));
+        Optional<IdentifierValue> actual = CreateSchemaStatementHandler.getUsername(createSchemaStatement);
         assertTrue(actual.isPresent());
-        assertThat(actual.get(), is("root"));
+        assertThat(actual.get().getValue(), is("root"));
     }
     
     @Test
     public void assertGetUsernameForOpenGauss() {
         OpenGaussCreateSchemaStatement createSchemaStatement = new OpenGaussCreateSchemaStatement();
-        createSchemaStatement.setUsername("root");
-        Optional<String> actual = CreateSchemaStatementHandler.getUsername(createSchemaStatement);
+        createSchemaStatement.setUsername(new IdentifierValue("root"));
+        Optional<IdentifierValue> actual = CreateSchemaStatementHandler.getUsername(createSchemaStatement);
         assertTrue(actual.isPresent());
-        assertThat(actual.get(), is("root"));
+        assertThat(actual.get().getValue(), is("root"));
     }
 }


### PR DESCRIPTION
Fixes #17380.

Changes proposed in this pull request:
- optimize create, alter and drop schema statement parse logic
- update unit test
