### PR TITLE
support inline constraint support

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDDLStatementSQLVisitor.java
@@ -252,8 +252,10 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
         DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
         boolean isPrimaryKey = isPrimaryKey(ctx);
+        boolean isNotNull = isNotNull(ctx);
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(
                 ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey);
+        result.setNotNull(isNotNull);
         for (InlineConstraintContext each : ctx.inlineConstraint()) {
             if (null != each.referencesClause()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referencesClause().tableName()));
@@ -268,6 +270,15 @@ public final class OracleDDLStatementSQLVisitor extends OracleStatementSQLVisito
     private boolean isPrimaryKey(final ColumnDefinitionContext ctx) {
         for (InlineConstraintContext each : ctx.inlineConstraint()) {
             if (null != each.primaryKey()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isNotNull(final ColumnDefinitionContext ctx) {
+        for (InlineConstraintContext each : ctx.inlineConstraint()) {
+            if (null != each.NOT() && null != each.NULL()) {
                 return true;
             }
         }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
@@ -42,6 +42,8 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     private DataTypeSegment dataType;
     
     private boolean primaryKey;
+
+    private boolean notNull;
     
     private final Collection<SimpleTableSegment> referencedTables = new LinkedList<>();
     


### PR DESCRIPTION
Fixes #18230 .

Changes proposed in this pull request:
- modify org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment，support notNull constraint.
- modify org.apache.shardingsphere.sql.parser.oracle.visitor.statement.impl.OracleDDLStatementSQLVisitor, support what I changed above.
