### PR TITLE
addComputeNodeInstance when modeType is not cluster

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/InstanceContext.java
@@ -52,6 +52,9 @@ public final class InstanceContext {
         this.workerIdGenerator = workerIdGenerator;
         this.modeConfiguration = modeConfiguration;
         this.lockContext = lockContext;
+        if (!isCluster()) {
+            addComputeNodeInstance(this.instance);
+        }
         initLockContext();
         getWorkerId();
     }


### PR DESCRIPTION
Fixes #18154 .

Changes proposed in this pull request:
- Execute addComputeNodeInstance when modeType is not cluster, so that some related distsql can be executed in non-cluster mode. 
