### PR TITLE
add unit test for JdbcQueryPropertiesExtension

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.mysql.datasource;
+
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtension;
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtensionFactory;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class MySQLJdbcQueryPropertiesExtensionTest {
+    
+    @Test
+    public void assertExtendQueryProperties() {
+        Optional<JdbcQueryPropertiesExtension> extensionOptional = JdbcQueryPropertiesExtensionFactory.getInstance("MySQL");
+        assertTrue(extensionOptional.isPresent());
+        
+        JdbcQueryPropertiesExtension extension = extensionOptional.get();
+        assertThat(extension, instanceOf(MySQLJdbcQueryPropertiesExtension.class));
+        assertThat(extension.getType(), equalTo("MySQL"));
+        
+        Properties queryProps = extension.extendQueryProperties();
+        assertThat(queryProps.size(), equalTo(6));
+        assertThat(queryProps.getProperty("useSSL"), equalTo(Boolean.FALSE.toString()));
+        assertThat(queryProps.getProperty("rewriteBatchedStatements"), equalTo(Boolean.TRUE.toString()));
+        assertThat(queryProps.getProperty("yearIsDateType"), equalTo(Boolean.FALSE.toString()));
+        assertThat(queryProps.getProperty("zeroDateTimeBehavior"), equalTo("convertToNull"));
+        assertThat(queryProps.getProperty("noDatetimeStringSync"), equalTo(Boolean.TRUE.toString()));
+        assertThat(queryProps.getProperty("jdbcCompliantTruncation"), equalTo(Boolean.FALSE.toString()));
+    }
+    
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/datasource/OpenGaussJdbcQueryPropertiesExtensionTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-opengauss/src/test/java/org/apache/shardingsphere/data/pipeline/opengauss/datasource/OpenGaussJdbcQueryPropertiesExtensionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.opengauss.datasource;
+
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtension;
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtensionFactory;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class OpenGaussJdbcQueryPropertiesExtensionTest {
+    
+    @Test
+    public void assertExtendQueryProperties() {
+        Optional<JdbcQueryPropertiesExtension> extensionOptional = JdbcQueryPropertiesExtensionFactory.getInstance("openGauss");
+        assertTrue(extensionOptional.isPresent());
+        
+        JdbcQueryPropertiesExtension extension = extensionOptional.get();
+        assertThat(extension, instanceOf(OpenGaussJdbcQueryPropertiesExtension.class));
+        assertThat(extension.getType(), equalTo("openGauss"));
+        assertTrue(extension.extendQueryProperties().isEmpty());
+    }
+    
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/datasource/PostgreSQLJdbcQueryPropertiesExtensionTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-postgresql/src/test/java/org/apache/shardingsphere/data/pipeline/postgresql/datasource/PostgreSQLJdbcQueryPropertiesExtensionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.postgresql.datasource;
+
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtension;
+import org.apache.shardingsphere.data.pipeline.spi.datasource.JdbcQueryPropertiesExtensionFactory;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class PostgreSQLJdbcQueryPropertiesExtensionTest {
+    
+    @Test
+    public void assertExtendQueryProperties() {
+        Optional<JdbcQueryPropertiesExtension> extensionOptional = JdbcQueryPropertiesExtensionFactory.getInstance("PostgreSQL");
+        assertTrue(extensionOptional.isPresent());
+        
+        JdbcQueryPropertiesExtension extension = extensionOptional.get();
+        assertThat(extension, instanceOf(PostgreSQLJdbcQueryPropertiesExtension.class));
+        assertThat(extension.getType(), equalTo("PostgreSQL"));
+        assertTrue(extension.extendQueryProperties().isEmpty());
+    }
+    
+}


### PR DESCRIPTION
Fixes #18151 .

Changes proposed in this pull request:
- add unit test for JdbcQueryPropertiesExtension, about MySQL, openGauss, PostgreSQL
