### PR TITLE
Fixi EncryptColumnRuleConfigurationYamlSwapper swapToYamlConfiguration method loss of the logicColumn problem

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/EncryptColumnRuleConfigurationYamlSwapper.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/EncryptColumnRuleConfigurationYamlSwapper.java
@@ -29,6 +29,7 @@ public final class EncryptColumnRuleConfigurationYamlSwapper implements YamlConf
     @Override
     public YamlEncryptColumnRuleConfiguration swapToYamlConfiguration(final EncryptColumnRuleConfiguration data) {
         YamlEncryptColumnRuleConfiguration result = new YamlEncryptColumnRuleConfiguration();
+        result.setLogicColumn(data.getLogicColumn());
         result.setPlainColumn(data.getPlainColumn());
         result.setCipherColumn(data.getCipherColumn());
         result.setAssistedQueryColumn(data.getAssistedQueryColumn());

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/EncryptColumnRuleConfigurationYamlSwapperTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/EncryptColumnRuleConfigurationYamlSwapperTest.java
@@ -31,6 +31,7 @@ public final class EncryptColumnRuleConfigurationYamlSwapperTest {
         EncryptColumnRuleConfigurationYamlSwapper swapper = new EncryptColumnRuleConfigurationYamlSwapper();
         EncryptColumnRuleConfiguration encryptColumnRuleConfig = new EncryptColumnRuleConfiguration("logicColumn", "cipherColumn", "assistedQueryColumn", "plainColumn", "encryptorName", true);
         YamlEncryptColumnRuleConfiguration actual = swapper.swapToYamlConfiguration(encryptColumnRuleConfig);
+        assertThat(actual.getLogicColumn(), is("logicColumn"));
         assertThat(actual.getCipherColumn(), is("cipherColumn"));
         assertThat(actual.getAssistedQueryColumn(), is("assistedQueryColumn"));
         assertThat(actual.getPlainColumn(), is("plainColumn"));


### PR DESCRIPTION
Fixi EncryptColumnRuleConfigurationYamlSwapper swapToYamlConfiguration method loss of the logicColumn problem

Fixes #18044