### PR TITLE
Remove useless findRuleConfigurations in ShardingSphereRuleMetaData

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/rule/ShardingSphereRuleMetaData.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/rule/ShardingSphereRuleMetaData.java
@@ -91,21 +91,4 @@ public final class ShardingSphereRuleMetaData {
         Preconditions.checkState(1 == foundRules.size(), "Rule `%s` should have and only have one instance.", clazz.getSimpleName());
         return foundRules.iterator().next();
     }
-    
-    /**
-     * Find rule configuration by class.
-     *
-     * @param clazz target class
-     * @param <T> type of rule configuration
-     * @return found rule configurations
-     */
-    public <T extends RuleConfiguration> Collection<T> findRuleConfigurations(final Class<T> clazz) {
-        Collection<T> result = new LinkedList<>();
-        for (ShardingSphereRule each : rules) {
-            if (clazz.isAssignableFrom(each.getConfiguration().getClass())) {
-                result.add(clazz.cast(each.getConfiguration()));
-            }
-        }
-        return result;
-    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove useless findRuleConfigurations in ShardingSphereRuleMetaData
