### PR TITLE
Exclude unused dependency listenablefuture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,6 @@
         <shade.package>org.apache.shardingsphere.dependencies</shade.package>
         
         <guava.version>30.0-jre</guava.version>
-        <guava-listenablefuture.version>1.0</guava-listenablefuture.version>
         <commons-lang3.version>3.8</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-codec.version>1.15</commons-codec.version>
@@ -167,6 +166,10 @@
                     <exclusion>
                         <groupId>com.google.j2objc</groupId>
                         <artifactId>j2objc-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.guava</groupId>
+                        <artifactId>listenablefuture</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -689,12 +692,6 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
-            </dependency>
-            
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>listenablefuture</artifactId>
-                <version>${guava-listenablefuture.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -265,7 +265,6 @@ The text of each license is the standard Apache 2.0 license.
     json-path 2.4.0: https://github.com/jayway/JsonPath, Apache 2.0
     json-smart 2.3: https://www.minidev.net/, Apache 2.0
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
-    listenablefuture 1.0:https://github.com/google/guava, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
     memory 0.9.0, Apache 2.0
     netty-buffer 4.1.73.Final: https://github.com/netty, Apache 2.0


### PR DESCRIPTION
There is already a class `ListenableFuture` in Guava jar. We don't need the indenpendent one.
