### PR TITLE
Optimize inter mutex lock add re-set lock state

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/mutex/LockAckAble.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/mutex/LockAckAble.java
@@ -48,4 +48,9 @@ public interface LockAckAble {
      * @param instanceId instance id
      */
     void removeLockedInstance(String instanceId);
+    
+    /**
+     * Re-set lock state.
+     */
+    void reSetLockState();
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/mutex/ShardingSphereDistributeMutexLock.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/mutex/ShardingSphereDistributeMutexLock.java
@@ -46,6 +46,10 @@ public final class ShardingSphereDistributeMutexLock implements ShardingSphereLo
         this.lockHolder = lockHolder;
         this.sequenced = lockHolder.getInterReentrantMutexLock(lockNodeService.getSequenceNodePath());
         ShardingSphereEventBus.getInstance().register(this);
+        syncMutexLockStatus();
+    }
+    
+    private void syncMutexLockStatus() {
         lockHolder.synchronizeMutexLock(lockNodeService);
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/util/TimeoutMilliseconds.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/lock/util/TimeoutMilliseconds.java
@@ -17,6 +17,10 @@
 
 package org.apache.shardingsphere.mode.manager.cluster.coordinator.lock.util;
 
+import lombok.SneakyThrows;
+
+import java.util.concurrent.TimeUnit;
+
 /**
  * Timeout milliseconds.
  */
@@ -29,4 +33,14 @@ public final class TimeoutMilliseconds {
     public static final long DEFAULT_REGISTRY = 50L;
     
     public static final long MAX_ACK_EXPEND = 100L;
+    
+    /**
+     * Sleep interval.
+     *
+     * @param timeMilliseconds time milliseconds
+     */
+    @SneakyThrows(InterruptedException.class)
+    public static void sleepInterval(final long timeMilliseconds) {
+        TimeUnit.MILLISECONDS.sleep(timeMilliseconds);
+    }
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/listener/SessionConnectionListener.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/listener/SessionConnectionListener.java
@@ -57,7 +57,6 @@ public final class SessionConnectionListener implements ConnectionStateListener 
     private boolean reRegister(final CuratorFramework client) {
         try {
             if (client.getZookeeperClient().blockUntilConnectedOrTimedOut()) {
-                instanceContext.initLockContext();
                 repository.persistEphemeral(ComputeNode.getOnlineInstanceNodePath(instanceContext.getInstance().getCurrentInstanceId(),
                         instanceContext.getInstance().getInstanceDefinition().getInstanceType()), "");
                 return true;


### PR DESCRIPTION
## Optimize inter mutex lock add re-set lock state

Related #16564.

Changes proposed in this pull request:
-  Optimize inter mutex lock add re-set lock state
-  Remove `initLockContext()` from re-register for cluster
