### PR TITLE
Remove JapaneseDate related context in IntervalShardingAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -33,8 +33,9 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.chrono.ChronoZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -220,9 +221,9 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     private LocalTime parseLocalTime(final Comparable<?> endpoint) {
         return LocalTime.parse(getDateTimeText(endpoint).substring(0, dateTimePatternLength), dateTimeFormatter);
     }
-    
+
     private String getDateTimeText(final Comparable<?> endpoint) {
-        if (endpoint instanceof LocalDateTime || endpoint instanceof ZonedDateTime
+        if (endpoint instanceof ChronoLocalDateTime || endpoint instanceof ChronoZonedDateTime
                 || endpoint instanceof OffsetDateTime || endpoint instanceof ChronoLocalDate
                 || endpoint instanceof LocalTime || endpoint instanceof OffsetTime) {
             return dateTimeFormatter.format((TemporalAccessor) endpoint);

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -34,7 +34,7 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.chrono.JapaneseDate;
+import java.time.chrono.ChronoLocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -146,10 +146,8 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
         TemporalAccessor calculateTime = dateTimeLower;
         LocalDate queryToLocalDate = calculateTime.query(TemporalQueries.localDate());
         LocalTime queryToLocalTime = calculateTime.query(TemporalQueries.localTime());
-        LocalDate dateTimeLowerAsLocalDate = dateTimeLower.query(TemporalQueries.localDate());
-        LocalTime dateTimeLowerAsLocalTime = dateTimeLower.query(TemporalQueries.localTime());
         LocalDate dateTimeUpperAsLocalDate = dateTimeUpper.query(TemporalQueries.localDate());
-        LocalTime dateTimeUpperAsLocalTime = dateTimeUpper.query(TemporalQueries.localTime());
+        LocalDate dateTimeLowerAsLocalDate = dateTimeLower.query(TemporalQueries.localDate());
         if (null == queryToLocalTime) {
             LocalDate calculateTimeAsView = calculateTime.query(TemporalQueries.localDate());
             while (!calculateTimeAsView.isAfter(dateTimeUpperAsLocalDate)) {
@@ -160,6 +158,8 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
             }
             return result;
         }
+        LocalTime dateTimeUpperAsLocalTime = dateTimeUpper.query(TemporalQueries.localTime());
+        LocalTime dateTimeLowerAsLocalTime = dateTimeLower.query(TemporalQueries.localTime());
         if (null == queryToLocalDate) {
             LocalTime calculateTimeAsView = calculateTime.query(TemporalQueries.localTime());
             while (!calculateTimeAsView.isAfter(dateTimeUpperAsLocalTime)) {
@@ -171,8 +171,8 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
             return result;
         }
         LocalDateTime calculateTimeAsView = LocalDateTime.of(calculateTime.query(TemporalQueries.localDate()), calculateTime.query(TemporalQueries.localTime()));
-        LocalDateTime dateTimeLowerAsLocalDateTime = LocalDateTime.of(dateTimeLowerAsLocalDate, dateTimeLowerAsLocalTime);
         LocalDateTime dateTimeUpperAsLocalDateTime = LocalDateTime.of(dateTimeUpperAsLocalDate, dateTimeUpperAsLocalTime);
+        LocalDateTime dateTimeLowerAsLocalDateTime = LocalDateTime.of(dateTimeLowerAsLocalDate, dateTimeLowerAsLocalTime);
         while (!calculateTimeAsView.isAfter(dateTimeUpperAsLocalDateTime)) {
             if (hasIntersection(Range.closedOpen(calculateTimeAsView, calculateTimeAsView.plus(stepAmount, stepUnit)), range, dateTimeLowerAsLocalDateTime, dateTimeUpperAsLocalDateTime)) {
                 result.addAll(getMatchedTables(calculateTimeAsView, availableTargetNames));
@@ -223,8 +223,8 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     
     private String getDateTimeText(final Comparable<?> endpoint) {
         if (endpoint instanceof LocalDateTime || endpoint instanceof ZonedDateTime
-                || endpoint instanceof OffsetDateTime || endpoint instanceof LocalTime
-                || endpoint instanceof OffsetTime || endpoint instanceof JapaneseDate) {
+                || endpoint instanceof OffsetDateTime || endpoint instanceof ChronoLocalDate
+                || endpoint instanceof LocalTime || endpoint instanceof OffsetTime) {
             return dateTimeFormatter.format((TemporalAccessor) endpoint);
         }
         if (endpoint instanceof Instant) {


### PR DESCRIPTION
For #17948.

Changes proposed in this pull request:
- Remove `java.time.chrono.JapaneseDate` related context in IntervalShardingAlgorithm due to JDK 8 limitations. Refer to https://stackoverflow.com/a/55946953 and https://bugs.openjdk.java.net/browse/JDK-8210633 .
- This is the first addition to #17948 .
- Fix LocalDate not being explicitly handled by DateTimeFormatter.
