### PR TITLE
Data consistency check does not require source writing stop

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/RuleAlteredJobAPIImpl.java
@@ -162,14 +162,6 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
         }
     }
     
-    private void verifySourceWritingStopped(final RuleAlteredJobConfiguration jobConfig) {
-        LockContext lockContext = PipelineContext.getContextManager().getInstanceContext().getLockContext();
-        String databaseName = jobConfig.getDatabaseName();
-        if (!lockContext.isLocked(databaseName)) {
-            throw new PipelineVerifyFailedException("Source writing is not stopped. You could run `STOP SCALING SOURCE WRITING {jobId}` to stop it.");
-        }
-    }
-    
     @Override
     public void stopClusterWriteDB(final String jobId) {
         checkModeConfig();
@@ -286,7 +278,6 @@ public final class RuleAlteredJobAPIImpl extends AbstractPipelineJobAPIImpl impl
     
     private void verifyDataConsistencyCheck(final RuleAlteredJobConfiguration jobConfig) {
         verifyManualMode(jobConfig);
-        verifySourceWritingStopped(jobConfig);
     }
     
     @Override


### PR DESCRIPTION

Changes proposed in this pull request:
- Data consistency check does not require source writing stop
