### PR TITLE
Add : add notification for failed github action

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,6 +19,7 @@ notifications:
   commits: notifications@shardingsphere.apache.org
   issues: notifications@shardingsphere.apache.org
   pullrequests: notifications@shardingsphere.apache.org
+  jobs: notifications@shardingsphere.apache.org
 
 github:
   description: Ecosystem to transform any database into a distributed database system, and enhance it with sharding, elastic scaling, encryption features & more


### PR DESCRIPTION
This triggers emails when a workflow run fails or if it succeeds after a series of failures. 

We do not send notifications on normal successful runs, so as to not spam too much.

