### PR TITLE
Add minPoolSize: 1 in data source properties by default

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfiguration.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -62,6 +63,7 @@ public final class ShardingSpherePipelineDataSourceConfiguration implements Pipe
         Map<String, Object> props = rootConfig.getDataSources().values().iterator().next();
         databaseType = DatabaseTypeEngine.getDatabaseType(getJdbcUrl(props));
         appendJdbcQueryProperties(databaseType.getType());
+        adjustDataSourceProperties(rootConfig.getDataSources());
     }
     
     public ShardingSpherePipelineDataSourceConfiguration(final YamlRootConfiguration rootConfig) {
@@ -71,6 +73,7 @@ public final class ShardingSpherePipelineDataSourceConfiguration implements Pipe
         Map<String, Object> props = rootConfig.getDataSources().values().iterator().next();
         databaseType = DatabaseTypeEngine.getDatabaseType(getJdbcUrl(props));
         appendJdbcQueryProperties(databaseType.getType());
+        adjustDataSourceProperties(rootConfig.getDataSources());
     }
     
     private String getJdbcUrl(final Map<String, Object> props) {
@@ -93,6 +96,14 @@ public final class ShardingSpherePipelineDataSourceConfiguration implements Pipe
                     String jdbcUrlKey = value.containsKey("url") ? "url" : "jdbcUrl";
                     value.replace(jdbcUrlKey, new JdbcUrlAppender().appendQueryProperties(value.get(jdbcUrlKey).toString(), queryProps));
                 });
+    }
+    
+    private void adjustDataSourceProperties(final Map<String, Map<String, Object>> dataSources) {
+        for (Map<String, Object> queryProps : dataSources.values()) {
+            for (String each : Arrays.asList("minPoolSize", "minimumIdle")) {
+                queryProps.put(each, "1");
+            }
+        }
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfiguration.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/StandardPipelineDataSourceConfiguration.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.yaml.config.swapper.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.engine.YamlEngine;
 
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -70,6 +71,9 @@ public final class StandardPipelineDataSourceConfiguration implements PipelineDa
         this.parameter = parameter;
         if (!yamlConfig.containsKey(DATA_SOURCE_CLASS_NAME)) {
             yamlConfig.put(DATA_SOURCE_CLASS_NAME, "com.zaxxer.hikari.HikariDataSource");
+        }
+        for (String each : Arrays.asList("minPoolSize", "minimumIdle")) {
+            yamlConfig.put(each, "1");
         }
         dataSourceProperties = new YamlDataSourceConfigurationSwapper().swapToDataSourceProperties(yamlConfig);
         yamlConfig.remove(DATA_SOURCE_CLASS_NAME);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfigurationTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/test/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfigurationTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.api.datasource.config.impl;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -43,14 +44,23 @@ public final class ShardingSpherePipelineDataSourceConfigurationTest {
         assertThat(dataSources.size(), is(2));
         assertTrue(dataSources.containsKey("ds_0"));
         assertTrue(dataSources.containsKey("ds_1"));
+        for (Map<String, Object> queryProps : dataSources.values()) {
+            for (String each : Arrays.asList("minPoolSize", "minimumIdle")) {
+                assertThat(queryProps.get(each), is("1"));
+            }
+        }
     }
     
     private String getDataSourceYaml() {
         return "dataSources:\n"
                 + "  ds_1:\n"
+                + "    minPoolSize: 20\n"
+                + "    minimumIdle: 20\n"
                 + "    dataSourceClassName: com.zaxxer.hikari.HikariDataSource\n"
                 + "    url: jdbc:mysql://192.168.0.2:3306/scaling?serverTimezone=UTC&useSSL=false\n"
                 + "  ds_0:\n"
+                + "    minPoolSize: 20\n"
+                + "    minimumIdle: 20\n"
                 + "    dataSourceClassName: com.zaxxer.hikari.HikariDataSource\n"
                 + "    url: jdbc:mysql://192.168.0.1:3306/scaling?serverTimezone=UTC&useSSL=false\n";
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/cache/subscriber/ScalingRegistrySubscriber.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/cache/subscriber/ScalingRegistrySubscriber.java
@@ -20,10 +20,8 @@ package org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cach
 import com.google.common.eventbus.Subscribe;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.eventbus.ShardingSphereEventBus;
-import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.cache.event.StartScalingEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.rule.ScalingTaskFinishedEvent;
-import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.schema.SchemaChangedEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.config.event.version.MetadataVersionPreparedEvent;
 import org.apache.shardingsphere.mode.metadata.persist.node.DatabaseMetaDataNode;
 import org.apache.shardingsphere.mode.metadata.persist.service.DatabaseVersionPersistService;
@@ -83,17 +81,5 @@ public final class ScalingRegistrySubscriber {
         } else {
             log.error("targetActiveVersion does not match current activeVersion, targetActiveVersion={}, activeVersion={}", targetActiveVersion, activeVersion.orElse(null));
         }
-    }
-    
-    /**
-     * Schema changed.
-     *
-     * @param event event
-     */
-    @Subscribe
-    public void schemaChanged(final SchemaChangedEvent event) {
-        ShardingSphereTable changedTableMetaData = event.getChangedTableMetaData();
-        String changedTableName = null != changedTableMetaData ? changedTableMetaData.getName() : null;
-        log.info("schemaChanged, databaseName={}, schemaName={}, changedTableName={}, deletedTable={}", event.getDatabaseName(), event.getSchemaName(), changedTableName, event.getDeletedTable());
     }
 }


### PR DESCRIPTION
Purpose:
- Reduce working database connections

Changes proposed in this pull request:
- Add minPoolSize: 1 in data source properties by default
