### PR TITLE
Fix wrong route result when execute `SELECT LAST_INSERT_ID() AS id;` statement

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/route/ReadwriteSplittingSQLRouterTest.java
@@ -216,9 +216,10 @@ public final class ReadwriteSplittingSQLRouterTest {
     @Test
     public void assertSqlHintRouteWriteOnly() {
         SelectStatement statement = mock(SelectStatement.class);
-        CommonSQLStatementContext<SelectStatement> sqlStatementContext = mock(SelectStatementContext.class);
+        SelectStatementContext sqlStatementContext = mock(SelectStatementContext.class, RETURNS_DEEP_STUBS);
         when(sqlStatementContext.getSqlStatement()).thenReturn(statement);
         when(sqlStatementContext.isHintWriteRouteOnly()).thenReturn(true);
+        when(sqlStatementContext.getProjectionsContext().isContainsLastInsertIdProjection()).thenReturn(false);
         LogicSQL logicSQL = new LogicSQL(sqlStatementContext, "", Collections.emptyList());
         ShardingSphereRuleMetaData ruleMetaData = new ShardingSphereRuleMetaData(Collections.emptyList(), Collections.singleton(rule));
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
@@ -38,6 +38,8 @@ import java.util.Optional;
 @ToString
 public final class ProjectionsContext {
     
+    private static final String LAST_INSERT_ID_FUNCTION_EXPRESSION = "LAST_INSERT_ID()";
+    
     private final int startIndex;
     
     private final int stopIndex;
@@ -50,6 +52,8 @@ public final class ProjectionsContext {
     
     private final List<Projection> expandProjections;
     
+    private final boolean containsLastInsertIdProjection;
+    
     public ProjectionsContext(final int startIndex, final int stopIndex, final boolean distinctRow, final Collection<Projection> projections) {
         this.startIndex = startIndex;
         this.stopIndex = stopIndex;
@@ -57,6 +61,7 @@ public final class ProjectionsContext {
         this.projections = projections;
         aggregationDistinctProjections = createAggregationDistinctProjections();
         expandProjections = expandProjections();
+        containsLastInsertIdProjection = isContainsLastInsertIdProjection(projections);
     }
     
     private Collection<AggregationDistinctProjection> createAggregationDistinctProjections() {
@@ -144,5 +149,14 @@ public final class ProjectionsContext {
             }
         }
         return result;
+    }
+    
+    private boolean isContainsLastInsertIdProjection(final Collection<Projection> projections) {
+        for (Projection each : projections) {
+            if (LAST_INSERT_ID_FUNCTION_EXPRESSION.equalsIgnoreCase(SQLUtil.getExactlyExpression(each.getExpression()))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.Agg
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.AggregationProjection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.DerivedProjection;
+import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ShorthandProjection;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
@@ -144,5 +145,13 @@ public final class ProjectionsContextTest {
         assertThat(actual.getExpandProjections().get(0), is(columnProjection1));
         assertThat(actual.getExpandProjections().get(1), is(columnProjection2));
         assertThat(actual.getExpandProjections().get(2), is(columnProjection3));
+    }
+    
+    @Test
+    public void assertIsContainsLastInsertIdProjection() {
+        ProjectionsContext lastInsertIdProjection = new ProjectionsContext(0, 0, false, Collections.singletonList(new ExpressionProjection("LAST_INSERT_ID()", "id")));
+        assertTrue(lastInsertIdProjection.isContainsLastInsertIdProjection());
+        ProjectionsContext maxProjection = new ProjectionsContext(0, 0, false, Collections.singletonList(new ExpressionProjection("MAX(id)", "max")));
+        assertFalse(maxProjection.isContainsLastInsertIdProjection());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaDataTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/rule/ShardingSphereRuleMetaDataTest.java
@@ -44,7 +44,7 @@ public final class ShardingSphereRuleMetaDataTest {
     public void assertFindRuleConfigurations() {
         assertThat(ruleMetaData.findRuleConfigurations(ShardingSphereRuleConfigurationFixture.class).size(), is(1));
     }
-
+    
     @Test
     public void assertFindSingleRuleConfiguration() {
         assertTrue(ruleMetaData.findSingleRuleConfiguration(ShardingSphereRuleConfigurationFixture.class).isPresent());


### PR DESCRIPTION
Fixes #17942.

Changes proposed in this pull request:
- fix wrong route result when execute `SELECT LAST_INSERT_ID() AS id;` statement
- add unit test
