### PR TITLE
add MySQLNormalReplicationCheckedDelayByDefinedSQLDatabaseDiscoveryProviderAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationCheckedDelayByDefinedSQLDatabaseDiscoveryProviderAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationCheckedDelayByDefinedSQLDatabaseDiscoveryProviderAlgorithm.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.shardingsphere.dbdiscovery.mysql.type;
 
 import com.google.common.base.Preconditions;

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.dbdiscovery.spi.DatabaseDiscoveryProviderAlgorithm
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/resources/META-INF/services/org.apache.shardingsphere.dbdiscovery.spi.DatabaseDiscoveryProviderAlgorithm
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.dbdiscovery.mysql.type.MGRMySQLDatabaseDiscoveryProviderAlgorithm
 org.apache.shardingsphere.dbdiscovery.mysql.type.MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm
+org.apache.shardingsphere.dbdiscovery.mysql.type.MySQLNormalReplicationCheckedDelayByDefinedSQLDatabaseDiscoveryProviderAlgorithm


### PR DESCRIPTION
Fixes #18327 .

Changes proposed in this pull request:
- add MySQLNormalReplicationCheckedDelayByDefinedSQLDatabaseDiscoveryProviderAlgorithm
