### PR TITLE
Delay is Long.MAX_VALUE if show slave status result is null or second_behind_master is null

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm.java
@@ -124,7 +124,11 @@ public final class MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm impl
     
     private long queryReplicationDelayMilliseconds(final Statement statement) throws SQLException {
         try (ResultSet resultSet = statement.executeQuery(SHOW_SLAVE_STATUS)) {
-            return resultSet.next() ? resultSet.getLong("Seconds_Behind_Master") * 1000L : 0L;
+            if (resultSet.next()) {
+                long delay = resultSet.getLong("Seconds_Behind_Master") * 1000;
+                return resultSet.wasNull() ? Long.MAX_VALUE : delay;
+            }
+            return Long.MAX_VALUE;
         }
     }
     


### PR DESCRIPTION
Fixes #18360 .

Changes proposed in this pull request:
- Delay is Long.MAX_VALUE if show slave status result is null or second_behind_master is null.
