### PR TITLE
Refactor EncryptParameterAssignmentToken with JDK library

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptParameterAssignmentToken.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptParameterAssignmentToken.java
@@ -17,10 +17,9 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.pojo;
 
-import com.google.common.collect.Collections2;
-
 import java.util.Collection;
 import java.util.LinkedList;
+import java.util.StringJoiner;
 
 /**
  * Parameter assignment token for encrypt.
@@ -44,7 +43,10 @@ public final class EncryptParameterAssignmentToken extends EncryptAssignmentToke
     
     @Override
     public String toString() {
-        Collection<String> items = Collections2.transform(columnNames, input -> input + " = ?");
-        return String.join(", ", items);
+        StringJoiner result = new StringJoiner(", ");
+        for (String input : columnNames) {
+            result.add(input + " = ?");
+        }
+        return result.toString();
     }
 }


### PR DESCRIPTION
Fixes #17687.

### Summary

```
Benchmark                                               Mode  Cnt      Score     Error   Units

5.1.0:
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  3113.274 ± 26.429  ops/ms

5.1.2-SNAPSHOT before PR:
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  13067.026 ± 235.881  ops/ms

5.1.2-SNAPSHOT after PR:
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  13868.939 ± 178.703  ops/ms
```

### JMH Code

```java
package icu.wwj.jmh.shardingsphere5.code;

import org.apache.commons.lang3.RandomStringUtils;
import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.CompilerControl;
import org.openjdk.jmh.annotations.CompilerControl.Mode;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.profile.AsyncProfiler;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.RunnerException;
import org.openjdk.jmh.runner.options.OptionsBuilder;
import org.openjdk.jmh.runner.options.TimeValue;

import java.util.concurrent.TimeUnit;

@State(Scope.Thread)
public class EncryptParameterAssignmentTokenBenchmark {
    
    private EncryptParameterAssignmentToken target;
    
    @Setup(Level.Trial)
    public void setup() {
        target = new EncryptParameterAssignmentToken(0, 0);
        for (int i = 0; i < 16; i++) {
            target.addColumnName(RandomStringUtils.randomAlphanumeric(8));
        }
    }
    
    @Benchmark
    @CompilerControl(Mode.DONT_INLINE)
    public String bench() {
        return target.toString();
    }
    
    public static void main(String[] args) throws RunnerException {
        new Runner(new OptionsBuilder()
                .include(EncryptParameterAssignmentTokenBenchmark.class.getName())
                .forks(3)
                .warmupIterations(5)
                .warmupTime(TimeValue.seconds(3))
                .measurementIterations(5)
                .measurementTime(TimeValue.seconds(3))
                .timeUnit(TimeUnit.MILLISECONDS)
                .jvmArgs("-XX:+SegmentedCodeCache", "-XX:+AggressiveHeap")
                .threads(Runtime.getRuntime().availableProcessors() / 2)
                .addProfiler(AsyncProfiler.class, "libPath=/home/wuweijie/dev/async-profiler/async-profiler-2.8-linux-x64/build/libasyncProfiler.so;traces=0;flat=50;alluser=true")
                .build()).run();
    }
}
```

### 5.1.0

```
# JMH version: 1.33
# VM version: JDK 17.0.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.1+12-LTS-39
# VM invoker: /usr/local/java/jdk-17.0.1/bin/java
# VM options: -XX:+SegmentedCodeCache -XX:+AggressiveHeap
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 5 iterations, 3 s each
# Measurement: 5 iterations, 3 s each
# Timeout: 10 min per iteration
# Threads: 8 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench

# Run progress: 0.00% complete, ETA 00:01:30
# Fork: 1 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 2717.733 ops/ms
# Warmup Iteration   2: 3132.016 ops/ms
# Warmup Iteration   3: 3074.729 ops/ms
# Warmup Iteration   4: 3137.834 ops/ms
# Warmup Iteration   5: 3152.314 ops/ms
Iteration   1: 3138.202 ops/ms
Iteration   2: 3091.051 ops/ms
Iteration   3: 3130.710 ops/ms
Iteration   4: 3036.444 ops/ms
Iteration   5: [WARN] Unknown argument: summary
3119.229 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 33.33% complete, ETA 00:01:01
# Fork: 2 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 2873.575 ops/ms
# Warmup Iteration   2: 3120.873 ops/ms
# Warmup Iteration   3: 3097.420 ops/ms
# Warmup Iteration   4: 3124.724 ops/ms
# Warmup Iteration   5: 3089.387 ops/ms
Iteration   1: 3121.724 ops/ms
Iteration   2: 3123.199 ops/ms
Iteration   3: 3121.065 ops/ms
Iteration   4: 3108.972 ops/ms
Iteration   5: [WARN] Unknown argument: summary
3125.970 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 66.67% complete, ETA 00:00:30
# Fork: 3 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 2888.200 ops/ms
# Warmup Iteration   2: 3085.853 ops/ms
# Warmup Iteration   3: 3123.679 ops/ms
# Warmup Iteration   4: 3135.261 ops/ms
# Warmup Iteration   5: 3098.285 ops/ms
Iteration   1: 3129.475 ops/ms
Iteration   2: 3102.560 ops/ms
Iteration   3: 3123.368 ops/ms
Iteration   4: 3125.997 ops/ms
Iteration   5: [WARN] Unknown argument: summary
3101.138 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 


Result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench":
  3113.274 ±(99.9%) 26.429 ops/ms [Average]
  (min, avg, max) = (3036.444, 3113.274, 3138.202), stdev = 24.722
  CI (99.9%): [3086.845, 3139.703] (assumes normal distribution)

Secondary result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench:·async":
--- Execution profile ---
Total samples       : 11743
unknown_Java        : 776 (6.61%)
not_walkable_Java   : 1 (0.01%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 11784521144   10.00%     1175  java.util.Formatter.format
  8641669214    7.33%      860  java.lang.AbstractStringBuilder.ensureCapacityInternal
  7357883813    6.25%      734  java.util.ArrayList.add
  7012762110    5.95%      697  java.lang.StringLatin1.indexOf
  6683570924    5.67%      666  jbyte_disjoint_arraycopy
  5401537104    4.58%      539  com.google.common.base.Joiner.appendTo
  4867458078    4.13%      486  java.util.Formatter.parse
  4641170062    3.94%      464  java.lang.StringBuilder.append
  4279421030    3.63%      427  java.util.Formatter$Flags.contains
  4004845144    3.40%      399  java.lang.String.length
  3870866632    3.29%      387  java.lang.AbstractStringBuilder.append
  3650166103    3.10%      365  java.util.ArrayList.grow
  2841623561    2.41%      284  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
  2731834899    2.32%      272  java.util.ArrayList.elementData
  2532504798    2.15%      252  java.util.Formatter$FormatSpecifier.<init>
  2081678124    1.77%      207  java.util.LinkedList.listIterator
  2031755323    1.72%      201  java.lang.CharacterDataLatin1.isUpperCase
  1922044601    1.63%      191  java.util.LinkedList$ListItr.next
  1801168035    1.53%      180  java.util.Formatter.toString
  1740240224    1.48%      174  com.google.common.collect.Collections2$TransformedCollection.iterator
  1651954654    1.40%      164  java.lang.String.isLatin1
  1600451564    1.36%      159  java.lang.Object.<init>
  1512461696    1.28%      151  com.google.common.collect.Iterators$6.transform
  1432027471    1.22%      143  jlong_disjoint_arraycopy
  1351089415    1.15%      135  java.util.Formatter.<init>
  1241102194    1.05%      124  java.lang.String.format
  1131198294    0.96%      113  com.google.common.collect.TransformedIterator.<init>
  1100957209    0.93%      109  com.google.common.base.Preconditions.checkNotNull
  1070570512    0.91%      107  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
   890687799    0.76%       88  java.lang.AbstractStringBuilder.newCapacity
   870552663    0.74%       87  java.lang.String.getBytes
   868797992    0.74%       86  com.google.common.base.Joiner.toString
   861032404    0.73%       85  java.util.Formatter$Conversion.isValid
   820979835    0.70%       82  java.lang.String.charAt
   799996398    0.68%       80  jdk.internal.util.ArraysSupport.newLength
   770740856    0.65%       77  jbyte_arraycopy
   669819430    0.57%       67  java.util.LinkedList$ListItr.hasNext
   620274104    0.53%       62  java.lang.AbstractStringBuilder.putStringAt
   580208242    0.49%       58  com.google.common.collect.TransformedIterator.next
   530070678    0.45%       53  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   410258213    0.35%       41  java.lang.Character.isUpperCase
   390773843    0.33%       39  java.util.LinkedList.checkPositionIndex
   389930473    0.33%       39  java.lang.StringLatin1.charAt
   381090667    0.32%       38  java.util.Arrays.copyOf
   331339525    0.28%       33  com.google.common.collect.Iterators$6.<init>
   299274274    0.25%       30  ObjAllocator::initialize(HeapWordImpl**) const
   270451931    0.23%       27  java.util.LinkedList.isPositionIndex
   260576878    0.22%       26  org.openjdk.jmh.infra.Blackhole.consumeFull
   259996728    0.22%       26  java.lang.String.indexOf
   259942481    0.22%       26  ObjArrayAllocator::initialize(HeapWordImpl**) const
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11763
unknown_Java        : 594 (5.05%)
skipped             : 1 (0.01%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 16053080513   13.61%     1604  java.util.ArrayList.add
 15713816269   13.32%     1566  java.util.Formatter.format
  6751981135    5.72%      674  java.util.ArrayList.get
  6494407889    5.51%      646  java.util.Formatter.parse
  6125909324    5.19%      611  jbyte_disjoint_arraycopy
  5490486001    4.66%      549  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
  4660727455    3.95%      464  java.util.LinkedList$ListItr.next
  4001264370    3.39%      399  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
  3911887106    3.32%      389  java.util.Formatter$FormatSpecifier.print
  3612125285    3.06%      360  java.util.ArrayList.grow
  3331530960    2.82%      333  java.lang.String.getBytes
  2531562288    2.15%      253  com.google.common.base.Joiner.join
  2412467988    2.05%      241  java.lang.AbstractStringBuilder.append
  2241459315    1.90%      224  java.lang.StringLatin1.indexOf
  2240652425    1.90%      224  java.lang.AbstractStringBuilder.ensureCapacityInternal
  2061396718    1.75%      203  java.util.Formatter$FormatSpecifier.printString
  1800712217    1.53%      180  java.util.Objects.checkIndex
  1669676208    1.42%      167  com.google.common.collect.TransformedIterator.next
  1562107663    1.32%      156  java.lang.String.length
  1521282050    1.29%      152  java.lang.AbstractStringBuilder.appendChars
  1481646616    1.26%      148  jlong_disjoint_arraycopy
  1360761669    1.15%      136  com.google.common.collect.TransformedIterator.<init>
  1311395068    1.11%      131  com.google.common.collect.Iterators$6.transform
  1059300442    0.90%      106  java.util.Formatter$FormatSpecifier.index
   940043502    0.80%       94  com.google.common.collect.Iterators.transform
   910486576    0.77%       91  java.lang.String.format
   861481321    0.73%       85  java.lang.StringBuilder.append
   809662169    0.69%       81  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken$$Lambda$41.0x0000000800c2c4c0.apply
   800783968    0.68%       80  java.util.Formatter$Conversion.isValid
   790823695    0.67%       79  com.google.common.collect.TransformedIterator.hasNext
   771173739    0.65%       77  jbyte_arraycopy
   770474798    0.65%       76  java.util.Formatter$Flags.contains
   750655043    0.64%       75  com.google.common.base.Joiner.appendTo
   650410797    0.55%       65  java.lang.AbstractStringBuilder.checkRange
   630919350    0.53%       63  java.util.LinkedList$ListItr.<init>
   580844527    0.49%       57  java.util.LinkedList$ListItr.hasNext
   500487337    0.42%       50  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   440371690    0.37%       44  java.util.Formatter.<init>
   430669800    0.37%       43  java.util.Formatter$FixedString.print
   410529259    0.35%       41  java.lang.CharacterDataLatin1.isUpperCase
   400442922    0.34%       40  com.google.common.collect.Collections2$TransformedCollection.iterator
   370244487    0.31%       36  java.lang.AbstractStringBuilder.putStringAt
   370230606    0.31%       37  ObjArrayAllocator::initialize(HeapWordImpl**) const
   349861875    0.30%       35  java.lang.String.coder
   330291774    0.28%       33  com.google.common.base.Preconditions.checkNotNull
   320366772    0.27%       32  ObjAllocator::initialize(HeapWordImpl**) const
   300287310    0.25%       30  java.util.Formatter$FixedString.<init>
   289664110    0.25%       29  java.util.Formatter.ensureOpen
   240218481    0.20%       24  java.lang.AbstractStringBuilder.getCoder
   240163940    0.20%       24  org.openjdk.jmh.infra.Blackhole.consumeFull
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11755
unknown_Java        : 591 (5.03%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 22150308257   18.79%     2210  java.util.Formatter.format
 15373771513   13.04%     1534  java.util.ArrayList.add
  6723325806    5.70%      671  java.util.Formatter.parse
  6716147837    5.70%      668  jbyte_disjoint_arraycopy
  5481740269    4.65%      546  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
  4422008947    3.75%      441  java.util.LinkedList$ListItr.next
  3841063172    3.26%      384  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
  3612785381    3.06%      361  java.util.ArrayList.grow
  3141197633    2.66%      314  java.lang.String.getBytes
  3101373960    2.63%      307  java.util.Formatter$FormatSpecifier.print
  2673585479    2.27%      267  java.util.Formatter$FormatSpecifier.printString
  2462533790    2.09%      245  com.google.common.base.Joiner.join
  2261524435    1.92%      226  java.lang.StringLatin1.indexOf
  1940454542    1.65%      194  java.util.Formatter.<init>
  1883751704    1.60%      188  com.google.common.collect.TransformedIterator.<init>
  1731770288    1.47%      173  java.lang.AbstractStringBuilder.ensureCapacityInternal
  1660972422    1.41%      166  java.util.Formatter$FixedString.print
  1541178858    1.31%      154  java.lang.String.length
  1522002995    1.29%      152  com.google.common.collect.TransformedIterator.next
  1521826440    1.29%      152  java.lang.AbstractStringBuilder.appendChars
  1459735283    1.24%      146  java.util.Formatter$Flags.contains
  1341724476    1.14%      134  com.google.common.collect.Iterators$6.transform
  1301376877    1.10%      130  jlong_disjoint_arraycopy
  1239934609    1.05%      124  java.util.Objects.checkIndex
  1121569894    0.95%      112  java.lang.AbstractStringBuilder.append
  1011016656    0.86%       99  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken$$Lambda$37.0x0000000800c2ce40.apply
   920681490    0.78%       92  java.lang.StringBuilder.append
   871279781    0.74%       87  java.util.Formatter$Conversion.isValid
   790283858    0.67%       79  com.google.common.collect.TransformedIterator.hasNext
   780050839    0.66%       78  com.google.common.collect.Iterators.transform
   650048696    0.55%       65  jbyte_arraycopy
   620631101    0.53%       62  com.google.common.base.Joiner.appendTo
   620381030    0.53%       60  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   590669196    0.50%       59  java.lang.CharacterDataLatin1.isUpperCase
   560847625    0.48%       56  java.lang.AbstractStringBuilder.checkRange
   489784852    0.42%       49  java.util.LinkedList$ListItr.checkForComodification
   489445533    0.42%       48  java.util.ArrayList.elementData
   480558649    0.41%       48  java.lang.String.format
   441487523    0.37%       44  java.lang.AbstractStringBuilder.putStringAt
   429959628    0.36%       43  java.util.LinkedList$ListItr.<init>
   389869899    0.33%       39  java.util.Arrays.copyOf
   370195280    0.31%       37  java.util.Formatter$FormatSpecifier.index
   331086038    0.28%       33  java.util.Formatter.ensureOpen
   320458295    0.27%       32  java.lang.StringLatin1.charAt
   310193749    0.26%       31  com.google.common.collect.Iterators$6.<init>
   280098314    0.24%       28  ObjAllocator::initialize(HeapWordImpl**) const
   260692994    0.22%       26  com.google.common.base.Preconditions.checkNotNull
   260302223    0.22%       26  java.util.LinkedList$ListItr.hasNext
   259804307    0.22%       26  com.google.common.collect.Collections2$TransformedCollection.iterator
   240271062    0.20%       23  java.lang.String.coder
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt


# Run complete. Total time: 00:01:31

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                               Mode  Cnt     Score    Error   Units
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  3113.274 ± 26.429  ops/ms
EncryptParameterAssignmentTokenBenchmark.bench:·async  thrpt            NaN              ---

```


### 5.1.2-SNAPSHOT before PR

```
# JMH version: 1.33
# VM version: JDK 17.0.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.1+12-LTS-39
# VM invoker: /usr/local/java/jdk-17.0.1/bin/java
# VM options: -XX:+SegmentedCodeCache -XX:+AggressiveHeap
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 5 iterations, 3 s each
# Measurement: 5 iterations, 3 s each
# Timeout: 10 min per iteration
# Threads: 8 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench

# Run progress: 0.00% complete, ETA 00:01:30
# Fork: 1 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 10982.734 ops/ms
# Warmup Iteration   2: 12016.189 ops/ms
# Warmup Iteration   3: 12614.704 ops/ms
# Warmup Iteration   4: 12421.049 ops/ms
# Warmup Iteration   5: 12397.115 ops/ms
Iteration   1: 12813.243 ops/ms
Iteration   2: 13299.679 ops/ms
Iteration   3: 13329.727 ops/ms
Iteration   4: 13131.997 ops/ms
Iteration   5: [WARN] Unknown argument: summary
13242.945 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 33.33% complete, ETA 00:01:01
# Fork: 2 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 12476.148 ops/ms
# Warmup Iteration   2: 13217.482 ops/ms
# Warmup Iteration   3: 13089.608 ops/ms
# Warmup Iteration   4: 13112.485 ops/ms
# Warmup Iteration   5: 13316.740 ops/ms
Iteration   1: 13009.852 ops/ms
Iteration   2: 13261.832 ops/ms
Iteration   3: 13282.142 ops/ms
Iteration   4: 13213.555 ops/ms
Iteration   5: [WARN] Unknown argument: summary
13223.462 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 66.67% complete, ETA 00:00:30
# Fork: 3 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 12054.380 ops/ms
# Warmup Iteration   2: 12814.121 ops/ms
# Warmup Iteration   3: 12911.213 ops/ms
# Warmup Iteration   4: 12768.089 ops/ms
# Warmup Iteration   5: 12990.655 ops/ms
Iteration   1: 12932.934 ops/ms
Iteration   2: 12876.084 ops/ms
Iteration   3: 12976.064 ops/ms
Iteration   4: 12674.833 ops/ms
Iteration   5: [WARN] Unknown argument: summary
12737.041 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 


Result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench":
  13067.026 ±(99.9%) 235.881 ops/ms [Average]
  (min, avg, max) = (12674.833, 13067.026, 13329.727), stdev = 220.643
  CI (99.9%): [12831.145, 13302.907] (assumes normal distribution)

Secondary result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench:·async":
--- Execution profile ---
Total samples       : 11718
unknown_Java        : 7 (0.06%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 25422143718   21.61%     2535  java.lang.String.join
 20273384635   17.24%     2020  java.util.LinkedList$ListItr.next
 17184727438   14.61%     1708  jbyte_disjoint_arraycopy
  8100784888    6.89%      809  java.util.LinkedList.isPositionIndex
  6637031314    5.64%      662  java.util.LinkedList$ListItr.checkForComodification
  5813534056    4.94%      579  com.google.common.collect.TransformedIterator.<init>
  3769148376    3.20%      374  java.util.LinkedList.checkPositionIndex
  3038949965    2.58%      304  jbyte_arraycopy
  2991474419    2.54%      296  com.google.common.collect.TransformedIterator.next
  2730184282    2.32%      273  java.lang.Object.<init>
  2720294112    2.31%      272  com.google.common.collect.Collections2$TransformedCollection.iterator
  1941054417    1.65%      193  jint_disjoint_arraycopy
  1520162867    1.29%      152  com.google.common.collect.Iterators.transform
  1470592834    1.25%      146  java.util.LinkedList$ListItr.<init>
  1231302377    1.05%      123  java.lang.String.coder
  1070931378    0.91%      107  java.util.LinkedList.node
  1011898476    0.86%      101  com.google.common.collect.TransformedIterator.hasNext
  1011788266    0.86%      101  java.lang.String.length
   920992730    0.78%       91  org.openjdk.jmh.infra.Blackhole.consumeFull
   731061757    0.62%       73  java.util.Arrays.copyOf
   730987692    0.62%       73  java.util.Objects.requireNonNull
   520450301    0.44%       52  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
   519640783    0.44%       52  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   510016127    0.43%       51  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
   489649890    0.42%       49  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   439873410    0.37%       44  com.google.common.collect.Iterators$6.<init>
   401012097    0.34%       40  java.util.LinkedList.listIterator
   400669972    0.34%       40  java.util.AbstractSequentialList.iterator
   350618581    0.30%       35  java.util.AbstractList.listIterator
   340060612    0.29%       34  com.google.common.base.Preconditions.checkNotNull
   339977954    0.29%       34  ObjArrayAllocator::initialize(HeapWordImpl**) const
   260290216    0.22%       26  ObjAllocator::initialize(HeapWordImpl**) const
   240105360    0.20%       24  com.google.common.collect.Collections2.transform
   229973246    0.20%       23  OptoRuntime::new_instance_C(Klass*, JavaThread*)
   190501803    0.16%       19  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
   169938302    0.14%       17  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
   140913634    0.12%       14  org.openjdk.jmh.infra.Blackhole.consume
   130263009    0.11%       13  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
   130214463    0.11%       13  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
   129984554    0.11%       13  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
   110150503    0.09%       10  SharedRuntime::on_slowpath_allocation_exit(JavaThread*)
   110000066    0.09%       11  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
    90156962    0.08%        9  com.google.common.collect.Collections2$TransformedCollection.<init>
    90118203    0.08%        9  MemAllocator::allocate() const
    79994759    0.07%        7  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    70162174    0.06%        7  HandleMark::initialize(Thread*)
    60136876    0.05%        6  __tls_get_addr
    60099995    0.05%        6  JfrObjectAllocationSample::send_event(Klass const*, unsigned long, bool, Thread*)
    60017200    0.05%        6  InstanceKlass::allocate_objArray(int, int, JavaThread*)
    50873299    0.04%        5  CardTableBarrierSet::on_slowpath_allocation_exit(JavaThread*, oopDesc*)
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11721
unknown_Java        : 6 (0.05%)
not_walkable_Java   : 1 (0.01%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 25407671408   21.61%     2532  java.lang.String.join
 20358073035   17.31%     2026  java.util.LinkedList$ListItr.next
 16851968391   14.33%     1682  jbyte_disjoint_arraycopy
  8472570984    7.21%      845  java.util.LinkedList.isPositionIndex
  7045722938    5.99%      703  java.util.LinkedList$ListItr.checkForComodification
  5740868021    4.88%      573  com.google.common.collect.TransformedIterator.<init>
  3532573479    3.00%      353  java.util.LinkedList.checkPositionIndex
  3001327447    2.55%      300  jbyte_arraycopy
  2960669504    2.52%      296  com.google.common.collect.TransformedIterator.next
  2876305847    2.45%      286  com.google.common.collect.Collections2$TransformedCollection.iterator
  2844216133    2.42%      283  java.lang.Object.<init>
  1822121067    1.55%      182  jint_disjoint_arraycopy
  1491467723    1.27%      148  java.lang.String.coder
  1440951630    1.23%      144  java.util.LinkedList$ListItr.<init>
  1408722499    1.20%      141  com.google.common.collect.Iterators.transform
   990951367    0.84%       98  java.util.LinkedList.node
   949078463    0.81%       95  com.google.common.collect.TransformedIterator.hasNext
   892755285    0.76%       88  java.lang.String.length
   750143531    0.64%       75  org.openjdk.jmh.infra.Blackhole.consumeFull
   711770239    0.61%       71  java.util.Objects.requireNonNull
   581661677    0.49%       58  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
   552501273    0.47%       55  java.util.AbstractList.listIterator
   540485895    0.46%       54  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   499843567    0.43%       50  java.util.Arrays.copyOf
   479140435    0.41%       48  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
   470458677    0.40%       47  com.google.common.collect.Iterators$6.<init>
   459778354    0.39%       46  ObjAllocator::initialize(HeapWordImpl**) const
   440926588    0.38%       44  java.util.AbstractSequentialList.iterator
   360351797    0.31%       36  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   280128262    0.24%       28  com.google.common.base.Preconditions.checkNotNull
   260126660    0.22%       26  ObjArrayAllocator::initialize(HeapWordImpl**) const
   239917195    0.20%       24  org.openjdk.jmh.infra.Blackhole.consume
   230379654    0.20%       23  OptoRuntime::new_instance_C(Klass*, JavaThread*)
   220119078    0.19%       22  com.google.common.collect.Collections2.transform
   210589045    0.18%       21  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
   210169181    0.18%       21  java.util.LinkedList.listIterator
   160189601    0.14%       16  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
   159954788    0.14%       16  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
   151048956    0.13%       15  MemAllocator::allocate() const
   120172159    0.10%       12  HandleMark::initialize(Thread*)
   110146411    0.09%       11  SharedRuntime::on_slowpath_allocation_exit(JavaThread*)
   100234067    0.09%       10  __tls_get_addr
    99493768    0.08%       10  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    91070441    0.08%        9  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
    90013770    0.08%        9  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
    70193839    0.06%        7  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
    70187714    0.06%        7  com.google.common.collect.Collections2$TransformedCollection.<init>
    60072594    0.05%        6  MutableSpace::cas_allocate(unsigned long)
    50735063    0.04%        5  PSCardTable::is_in_young(oopDesc*) const
    50212132    0.04%        5  ThreadLocalAllocBuffer::insert_filler()
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11732
unknown_Java        : 15 (0.13%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 21032200274   17.87%     2099  java.lang.String.join
 17970699778   15.27%     1789  jbyte_disjoint_arraycopy
 17535469834   14.90%     1750  java.util.Arrays.copyOf
  6875061035    5.84%      686  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.lambda$toString$0
  6692619843    5.69%      668  com.google.common.collect.TransformedIterator.<init>
  5803863716    4.93%      578  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken$$Lambda$37.0x0000000800c2c720.apply
  5395057269    4.58%      535  jdk.internal.misc.Unsafe.allocateUninitializedArray
  3751856865    3.19%      375  java.util.LinkedList$ListItr.hasNext
  3514047857    2.99%      349  java.lang.String.coder
  3340160907    2.84%      332  java.util.LinkedList$ListItr.checkForComodification
  3111286513    2.64%      311  jbyte_arraycopy
  2842156825    2.41%      284  com.google.common.collect.TransformedIterator.hasNext
  2569244237    2.18%      257  com.google.common.collect.Iterators$6.transform
  2109824554    1.79%      210  com.google.common.collect.TransformedIterator.next
  1830051885    1.55%      183  java.util.LinkedList$ListItr.next
  1780841821    1.51%      178  com.google.common.collect.Iterators$6.<init>
  1539759728    1.31%      154  java.lang.String.valueOf
  1342386237    1.14%      134  java.lang.String.getBytes
  1311210992    1.11%      131  java.lang.StringConcatHelper.newArray
   860471594    0.73%       85  jint_disjoint_arraycopy
   831603101    0.71%       83  java.lang.String.length
   670569824    0.57%       66  org.openjdk.jmh.infra.Blackhole.consumeFull
   470907326    0.40%       47  java.util.LinkedList.listIterator
   430902287    0.37%       43  com.google.common.collect.Collections2.transform
   370235968    0.31%       37  ObjArrayAllocator::initialize(HeapWordImpl**) const
   360166291    0.31%       36  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   320192823    0.27%       32  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   311984319    0.27%       31  java.util.AbstractSequentialList.iterator
   220493831    0.19%       22  com.google.common.collect.Collections2$TransformedCollection.<init>
   190060276    0.16%       19  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
   190031424    0.16%       19  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
   180252365    0.15%       18  java.util.LinkedList.node
   139940866    0.12%       14  ObjAllocator::initialize(HeapWordImpl**) const
   130395374    0.11%       13  java.util.LinkedList$ListItr.<init>
   129599414    0.11%       13  org.openjdk.jmh.infra.Blackhole.consume
   110355004    0.09%       11  OptoRuntime::new_instance_C(Klass*, JavaThread*)
   110152877    0.09%       11  MemAllocator::allocate() const
   110007057    0.09%       11  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
   100060687    0.09%       10  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    99962868    0.08%       10  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
    90123669    0.08%        9  HandleMark::initialize(Thread*)
    80001328    0.07%        8  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
    70386597    0.06%        7  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
    50628235    0.04%        4  __tls_get_addr
    50231317    0.04%        5  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
    50063513    0.04%        5  CollectedHeap::tlab_alloc_reserve() const
    50023270    0.04%        5  MutableSpace::cas_allocate(unsigned long)
    49985319    0.04%        5  ThreadLocalAllocBuffer::insert_filler()
    49953429    0.04%        5  MemAllocator::Allocation::check_out_of_memory()
    40214680    0.03%        4  AllocTracer::send_allocation_in_new_tlab(Klass*, HeapWordImpl**, unsigned long, unsigned long, JavaThread*)
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt


# Run complete. Total time: 00:01:31

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                               Mode  Cnt      Score     Error   Units
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  13067.026 ± 235.881  ops/ms
EncryptParameterAssignmentTokenBenchmark.bench:·async  thrpt             NaN               ---

```


### 5.1.2-SNAPSHOT after PR

```
# JMH version: 1.33
# VM version: JDK 17.0.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.1+12-LTS-39
# VM invoker: /usr/local/java/jdk-17.0.1/bin/java
# VM options: -XX:+SegmentedCodeCache -XX:+AggressiveHeap
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 5 iterations, 3 s each
# Measurement: 5 iterations, 3 s each
# Timeout: 10 min per iteration
# Threads: 8 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench

# Run progress: 0.00% complete, ETA 00:01:30
# Fork: 1 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 11857.156 ops/ms
# Warmup Iteration   2: 13081.091 ops/ms
# Warmup Iteration   3: 13055.990 ops/ms
# Warmup Iteration   4: 12875.185 ops/ms
# Warmup Iteration   5: 14040.790 ops/ms
Iteration   1: 13836.124 ops/ms
Iteration   2: 14016.284 ops/ms
Iteration   3: 13975.880 ops/ms
Iteration   4: 13854.622 ops/ms
Iteration   5: [WARN] Unknown argument: summary
14040.379 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 33.33% complete, ETA 00:01:01
# Fork: 2 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 13159.989 ops/ms
# Warmup Iteration   2: 13865.879 ops/ms
# Warmup Iteration   3: 14002.878 ops/ms
# Warmup Iteration   4: 13742.966 ops/ms
# Warmup Iteration   5: 13862.933 ops/ms
Iteration   1: 13723.511 ops/ms
Iteration   2: 14011.851 ops/ms
Iteration   3: 13819.349 ops/ms
Iteration   4: 13703.142 ops/ms
Iteration   5: [WARN] Unknown argument: summary
13618.464 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 

# Run progress: 66.67% complete, ETA 00:00:30
# Fork: 3 of 3
# Preparing profilers: AsyncProfiler 
# Warmup Iteration   1: 13136.095 ops/ms
# Warmup Iteration   2: 13953.217 ops/ms
# Warmup Iteration   3: 13810.267 ops/ms
# Warmup Iteration   4: 13924.420 ops/ms
# Warmup Iteration   5: 13921.736 ops/ms
Iteration   1: 13497.128 ops/ms
Iteration   2: 13998.156 ops/ms
Iteration   3: 13956.974 ops/ms
Iteration   4: 14008.003 ops/ms
Iteration   5: [WARN] Unknown argument: summary
13974.212 ops/ms
                 ·async: (text only)

# Processing profiler results: AsyncProfiler 


Result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench":
  13868.939 ±(99.9%) 178.703 ops/ms [Average]
  (min, avg, max) = (13497.128, 13868.939, 14040.379), stdev = 167.159
  CI (99.9%): [13690.235, 14047.642] (assumes normal distribution)

Secondary result "icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench:·async":
--- Execution profile ---
Total samples       : 11774
unknown_Java        : 10 (0.08%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 24534216900   20.79%     2449  java.lang.String.length
 21286705280   18.04%     2120  jbyte_disjoint_arraycopy
 19982596763   16.94%     1995  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
 10617180311    9.00%     1060  java.lang.String.getBytes
  7844180707    6.65%      779  java.util.LinkedList$ListItr.next
  5851967010    4.96%      585  java.lang.String.join
  4930099002    4.18%      493  java.util.StringJoiner.checkAddLength
  4782199100    4.05%      478  java.lang.String.coder
  4273237706    3.62%      427  java.util.StringJoiner.add
  3671842337    3.11%      367  jbyte_arraycopy
  2643080298    2.24%      264  java.lang.String.valueOf
   850750013    0.72%       85  java.util.LinkedList$ListItr.hasNext
   810442793    0.69%       81  org.openjdk.jmh.infra.Blackhole.consumeFull
   780087919    0.66%       78  jdk.internal.misc.Unsafe.allocateUninitializedArray
   720317773    0.61%       72  jint_disjoint_arraycopy
   681504261    0.58%       68  java.util.Arrays.copyOf
   420110605    0.36%       42  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   330089121    0.28%       33  java.lang.System$2.join
   320934047    0.27%       32  java.util.LinkedList$ListItr.checkForComodification
   320288426    0.27%       32  ObjArrayAllocator::initialize(HeapWordImpl**) const
   310179704    0.26%       31  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   259863403    0.22%       26  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
   200096988    0.17%       20  ObjAllocator::initialize(HeapWordImpl**) const
   140159406    0.12%       14  java.util.StringJoiner.toString
   120265233    0.10%       12  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
   120110364    0.10%       12  org.openjdk.jmh.infra.Blackhole.consume
   100241164    0.08%       10  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
   100044903    0.08%       10  OptoRuntime::new_instance_C(Klass*, JavaThread*)
    89674813    0.08%        9  __tls_get_addr
    79986260    0.07%        8  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
    70124192    0.06%        7  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
    60071865    0.05%        6  java.util.LinkedList$ListItr.<init>
    60040777    0.05%        6  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
    50136135    0.04%        5  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    50118210    0.04%        5  InstanceKlass::array_klass(int, JavaThread*)
    50021021    0.04%        5  MemAllocator::allocate() const
    49986526    0.04%        5  HandleMark::initialize(Thread*)
    49970210    0.04%        5  SharedRuntime::on_slowpath_allocation_exit(JavaThread*)
    30111822    0.03%        3  __memset_avx2_unaligned_erms
    30047096    0.03%        3  CardTableBarrierSet::on_slowpath_allocation_exit(JavaThread*, oopDesc*)
    30037245    0.03%        3  CollectedHeap::tlab_alloc_reserve() const
    30026622    0.03%        3  InstanceKlass::allocate_objArray(int, int, JavaThread*)
    29996094    0.03%        3  JfrObjectAllocationSample::send_event(Klass const*, unsigned long, bool, Thread*)
    20014461    0.02%        2  Klass::check_array_allocation_length(int, int, JavaThread*)
    20005077    0.02%        2  ClassLoaderData::holder_phantom() const
    19907406    0.02%        2  java.util.LinkedList.node
    10296267    0.01%        1  pthread_cond_timedwait@@GLIBC_2.3.2
    10244705    0.01%        1  __tls_get_addr_slow
    10186624    0.01%        1  __GI___clock_gettime
    10152435    0.01%        1  AllocTracer::send_allocation_in_new_tlab(Klass*, HeapWordImpl**, unsigned long, unsigned long, JavaThread*)
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11741
unknown_Java        : 9 (0.08%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 37659565780   31.98%     3753  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
 14190124245   12.05%     1415  jbyte_disjoint_arraycopy
 11761823925    9.99%     1173  java.lang.String.length
  7755296202    6.59%      773  java.util.Arrays.copyOf
  6168772974    5.24%      616  java.util.StringJoiner.add
  5127275781    4.35%      512  java.lang.String.valueOf
  4159348175    3.53%      415  java.util.LinkedList.listIterator
  4135042396    3.51%      410  java.lang.String.join
  3470372872    2.95%      347  java.util.AbstractList.listIterator
  3323929801    2.82%      332  java.util.LinkedList$ListItr.<init>
  3242901455    2.75%      323  jbyte_arraycopy
  2881470602    2.45%      288  java.util.StringJoiner.checkAddLength
  2121455059    1.80%      211  java.util.LinkedList$ListItr.next
  1501271072    1.27%      150  java.util.LinkedList$ListItr.hasNext
  1490509620    1.27%      149  java.lang.String.coder
  1392574208    1.18%      139  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
  1031594933    0.88%      103  java.util.LinkedList.node
   919937077    0.78%       92  jint_disjoint_arraycopy
   790333433    0.67%       77  org.openjdk.jmh.infra.Blackhole.consumeFull
   479792252    0.41%       48  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   440184157    0.37%       44  java.util.AbstractSequentialList.iterator
   399165940    0.34%       40  ObjArrayAllocator::initialize(HeapWordImpl**) const
   360371925    0.31%       36  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   339654395    0.29%       34  java.util.LinkedList$ListItr.checkForComodification
   290849478    0.25%       29  java.lang.Object.<init>
   270268486    0.23%       27  java.util.LinkedList.checkPositionIndex
   218366157    0.19%       22  ObjAllocator::initialize(HeapWordImpl**) const
   160128504    0.14%       15  java.util.StringJoiner.<init>
   150015551    0.13%       15  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
   140494938    0.12%       14  MemAllocator::allocate() const
   139703052    0.12%       14  org.openjdk.jmh.infra.Blackhole.consume
   129973451    0.11%       13  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
   110341309    0.09%       11  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
   100145453    0.09%       10  __tls_get_addr
    90185345    0.08%        9  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
    90119634    0.08%        9  OptoRuntime::new_instance_C(Klass*, JavaThread*)
    80111432    0.07%        8  SharedRuntime::on_slowpath_allocation_exit(JavaThread*)
    79997177    0.07%        8  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
    70009206    0.06%        7  oopFactory::new_typeArray(BasicType, int, JavaThread*)
    69997282    0.06%        7  Klass::check_array_allocation_length(int, int, JavaThread*)
    40163042    0.03%        4  ParallelScavengeHeap::allocate_new_tlab(unsigned long, unsigned long, unsigned long*)
    39991662    0.03%        4  CardTableBarrierSet::on_slowpath_allocation_exit(JavaThread*, oopDesc*)
    30647119    0.03%        3  __memset_avx2_unaligned_erms
    30015007    0.03%        3  ThreadLocalAllocBuffer::insert_filler()
    29960234    0.03%        3  CollectedHeap::tlab_alloc_reserve() const
    21226230    0.02%        2  JfrObjectAllocationSample::send_event(Klass const*, unsigned long, bool, Thread*)
    20113395    0.02%        2  AllocTracer::send_allocation_in_new_tlab(Klass*, HeapWordImpl**, unsigned long, unsigned long, JavaThread*)
    20067342    0.02%        2  InstanceKlass::array_klass(int, JavaThread*)
    20044462    0.02%        2  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    20002568    0.02%        2  java.util.LinkedList.isPositionIndex
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt
--- Execution profile ---
Total samples       : 11760
unknown_Java        : 11 (0.09%)

          ns  percent  samples  top
  ----------  -------  -------  ---
 42030838882   35.65%     4192  org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptParameterAssignmentToken.toString
 14144016925   12.00%     1409  jbyte_disjoint_arraycopy
 10155434036    8.61%     1014  java.lang.String.length
  8135355125    6.90%      813  java.util.Arrays.copyOf
  5651415379    4.79%      565  java.util.StringJoiner.add
  4703787582    3.99%      470  java.lang.String.join
  4422580018    3.75%      441  java.lang.String.coder
  4253473982    3.61%      425  java.util.LinkedList$ListItr.next
  4014940203    3.41%      401  java.util.LinkedList.checkPositionIndex
  3660836768    3.11%      364  jbyte_arraycopy
  3189535596    2.71%      318  java.util.LinkedList$ListItr.<init>
  2042569839    1.73%      202  java.lang.String.valueOf
  1259926636    1.07%      126  java.util.LinkedList$ListItr.hasNext
  1159916086    0.98%      116  java.util.AbstractSequentialList.iterator
   930852393    0.79%       93  jint_disjoint_arraycopy
   860790848    0.73%       86  org.openjdk.jmh.infra.Blackhole.consumeFull
   830239213    0.70%       83  java.lang.String.toString
   790559482    0.67%       79  java.util.StringJoiner.checkAddLength
   610759078    0.52%       61  java.util.LinkedList.listIterator
   550599970    0.47%       55  java.util.AbstractList.listIterator
   461706749    0.39%       46  java.lang.System$2.join
   439807928    0.37%       44  MemAllocator::Allocation::notify_allocation_jfr_sampler()
   380144346    0.32%       38  ObjArrayAllocator::initialize(HeapWordImpl**) const
   361367806    0.31%       36  icu.wwj.jmh.shardingsphere5.code.jmh_generated.EncryptParameterAssignmentTokenBenchmark_bench_jmhTest.bench_thrpt_jmhStub
   320336651    0.27%       32  icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench
   259775339    0.22%       26  java.util.LinkedList.node
   210431033    0.18%       21  org.openjdk.jmh.infra.Blackhole.consume
   210026187    0.18%       20  TypeArrayKlass::allocate_common(int, bool, JavaThread*)
   170543290    0.14%       17  MemAllocator::allocate() const
   160344186    0.14%       16  ObjAllocator::initialize(HeapWordImpl**) const
   149966516    0.13%       15  java.util.StringJoiner.<init>
   120844231    0.10%       12  java.lang.Object.<init>
   110200747    0.09%       11  OptoRuntime::new_instance_C(Klass*, JavaThread*)
   110007527    0.09%       11  MemAllocator::allocate_inside_tlab_slow(MemAllocator::Allocation&) const
    99962415    0.08%       10  OptoRuntime::new_array_C(Klass*, int, JavaThread*)
    90097595    0.08%        9  ParallelScavengeHeap::unsafe_max_tlab_alloc(Thread*) const
    80392918    0.07%        8  MutableSpace::cas_allocate(unsigned long)
    70011366    0.06%        7  SharedRuntime::on_slowpath_allocation_exit(JavaThread*)
    69997015    0.06%        7  CollectedHeap::fill_with_dummy_object(HeapWordImpl**, HeapWordImpl**, bool)
    69909896    0.06%        7  HandleMark::initialize(Thread*)
    60024204    0.05%        6  __tls_get_addr
    50457603    0.04%        5  ThreadLocalAllocBuffer::fill(HeapWordImpl**, HeapWordImpl**, unsigned long)
    50049986    0.04%        5  __memset_avx2_unaligned_erms
    40204267    0.03%        4  CardTableBarrierSet::on_slowpath_allocation_exit(JavaThread*, oopDesc*)
    40092713    0.03%        4  PSCardTable::is_in_young(oopDesc*) const
    30035157    0.03%        3  CollectedHeap::tlab_alloc_reserve() const
    20581093    0.02%        2  pthread_cond_timedwait@@GLIBC_2.3.2
    20206999    0.02%        2  java.util.StringJoiner.toString
    20038912    0.02%        2  HandleMark::~HandleMark()
    20036067    0.02%        2  ThreadLocalAllocBuffer::print_stats(char const*)
Async profiler results:
  /home/wuweijie/projects/database-jmh/icu.wwj.jmh.shardingsphere5.code.EncryptParameterAssignmentTokenBenchmark.bench-Throughput/summary-cpu.txt


# Run complete. Total time: 00:01:31

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                               Mode  Cnt      Score     Error   Units
EncryptParameterAssignmentTokenBenchmark.bench         thrpt   15  13868.939 ± 178.703  ops/ms
EncryptParameterAssignmentTokenBenchmark.bench:·async  thrpt             NaN               ---
```
