### PR TITLE
Fix h3 too large in community documents

### DIFF
--- a/docs/community/static/css/theme-white.css
+++ b/docs/community/static/css/theme-white.css
@@ -319,6 +319,11 @@ h2:first-of-type{
     margin-top:0;
 }
 
+h3{
+    text-align: left;
+    font-size: 1.2rem;
+}
+
 table{
     table-layout: fixed;
 }


### PR DESCRIPTION
h3 is too large:

<img width="816" alt="image" src="https://user-images.githubusercontent.com/20503072/174553704-ebd8d1df-b270-44e0-8305-f6e471e00423.png">