### PR TITLE
Support Parsing `ALTER PUBLICATION` in PostgreSQL

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -1808,8 +1808,8 @@ relationExprList
     ;
 
 relationExpr
-    : tableName (ASTERISK_)?
-    | ONLY LP_? tableName RP_?
+    : qualifiedName (ASTERISK_)?
+    | ONLY LP_? qualifiedName RP_?
     ;
 
 commonFuncOptItem

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/BaseRule.g4
@@ -1808,10 +1808,8 @@ relationExprList
     ;
 
 relationExpr
-    : qualifiedName
-    | qualifiedName ASTERISK_
-    | ONLY qualifiedName
-    | ONLY LP_ qualifiedName RP_
+    : tableName (ASTERISK_)?
+    | ONLY LP_? tableName RP_?
     ;
 
 commonFuncOptItem

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -1034,10 +1034,10 @@ alterFunctionClauses
 
 alterPublication
     : ALTER PUBLICATION name
-    (RENAME TO name
+    ( RENAME TO name
     | OWNER TO roleSpec
     | SET definition
-    | (ADD | SET | DROP)  TABLE relationExprList)
+    | (ADD | SET | DROP) TABLE relationExprList)
     ;
 
 alterRoutine

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
@@ -150,5 +150,6 @@ execute
     | cluster
     | alterOperator
     | createAccessMethod
+    | alterPublication
     ) SEMI_? EOF
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Al
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterDefinitionClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterDomainContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterPolicyContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterPublicationContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterExtensionContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterForeignDataWrapperContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterForeignTableContext;
@@ -168,6 +169,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterDefaultPrivilegesStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterDomainStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterPolicyStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterPublicationStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterExtensionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterForeignDataWrapperStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterForeignTableStatement;
@@ -434,6 +436,11 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitAlterPolicy(final AlterPolicyContext ctx) {
         return new PostgreSQLAlterPolicyStatement();
+    }
+    
+    @Override
+    public ASTNode visitAlterPublication(final AlterPublicationContext ctx) {
+        return new PostgreSQLAlterPublicationStatement();
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -86,6 +86,8 @@ public enum SQLVisitorRule {
     
     CREATE_PUBLICATION("CreatePublication", SQLStatementType.DDL),
     
+    ALTER_PUBLICATION("AlterPublication", SQLStatementType.DDL),
+    
     ALTER_PROCEDURE("AlterProcedure", SQLStatementType.DDL),
     
     ALTER_STATEMENT("AlterStatement", SQLStatementType.DDL),

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterPublicationStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterPublicationStatement.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.statement.ddl;
+
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+/**
+ * Alter publication statement.
+ */
+public abstract class AlterPublicationStatement extends AbstractSQLStatement implements DDLStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterPublicationStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterPublicationStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterPublicationStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
+
+/**
+ * PostgreSQL alter publication statement.
+ */
+@ToString
+public final class PostgreSQLAlterPublicationStatement extends AlterPublicationStatement implements PostgreSQLStatement {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -115,6 +115,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterOutlineStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterPackageStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterProcedureStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterPublicationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterPolicyStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSchemaStatementTestCase;
@@ -589,6 +590,9 @@ public final class SQLParserTestCases {
     
     @XmlElement(name = "alter-procedure")
     private final List<AlterProcedureStatementTestCase> alterProcedureTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "alter-publication")
+    private final List<AlterPublicationStatementTestCase> alterPublicationTestCases = new LinkedList<>();
     
     @XmlElement(name = "alter-policy")
     private final List<AlterPolicyStatementTestCase> alterPolicyTestCases = new LinkedList<>();
@@ -1534,6 +1538,7 @@ public final class SQLParserTestCases {
         putAll(alterDirectoryTestCases, result);
         putAll(alterSystemTestCases, result);
         putAll(alterProcedureTestCases, result);
+        putAll(alterPublicationTestCases, result);
         putAll(alterPolicyTestCases, result);
         putAll(alterDatabaseTestCases, result);
         putAll(alterDimensionTestCases, result);

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/AlterPublicationStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/AlterPublicationStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
+
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+/**
+ * Alter publication statement test case.
+ */
+public final class AlterPublicationStatementTestCase extends SQLParserTestCase {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-publication.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-publication.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <alter-publication sql-case-id="alter_publication_rename" />
+    <alter-publication sql-case-id="alter_publication_owner" />
+    <alter-publication sql-case-id="alter_publication_set_table" />
+    <alter-publication sql-case-id="alter_publication_add_table" />
+    <alter-publication sql-case-id="alter_publication_drop_table" />
+    <alter-publication sql-case-id="alter_publication_set_definition" />
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-publication.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-publication.xml
@@ -23,6 +23,4 @@
     <sql-case id="alter_publication_add_table" value="ALTER PUBLICATION mypublication ADD TABLE stores, cities;" db-types="PostgreSQL" />
     <sql-case id="alter_publication_drop_table" value="ALTER PUBLICATION mypublication DROP TABLE users;" db-types="PostgreSQL" />
     <sql-case id="alter_publication_set_definition" value="ALTER PUBLICATION noinsert SET (publish = 'update, delete');" db-types="PostgreSQL" />
-
-
 </sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-publication.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-publication.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="alter_publication_rename" value="ALTER PUBLICATION old_publication RENAME TO new_publication;" db-types="PostgreSQL" />
+    <sql-case id="alter_publication_owner" value="ALTER PUBLICATION new_publication OWNER TO CURRENT_ROLE;" db-types="PostgreSQL" />
+    <sql-case id="alter_publication_set_table" value="ALTER PUBLICATION mypublication SET TABLE users, departments;" db-types="PostgreSQL" />
+    <sql-case id="alter_publication_add_table" value="ALTER PUBLICATION mypublication ADD TABLE stores, cities;" db-types="PostgreSQL" />
+    <sql-case id="alter_publication_drop_table" value="ALTER PUBLICATION mypublication DROP TABLE users;" db-types="PostgreSQL" />
+    <sql-case id="alter_publication_set_definition" value="ALTER PUBLICATION noinsert SET (publish = 'update, delete');" db-types="PostgreSQL" />
+
+
+</sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -3940,54 +3940,6 @@
     <sql-case id="alter_by_postgresql_source_test_case214" value="ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8);" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case215" value="ALTER OPERATOR FAMILY alt_opf8 USING btree ADD OPERATOR 1 &lt; (int4, int4);" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case216" value="ALTER OPERATOR FAMILY alt_opf9 USING gist ADD OPERATOR 1 &lt; (int4, int4) FOR ORDER BY float_ops;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case234" value="ALTER PUBLICATION testpib_ins_trunct ADD TABLE pub_test.testpub_nopk, testpub_tbl1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case235" value="ALTER PUBLICATION testpub1_forschema ADD ALL TABLES IN SCHEMA non_existent_schema;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case236" value="ALTER PUBLICATION testpub1_forschema ADD ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case237" value="ALTER PUBLICATION testpub1_forschema ADD ALL TABLES IN SCHEMA pub_test2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case238" value="ALTER PUBLICATION testpub1_forschema DROP ALL TABLES IN SCHEMA non_existent_schema;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case239" value="ALTER PUBLICATION testpub1_forschema DROP ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case240" value="ALTER PUBLICATION testpub1_forschema DROP ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case241" value="ALTER PUBLICATION testpub1_forschema DROP ALL TABLES IN SCHEMA pub_test2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case242" value="ALTER PUBLICATION testpub1_forschema DROP ALL TABLES IN SCHEMA pub_test2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case243" value="ALTER PUBLICATION testpub1_forschema SET ALL TABLES IN SCHEMA non_existent_schema;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case244" value="ALTER PUBLICATION testpub1_forschema SET ALL TABLES IN SCHEMA pub_test1, pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case245" value="ALTER PUBLICATION testpub1_forschema SET ALL TABLES IN SCHEMA pub_test1, pub_test2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case246" value="ALTER PUBLICATION testpub1_forschema SET ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case247" value="ALTER PUBLICATION testpub2 ADD TABLE testpub_tbl1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case248" value="ALTER PUBLICATION testpub2 ADD TABLE testpub_tbl1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case249" value="ALTER PUBLICATION testpub2_forschema DROP ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case250" value="ALTER PUBLICATION testpub3 ADD ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case251" value="ALTER PUBLICATION testpub3_forschema SET ALL TABLES IN SCHEMA pub_test1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case252" value="ALTER PUBLICATION testpub_default ADD TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case253" value="ALTER PUBLICATION testpub_default ADD TABLE testpub_tbl1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case254" value="ALTER PUBLICATION testpub_default ADD TABLE testpub_view;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case255" value="ALTER PUBLICATION testpub_default DROP TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case256" value="ALTER PUBLICATION testpub_default DROP TABLE testpub_tbl1, pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case257" value="ALTER PUBLICATION testpub_default OWNER TO regress_publication_user2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case258" value="ALTER PUBLICATION testpub_default RENAME TO testpub_dummy;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case259" value="ALTER PUBLICATION testpub_default RENAME TO testpub_foo;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case260" value="ALTER PUBLICATION testpub_default SET (publish = &apos;insert, update, delete&apos;);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case261" value="ALTER PUBLICATION testpub_default SET (publish = update);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case262" value="ALTER PUBLICATION testpub_default SET TABLE testpub_tbl1;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case263" value="ALTER PUBLICATION testpub_foo RENAME TO testpub_default;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case264" value="ALTER PUBLICATION testpub_foralltables ADD ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case265" value="ALTER PUBLICATION testpub_foralltables ADD TABLE testpub_tbl2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case266" value="ALTER PUBLICATION testpub_foralltables DROP ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case267" value="ALTER PUBLICATION testpub_foralltables DROP TABLE testpub_tbl2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case268" value="ALTER PUBLICATION testpub_foralltables SET (publish = &apos;insert, update&apos;);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case269" value="ALTER PUBLICATION testpub_foralltables SET ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case270" value="ALTER PUBLICATION testpub_foralltables SET TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case271" value="ALTER PUBLICATION testpub_forparted ADD TABLE testpub_parted;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case272" value="ALTER PUBLICATION testpub_forparted DROP TABLE testpub_parted;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case273" value="ALTER PUBLICATION testpub_forparted SET (publish_via_partition_root = true);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case274" value="ALTER PUBLICATION testpub_forparted1 SET (publish=&apos;insert&apos;);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case275" value="ALTER PUBLICATION testpub_forschema ADD TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case276" value="ALTER PUBLICATION testpub_forschema DROP TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case277" value="ALTER PUBLICATION testpub_forschema SET TABLE pub_test.testpub_nopk;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case278" value="ALTER PUBLICATION testpub_fortable ADD ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case279" value="ALTER PUBLICATION testpub_fortable DROP ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case280" value="ALTER PUBLICATION testpub_fortable SET ALL TABLES IN SCHEMA pub_test;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case281" value="ALTER PUBLICATION testpub_fortbl ADD TABLE testpub_tbl1;" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case282" value="ALTER ROUTINE cp_testfunc1(int) RENAME TO cp_testfunc1a;" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case283" value="ALTER ROUTINE cp_testfunc1a RENAME TO cp_testfunc1;" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case284" value="ALTER ROUTINE ptest1(text) RENAME TO ptest1a;" db-types="PostgreSQL" />


### PR DESCRIPTION
Ref #17848 
Sub-issue of  #14015

Changes proposed in this pull request:
- Proofread `ALTER PUBLICATION` grammar
- Support Parsing `ALTER PUBLICATION` in PostgreSQL
- Adds tests

✅ Builds locally
🥳 GSoC Task 3