### PR TITLE
Remove schema from some DistSQL result sets.

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding.cn.md
@@ -14,6 +14,8 @@ SHOW SHARDING ALGORITHMS [FROM databaseName]
 
 SHOW UNUSED SHARDING ALGORITHMS [FROM databaseName]
 
+SHOW SHARDING TABLE RULES USED ALGORITHM algorithmName [FROM databaseName]
+
 SHOW SHARDING KEY GENERATORS [FROM databaseName]
 
 SHOW UNUSED SHARDING KEY GENERATORS [FROM databaseName]
@@ -86,19 +88,19 @@ SHOW SHARDING SCALING RULES [FROM databaseName]
 
 ### Sharding Key Generators
 
-| 列     | 说明             |
-| ------| -----------------|
-| name  | 分片列生成器名称    |
-| type  | 分片列生成器类型    |
-| props | 分片列生成器参数    |
+| 列     | 说明        |
+| ------|-------------|
+| name  | 主键生成器名称 |
+| type  | 主键生成器类型 |
+| props | 主键生成器参数 |
 
 ### Unused Sharding Key Generators
 
-| 列     | 说明             |
-| ------| -----------------|
-| name  | 分片列生成器名称    |
-| type  | 分片列生成器类型    |
-| props | 分片列生成器参数    |
+| 列     | 说明        |
+| ------|-------------|
+| name  | 主键生成器名称 |
+| type  | 主键生成器类型 |
+| props | 主键生成器参数 |
 
 ### Default Sharding Strategy
 
@@ -192,6 +194,17 @@ mysql> SHOW UNUSED SHARDING ALGORITHMS;
 1 row in set (0.01 sec)
 ```
 
+*SHOW SHARDING TABLE RULES USED ALGORITHM algorithmName*
+```sql
+mysql> SHOW SHARDING TABLE RULES USED ALGORITHM t_order_inline;
++-------+---------+
+| type  | name    |
++-------+---------+
+| table | t_order |
++-------+---------+
+1 row in set (0.01 sec)
+```
+
 *SHOW SHARDING KEY GENERATORS*
 ```sql
 mysql> SHOW SHARDING KEY GENERATORS;
@@ -218,12 +231,12 @@ mysql> SHOW UNUSED SHARDING KEY GENERATORS;
 
 *SHOW SHARDING TABLE RULES USED KEY GENERATOR keyGeneratorName*
 ```sql
-mysql> SHOW SHARDING TABLE RULES USED KEY GENERATOR keyGeneratorName;
-+------------------------+-----------+-----------------+
-| schema                 | type      | name            |
-+------------------------+-----------+-----------------+
-| sharding_db            | table     | t_order         |
-+------------------------+-----------+-----------------+
+mysql> SHOW SHARDING TABLE RULES USED KEY GENERATOR t_order_snowflake;
++-------+---------+
+| type  | name    |
++-------+---------+
+| table | t_order |
++-------+---------+
 1 row in set (0.01 sec)
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding.en.md
@@ -14,6 +14,8 @@ SHOW SHARDING ALGORITHMS [FROM databaseName]
 
 SHOW UNUSED SHARDING ALGORITHMS [FROM databaseName]
 
+SHOW SHARDING TABLE RULES USED ALGORITHM algorithmName [FROM databaseName]
+
 SHOW SHARDING KEY GENERATORS [FROM databaseName]
 
 SHOW UNUSED SHARDING KEY GENERATORS [FROM databaseName]
@@ -192,6 +194,17 @@ mysql> SHOW UNUSED SHARDING ALGORITHMS;
 1 row in set (0.01 sec)
 ```
 
+*SHOW SHARDING TABLE RULES USED ALGORITHM algorithmName*
+```sql
+mysql> SHOW SHARDING TABLE RULES USED ALGORITHM t_order_inline;
++-------+---------+
+| type  | name    |
++-------+---------+
+| table | t_order |
++-------+---------+
+1 row in set (0.01 sec)
+```
+
 *SHOW SHARDING KEY GENERATORS*
 ```sql
 mysql> SHOW SHARDING KEY GENERATORS;
@@ -219,11 +232,11 @@ mysql> SHOW UNUSED SHARDING KEY GENERATORS;
 *SHOW SHARDING TABLE RULES USED KEY GENERATOR keyGeneratorName*
 ```sql
 mysql> SHOW SHARDING TABLE RULES USED KEY GENERATOR keyGeneratorName;
-+------------------------+-----------+-----------------+
-| schema                 | type      | name            |
-+------------------------+-----------+-----------------+
-| sharding_db            | table     | t_order         |
-+------------------------+-----------+-----------------+
++-------+---------+
+| type  | name    |
++-------+---------+
+| table | t_order |
++-------+---------+
 1 row in set (0.01 sec)
 ```
 

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRulesUsedAlgorithmQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRulesUsedAlgorithmQueryResultSet.java
@@ -41,31 +41,30 @@ public final class ShardingTableRulesUsedAlgorithmQueryResultSet implements Dist
         ShowShardingTableRulesUsedAlgorithmStatement statement = (ShowShardingTableRulesUsedAlgorithmStatement) sqlStatement;
         Collection<Collection<Object>> data = new LinkedList<>();
         Collection<ShardingRuleConfiguration> shardingTableRules = database.getRuleMetaData().findRuleConfigurations(ShardingRuleConfiguration.class);
-        shardingTableRules.forEach(each -> requireResult(statement, database.getName(), data, each));
+        shardingTableRules.forEach(each -> requireResult(statement, data, each));
         this.data = data.iterator();
     }
     
-    private void requireResult(final ShowShardingTableRulesUsedAlgorithmStatement statement, final String databaseName,
-                               final Collection<Collection<Object>> data, final ShardingRuleConfiguration shardingRuleConfig) {
+    private void requireResult(final ShowShardingTableRulesUsedAlgorithmStatement statement, final Collection<Collection<Object>> data, final ShardingRuleConfiguration shardingRuleConfig) {
         if (!statement.getAlgorithmName().isPresent()) {
             return;
         }
         shardingRuleConfig.getTables().forEach(each -> {
             if (((null != each.getDatabaseShardingStrategy() && statement.getAlgorithmName().get().equals(each.getDatabaseShardingStrategy().getShardingAlgorithmName())))
                     || (null != each.getTableShardingStrategy() && statement.getAlgorithmName().get().equals(each.getTableShardingStrategy().getShardingAlgorithmName()))) {
-                data.add(Arrays.asList(databaseName, "table", each.getLogicTable()));
+                data.add(Arrays.asList("table", each.getLogicTable()));
             }
         });
         shardingRuleConfig.getAutoTables().forEach(each -> {
             if (null != each.getShardingStrategy() && statement.getAlgorithmName().get().equals(each.getShardingStrategy().getShardingAlgorithmName())) {
-                data.add(Arrays.asList(databaseName, "auto_table", each.getLogicTable()));
+                data.add(Arrays.asList("auto_table", each.getLogicTable()));
             }
         });
     }
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("schema", "type", "name");
+        return Arrays.asList("type", "name");
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRulesUsedKeyGeneratorQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRulesUsedKeyGeneratorQueryResultSet.java
@@ -42,30 +42,29 @@ public final class ShardingTableRulesUsedKeyGeneratorQueryResultSet implements D
         ShowShardingTableRulesUsedKeyGeneratorStatement statement = (ShowShardingTableRulesUsedKeyGeneratorStatement) sqlStatement;
         List<Collection<Object>> result = new ArrayList<>();
         Collection<ShardingRuleConfiguration> shardingTableRules = database.getRuleMetaData().findRuleConfigurations(ShardingRuleConfiguration.class);
-        shardingTableRules.forEach(each -> requireResult(statement, database.getName(), result, each));
+        shardingTableRules.forEach(each -> requireResult(statement, result, each));
         data = result.iterator();
     }
     
-    private void requireResult(final ShowShardingTableRulesUsedKeyGeneratorStatement statement, final String databaseName, final List<Collection<Object>> result,
-                               final ShardingRuleConfiguration shardingRuleConfig) {
+    private void requireResult(final ShowShardingTableRulesUsedKeyGeneratorStatement statement, final List<Collection<Object>> result, final ShardingRuleConfiguration shardingRuleConfig) {
         if (!statement.getKeyGeneratorName().isPresent()) {
             return;
         }
         shardingRuleConfig.getTables().forEach(each -> {
             if (null != each.getKeyGenerateStrategy() && statement.getKeyGeneratorName().get().equals(each.getKeyGenerateStrategy().getKeyGeneratorName())) {
-                result.add(Arrays.asList(databaseName, "table", each.getLogicTable()));
+                result.add(Arrays.asList("table", each.getLogicTable()));
             }
         });
         shardingRuleConfig.getAutoTables().forEach(each -> {
             if (null != each.getKeyGenerateStrategy() && statement.getKeyGeneratorName().get().equals(each.getKeyGenerateStrategy().getKeyGeneratorName())) {
-                result.add(Arrays.asList(databaseName, "auto_table", each.getLogicTable()));
+                result.add(Arrays.asList("auto_table", each.getLogicTable()));
             }
         });
     }
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("schema", "type", "name");
+        return Arrays.asList("type", "name");
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedAlgorithmQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedAlgorithmQueryResultSetTest.java
@@ -48,23 +48,20 @@ public final class ShowShardingTableRulesUsedAlgorithmQueryResultSetTest {
     public void assertGetRowData() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getRuleMetaData().findRuleConfigurations(ShardingRuleConfiguration.class)).thenReturn(Collections.singleton(createRuleConfiguration()));
-        when(database.getName()).thenReturn("sharding_db");
         DistSQLResultSet resultSet = new ShardingTableRulesUsedAlgorithmQueryResultSet();
         ShowShardingTableRulesUsedAlgorithmStatement statement = mock(ShowShardingTableRulesUsedAlgorithmStatement.class);
         when(statement.getAlgorithmName()).thenReturn(Optional.of("t_order_inline"));
         resultSet.init(database, statement);
         List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_db"));
-        assertThat(actual.get(1), is("table"));
-        assertThat(actual.get(2), is("t_order"));
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(0), is("table"));
+        assertThat(actual.get(1), is("t_order"));
         when(statement.getAlgorithmName()).thenReturn(Optional.of("auto_mod"));
         resultSet.init(database, statement);
         actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_db"));
-        assertThat(actual.get(1), is("auto_table"));
-        assertThat(actual.get(2), is("t_order_auto"));
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(0), is("auto_table"));
+        assertThat(actual.get(1), is("t_order_auto"));
     }
     
     private ShardingRuleConfiguration createRuleConfiguration() {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorQueryResultSetTest.java
@@ -48,21 +48,18 @@ public final class ShowShardingTableRulesUsedKeyGeneratorQueryResultSetTest {
     public void assertGetRowData() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getRuleMetaData().findRuleConfigurations(ShardingRuleConfiguration.class)).thenReturn(Collections.singleton(createRuleConfiguration()));
-        when(database.getName()).thenReturn("sharding_db");
         DistSQLResultSet resultSet = new ShardingTableRulesUsedKeyGeneratorQueryResultSet();
         ShowShardingTableRulesUsedKeyGeneratorStatement statement = mock(ShowShardingTableRulesUsedKeyGeneratorStatement.class);
         when(statement.getKeyGeneratorName()).thenReturn(Optional.of("snowflake"));
         resultSet.init(database, statement);
         List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_db"));
-        assertThat(actual.get(1), is("table"));
-        assertThat(actual.get(2), is("t_order"));
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(0), is("table"));
+        assertThat(actual.get(1), is("t_order"));
         actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_db"));
-        assertThat(actual.get(1), is("auto_table"));
-        assertThat(actual.get(2), is("t_order_auto"));
+        assertThat(actual.size(), is(2));
+        assertThat(actual.get(0), is("auto_table"));
+        assertThat(actual.get(1), is("t_order_auto"));
     }
     
     private ShardingRuleConfiguration createRuleConfiguration() {


### PR DESCRIPTION
Remove schema from DistSQL result sets:
- ShardingTableRulesUsedAlgorithmQueryResultSet
- ShardingTableRulesUsedKeyGeneratorQueryResultSet

### Before
```sql
mysql> SHOW SHARDING TABLE RULES USED ALGORITHM order_inline;
+-------------+-------+---------+
| schema      | type  | name    |
+-------------+-------+---------+
| sharding_db | table | t_order |
+-------------+-------+---------+
1 row in set (0.00 sec)


mysql> SHOW SHARDING TABLE RULES USED KEY GENERATOR snowflake;
+-------------+-------+---------+
| schema      | type  | name    |
+-------------+-------+---------+
| sharding_db | table | t_order |
+-------------+-------+---------+
1 row in set (0.01 sec)
```


### After
```sql
mysql> SHOW SHARDING TABLE RULES USED ALGORITHM order_inline;
+-------+---------+
| type  | name    |
+-------+---------+
| table | t_order |
+-------+---------+
1 row in set (0.27 sec)


mysql> SHOW SHARDING TABLE RULES USED KEY GENERATOR snowflake;
+-------+---------+
| type  | name    |
+-------+---------+
| table | t_order |
+-------+---------+
1 row in set (0.01 sec)

```