### PR TITLE
Fix bug: set default shadow algorithm by error name in example

### DIFF
--- a/examples/shardingsphere-jdbc-example/single-feature-example/shadow-example/shadow-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/shadow/raw/jdbc/config/ShadowDefaultAlgorithmConfiguration.java
+++ b/examples/shardingsphere-jdbc-example/single-feature-example/shadow-example/shadow-raw-jdbc-example/src/main/java/org/apache/shardingsphere/example/shadow/raw/jdbc/config/ShadowDefaultAlgorithmConfiguration.java
@@ -47,7 +47,7 @@ public final class ShadowDefaultAlgorithmConfiguration extends BaseShadowConfigu
     
     private RuleConfiguration createShadowRuleConfiguration() {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
-        result.setDefaultShadowAlgorithmName("simple-note-algorithm");
+        result.setDefaultShadowAlgorithmName("simple-hint-algorithm");
         result.setShadowAlgorithms(createShadowAlgorithmConfigurations());
         result.setDataSources(createShadowDataSources());
         result.setTables(createShadowTables());


### PR DESCRIPTION
##  Fix bug: set default shadow algorithm by error name

Fixes  #17697.

Changes proposed in this pull request:
-  Fix bug: set default shadow algorithm by error name in example
