### PR TITLE
Add remainingRowCount for fetch statement to reduce result set hold in memory

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchOrderByValueQueuesHolder.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchOrderByValueQueuesHolder.java
@@ -33,13 +33,24 @@ public final class FetchOrderByValueQueuesHolder {
     
     private static final ThreadLocal<Map<String, Queue<OrderByValue>>> ORDER_BY_VALUE_QUEUES = ThreadLocal.withInitial(ConcurrentHashMap::new);
     
+    private static final ThreadLocal<Map<String, Long>> REMAINING_ROW_COUNTS = ThreadLocal.withInitial(ConcurrentHashMap::new);
+    
     /**
-     * Get fetch order by value queues.
+     * Get order by value queues.
      *
-     * @return fetch order by value queues
+     * @return order by value queues
      */
-    public static Map<String, Queue<OrderByValue>> get() {
+    public static Map<String, Queue<OrderByValue>> getOrderByValueQueues() {
         return ORDER_BY_VALUE_QUEUES.get();
+    }
+    
+    /**
+     * Get remaining row counts.
+     *
+     * @return remaining row counts
+     */
+    public static Map<String, Long> getRemainingRowCounts() {
+        return REMAINING_ROW_COUNTS.get();
     }
     
     /**
@@ -47,5 +58,6 @@ public final class FetchOrderByValueQueuesHolder {
      */
     public static void remove() {
         ORDER_BY_VALUE_QUEUES.remove();
+        REMAINING_ROW_COUNTS.remove();
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchOrderByValueQueuesHolderTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/merge/ddl/fetch/FetchOrderByValueQueuesHolderTest.java
@@ -33,11 +33,15 @@ public final class FetchOrderByValueQueuesHolderTest {
     }
     
     @Test
-    public void assertTrafficContextHolder() {
-        assertFalse(FetchOrderByValueQueuesHolder.get().containsKey("t_order_cursor"));
-        FetchOrderByValueQueuesHolder.get().computeIfAbsent("t_order_cursor", key -> new PriorityQueue<>());
-        assertTrue(FetchOrderByValueQueuesHolder.get().containsKey("t_order_cursor"));
+    public void assertFetchOrderByValueQueuesHolder() {
+        assertFalse(FetchOrderByValueQueuesHolder.getOrderByValueQueues().containsKey("t_order_cursor"));
+        assertFalse(FetchOrderByValueQueuesHolder.getRemainingRowCounts().containsKey("t_order_cursor"));
+        FetchOrderByValueQueuesHolder.getOrderByValueQueues().computeIfAbsent("t_order_cursor", key -> new PriorityQueue<>());
+        FetchOrderByValueQueuesHolder.getRemainingRowCounts().put("t_order_cursor", 0L);
+        assertTrue(FetchOrderByValueQueuesHolder.getOrderByValueQueues().containsKey("t_order_cursor"));
+        assertTrue(FetchOrderByValueQueuesHolder.getRemainingRowCounts().containsKey("t_order_cursor"));
         FetchOrderByValueQueuesHolder.remove();
-        assertFalse(FetchOrderByValueQueuesHolder.get().containsKey("t_order_cursor"));
+        assertFalse(FetchOrderByValueQueuesHolder.getOrderByValueQueues().containsKey("t_order_cursor"));
+        assertFalse(FetchOrderByValueQueuesHolder.getRemainingRowCounts().containsKey("t_order_cursor"));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResult.java
@@ -31,6 +31,6 @@ import java.sql.SQLException;
 public final class JDBCMemoryQueryResult extends AbstractMemoryQueryResult {
     
     public JDBCMemoryQueryResult(final ResultSet resultSet, final DatabaseType databaseType) throws SQLException {
-        super(new JDBCQueryResultMetaData(resultSet.getMetaData()), DialectJDBCRowsLoaderFactory.getInstance(databaseType).load(resultSet.getMetaData().getColumnCount(), resultSet).iterator());
+        super(new JDBCQueryResultMetaData(resultSet.getMetaData()), DialectJDBCRowsLoaderFactory.getInstance(databaseType).load(resultSet.getMetaData().getColumnCount(), resultSet));
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/raw/type/RawMemoryQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/raw/type/RawMemoryQueryResult.java
@@ -29,6 +29,6 @@ import java.util.List;
 public final class RawMemoryQueryResult extends AbstractMemoryQueryResult {
     
     public RawMemoryQueryResult(final QueryResultMetaData metaData, final List<MemoryQueryResultDataRow> rows) {
-        super(metaData, rows.iterator());
+        super(metaData, rows);
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/type/memory/AbstractMemoryQueryResult.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/type/memory/AbstractMemoryQueryResult.java
@@ -17,9 +17,7 @@
 
 package org.apache.shardingsphere.infra.executor.sql.execute.result.query.type.memory;
 
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
@@ -31,12 +29,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Iterator;
 
 /**
  * Abstract memory query result.
  */
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractMemoryQueryResult implements QueryResult {
     
     @Getter
@@ -46,10 +44,20 @@ public abstract class AbstractMemoryQueryResult implements QueryResult {
     
     private MemoryQueryResultDataRow currentRow;
     
+    @Getter
+    private long rowCount;
+    
+    protected AbstractMemoryQueryResult(final QueryResultMetaData metaData, final Collection<MemoryQueryResultDataRow> rows) {
+        this.metaData = metaData;
+        this.rows = rows.iterator();
+        rowCount = rows.size();
+    }
+    
     @Override
     public final boolean next() {
         if (rows.hasNext()) {
             currentRow = rows.next();
+            rowCount--;
             return true;
         }
         currentRow = null;

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
@@ -364,6 +364,16 @@ public final class JDBCMemoryQueryResultTest {
         assertTrue(queryResult.wasNull());
     }
     
+    @Test
+    public void assertGetRowCount() throws SQLException {
+        JDBCMemoryQueryResult queryResult = new JDBCMemoryQueryResult(mockResultSet(), databaseType);
+        assertThat(queryResult.getRowCount(), is(1L));
+        queryResult.next();
+        assertThat(queryResult.getRowCount(), is(0L));
+        queryResult.next();
+        assertThat(queryResult.getRowCount(), is(0L));
+    }
+    
     private ResultSet mockResultSet() throws SQLException {
         ResultSet result = mock(ResultSet.class);
         when(result.next()).thenReturn(true).thenReturn(false);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/SchemaAssignedDatabaseBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/data/impl/SchemaAssignedDatabaseBackendHandler.java
@@ -101,7 +101,8 @@ public final class SchemaAssignedDatabaseBackendHandler implements DatabaseBacke
             ((CursorDefinitionAware) statementContext).setUpCursorDefinition(cursorStatementContext);
         }
         if (statementContext instanceof CloseStatementContext) {
-            FetchOrderByValueQueuesHolder.get().remove(cursorName);
+            FetchOrderByValueQueuesHolder.getOrderByValueQueues().remove(cursorName);
+            FetchOrderByValueQueuesHolder.getRemainingRowCounts().remove(cursorName);
             connectionSession.getCursorDefinitions().remove(cursorName);
         }
     }


### PR DESCRIPTION
Ref #17825.

Changes proposed in this pull request:
- add remainingRowCount for fetch statement to reduce result set hold in memory
- optimize FetchStreamMergedResult logic
- add rowCount filed in AbstractMemoryQueryResult
- update unit test
