### PR TITLE
Fix resource leak when error occurred in ShardingSpherePipelineDataSourceCreator

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -45,8 +45,7 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
         enableRangeQueryForInline(shardingRuleConfig);
         Map<String, DataSource> dataSourceMap = new YamlDataSourceConfigurationSwapper().swapToDataSources(rootConfig.getDataSources());
         try {
-            return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), dataSourceMap,
-                    Collections.singletonList(shardingRuleConfig), null);
+            return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), dataSourceMap, Collections.singletonList(shardingRuleConfig), null);
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -47,7 +47,9 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
         try {
             return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), dataSourceMap,
                     Collections.singletonList(shardingRuleConfig), null);
-        } catch (final SQLException ex) {
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
             closeDataSources(dataSourceMap.values());
             throw ex;
         }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -17,10 +17,11 @@
 
 package org.apache.shardingsphere.driver.data.pipeline.datasource.creator;
 
-import org.apache.shardingsphere.driver.api.ShardingSphereDataSourceFactory;
-import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.ShardingSpherePipelineDataSourceConfiguration;
 import org.apache.shardingsphere.data.pipeline.core.datasource.creator.PipelineDataSourceCreator;
+import org.apache.shardingsphere.driver.api.ShardingSphereDataSourceFactory;
+import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.datasource.pool.destroyer.DataSourcePoolDestroyer;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
@@ -28,7 +29,9 @@ import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfiguration
 
 import javax.sql.DataSource;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 
 /**
  * ShardingSphere pipeline data source creator.
@@ -40,8 +43,14 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
         YamlRootConfiguration rootConfig = (YamlRootConfiguration) pipelineDataSourceConfig;
         ShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(rootConfig.getRules());
         enableRangeQueryForInline(shardingRuleConfig);
-        return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), new YamlDataSourceConfigurationSwapper().swapToDataSources(rootConfig.getDataSources()),
-                Collections.singletonList(shardingRuleConfig), null);
+        Map<String, DataSource> dataSourceMap = new YamlDataSourceConfigurationSwapper().swapToDataSources(rootConfig.getDataSources());
+        try {
+            return ShardingSphereDataSourceFactory.createDataSource(rootConfig.getDatabaseName(), dataSourceMap,
+                    Collections.singletonList(shardingRuleConfig), null);
+        } catch (final SQLException ex) {
+            closeDataSources(dataSourceMap.values());
+            throw ex;
+        }
     }
     
     private void enableRangeQueryForInline(final ShardingRuleConfiguration shardingRuleConfig) {
@@ -50,6 +59,10 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
                 each.getProps().put("allow-range-query-with-inline-sharding", Boolean.TRUE.toString());
             }
         }
+    }
+    
+    private void closeDataSources(final Collection<DataSource> dataSourceMap) {
+        dataSourceMap.stream().map(DataSourcePoolDestroyer::new).forEach(DataSourcePoolDestroyer::asyncDestroy);
     }
     
     @Override


### PR DESCRIPTION
Fixes #17808.

Before:
Thousands of instances of HikariDataSource are not shutdown.
![image](https://user-images.githubusercontent.com/20503072/169482614-3e9ca235-7d22-4f6e-a59b-ed07b3770d77.png)

After:
![image](https://user-images.githubusercontent.com/20503072/169482532-fad8d840-cc26-456e-915e-b85d8a03a8e7.png)
