### PR TITLE
adapt SQLBuilder.toSQL for SubstitutableColumnNameToken

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.rewrite.sql.SQLBuilder;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Substitutable;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.ComposableSQLToken;
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.SubstitutableColumnNameToken;
 
 import java.util.Collections;
 
@@ -43,7 +44,13 @@ public abstract class AbstractSQLBuilder implements SQLBuilder {
         StringBuilder result = new StringBuilder();
         result.append(context.getSql(), 0, context.getSqlTokens().get(0).getStartIndex());
         for (SQLToken each : context.getSqlTokens()) {
-            result.append(each instanceof ComposableSQLToken ? getComposableSQLTokenText((ComposableSQLToken) each) : getSQLTokenText(each));
+            if (each instanceof ComposableSQLToken) {
+                result.append(getComposableSQLTokenText((ComposableSQLToken) each));
+            } else if (each instanceof SubstitutableColumnNameToken) {
+                result.append(((SubstitutableColumnNameToken) each).toString(null));
+            } else {
+                result.append(getSQLTokenText(each));
+            }
             result.append(getConjunctionText(each));
         }
         return result.toString();

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
@@ -39,7 +39,7 @@ public abstract class AbstractSQLBuilder implements SQLBuilder {
     private final RouteUnit routeUnit;
     
     @Override
-    public String toSQL() {
+    public final String toSQL() {
         if (context.getSqlTokens().isEmpty()) {
             return context.getSql();
         }

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/AbstractSQLBuilder.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Substitutable;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.ComposableSQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.SubstitutableColumnNameToken;
+import org.apache.shardingsphere.infra.route.context.RouteUnit;
 
 import java.util.Collections;
 
@@ -35,8 +36,10 @@ public abstract class AbstractSQLBuilder implements SQLBuilder {
     
     private final SQLRewriteContext context;
     
+    private final RouteUnit routeUnit;
+    
     @Override
-    public final String toSQL() {
+    public String toSQL() {
         if (context.getSqlTokens().isEmpty()) {
             return context.getSql();
         }
@@ -47,7 +50,7 @@ public abstract class AbstractSQLBuilder implements SQLBuilder {
             if (each instanceof ComposableSQLToken) {
                 result.append(getComposableSQLTokenText((ComposableSQLToken) each));
             } else if (each instanceof SubstitutableColumnNameToken) {
-                result.append(((SubstitutableColumnNameToken) each).toString(null));
+                result.append(((SubstitutableColumnNameToken) each).toString(routeUnit));
             } else {
                 result.append(getSQLTokenText(each));
             }

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/DefaultSQLBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/DefaultSQLBuilder.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 public final class DefaultSQLBuilder extends AbstractSQLBuilder {
     
     public DefaultSQLBuilder(final SQLRewriteContext context) {
-        super(context);
+        super(context, null);
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/impl/RouteSQLBuilder.java
@@ -30,7 +30,7 @@ public final class RouteSQLBuilder extends AbstractSQLBuilder {
     private final RouteUnit routeUnit;
     
     public RouteSQLBuilder(final SQLRewriteContext context, final RouteUnit routeUnit) {
-        super(context);
+        super(context, routeUnit);
         this.routeUnit = routeUnit;
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
@@ -95,7 +95,7 @@ public final class SubstitutableColumnNameToken extends SQLToken implements Subs
     }
     
     private Map<String, String> getLogicAndActualTables(final RouteUnit routeUnit) {
-        if (null != routeUnit) {
+        if (null == routeUnit) {
             return Collections.emptyMap();
         }
         Map<String, String> result = new LinkedHashMap<>();

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameToken.java
@@ -29,6 +29,8 @@ import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.QuoteCharacter;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -75,7 +77,10 @@ public final class SubstitutableColumnNameToken extends SQLToken implements Subs
     
     @Override
     public String toString(final RouteUnit routeUnit) {
-        Map<String, String> logicAndActualTables = getLogicAndActualTables(routeUnit);
+        Map<String, String> logicAndActualTables = new HashMap<>();
+        if (null != routeUnit) {
+            logicAndActualTables.putAll(getLogicAndActualTables(routeUnit));
+        }
         StringBuilder result = new StringBuilder();
         int count = 0;
         for (ColumnProjection each : projections) {
@@ -90,6 +95,9 @@ public final class SubstitutableColumnNameToken extends SQLToken implements Subs
     }
     
     private Map<String, String> getLogicAndActualTables(final RouteUnit routeUnit) {
+        if (null != routeUnit) {
+            return Collections.emptyMap();
+        }
         Map<String, String> result = new LinkedHashMap<>();
         for (RouteMapper each : routeUnit.getTableMappers()) {
             result.put(each.getLogicName(), each.getActualName());

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/insert/insert-column.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/insert/insert-column.xml
@@ -22,6 +22,11 @@
         <output sql="INSERT INTO t_account(account_id, cipher_certificate_number, assisted_query_certificate_number, cipher_password, assisted_query_password, cipher_amount, status) VALUES (?, ?, ?, ?, ?, ?, ?), (2, 'encrypt_222X', 'assisted_query_222X', 'encrypt_bbb', 'assisted_query_bbb', 'encrypt_2000', 'OK'), (?, ?, ?, ?, ?, ?, ?), (4, 'encrypt_444X', 'assisted_query_444X', 'encrypt_ddd', 'assisted_query_ddd', 'encrypt_4000', 'OK')" parameters="1, encrypt_111X, assisted_query_111X, encrypt_aaa, assisted_query_aaa, encrypt_1000, OK, 3, encrypt_333X, assisted_query_333X, encrypt_ccc, assisted_query_ccc, encrypt_3000, OK" />
     </rewrite-assertion>
 
+    <rewrite-assertion id="insert_values_with_columns_for_parameters_with_plain_column" db-types="PostgreSQL">
+        <input sql="INSERT INTO t_account_bak(account_id, certificate_number, password, amount, status) VALUES (?, ?, ?, ?, ?)" parameters="1, 111X, aaa, 1000, OK" />
+        <output sql="INSERT INTO t_account_bak(account_id, cipher_certificate_number, assisted_query_certificate_number, plain_certificate_number, cipher_password, assisted_query_password, plain_password, cipher_amount, plain_amount, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)" parameters="1, encrypt_111X, assisted_query_111X, 111X, encrypt_aaa, assisted_query_aaa, aaa, encrypt_1000, 1000, OK" />
+    </rewrite-assertion>
+
     <rewrite-assertion id="insert_values_with_columns_for_literals" db-types="MySQL">
         <input sql="INSERT INTO t_account(account_id, certificate_number, password, amount, status) VALUES (1, '111X', 'aaa', 1000, 'OK'), (2, '222X', 'bbb', 2000, 'OK'), (3, '333X', 'ccc', 3000, 'OK'), (4, '444X', 'ddd', 4000, 'OK')" />
         <output sql="INSERT INTO t_account(account_id, cipher_certificate_number, assisted_query_certificate_number, cipher_password, assisted_query_password, cipher_amount, status) VALUES (1, 'encrypt_111X', 'assisted_query_111X', 'encrypt_aaa', 'assisted_query_aaa', 'encrypt_1000', 'OK'), (2, 'encrypt_222X', 'assisted_query_222X', 'encrypt_bbb', 'assisted_query_bbb', 'encrypt_2000', 'OK'), (3, 'encrypt_333X', 'assisted_query_333X', 'encrypt_ccc', 'assisted_query_ccc', 'encrypt_3000', 'OK'), (4, 'encrypt_444X', 'assisted_query_444X', 'encrypt_ddd', 'assisted_query_ddd', 'encrypt_4000', 'OK')" />


### PR DESCRIPTION
Fixes #18525.

Changes proposed in this pull request:
-adapt SQLBuilder.toSQL for SubstitutableColumnNameToken

- [x] manual tested OK