### PR TITLE
Update Groovy version to fix the problem about IndyInterface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <antlr4.version>4.9.2</antlr4.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <gson.version>2.8.6</gson.version>
-        <groovy.version>4.0.2</groovy.version>
+        <groovy.version>4.0.3</groovy.version>
         
         <jaxb.version>2.3.0</jaxb.version>
         <annotation-api.version>1.3.2</annotation-api.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -239,7 +239,7 @@ The text of each license is the standard Apache 2.0 license.
     failsafe 2.3.3: https://github.com/jhalterman/failsafe, Apache 2.0
     failureaccess 1.0.1:https://github.com/google/guava, Apache 2.0 
     freemarker 2.3.31: https://freemarker.apache.org/, Apache 2.0
-    groovy 4.0.2: https://groovy.apache.org/, Apache 2.0
+    groovy 4.0.3: https://groovy.apache.org/, Apache 2.0
     grpc-api 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-context 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-core 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0


### PR DESCRIPTION
Fixes #17779 .

Changes proposed in this pull request:
- update pom.xml .
- update LICENSE.
- As a remark, on Groovy 4.0.3, if users need to restore Groovy's support for GraalVM Native Image, they need to manually add the following fields in `conf/reflect-config.json`. Refer to https://github.com/oracle/graal/issues/4492#issuecomment-1143649719 .
```json
 {
   "name": "org.codehaus.groovy.runtime.dgm$53",
   "allDeclaredConstructors": true,
   "allPublicConstructors": true,
   "allDeclaredMethods": true,
   "allPublicMethods": true
 }
```
