### PR TITLE
refactor StandardJdbcUrlParser's regex, redundant character escape '\\+' in regExp

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/url/StandardJdbcUrlParser.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/database/metadata/url/StandardJdbcUrlParser.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  */
 public final class StandardJdbcUrlParser {
     
-    private static final String SCHEMA_PATTERN = "(?<schema>[\\w\\+:%]+)\\s*";
+    private static final String SCHEMA_PATTERN = "(?<schema>[\\w+:%]+)\\s*";
     
     private static final String AUTHORITY_PATTERN = "(?://(?<authority>[^/?#]*))?\\s*";
     


### PR DESCRIPTION
in regex [\\+\\*] do not need escaped character , the original character can work fine.
-
-
-
