### PR TITLE
Rename ApmPluginLoader to AgentPluginLoader.

### DIFF
--- a/shardingsphere-agent/shardingsphere-agent-bootstrap/src/main/java/org/apache/shardingsphere/agent/bootstrap/ShardingSphereAgent.java
+++ b/shardingsphere-agent/shardingsphere-agent-bootstrap/src/main/java/org/apache/shardingsphere/agent/bootstrap/ShardingSphereAgent.java
@@ -30,7 +30,7 @@ import org.apache.shardingsphere.agent.core.bytebuddy.transformer.ShardingSphere
 import org.apache.shardingsphere.agent.core.config.registry.AgentConfigurationRegistry;
 import org.apache.shardingsphere.agent.core.config.loader.AgentConfigurationLoader;
 import org.apache.shardingsphere.agent.core.plugin.PluginBootServiceManager;
-import org.apache.shardingsphere.agent.core.plugin.ApmPluginLoader;
+import org.apache.shardingsphere.agent.core.plugin.AgentPluginLoader;
 
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -52,13 +52,13 @@ public final class ShardingSphereAgent {
     public static void premain(final String arguments, final Instrumentation instrumentation) throws IOException {
         AgentConfiguration agentConfig = AgentConfigurationLoader.load();
         AgentConfigurationRegistry.INSTANCE.put(agentConfig);
-        ApmPluginLoader loader = createPluginLoader();
+        AgentPluginLoader loader = createPluginLoader();
         setUpAgentBuilder(instrumentation, loader);
         setupPluginBootService(agentConfig.getPlugins());
     }
     
-    private static ApmPluginLoader createPluginLoader() throws IOException {
-        ApmPluginLoader result = ApmPluginLoader.getInstance();
+    private static AgentPluginLoader createPluginLoader() throws IOException {
+        AgentPluginLoader result = AgentPluginLoader.getInstance();
         result.loadAllPlugins();
         return result;
     }
@@ -68,7 +68,7 @@ public final class ShardingSphereAgent {
         Runtime.getRuntime().addShutdownHook(new Thread(PluginBootServiceManager::closeAllServices));
     }
     
-    private static void setUpAgentBuilder(final Instrumentation instrumentation, final ApmPluginLoader loader) {
+    private static void setUpAgentBuilder(final Instrumentation instrumentation, final AgentPluginLoader loader) {
         AgentBuilder agentBuilder = new AgentBuilder.Default().with(new ByteBuddy().with(TypeValidation.ENABLED))
                 .ignore(ElementMatchers.isSynthetic()).or(ElementMatchers.nameStartsWith("org.apache.shardingsphere.agent."));
         agentBuilder.type(loader.typeMatcher())

--- a/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/plugin/AgentPluginLoader.java
+++ b/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/plugin/AgentPluginLoader.java
@@ -58,16 +58,16 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
 /**
- * Plugin loader.
+ * Agent plugin loader.
  */
 @Slf4j
-public final class ApmPluginLoader extends ClassLoader implements Closeable, PluginLoader {
+public final class AgentPluginLoader extends ClassLoader implements Closeable, PluginLoader {
     
     static {
         registerAsParallelCapable();
     }
     
-    private static volatile ApmPluginLoader pluginLoader;
+    private static volatile AgentPluginLoader pluginLoader;
     
     private final ConcurrentHashMap<String, Object> objectPool = new ConcurrentHashMap<>();
     
@@ -77,8 +77,8 @@ public final class ApmPluginLoader extends ClassLoader implements Closeable, Plu
     
     private Map<String, PluginInterceptorPoint> interceptorPointMap;
     
-    private ApmPluginLoader() {
-        super(ApmPluginLoader.class.getClassLoader());
+    private AgentPluginLoader() {
+        super(AgentPluginLoader.class.getClassLoader());
     }
     
     /**
@@ -86,11 +86,11 @@ public final class ApmPluginLoader extends ClassLoader implements Closeable, Plu
      *
      * @return plugin loader instance
      */
-    public static ApmPluginLoader getInstance() {
+    public static AgentPluginLoader getInstance() {
         if (null == pluginLoader) {
-            synchronized (ApmPluginLoader.class) {
+            synchronized (AgentPluginLoader.class) {
                 if (null == pluginLoader) {
-                    pluginLoader = new ApmPluginLoader();
+                    pluginLoader = new AgentPluginLoader();
                 }
             }
         }

--- a/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/spi/AgentServiceLoader.java
+++ b/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/spi/AgentServiceLoader.java
@@ -17,12 +17,13 @@
 
 package org.apache.shardingsphere.agent.core.spi;
 
+import org.apache.shardingsphere.agent.core.plugin.AgentPluginLoader;
+
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.shardingsphere.agent.core.plugin.ApmPluginLoader;
 
 /**
  * Agent service loader.
@@ -77,7 +78,7 @@ public final class AgentServiceLoader<T> {
             return;
         }
         serviceMap.put(service, new LinkedList<>());
-        ServiceLoader.load(service, ApmPluginLoader.getInstance())
+        ServiceLoader.load(service, AgentPluginLoader.getInstance())
                 .forEach(each -> serviceMap.get(service).add(each));
     }
 }

--- a/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/spi/PluginServiceLoader.java
+++ b/shardingsphere-agent/shardingsphere-agent-core/src/main/java/org/apache/shardingsphere/agent/core/spi/PluginServiceLoader.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.agent.core.spi;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.agent.core.plugin.ApmPluginLoader;
+import org.apache.shardingsphere.agent.core.plugin.AgentPluginLoader;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -41,7 +41,7 @@ public final class PluginServiceLoader {
      */
     public static <T> Collection<T> newServiceInstances(final Class<T> service) {
         List<T> result = new LinkedList<>();
-        ServiceLoader.load(service, ApmPluginLoader.getInstance()).forEach(result::add);
+        ServiceLoader.load(service, AgentPluginLoader.getInstance()).forEach(result::add);
         return result;
     }
 }

--- a/shardingsphere-agent/shardingsphere-agent-core/src/test/java/org/apache/shardingsphere/agent/core/bytebuddy/transformer/ShardingSphereTransformerTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-core/src/test/java/org/apache/shardingsphere/agent/core/bytebuddy/transformer/ShardingSphereTransformerTest.java
@@ -32,7 +32,7 @@ import org.apache.shardingsphere.agent.core.mock.advice.MockInstanceMethodAround
 import org.apache.shardingsphere.agent.core.mock.advice.MockInstanceMethodAroundRepeatedAdvice;
 import org.apache.shardingsphere.agent.core.mock.material.Material;
 import org.apache.shardingsphere.agent.core.mock.material.RepeatedAdviceMaterial;
-import org.apache.shardingsphere.agent.core.plugin.ApmPluginLoader;
+import org.apache.shardingsphere.agent.core.plugin.AgentPluginLoader;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertThat;
 
 public final class ShardingSphereTransformerTest {
     
-    private static final ApmPluginLoader LOADER = ApmPluginLoader.getInstance();
+    private static final AgentPluginLoader LOADER = AgentPluginLoader.getInstance();
     
     private static ResettableClassFileTransformer byteBuddyAgent;
     

--- a/shardingsphere-agent/shardingsphere-agent-core/src/test/java/org/apache/shardingsphere/agent/core/plugin/loader/AgentPluginLoaderTest.java
+++ b/shardingsphere-agent/shardingsphere-agent-core/src/test/java/org/apache/shardingsphere/agent/core/plugin/loader/AgentPluginLoaderTest.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.agent.api.point.PluginInterceptorPoint;
 import org.apache.shardingsphere.agent.core.mock.advice.MockClassStaticMethodAroundAdvice;
 import org.apache.shardingsphere.agent.core.mock.advice.MockConstructorAdvice;
 import org.apache.shardingsphere.agent.core.mock.advice.MockInstanceMethodAroundAdvice;
-import org.apache.shardingsphere.agent.core.plugin.ApmPluginLoader;
+import org.apache.shardingsphere.agent.core.plugin.AgentPluginLoader;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -39,10 +39,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-@Category(ApmPluginLoaderTest.class)
-public final class ApmPluginLoaderTest {
+@Category(AgentPluginLoaderTest.class)
+public final class AgentPluginLoaderTest {
     
-    private static final ApmPluginLoader LOADER = ApmPluginLoader.getInstance();
+    private static final AgentPluginLoader LOADER = AgentPluginLoader.getInstance();
     
     private static final TypePool POOL = TypePool.Default.ofSystemLoader();
     


### PR DESCRIPTION
In the agent, the plugin loader is responsible for loading plugins resources.
Now, the plugin loader has only one implementation: `ApmPluginLoader`.
It actually loads all plugins, including metrics, tracing, logging, etc., and prints logs when the Proxy starts:
````
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-metrics-prometheus-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-tracing-zipkin-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-tracing-opentracing-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-tracing-jaeger-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-tracing-opentelemetry-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Loaded jar shardingsphere-agent-logging-base-5.1.2-SNAPSHOT.jar
[main] o.a.s.a.core.plugin.ApmPluginLoader - Load plugin: Logging
````
I think `Apm` might confuse users, so it would be better to call `AgentPluginLoader`.
