### PR TITLE
Repair the error reported by the shade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <shade.package>org.apache.shardingsphere.dependencies</shade.package>
         
         <guava.version>30.0-jre</guava.version>
+        <guava-listenablefuture.version>1.0</guava-listenablefuture.version>
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-codec.version>1.15</commons-codec.version>
@@ -688,6 +689,12 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+            </dependency>
+            
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>listenablefuture</artifactId>
+                <version>${guava-listenablefuture.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/shardingsphere-agent/shardingsphere-agent-plugins/pom.xml
+++ b/shardingsphere-agent/shardingsphere-agent-plugins/pom.xml
@@ -64,7 +64,6 @@
                         <configuration>
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <createSourcesJar>true</createSourcesJar>
                             <shadeSourcesContent>true</shadeSourcesContent>
                             <artifactSet>
                                 <excludes>


### PR DESCRIPTION
Changes proposed in this pull request:
-  Repair agent related source package not found;
- Repair could not find listenablefuture:jar:sources.


Corresponding error message:

```
Failure to find org.apache.shardingsphere:shardingsphere-agent-plugins:jar:sources:5.1.2-SNAPSHOT in https://repository.apache.org/snapshots was cached in the local repository, resolution will not be reattempted until the update interval of apache.snapshots has elapsed or updates are forced


Failure to find com.google.guava:listenablefuture:jar:sources:9999.0-empty-to-avoid-conflict-with-guava in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
````
