### PR TITLE
Assemble openGauss JDBC Driver into Proxy distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <lombok.version>1.18.20</lombok.version>
         
         <postgresql.version>42.3.3</postgresql.version>
-        <opengauss.version>2.0.1-compatibility</opengauss.version>
+        <opengauss.version>3.0.0</opengauss.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         <h2.version>1.4.196</h2.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/pom.xml
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
         
         <dependency>
+            <groupId>org.opengauss</groupId>
+            <artifactId>opengauss-jdbc</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -322,7 +322,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     asm 5.0.4: https://github.com/llbit/ow2-asm, BSD-3-Clause
     commons-compiler 3.0.11: https://github.com/janino-compiler/janino, New BSD License
     janino 3.0.11: https://github.com/janino-compiler/janino, New BSD License
-    postgresql 42.3.3: https://github.com/pgjdbc/pgjdbc, BSD 2-Clause
+    opengauss-jdbc 3.0.0: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
+    postgresql 42.3.3: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
     protobuf-java 3.11.0: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     protobuf-java-util 3.11.0: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause 
 

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/licenses/LICENSE-opengauss-jdbc.txt
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/licenses/LICENSE-opengauss-jdbc.txt
@@ -1,0 +1,23 @@
+Copyright (c) 1997, PostgreSQL Global Development Group
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
- Bump `opengauss-jdbc` from `2.0.1-compatibility` to `3.0.0`
- Assemble openGauss JDBC Driver into Proxy distribution
