### PR TITLE
Add support for more JSR-310 related classes about JDBC Timestamp in IntervalShardingAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingVal
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
 
 import java.time.Instant;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingVal
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -34,10 +35,10 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -161,20 +162,14 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     }
     
     private String getDateTimeText(final Comparable<?> endpoint) {
-        if (endpoint instanceof LocalDateTime) {
-            return ((LocalDateTime) endpoint).format(dateTimeFormatter);
+        if (endpoint instanceof LocalDateTime || endpoint instanceof ZonedDateTime || endpoint instanceof OffsetDateTime) {
+            return dateTimeFormatter.format((TemporalAccessor) endpoint);
         }
         if (endpoint instanceof Instant) {
-            return dateTimeFormatter.withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault()).format(((Instant) endpoint));
-        }
-        if (endpoint instanceof OffsetDateTime) {
-            return dateTimeFormatter.withZone(ZoneId.systemDefault()).format(((OffsetDateTime) endpoint));
-        }
-        if (endpoint instanceof ZonedDateTime) {
-            return dateTimeFormatter.withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault()).format(((ZonedDateTime) endpoint));
+            return dateTimeFormatter.withZone(ZoneId.systemDefault()).format((Instant) endpoint);
         }
         if (endpoint instanceof Date) {
-            return ((Date) endpoint).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().format(dateTimeFormatter);
+            return dateTimeFormatter.format(((Date) endpoint).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         }
         return endpoint.toString();
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -26,14 +26,18 @@ import org.apache.shardingsphere.sharding.api.sharding.standard.PreciseShardingV
 import org.apache.shardingsphere.sharding.api.sharding.standard.RangeShardingValue;
 import org.apache.shardingsphere.sharding.api.sharding.standard.StandardShardingAlgorithm;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -159,6 +163,15 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     private String getDateTimeText(final Comparable<?> endpoint) {
         if (endpoint instanceof LocalDateTime) {
             return ((LocalDateTime) endpoint).format(dateTimeFormatter);
+        }
+        if (endpoint instanceof Instant) {
+            return dateTimeFormatter.withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault()).format(((Instant) endpoint));
+        }
+        if (endpoint instanceof OffsetDateTime) {
+            return dateTimeFormatter.withZone(ZoneId.systemDefault()).format(((OffsetDateTime) endpoint));
+        }
+        if (endpoint instanceof ZonedDateTime) {
+            return dateTimeFormatter.withLocale(Locale.getDefault()).withZone(ZoneId.systemDefault()).format(((ZonedDateTime) endpoint));
         }
         if (endpoint instanceof Date) {
             return ((Date) endpoint).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime().format(dateTimeFormatter);

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -241,60 +241,40 @@ public final class IntervalShardingAlgorithmTest {
     }
     
     @Test
-    public void assertLocalDateTimeWithZeroMillisecond() {
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+    @SneakyThrows(ParseException.class)
+    public void assertTimestampInJDBCTypeWithZeroMillisecond() {
+        Collection<String> actualAsLocalDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(LocalDateTime.of(2021, 6, 15, 2, 25, 27), LocalDateTime.of(2021, 7, 31, 2, 25, 27))));
-        assertThat(actual.size(), is(24));
-    }
-    
-    @Test
-    @SneakyThrows(ParseException.class)
-    public void assertDateWithZeroMillisecond() {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
-                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
-                        Range.closed(simpleDateFormat.parse("2021-06-15 02:25:27.000"), simpleDateFormat.parse("2021-07-31 02:25:27.000"))));
-        assertThat(actual.size(), is(24));
-    }
-
-    @Test
-    public void assertInstantWithZeroMillisecond() {
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+        Collection<String> actualAsInstant = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 LocalDateTime.of(2021, 6, 15, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant(),
                                 LocalDateTime.of(2021, 7, 31, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant())));
-        assertThat(actual.size(), is(24));
-    }
-
-    @Test
-    public void assertTimestampWithZeroMillisecond() {
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+        Collection<String> actualAsTimestamp = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 Timestamp.valueOf(LocalDateTime.of(2021, 6, 15, 2, 25, 27)),
                                 Timestamp.valueOf(LocalDateTime.of(2021, 7, 31, 2, 25, 27)))));
-        assertThat(actual.size(), is(24));
-    }
-
-    @Test
-    public void assertOffsetDateTimeWithZeroMillisecond() {
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+        Collection<String> actualAsOffsetDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
-                                OffsetDateTime.of(LocalDateTime.of(2021, 6, 15, 2, 25, 27), OffsetDateTime.now().getOffset()),
-                                OffsetDateTime.of(LocalDateTime.of(2021, 7, 31, 2, 25, 27), OffsetDateTime.now().getOffset()))));
-        assertThat(actual.size(), is(24));
-    }
-
-    @Test
-    public void assertZonedDateTimeWithZeroMillisecond() {
-        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                                OffsetDateTime.of(2021, 6, 15, 2, 25, 27, 0, OffsetDateTime.now().getOffset()),
+                                OffsetDateTime.of(2021, 7, 31, 2, 25, 27, 0, OffsetDateTime.now().getOffset()))));
+        Collection<String> actualAsZonedDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
-                                ZonedDateTime.of(LocalDateTime.of(2021, 6, 15, 2, 25, 27), ZoneId.systemDefault()),
-                                ZonedDateTime.of(LocalDateTime.of(2021, 7, 31, 2, 25, 27), ZoneId.systemDefault()))));
-        assertThat(actual.size(), is(24));
+                                ZonedDateTime.of(2021, 6, 15, 2, 25, 27, 0, ZoneId.systemDefault()),
+                                ZonedDateTime.of(2021, 7, 31, 2, 25, 27, 0, ZoneId.systemDefault()))));
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
+        Collection<String> actualAsDate = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(simpleDateFormat.parse("2021-06-15 02:25:27.000"), simpleDateFormat.parse("2021-07-31 02:25:27.000"))));
+        assertThat(actualAsLocalDateTime.size(), is(24));
+        assertThat(actualAsInstant.size(), is(24));
+        assertThat(actualAsTimestamp.size(), is(24));
+        assertThat(actualAsOffsetDateTime.size(), is(24));
+        assertThat(actualAsZonedDateTime.size(), is(24));
+        assertThat(actualAsDate.size(), is(24));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -27,9 +27,13 @@ import org.apache.shardingsphere.sharding.factory.ShardingAlgorithmFactory;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -251,6 +255,46 @@ public final class IntervalShardingAlgorithmTest {
         Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(simpleDateFormat.parse("2021-06-15 02:25:27.000"), simpleDateFormat.parse("2021-07-31 02:25:27.000"))));
+        assertThat(actual.size(), is(24));
+    }
+
+    @Test
+    public void assertInstantWithZeroMillisecond() {
+        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(
+                                LocalDateTime.of(2021, 6, 15, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant(),
+                                LocalDateTime.of(2021, 7, 31, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant())));
+        assertThat(actual.size(), is(24));
+    }
+
+    @Test
+    public void assertTimestampWithZeroMillisecond() {
+        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(
+                                Timestamp.valueOf(LocalDateTime.of(2021, 6, 15, 2, 25, 27)),
+                                Timestamp.valueOf(LocalDateTime.of(2021, 7, 31, 2, 25, 27)))));
+        assertThat(actual.size(), is(24));
+    }
+
+    @Test
+    public void assertOffsetDateTimeWithZeroMillisecond() {
+        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(
+                                OffsetDateTime.of(LocalDateTime.of(2021, 6, 15, 2, 25, 27), OffsetDateTime.now().getOffset()),
+                                OffsetDateTime.of(LocalDateTime.of(2021, 7, 31, 2, 25, 27), OffsetDateTime.now().getOffset()))));
+        assertThat(actual.size(), is(24));
+    }
+
+    @Test
+    public void assertZonedDateTimeWithZeroMillisecond() {
+        Collection<String> actual = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(
+                                ZonedDateTime.of(LocalDateTime.of(2021, 6, 15, 2, 25, 27), ZoneId.systemDefault()),
+                                ZonedDateTime.of(LocalDateTime.of(2021, 7, 31, 2, 25, 27), ZoneId.systemDefault()))));
         assertThat(actual.size(), is(24));
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -246,35 +246,35 @@ public final class IntervalShardingAlgorithmTest {
         Collection<String> actualAsLocalDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(LocalDateTime.of(2021, 6, 15, 2, 25, 27), LocalDateTime.of(2021, 7, 31, 2, 25, 27))));
+        assertThat(actualAsLocalDateTime.size(), is(24));
         Collection<String> actualAsInstant = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 LocalDateTime.of(2021, 6, 15, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant(),
                                 LocalDateTime.of(2021, 7, 31, 2, 25, 27).atZone(ZoneId.systemDefault()).toInstant())));
+        assertThat(actualAsInstant.size(), is(24));
         Collection<String> actualAsTimestamp = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 Timestamp.valueOf(LocalDateTime.of(2021, 6, 15, 2, 25, 27)),
                                 Timestamp.valueOf(LocalDateTime.of(2021, 7, 31, 2, 25, 27)))));
+        assertThat(actualAsTimestamp.size(), is(24));
         Collection<String> actualAsOffsetDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 OffsetDateTime.of(2021, 6, 15, 2, 25, 27, 0, OffsetDateTime.now().getOffset()),
                                 OffsetDateTime.of(2021, 7, 31, 2, 25, 27, 0, OffsetDateTime.now().getOffset()))));
+        assertThat(actualAsOffsetDateTime.size(), is(24));
         Collection<String> actualAsZonedDateTime = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(
                                 ZonedDateTime.of(2021, 6, 15, 2, 25, 27, 0, ZoneId.systemDefault()),
                                 ZonedDateTime.of(2021, 7, 31, 2, 25, 27, 0, ZoneId.systemDefault()))));
+        assertThat(actualAsZonedDateTime.size(), is(24));
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
         Collection<String> actualAsDate = shardingAlgorithmByDayWithMillisecond.doSharding(availableTablesForDayWithMillisecondDataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
                         Range.closed(simpleDateFormat.parse("2021-06-15 02:25:27.000"), simpleDateFormat.parse("2021-07-31 02:25:27.000"))));
-        assertThat(actualAsLocalDateTime.size(), is(24));
-        assertThat(actualAsInstant.size(), is(24));
-        assertThat(actualAsTimestamp.size(), is(24));
-        assertThat(actualAsOffsetDateTime.size(), is(24));
-        assertThat(actualAsZonedDateTime.size(), is(24));
         assertThat(actualAsDate.size(), is(24));
     }
 }


### PR DESCRIPTION
For #17752.

Changes proposed in this pull request:
- Added support for `java.time.Instant`, `java.time.OffsetDateTime`, `java.time.ZonedDateTime` in `org.apache.shardingsphere.sharding.algorithm.sharding.datetime.IntervalShardingAlgorithm`.
- Added unit tests for `java.sql.Timestamp`, `java.time.Instant`, `java.time.OffsetDateTime`, `java.time.ZonedDateTime` in `org.apache.shardingsphere.sharding.algorithm.sharding.datetime.IntervalShardingAlgorithmTest`.  
