### PR TITLE
Unit test DataSourcePoolDestroyerTest.assertAsyncDestroyHikariDataSource failed occasionally

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/pool/destroyer/DataSourcePoolDestroyerTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/datasource/pool/destroyer/DataSourcePoolDestroyerTest.java
@@ -35,7 +35,7 @@ public final class DataSourcePoolDestroyerTest {
         new DataSourcePoolDestroyer(new MockedDataSource()).asyncDestroy();
     }
     
-    @Test(timeout = 1000L)
+    @Test(timeout = 2000L)
     public void assertAsyncDestroyHikariDataSource() throws SQLException, InterruptedException {
         HikariDataSource dataSource = createHikariDataSource();
         try (Connection ignored = dataSource.getConnection()) {


### PR DESCRIPTION
For #17727.

Changes proposed in this pull request:
-
-
-
