### PR TITLE
Fix the exception when user does not contain @ in the authority configuration.

### DIFF
--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/yaml/config/YamlAuthorityUserConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/yaml/config/YamlAuthorityUserConfiguration.java
@@ -40,6 +40,6 @@ public final class YamlAuthorityUserConfiguration implements YamlConfiguration {
     
     @Override
     public String toString() {
-        return user + ":" + password;
+        return !user.contains("@") ? user + "@%:" + password : user + ":" + password;
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `@` by default when `@` is not included
