### PR TITLE
Support useOriginalSQLWhenTranslatingFailed

### DIFF
--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-api/src/main/java/org/apache/shardingsphere/sqltranslator/config/SQLTranslatorRuleConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-api/src/main/java/org/apache/shardingsphere/sqltranslator/config/SQLTranslatorRuleConfiguration.java
@@ -17,31 +17,22 @@
 
 package org.apache.shardingsphere.sqltranslator.config;
 
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.config.scope.GlobalRuleConfiguration;
-
-import java.util.Optional;
 
 /**
  * SQL translator rule configuration.
  */
-@AllArgsConstructor
-@NoArgsConstructor
-@Setter
+@RequiredArgsConstructor
+@Getter
 public final class SQLTranslatorRuleConfiguration implements GlobalRuleConfiguration {
     
-    private String type;
+    private final String type;
     
-    // TODO is ignore translate fail
+    private final boolean useOriginalSQLWhenTranslatingFailed;
     
-    /**
-     * Get type.
-     * 
-     * @return type
-     */
-    public Optional<String> getType() {
-        return Optional.ofNullable(type);
+    public SQLTranslatorRuleConfiguration() {
+        this(null, true);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/exception/SQLTranslationException.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/exception/SQLTranslationException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sqltranslator.exception;
+
+/**
+ * SQL translation exception.
+ */
+public final class SQLTranslationException extends Exception {
+    
+    private static final String ERROR_MESSAGE = "SQL `%s` translation error.";
+    
+    public SQLTranslationException(final String sql, final Exception cause) {
+        super(String.format(ERROR_MESSAGE, sql), cause);
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/rule/SQLTranslatorRule.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/rule/SQLTranslatorRule.java
@@ -32,7 +32,7 @@ public final class SQLTranslatorRule implements GlobalRule {
     private final SQLTranslator translator;
     
     public SQLTranslatorRule(final SQLTranslatorRuleConfiguration ruleConfig) {
-        translator = SQLTranslatorFactory.getInstance(ruleConfig.getType().orElse(""));
+        translator = SQLTranslatorFactory.getInstance(ruleConfig.getType());
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/spi/SQLTranslator.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/spi/SQLTranslator.java
@@ -22,6 +22,7 @@ import org.apache.shardingsphere.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.spi.type.required.RequiredSPI;
 import org.apache.shardingsphere.spi.type.typed.TypedSPI;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sqltranslator.exception.SQLTranslationException;
 
 /**
  * SQL translator.
@@ -37,6 +38,7 @@ public interface SQLTranslator extends TypedSPI, RequiredSPI {
      * @param frontendDatabaseType frontend database type
      * @param backendDatabaseType backend database type
      * @return translated SQL
+     * @throws SQLTranslationException SQL translation exception
      */
-    String translate(String sql, SQLStatement sqlStatement, DatabaseType frontendDatabaseType, DatabaseType backendDatabaseType);
+    String translate(String sql, SQLStatement sqlStatement, DatabaseType frontendDatabaseType, DatabaseType backendDatabaseType) throws SQLTranslationException;
 }

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/spi/type/NativeSQLTranslator.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/spi/type/NativeSQLTranslator.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sqltranslator.spi.type;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sqltranslator.exception.SQLTranslationException;
 import org.apache.shardingsphere.sqltranslator.spi.SQLTranslator;
 
 /**
@@ -27,7 +28,7 @@ import org.apache.shardingsphere.sqltranslator.spi.SQLTranslator;
 public final class NativeSQLTranslator implements SQLTranslator {
     
     @Override
-    public String translate(final String sql, final SQLStatement statement, final DatabaseType frontendDatabaseType, final DatabaseType backendDatabaseType) {
+    public String translate(final String sql, final SQLStatement statement, final DatabaseType frontendDatabaseType, final DatabaseType backendDatabaseType) throws SQLTranslationException {
         // TODO
         return sql;
     }

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/yaml/config/YamlSQLTranslatorRuleConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/yaml/config/YamlSQLTranslatorRuleConfiguration.java
@@ -31,6 +31,8 @@ public final class YamlSQLTranslatorRuleConfiguration implements YamlRuleConfigu
     
     private String type;
     
+    private boolean useOriginalSQLWhenTranslatingFailed = true;
+    
     @Override
     public Class<SQLTranslatorRuleConfiguration> getRuleConfigurationType() {
         return SQLTranslatorRuleConfiguration.class;

--- a/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/yaml/swapper/SQLTranslatorRuleConfigurationYamlSwapper.java
+++ b/shardingsphere-kernel/shardingsphere-sql-translator/shardingsphere-sql-translator-core/src/main/java/org/apache/shardingsphere/sqltranslator/yaml/swapper/SQLTranslatorRuleConfigurationYamlSwapper.java
@@ -30,13 +30,13 @@ public final class SQLTranslatorRuleConfigurationYamlSwapper implements YamlRule
     @Override
     public YamlSQLTranslatorRuleConfiguration swapToYamlConfiguration(final SQLTranslatorRuleConfiguration data) {
         YamlSQLTranslatorRuleConfiguration result = new YamlSQLTranslatorRuleConfiguration();
-        result.setType(data.getType().orElse(null));
+        result.setType(data.getType());
         return result;
     }
     
     @Override
     public SQLTranslatorRuleConfiguration swapToObject(final YamlSQLTranslatorRuleConfiguration yamlConfig) {
-        return new SQLTranslatorRuleConfiguration(yamlConfig.getType());
+        return new SQLTranslatorRuleConfiguration(yamlConfig.getType(), yamlConfig.isUseOriginalSQLWhenTranslatingFailed());
     }
     
     @Override


### PR DESCRIPTION
For #17619.

Changes proposed in this pull request:
- Add SQLTranslatorRuleConfiguration.useOriginalSQLWhenTranslatingFailed
- Use useOriginalSQLWhenTranslatingFailed
