### PR TITLE
Fix scaling increment task consumed incomplete data

### DIFF
--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeader.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeader.java
@@ -44,6 +44,9 @@ public final class MySQLBinlogEventHeader implements MySQLPacket {
     
     private final int serverId;
     
+    /**
+     * Size of the event (header, post-header, body).
+     */
     private final int eventSize;
     
     private final int logPos;

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeader.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeader.java
@@ -53,13 +53,16 @@ public final class MySQLBinlogEventHeader implements MySQLPacket {
     
     private final int flags;
     
-    public MySQLBinlogEventHeader(final MySQLPacketPayload payload) {
+    private final int checksumLength;
+    
+    public MySQLBinlogEventHeader(final MySQLPacketPayload payload, final int checksumLength) {
         timestamp = payload.readInt4();
         eventType = payload.readInt1();
         serverId = payload.readInt4();
         eventSize = payload.readInt4();
         logPos = payload.readInt4();
         flags = payload.readInt2();
+        this.checksumLength = checksumLength;
     }
     
     @Override

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacket.java
@@ -40,10 +40,10 @@ public final class MySQLBinlogRotateEventPacket extends AbstractMySQLBinlogEvent
         this.nextBinlogName = nextBinlogName;
     }
     
-    public MySQLBinlogRotateEventPacket(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
+    public MySQLBinlogRotateEventPacket(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload, final int checksumLength) {
         super(binlogEventHeader);
         position = payload.readInt8();
-        nextBinlogName = payload.readStringEOF();
+        nextBinlogName = payload.readStringFix(getRemainBytesLength(payload, checksumLength));
     }
     
     @Override

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacket.java
@@ -40,10 +40,10 @@ public final class MySQLBinlogRotateEventPacket extends AbstractMySQLBinlogEvent
         this.nextBinlogName = nextBinlogName;
     }
     
-    public MySQLBinlogRotateEventPacket(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload, final int checksumLength) {
+    public MySQLBinlogRotateEventPacket(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
         super(binlogEventHeader);
         position = payload.readInt8();
-        nextBinlogName = payload.readStringFix(getRemainBytesLength(payload, checksumLength));
+        nextBinlogName = payload.readStringFix(getRemainBytesLength(payload));
     }
     
     @Override

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacket.java
@@ -90,16 +90,12 @@ public final class MySQLBinlogRowsEventPacket extends AbstractMySQLBinlogEventPa
      */
     public void readRows(final MySQLBinlogTableMapEventPacket tableMapEventPacket, final MySQLPacketPayload payload) {
         List<MySQLBinlogColumnDef> columnDefs = tableMapEventPacket.getColumnDefs();
-        while (hasNextRow(payload)) {
+        while (getRemainBytesLength(payload) > 0) {
             rows.add(readRow(columnDefs, payload));
             if (isUpdateRowsEvent(getBinlogEventHeader().getEventType())) {
                 rows2.add(readRow(columnDefs, payload));
             }
         }
-    }
-    
-    private boolean hasNextRow(final MySQLPacketPayload payload) {
-        return payload.getByteBuf().isReadable();
     }
     
     private Serializable[] readRow(final List<MySQLBinlogColumnDef> columnDefs, final MySQLPacketPayload payload) {

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogTableMapEventPacket.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogTableMapEventPacket.java
@@ -66,7 +66,10 @@ public final class MySQLBinlogTableMapEventPacket extends AbstractMySQLBinlogEve
         // mysql 8 binlog table map event include column type def
         // for support lower than 8, read column type def by sql query
         // so skip readable bytes here
-        payload.getByteBuf().skipBytes(payload.getByteBuf().readableBytes());
+        int remainBytesLength = getRemainBytesLength(payload);
+        if (remainBytesLength > 0) {
+            payload.skipReserved(remainBytesLength);
+        }
     }
     
     private void readColumnDefs(final MySQLPacketPayload payload) {

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeaderTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/MySQLBinlogEventHeaderTest.java
@@ -41,7 +41,7 @@ public final class MySQLBinlogEventHeaderTest {
         when(payload.readInt4()).thenReturn(1234567890, 123456, 19, 4);
         when(payload.readInt1()).thenReturn(MySQLBinlogEventType.UNKNOWN_EVENT.getValue());
         when(payload.readInt2()).thenReturn(MySQLBinlogEventFlag.LOG_EVENT_BINLOG_IN_USE_F.getValue());
-        MySQLBinlogEventHeader actual = new MySQLBinlogEventHeader(payload);
+        MySQLBinlogEventHeader actual = new MySQLBinlogEventHeader(payload, 4);
         assertThat(actual.getSequenceId(), is(0));
         assertThat(actual.getTimestamp(), is(1234567890));
         assertThat(actual.getEventType(), is(MySQLBinlogEventType.UNKNOWN_EVENT.getValue()));
@@ -53,7 +53,7 @@ public final class MySQLBinlogEventHeaderTest {
     
     @Test
     public void assertWrite() {
-        new MySQLBinlogEventHeader(1234567890, MySQLBinlogEventType.UNKNOWN_EVENT.getValue(), 123456, 19, 4, MySQLBinlogEventFlag.LOG_EVENT_BINLOG_IN_USE_F.getValue()).write(payload);
+        new MySQLBinlogEventHeader(1234567890, MySQLBinlogEventType.UNKNOWN_EVENT.getValue(), 123456, 19, 4, MySQLBinlogEventFlag.LOG_EVENT_BINLOG_IN_USE_F.getValue(), 4).write(payload);
         verify(payload).writeInt4(1234567890);
         verify(payload).writeInt1(MySQLBinlogEventType.UNKNOWN_EVENT.getValue());
         verify(payload).writeInt4(123456);

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/management/MySQLBinlogRotateEventPacketTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.db.protocol.mysql.packet.binlog.management;
 
+import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.MySQLBinlogEventHeader;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
 import org.junit.Test;
@@ -26,6 +27,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,7 +43,8 @@ public final class MySQLBinlogRotateEventPacketTest {
     @Test
     public void assertNew() {
         when(payload.readInt8()).thenReturn(4L);
-        when(payload.readStringEOF()).thenReturn("binlog-000001");
+        when(payload.readStringFix(anyInt())).thenReturn("binlog-000001");
+        when(payload.getByteBuf()).thenReturn(Unpooled.buffer());
         MySQLBinlogRotateEventPacket actual = new MySQLBinlogRotateEventPacket(binlogEventHeader, payload);
         assertThat(actual.getSequenceId(), is(0));
         assertThat(actual.getBinlogEventHeader(), is(binlogEventHeader));

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacketTest.java
@@ -73,11 +73,11 @@ public final class MySQLBinlogRowsEventPacketTest {
     @Test
     public void assertReadWriteRowV1WithoutNullValue() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        MySQLPacketPayload packetPayload = new MySQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        Serializable[] result = (Serializable[]) invokeMethod(actual, "readRow", new Class[]{List.class, MySQLPacketPayload.class}, new Object[]{columnDefs, packetPayload});
         assertBinlogRowsEventV1BeforeRows(actual);
         assertFalse(actual.getColumnsPresentBitmap().isNullParameter(0));
         assertNull(actual.getColumnsPresentBitmap2());
+        MySQLPacketPayload packetPayload = new MySQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        Serializable[] result = (Serializable[]) invokeMethod(actual, "readRow", new Class[]{List.class, MySQLPacketPayload.class}, new Object[]{columnDefs, packetPayload});
         assertThat(result[0], is(0L));
     }
     

--- a/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacketTest.java
+++ b/shardingsphere-db-protocol/shardingsphere-db-protocol-mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/MySQLBinlogRowsEventPacketTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row;
 
 import io.netty.buffer.ByteBuf;
-import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinlogEventType;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinaryColumnType;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.MySQLBinlogEventHeader;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.column.MySQLBinlogColumnDef;
@@ -29,6 +28,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,7 +39,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,20 +55,14 @@ public final class MySQLBinlogRowsEventPacketTest {
     @Mock
     private MySQLBinlogEventHeader binlogEventHeader;
     
-    @Mock
-    private MySQLBinlogTableMapEventPacket tableMapEventPacket;
-    
     private List<MySQLBinlogColumnDef> columnDefs;
     
     @Before
     public void setUp() {
         mockColumnDefs();
-        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
         when(payload.readInt6()).thenReturn(1L);
         when(payload.readInt2()).thenReturn(2);
         when(payload.readIntLenenc()).thenReturn(1L);
-        when(payload.getByteBuf()).thenReturn(byteBuf);
-        when(byteBuf.isReadable()).thenReturn(true, false);
     }
     
     private void mockColumnDefs() {
@@ -75,46 +71,14 @@ public final class MySQLBinlogRowsEventPacketTest {
     }
     
     @Test
-    public void assertReadWriteRowV1WithoutNullValue() {
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.WRITE_ROWS_EVENTv1.getValue());
-        when(payload.readInt8()).thenReturn(Long.MAX_VALUE);
+    public void assertReadWriteRowV1WithoutNullValue() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
+        MySQLPacketPayload packetPayload = new MySQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        Serializable[] result = (Serializable[]) invokeMethod(actual, "readRow", new Class[]{List.class, MySQLPacketPayload.class}, new Object[]{columnDefs, packetPayload});
         assertBinlogRowsEventV1BeforeRows(actual);
         assertFalse(actual.getColumnsPresentBitmap().isNullParameter(0));
         assertNull(actual.getColumnsPresentBitmap2());
-        assertThat(actual.getRows().size(), is(1));
-        assertThat(actual.getRows().get(0)[0], is(Long.MAX_VALUE));
-        assertTrue(actual.getRows2().isEmpty());
-    }
-    
-    @Test
-    public void assertReadWriteRowV1WithNullValue() {
-        when(payload.readInt1()).thenReturn(0x01);
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.WRITE_ROWS_EVENTv1.getValue());
-        MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
-        assertBinlogRowsEventV1BeforeRows(actual);
-        assertTrue(actual.getColumnsPresentBitmap().isNullParameter(0));
-        assertNull(actual.getColumnsPresentBitmap2());
-        assertThat(actual.getRows().size(), is(1));
-        assertNull(actual.getRows().get(0)[0]);
-        assertTrue(actual.getRows2().isEmpty());
-    }
-    
-    @Test
-    public void assertReadUpdateRowV1WithoutNullValue() {
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.UPDATE_ROWS_EVENTv1.getValue());
-        when(payload.readInt8()).thenReturn(Long.MAX_VALUE, Long.MIN_VALUE);
-        MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
-        assertBinlogRowsEventV1BeforeRows(actual);
-        assertFalse(actual.getColumnsPresentBitmap().isNullParameter(0));
-        assertFalse(actual.getColumnsPresentBitmap2().isNullParameter(0));
-        assertThat(actual.getRows().size(), is(1));
-        assertThat(actual.getRows().get(0)[0], is(Long.MAX_VALUE));
-        assertThat(actual.getRows2().size(), is(1));
-        assertThat(actual.getRows2().get(0)[0], is(Long.MIN_VALUE));
+        assertThat(result[0], is(0L));
     }
     
     private void assertBinlogRowsEventV1BeforeRows(final MySQLBinlogRowsEventPacket actual) {
@@ -124,53 +88,10 @@ public final class MySQLBinlogRowsEventPacketTest {
         assertThat(actual.getColumnNumber(), is(1));
     }
     
-    @Test
-    public void assertReadWriteRowV2WithoutNullValue() {
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.WRITE_ROWS_EVENTv2.getValue());
-        when(payload.readInt8()).thenReturn(Long.MAX_VALUE);
-        MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
-        assertBinlogRowsEventV2BeforeRows(actual);
-        assertFalse(actual.getColumnsPresentBitmap().isNullParameter(0));
-        assertNull(actual.getColumnsPresentBitmap2());
-        assertThat(actual.getRows().size(), is(1));
-        assertThat(actual.getRows().get(0)[0], is(Long.MAX_VALUE));
-        assertTrue(actual.getRows2().isEmpty());
-    }
-    
-    @Test
-    public void assertReadWriteRowV2WithNullValue() {
-        when(payload.readInt1()).thenReturn(0x01);
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.WRITE_ROWS_EVENTv2.getValue());
-        MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
-        assertBinlogRowsEventV2BeforeRows(actual);
-        assertTrue(actual.getColumnsPresentBitmap().isNullParameter(0));
-        assertNull(actual.getColumnsPresentBitmap2());
-        assertThat(actual.getRows().size(), is(1));
-        assertNull(actual.getRows().get(0)[0]);
-        assertTrue(actual.getRows2().isEmpty());
-    }
-    
-    @Test
-    public void assertReadUpdateRowV2WithoutNullValue() {
-        when(binlogEventHeader.getEventType()).thenReturn(MySQLBinlogEventType.UPDATE_ROWS_EVENTv2.getValue());
-        when(payload.readInt8()).thenReturn(Long.MAX_VALUE, Long.MIN_VALUE);
-        MySQLBinlogRowsEventPacket actual = new MySQLBinlogRowsEventPacket(binlogEventHeader, payload);
-        actual.readRows(tableMapEventPacket, payload);
-        assertBinlogRowsEventV2BeforeRows(actual);
-        assertFalse(actual.getColumnsPresentBitmap().isNullParameter(0));
-        assertFalse(actual.getColumnsPresentBitmap2().isNullParameter(0));
-        assertThat(actual.getRows().size(), is(1));
-        assertThat(actual.getRows().get(0)[0], is(Long.MAX_VALUE));
-        assertThat(actual.getRows2().size(), is(1));
-        assertThat(actual.getRows2().get(0)[0], is(Long.MIN_VALUE));
-    }
-    
-    private void assertBinlogRowsEventV2BeforeRows(final MySQLBinlogRowsEventPacket actual) {
-        assertThat(actual.getTableId(), is(1L));
-        assertThat(actual.getFlags(), is(2));
-        verify(payload).skipReserved(0);
-        assertThat(actual.getColumnNumber(), is(1));
+    private static Object invokeMethod(final Object target, final String methodName, final Class<?>[] parameterTypes,
+                                       final Object[] parameterValues) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(target, parameterValues);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoder.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoder.java
@@ -31,7 +31,6 @@ import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.UpdateR
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.WriteRowsEvent;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinlogEventType;
-import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.AbstractMySQLBinlogEventPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.MySQLBinlogEventHeader;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.management.MySQLBinlogFormatDescriptionEventPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.management.MySQLBinlogRotateEventPacket;
@@ -133,16 +132,14 @@ public final class MySQLBinlogEventPacketDecoder extends ByteToMessageDecoder {
         }
     }
     
-    private AbstractMySQLBinlogEventPacket decodeRotateEvent(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
-        MySQLBinlogRotateEventPacket result = new MySQLBinlogRotateEventPacket(binlogEventHeader, payload);
-        binlogContext.setFileName(result.getNextBinlogName());
-        return result;
+    private void decodeRotateEvent(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
+        MySQLBinlogRotateEventPacket rotateEventPacket = new MySQLBinlogRotateEventPacket(binlogEventHeader, payload);
+        binlogContext.setFileName(rotateEventPacket.getNextBinlogName());
     }
     
-    private MySQLBinlogTableMapEventPacket decodeTableMapEvent(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
-        MySQLBinlogTableMapEventPacket result = new MySQLBinlogTableMapEventPacket(binlogEventHeader, payload);
-        binlogContext.putTableMapEvent(result.getTableId(), result);
-        return result;
+    private void decodeTableMapEvent(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {
+        MySQLBinlogTableMapEventPacket tableMapEventPacket = new MySQLBinlogTableMapEventPacket(binlogEventHeader, payload);
+        binlogContext.putTableMapEvent(tableMapEventPacket.getTableId(), tableMapEventPacket);
     }
     
     private DeleteRowsEvent decodeDeleteRowsEventV2(final MySQLBinlogEventHeader binlogEventHeader, final MySQLPacketPayload payload) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
@@ -38,6 +38,7 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
@@ -126,6 +127,8 @@ public final class MySQLBinlogEventPacketDecoderTest {
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
         assertThat(decodedEvents.get(0), instanceOf(WriteRowsEvent.class));
+        WriteRowsEvent actual = (WriteRowsEvent) decodedEvents.get(0);
+        assertThat(actual.getAfterRows().get(0), is(new Serializable[]{1L, 1, "SUCCESS", null}));
     }
     
     @Test
@@ -140,6 +143,9 @@ public final class MySQLBinlogEventPacketDecoderTest {
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
         assertThat(decodedEvents.get(0), instanceOf(UpdateRowsEvent.class));
+        UpdateRowsEvent actual = (UpdateRowsEvent) decodedEvents.get(0);
+        assertThat(actual.getBeforeRows().get(0), is(new Serializable[]{1L, 1, "SUCCESS", null}));
+        assertThat(actual.getAfterRows().get(0), is(new Serializable[]{1L, 1, "updated", null}));
     }
     
     @Test
@@ -153,6 +159,8 @@ public final class MySQLBinlogEventPacketDecoderTest {
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
         assertThat(decodedEvents.get(0), instanceOf(DeleteRowsEvent.class));
+        DeleteRowsEvent actual = (DeleteRowsEvent) decodedEvents.get(0);
+        assertThat(actual.getBeforeRows().get(0), is(new Serializable[]{1L, 1, "SUCCESS", null}));
     }
     
     @Test

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
@@ -29,6 +29,8 @@ import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.UpdateR
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.WriteRowsEvent;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinaryColumnType;
+import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.management.MySQLBinlogFormatDescriptionEventPacket;
+import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.management.MySQLBinlogRotateEventPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.MySQLBinlogTableMapEventPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.column.MySQLBinlogColumnDef;
 import org.junit.Before;
@@ -46,7 +48,6 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -88,7 +89,8 @@ public final class MySQLBinlogEventPacketDecoderTest {
         byteBuf.writeBytes(StringUtil.decodeHexDump("01000000000004010000002c0000000000000020001a9100000000000062696e6c6f672e3030303032394af65c24"));
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
-        assertTrue(decodedEvents.isEmpty());
+        assertThat(decodedEvents.size(), is(1));
+        assertThat(decodedEvents.get(0), instanceOf(MySQLBinlogRotateEventPacket.class));
         assertThat(binlogContext.getFileName(), is("binlog.000029"));
     }
     
@@ -99,7 +101,8 @@ public final class MySQLBinlogEventPacketDecoderTest {
                 + "000000000013000d0008000000000400040000006100041a08000000080808020000000a0a0a2a2a001234000a280140081396"));
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
-        assertTrue(decodedEvents.isEmpty());
+        assertThat(decodedEvents.size(), is(1));
+        assertThat(decodedEvents.get(0), instanceOf(MySQLBinlogFormatDescriptionEventPacket.class));
         assertThat(binlogContext.getChecksumLength(), is(4));
     }
     
@@ -111,7 +114,8 @@ public final class MySQLBinlogEventPacketDecoderTest {
         binlogContext.getTableMap().put(123L, tableMapEventPacket);
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
-        assertTrue(decodedEvents.isEmpty());
+        assertThat(decodedEvents.size(), is(1));
+        assertThat(decodedEvents.get(0), instanceOf(MySQLBinlogTableMapEventPacket.class));
         assertThat(binlogContext.getTableMap().size(), is(1));
         assertThat(binlogContext.getTableMap().get(123L), instanceOf(MySQLBinlogTableMapEventPacket.class));
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/netty/MySQLBinlogEventPacketDecoderTest.java
@@ -17,16 +17,20 @@
 
 package org.apache.shardingsphere.data.pipeline.mysql.ingest.client.netty;
 
+import com.google.common.collect.Lists;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.util.internal.StringUtil;
 import org.apache.shardingsphere.data.pipeline.core.util.ReflectionUtil;
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.BinlogContext;
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.DeleteRowsEvent;
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.UpdateRowsEvent;
 import org.apache.shardingsphere.data.pipeline.mysql.ingest.binlog.event.WriteRowsEvent;
 import org.apache.shardingsphere.db.protocol.CommonConstants;
-import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinlogEventType;
+import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinaryColumnType;
 import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.MySQLBinlogTableMapEventPacket;
+import org.apache.shardingsphere.db.protocol.mysql.packet.binlog.row.column.MySQLBinlogColumnDef;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,7 +39,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -52,47 +55,47 @@ public final class MySQLBinlogEventPacketDecoderTest {
     private ChannelHandlerContext channelHandlerContext;
     
     @Mock
-    private ByteBuf byteBuf;
-    
-    @Mock
     private MySQLBinlogTableMapEventPacket tableMapEventPacket;
     
     private BinlogContext binlogContext;
     
     private MySQLBinlogEventPacketDecoder binlogEventPacketDecoder;
     
+    private List<MySQLBinlogColumnDef> columnDefs;
+    
     @Before
     public void setUp() throws NoSuchFieldException, IllegalAccessException {
         binlogEventPacketDecoder = new MySQLBinlogEventPacketDecoder(4);
         binlogContext = ReflectionUtil.getFieldValue(binlogEventPacketDecoder, "binlogContext", BinlogContext.class);
         when(channelHandlerContext.channel().attr(CommonConstants.CHARSET_ATTRIBUTE_KEY).get()).thenReturn(StandardCharsets.UTF_8);
+        columnDefs = Lists.newArrayList(new MySQLBinlogColumnDef(MySQLBinaryColumnType.MYSQL_TYPE_LONGLONG), new MySQLBinlogColumnDef(MySQLBinaryColumnType.MYSQL_TYPE_LONG),
+                new MySQLBinlogColumnDef(MySQLBinaryColumnType.MYSQL_TYPE_VARCHAR), new MySQLBinlogColumnDef(MySQLBinaryColumnType.MYSQL_TYPE_NEWDECIMAL));
     }
     
     @Test(expected = RuntimeException.class)
     public void assertDecodeWithPacketError() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 255);
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeByte(1);
+        byteBuf.writeByte(255);
+        byteBuf.writeBytes(new byte[20]);
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, null);
-    }
-    
-    @Test(expected = UnsupportedOperationException.class)
-    public void assertDecodeWithReadError() {
-        when(byteBuf.isReadable()).thenReturn(true);
-        binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, new LinkedList<>());
     }
     
     @Test
     public void assertDecodeRotateEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.ROTATE_EVENT.getValue());
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeBytes(StringUtil.decodeHexDump("01000000000004010000002c0000000000000020001a9100000000000062696e6c6f672e3030303032394af65c24"));
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertTrue(decodedEvents.isEmpty());
-        assertThat(binlogContext.getFileName(), is(""));
+        assertThat(binlogContext.getFileName(), is("binlog.000029"));
     }
     
     @Test
     public void assertDecodeFormatDescriptionEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.FORMAT_DESCRIPTION_EVENT.getValue(), (short) 19);
-        when(byteBuf.readUnsignedShortLE()).thenReturn(4);
+        ByteBuf byteBuf = Unpooled.buffer();
+        byteBuf.writeBytes(StringUtil.decodeHexDump("0200513aa8620f01000000790000000000000000000400382e302e323700000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                + "000000000013000d0008000000000400040000006100041a08000000080808020000000a0a0a2a2a001234000a280140081396"));
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertTrue(decodedEvents.isEmpty());
@@ -101,20 +104,24 @@ public final class MySQLBinlogEventPacketDecoderTest {
     
     @Test
     public void assertDecodeTableMapEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.TABLE_MAP_EVENT.getValue(), (short) 0);
+        ByteBuf byteBuf = Unpooled.buffer();
+        // the hex data is from binlog data, The first event used in Row Based Replication 
+        byteBuf.writeBytes(StringUtil.decodeHexDump("3400cb38a962130100000041000000be7d000000007b000000000001000464735f310009745f6f726465725f31000408030ff604c8000a020c0101000201e0ff0a9b3a"));
+        binlogContext.getTableMap().put(123L, tableMapEventPacket);
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertTrue(decodedEvents.isEmpty());
         assertThat(binlogContext.getTableMap().size(), is(1));
-        assertThat(binlogContext.getTableMap().get(0L), instanceOf(MySQLBinlogTableMapEventPacket.class));
+        assertThat(binlogContext.getTableMap().get(123L), instanceOf(MySQLBinlogTableMapEventPacket.class));
     }
     
     @Test
     public void assertDecodeWriteRowEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.WRITE_ROWS_EVENTv2.getValue(), (short) 0);
-        when(byteBuf.readUnsignedShortLE()).thenReturn(2);
-        binlogContext.getTableMap().put(0L, tableMapEventPacket);
-        when(tableMapEventPacket.getColumnDefs()).thenReturn(Collections.emptyList());
+        ByteBuf byteBuf = Unpooled.buffer();
+        // the hex data is from INSERT INTO t_order(order_id, user_id, status, t_numeric) VALUES (1, 1, 'SUCCESS',null);
+        byteBuf.writeBytes(StringUtil.decodeHexDump("30007a36a9621e0100000038000000bb7c000000007b00000000000100020004ff08010000000000000001000000075355434345535365eff9ff"));
+        binlogContext.getTableMap().put(123L, tableMapEventPacket);
+        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
@@ -123,10 +130,12 @@ public final class MySQLBinlogEventPacketDecoderTest {
     
     @Test
     public void assertDecodeUpdateRowEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.UPDATE_ROWS_EVENTv2.getValue(), (short) 0);
-        when(byteBuf.readUnsignedShortLE()).thenReturn(2);
-        binlogContext.getTableMap().put(0L, tableMapEventPacket);
-        when(tableMapEventPacket.getColumnDefs()).thenReturn(Collections.emptyList());
+        ByteBuf byteBuf = Unpooled.buffer();
+        // the hex data is from update t_order set status = 'updated' where order_id = 1;
+        byteBuf.writeBytes(StringUtil.decodeHexDump("3500cb38a9621f010000004e0000000c7e000000007b00000000000100020004ffff08010000000000000001000000075355434345535308010000000000000001000000077570"
+                + "6461746564e78cee6c"));
+        binlogContext.getTableMap().put(123L, tableMapEventPacket);
+        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
@@ -135,13 +144,44 @@ public final class MySQLBinlogEventPacketDecoderTest {
     
     @Test
     public void assertDecodeDeleteRowEvent() {
-        when(byteBuf.readUnsignedByte()).thenReturn((short) 0, (short) 0, (short) MySQLBinlogEventType.DELETE_ROWS_EVENTv2.getValue(), (short) 0);
-        when(byteBuf.readUnsignedShortLE()).thenReturn(2);
-        binlogContext.getTableMap().put(0L, tableMapEventPacket);
-        when(tableMapEventPacket.getColumnDefs()).thenReturn(Collections.emptyList());
+        ByteBuf byteBuf = Unpooled.buffer();
+        // delete from t_order where order_id = 1;
+        byteBuf.writeBytes(StringUtil.decodeHexDump("51002a80a862200100000038000000c569000000007400000000000100020004ff0801000000000000000100000007535543434553531c9580c5"));
+        binlogContext.getTableMap().put(116L, tableMapEventPacket);
+        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
         List<Object> decodedEvents = new LinkedList<>();
         binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
         assertThat(decodedEvents.size(), is(1));
         assertThat(decodedEvents.get(0), instanceOf(DeleteRowsEvent.class));
+    }
+    
+    @Test
+    public void assertBinlogEventHeaderIncomplete() {
+        ByteBuf byteBuf = Unpooled.buffer();
+        byte[] completeData = StringUtil.decodeHexDump("51002a80a862200100000038000000c569000000007400000000000100020004ff0801000000000000000100000007535543434553531c9580c5");
+        byteBuf.writeBytes(completeData);
+        // write incomplete event data
+        byteBuf.writeBytes(StringUtil.decodeHexDump("3400"));
+        List<Object> decodedEvents = new LinkedList<>();
+        binlogContext.getTableMap().put(116L, tableMapEventPacket);
+        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
+        binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
+        assertThat(decodedEvents.size(), is(1));
+        assertThat(byteBuf.readerIndex(), is(completeData.length));
+    }
+    
+    @Test
+    public void assertBinlogEventBodyIncomplete() {
+        ByteBuf byteBuf = Unpooled.buffer();
+        byte[] completeData = StringUtil.decodeHexDump("51002a80a862200100000038000000c569000000007400000000000100020004ff0801000000000000000100000007535543434553531c9580c5");
+        byteBuf.writeBytes(completeData);
+        byte[] notCompleteData = StringUtil.decodeHexDump("3400cb38a962130100000041000000be7d000000007b000000000001000464735f310009745f6f726465725f31000408030f");
+        byteBuf.writeBytes(notCompleteData);
+        List<Object> decodedEvents = new LinkedList<>();
+        binlogContext.getTableMap().put(116L, tableMapEventPacket);
+        when(tableMapEventPacket.getColumnDefs()).thenReturn(columnDefs);
+        binlogEventPacketDecoder.decode(channelHandlerContext, byteBuf, decodedEvents);
+        assertThat(decodedEvents.size(), is(1));
+        assertThat(byteBuf.readerIndex(), is(completeData.length));
     }
 }


### PR DESCRIPTION
Fixes #18075.

Changes proposed in this pull request:
- Improve decode method, not consume incomplete data
- skip checksum, not change the source ByteBuf.
- Improve unit test
