### PR TITLE
can set some parameters of narayana in server.yaml

### DIFF
--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/main/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGenerator.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/main/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGenerator.java
@@ -55,21 +55,20 @@ public final class NarayanaConfigurationFileGenerator implements TransactionConf
     
     @Override
     public void generateFile(final Properties transactionProps, final InstanceContext instanceContext) {
-        String instanceId = instanceContext.getInstance().getInstanceDefinition().getInstanceId();
-        String recoveryId = instanceContext.getInstance().getXaRecoveryIds().isEmpty() ? instanceId : Joiner.on(",").join(instanceContext.getInstance().getXaRecoveryIds());
-        NarayanaConfiguration config = createDefaultConfiguration(instanceId, recoveryId);
+        NarayanaConfiguration config = createDefaultConfiguration(transactionProps, instanceContext);
         if (!transactionProps.isEmpty()) {
             appendUserDefinedJdbcStoreConfiguration(transactionProps, config);
         }
         JAXB.marshal(config, new File(ClassLoader.getSystemResource("").getPath(), "jbossts-properties.xml"));
     }
     
-    private NarayanaConfiguration createDefaultConfiguration(final String instanceId, final String recoveryId) {
+    private NarayanaConfiguration createDefaultConfiguration(final Properties transactionProps, final InstanceContext instanceContext) {
         NarayanaConfiguration result = new NarayanaConfiguration();
-        result.getEntries().add(createEntry("CoordinatorEnvironmentBean.commitOnePhase", "YES"));
-        result.getEntries().add(createEntry("ObjectStoreEnvironmentBean.transactionSync", "NO"));
-        result.getEntries().add(createEntry("CoreEnvironmentBean.nodeIdentifier", instanceId));
-        result.getEntries().add(createEntry("JTAEnvironmentBean.xaRecoveryNodes", recoveryId));
+        result.getEntries().add(createEntry("CoordinatorEnvironmentBean.commitOnePhase", transactionProps.getOrDefault("commitOnePhase", Boolean.TRUE).toString()));
+        result.getEntries().add(createEntry("ObjectStoreEnvironmentBean.transactionSync", transactionProps.getOrDefault("transactionSync", Boolean.FALSE).toString()));
+        result.getEntries().add(createEntry("CoreEnvironmentBean.nodeIdentifier",
+                transactionProps.getOrDefault("nodeIdentifier", instanceContext.getInstance().getInstanceDefinition().getInstanceId()).toString()));
+        result.getEntries().add(createEntry("JTAEnvironmentBean.xaRecoveryNodes", getRecoveryId(transactionProps, instanceContext)));
         result.getEntries().add(createEntry("JTAEnvironmentBean.xaResourceOrphanFilterClassNames", createXAResourceOrphanFilterClassNames()));
         result.getEntries().add(createEntry("CoreEnvironmentBean.socketProcessIdPort", "0"));
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryModuleClassNames", getRecoveryModuleClassNames()));
@@ -78,9 +77,12 @@ public final class NarayanaConfigurationFileGenerator implements TransactionConf
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryAddress", ""));
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.transactionStatusManagerPort", "0"));
         result.getEntries().add(createEntry("RecoveryEnvironmentBean.transactionStatusManagerAddress", ""));
-        result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryListener", "NO"));
-        result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryBackoffPeriod", "1"));
-        result.getEntries().add(createEntry("CoordinatorEnvironmentBean.defaultTimeout", "180"));
+        result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryListener", Boolean.FALSE.toString()));
+        result.getEntries().add(createEntry("RecoveryEnvironmentBean.recoveryBackoffPeriod", transactionProps.getOrDefault("recoveryBackoffPeriod", "1").toString()));
+        result.getEntries().add(createEntry("CoordinatorEnvironmentBean.defaultTimeout", transactionProps.getOrDefault("defaultTimeout", "180").toString()));
+        result.getEntries().add(createEntry("RecoveryEnvironmentBean.expiryScanInterval", transactionProps.getOrDefault("expiryScanInterval", "12").toString()));
+        result.getEntries().add(createEntry("RecoveryEnvironmentBean.periodicRecoveryPeriod", transactionProps.getOrDefault("periodicRecoveryPeriod", "120").toString()));
+        
         return result;
     }
     
@@ -96,6 +98,17 @@ public final class NarayanaConfigurationFileGenerator implements TransactionConf
         result.setKey(key);
         result.getValue().addAll(values);
         return result;
+    }
+    
+    private String getRecoveryId(final Properties transactionProps, final InstanceContext instanceContext) {
+        if (transactionProps.containsKey("xaRecoveryNodes")) {
+            Collection<?> xaRecoveryNodes = (Collection<?>) transactionProps.get("xaRecoveryNodes");
+            return Joiner.on(",").join(xaRecoveryNodes);
+        } else {
+            return instanceContext.getInstance().getXaRecoveryIds().isEmpty()
+                    ? instanceContext.getInstance().getInstanceDefinition().getInstanceId()
+                    : Joiner.on(",").join(instanceContext.getInstance().getXaRecoveryIds());
+        }
     }
     
     private Collection<String> createXAResourceOrphanFilterClassNames() {

--- a/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/test/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGeneratorTest.java
+++ b/shardingsphere-kernel/shardingsphere-transaction/shardingsphere-transaction-type/shardingsphere-transaction-xa/shardingsphere-transaction-xa-provider/shardingsphere-transaction-xa-narayana/src/test/java/org/apache/shardingsphere/transaction/xa/narayana/config/NarayanaConfigurationFileGeneratorTest.java
@@ -87,7 +87,7 @@ public final class NarayanaConfigurationFileGeneratorTest {
         Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
         InputStream inputStream = new FileInputStream(new File(ClassLoader.getSystemResource("").getPath(), "jbossts-properties.xml"));
         NarayanaConfiguration narayanaConfig = (NarayanaConfiguration) unmarshaller.unmarshal(inputStream);
-        assertThat(narayanaConfig.getEntries().size(), is(27));
+        assertThat(narayanaConfig.getEntries().size(), is(29));
         assertCommitOnePhase(narayanaConfig);
         assertTransactionSync(narayanaConfig);
         assertNodeIdentifier(narayanaConfig);
@@ -100,6 +100,9 @@ public final class NarayanaConfigurationFileGeneratorTest {
         assertTransactionStatusManagerPort(narayanaConfig);
         assertRecoveryListener(narayanaConfig);
         assertRecoveryBackoffPeriod(narayanaConfig);
+        assertDefaultTimeout(narayanaConfig);
+        assertExpiryScanInterval(narayanaConfig);
+        assertPeriodicRecoveryPeriod(narayanaConfig);
         assertObjectStoreType(narayanaConfig);
         assertJdbcAccess(narayanaConfig);
         assertTablePrefix(narayanaConfig);
@@ -118,14 +121,14 @@ public final class NarayanaConfigurationFileGeneratorTest {
         Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "CoordinatorEnvironmentBean.commitOnePhase".equals(each.getKey())).findFirst();
         assertTrue(entry.isPresent());
         assertThat(entry.get().getValue().size(), is(1));
-        assertTrue(entry.get().getValue().contains("YES"));
+        assertTrue(entry.get().getValue().contains(Boolean.TRUE.toString()));
     }
     
     private void assertTransactionSync(final NarayanaConfiguration narayanaConfig) {
         Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "ObjectStoreEnvironmentBean.transactionSync".equals(each.getKey())).findFirst();
         assertTrue(entry.isPresent());
         assertThat(entry.get().getValue().size(), is(1));
-        assertTrue(entry.get().getValue().contains("NO"));
+        assertTrue(entry.get().getValue().contains(Boolean.FALSE.toString()));
     }
     
     private void assertNodeIdentifier(final NarayanaConfiguration narayanaConfig) {
@@ -191,7 +194,7 @@ public final class NarayanaConfigurationFileGeneratorTest {
         Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "RecoveryEnvironmentBean.recoveryListener".equals(each.getKey())).findFirst();
         assertTrue(entry.isPresent());
         assertThat(entry.get().getValue().size(), is(1));
-        assertTrue(entry.get().getValue().contains("NO"));
+        assertTrue(entry.get().getValue().contains(Boolean.FALSE.toString()));
     }
     
     private void assertRecoveryBackoffPeriod(final NarayanaConfiguration narayanaConfig) {
@@ -199,6 +202,27 @@ public final class NarayanaConfigurationFileGeneratorTest {
         assertTrue(entry.isPresent());
         assertThat(entry.get().getValue().size(), is(1));
         assertTrue(entry.get().getValue().contains("1"));
+    }
+    
+    private void assertDefaultTimeout(final NarayanaConfiguration narayanaConfig) {
+        Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "CoordinatorEnvironmentBean.defaultTimeout".equals(each.getKey())).findFirst();
+        assertTrue(entry.isPresent());
+        assertThat(entry.get().getValue().size(), is(1));
+        assertTrue(entry.get().getValue().contains("180"));
+    }
+    
+    private void assertExpiryScanInterval(final NarayanaConfiguration narayanaConfig) {
+        Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "RecoveryEnvironmentBean.expiryScanInterval".equals(each.getKey())).findFirst();
+        assertTrue(entry.isPresent());
+        assertThat(entry.get().getValue().size(), is(1));
+        assertTrue(entry.get().getValue().contains("12"));
+    }
+    
+    private void assertPeriodicRecoveryPeriod(final NarayanaConfiguration narayanaConfig) {
+        Optional<NarayanaConfigEntry> entry = narayanaConfig.getEntries().stream().filter(each -> "RecoveryEnvironmentBean.periodicRecoveryPeriod".equals(each.getKey())).findFirst();
+        assertTrue(entry.isPresent());
+        assertThat(entry.get().getValue().size(), is(1));
+        assertTrue(entry.get().getValue().contains("120"));
     }
     
     private void assertObjectStoreType(final NarayanaConfiguration narayanaConfig) {

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -52,9 +52,6 @@
 #      recoveryStorePassword: 12345678
 #      commitOnePhase: true
 #      transactionSync: false
-#      nodeIdentifier: 127.0.0.1@3307
-#      xaRecoveryNodes:
-#        - 127.0.0.1@3307
 #      recoveryBackoffPeriod: 1
 #      defaultTimeout: 180
 #      expiryScanInterval: 12

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -50,6 +50,7 @@
 #      recoveryStoreDataSource: com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 #      recoveryStoreUser: root
 #      recoveryStorePassword: 12345678
+#      # The following properties can be configured or not
 #      commitOnePhase: true
 #      transactionSync: false
 #      recoveryBackoffPeriod: 1

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/main/resources/conf/server.yaml
@@ -50,6 +50,15 @@
 #      recoveryStoreDataSource: com.mysql.jdbc.jdbc2.optional.MysqlDataSource
 #      recoveryStoreUser: root
 #      recoveryStorePassword: 12345678
+#      commitOnePhase: true
+#      transactionSync: false
+#      nodeIdentifier: 127.0.0.1@3307
+#      xaRecoveryNodes:
+#        - 127.0.0.1@3307
+#      recoveryBackoffPeriod: 1
+#      defaultTimeout: 180
+#      expiryScanInterval: 12
+#      periodicRecoveryPeriod: 120
 #  - !SQL_PARSER
 #    sqlCommentParseEnabled: true
 #    sqlStatementCache:


### PR DESCRIPTION
Fixes #18143 

Changes proposed in this pull request:
- Add two parameters RecoveryEnvironmentBean.expiryScanInterval and RecoveryEnvironmentBean.periodicRecoveryPeriod in Narayana.
- Allow users to customize some parameters of narayana in server.yaml, such as defaultTimeout, if not defined, use the default value.
- Modify the default 'YES' in the naraya parameter to be true, and 'NO' to be false, consistent with yaml.
