### PR TITLE
Fix Scaling throw PipelineJobPrepareFailedException, during the start/stop scaling switch

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/PipelineIgnoredException.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/PipelineIgnoredException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.exception;
+
+/**
+ * Pipeline job ignored exception.
+ */
+public final class PipelineIgnoredException extends RuntimeException {
+    
+    private static final long serialVersionUID = -606723977923290937L;
+    
+    public PipelineIgnoredException(final String message) {
+        super(message);
+    }
+    
+    public PipelineIgnoredException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobPreparer.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/rulealtered/RuleAlteredJobPreparer.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.JobProgress;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceManager;
+import org.apache.shardingsphere.data.pipeline.core.exception.PipelineIgnoredException;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobPrepareFailedException;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.core.ingest.position.PositionInitializerFactory;
@@ -77,11 +78,11 @@ public final class RuleAlteredJobPreparer {
     public void prepare(final RuleAlteredJobContext jobContext) {
         checkSourceDataSource(jobContext);
         if (jobContext.isStopping()) {
-            throw new PipelineJobPrepareFailedException("Job stopping, jobId=" + jobContext.getJobId());
+            throw new PipelineIgnoredException("Job stopping, jobId=" + jobContext.getJobId());
         }
         prepareAndCheckTargetWithLock(jobContext);
         if (jobContext.isStopping()) {
-            throw new PipelineJobPrepareFailedException("Job stopping, jobId=" + jobContext.getJobId());
+            throw new PipelineIgnoredException("Job stopping, jobId=" + jobContext.getJobId());
         }
         // TODO check metadata
         try {


### PR DESCRIPTION
Fixes #18442.

Changes proposed in this pull request:
- Handle job stop event correctly