### PR TITLE
feat(helm): add default serverConfig in helm charts

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
@@ -11,7 +11,7 @@ weight = 3
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-修改 values.yaml 中 serverConfig 部分
+# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
@@ -38,11 +38,18 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 以 ShardingSphere-Proxy 命名安装 charts：
+⚠️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
+
+```shell
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+```
+
+如需修改配置，请执行以下操作:
 
 ```shell
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-修改 values.yaml 中 serverConfig 部分
+# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
@@ -6,13 +6,10 @@ weight = 3
 使用 [Helm](https://helm.sh/) 在 Kubernetes 集群中引导 ShardingSphere-Proxy 实例进行安装。
 
 ## 快速入门
-
+注意️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm pull shardingsphere/apache-shardingsphere-proxy
-tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
-helm install shardingsphere-proxy apache-shardingsphere-proxy
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
 ```
 
 ## 操作步骤

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
@@ -38,7 +38,7 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 以 ShardingSphere-Proxy 命名安装 charts：
-⚠️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
+注意️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
 
 ```shell
 helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.cn.md
@@ -9,7 +9,10 @@ weight = 3
 
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+修改 values.yaml 中 serverConfig 部分
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 ## 操作步骤
@@ -37,7 +40,10 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 以 ShardingSphere-Proxy 命名安装 charts：
 
 ```shell
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+修改 values.yaml 中 serverConfig 部分
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 #### 源码安装
@@ -102,4 +108,27 @@ helm uninstall shardingsphere-proxy
 | `compute.service.port`             | ShardingSphere-Proxy 暴露端口         | `3307`                        |
 | `compute.mysqlConnector.version`   | MySQL 驱动版本                        | `5.1.49`                      |
 | `compute.startPort`                | ShardingSphere-Proxy 启动端口         | `3307`                        |
-| `compute.serverConfig`             | ShardingSphere-Proxy 模式配置文件       | `""`                          |
+
+### 计算节点--ShardingSphere-Proxy Server配置 权限配置项
+
+| Name                                               | Description                                                               | Value                      |
+| -------------------------------------------------- |---------------------------------------------------------------------------| -------------------------- |
+| `compute.serverConfig.authority.privilege.type`    | 存储节点数据授权的权限提供者类型，缺省值为 ALL_PERMITTED                                       | `ALL_PRIVILEGES_PERMITTED` |
+| `compute.serverConfig.authority.users[0].password` | 用于登录计算节点的密码                                                               | `root`                     |
+| `compute.serverConfig.authority.users[0].user`     | 用于登录计算节点的用户名，授权主机。格式: <username>@<hostname> hostname 为 % 或空字符串表示不限制授权主机   | `root@%`                   |
+
+
+### 计算节点--ShardingSphere-Proxy Server配置 模式配置项
+
+| Name                                                                      | Description               | Value                                                                 |
+| ------------------------------------------------------------------------- |---------------------------| --------------------------------------------------------------------- |
+| `compute.serverConfig.mode.type`                                          | 运行模式类型。 现阶段仅支持 Cluster 模式 | `Cluster`                                                             |
+| `compute.serverConfig.mode.repository.props.namespace`                    | 注册中心命名空间                  | `governance_ds`                                                       |
+| `compute.serverConfig.mode.repository.props.server-lists`                 | 注册中心连接地址                  | `{{ printf "%s-zookeeper.%s:2181" .Release.Name .Release.Namespace }}` |
+| `compute.serverConfig.mode.repository.props.maxRetries`                   | 客户端连接最大重试次数               | `3`                                                                   |
+| `compute.serverConfig.mode.repository.props.operationTimeoutMilliseconds` | 客户端操作超时的毫秒数               | `5000`                                                                |
+| `compute.serverConfig.mode.repository.props.retryIntervalMilliseconds`    | 重试间隔毫秒数                   | `500`                                                                 |
+| `compute.serverConfig.mode.repository.props.timeToLiveSeconds`            | 临时数据失效的秒数                 | `60`                                                                  |
+| `compute.serverConfig.mode.repository.type`                               | 持久化仓库类型。 现阶段仅支持 ZooKeeper | `ZooKeeper`                                                           |
+| `compute.serverConfig.mode.overwrite`                                     | 是否使用本地配置覆盖持久化配置           | `true`                                                                |
+

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
@@ -9,7 +9,10 @@ Use [Helm](https://helm.sh/) to provide guidance for the installation of Shardin
 
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+Modify the serverConfig section in values.yaml
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 ## Step By Step
@@ -36,7 +39,10 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 2. Install ShardingSphere-Proxy charts:
 
 ```shell
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+Modify the serverConfig section in values.yaml
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 #### Source installation
@@ -101,6 +107,29 @@ Delete all release records by default, add `--keep-history` to keep them.
 | `compute.service.port`              | ShardingSphere-Proxy expose port                             | `3307`                        |
 | `compute.mysqlConnector.version`    | MySQL connector version                                      | `5.1.49`                      |
 | `compute.startPort`                 | ShardingSphere-Proxy start port                              | `3307`                        |
-| `compute.serverConfig`              | ServerConfiguration file for ShardingSphere-Proxy            | `""`                          |
+
+### Compute-Node ShardingSphere-Proxy ServerConfiguration authority parameters
+
+| Name                                               | Description                                                                                                                                    | Value                      |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `compute.serverConfig.authority.privilege.type`    | authority provider for storage node, the default value is ALL_PERMITTED                                                                        | `ALL_PRIVILEGES_PERMITTED` |
+| `compute.serverConfig.authority.users[0].password` | Password for compute node.                                                                                                                     | `root`                     |
+| `compute.serverConfig.authority.users[0].user`     | Username,authorized host for compute node. Format: <username>@<hostname> hostname is % or empty string means do not care about authorized host | `root@%`                   |
+
+
+### Compute-Node ShardingSphere-Proxy ServerConfiguration mode Configuration parameters
+
+| Name                                                                      | Description                                                         | Value                                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `compute.serverConfig.mode.type`                                          | Type of mode configuration. Now only support Cluster mode           | `Cluster`                                                              |
+| `compute.serverConfig.mode.repository.props.namespace`                    | Namespace of registry center                                        | `governance_ds`                                                        |
+| `compute.serverConfig.mode.repository.props.server-lists`                 | Server lists of registry center                                     | `{{ printf "%s-zookeeper.%s:2181" .Release.Name .Release.Namespace }}` |
+| `compute.serverConfig.mode.repository.props.maxRetries`                   | Max retries of client connection                                    | `3`                                                                    |
+| `compute.serverConfig.mode.repository.props.operationTimeoutMilliseconds` | Milliseconds of operation timeout                                   | `5000`                                                                 |
+| `compute.serverConfig.mode.repository.props.retryIntervalMilliseconds`    | Milliseconds of retry interval                                      | `500`                                                                  |
+| `compute.serverConfig.mode.repository.props.timeToLiveSeconds`            | Seconds of ephemeral data live                                      | `60`                                                                   |
+| `compute.serverConfig.mode.repository.type`                               | Type of persist repository. Now only support ZooKeeper              | `ZooKeeper`                                                            |
+| `compute.serverConfig.mode.overwrite`                                     | Whether overwrite persistent configuration with local configuration | `true`                                                                 |
+
 
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
@@ -37,7 +37,7 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 2. Install ShardingSphere-Proxy charts:
-⚠️: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
+Attention: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
 
 ```shell
 helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
@@ -11,7 +11,7 @@ Use [Helm](https://helm.sh/) to provide guidance for the installation of Shardin
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-Modify the serverConfig section in values.yaml
+# Modify the serverConfig section in apache-shardingsphere-proxy/values.yaml
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
@@ -37,11 +37,18 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 2. Install ShardingSphere-Proxy charts:
+⚠️: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
+
+```shell
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+```
+
+To modify the configuration:
 
 ```shell
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-Modify the serverConfig section in values.yaml
+# Modify the serverConfig section in apache-shardingsphere-proxy/values.yaml
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/helm.en.md
@@ -6,13 +6,10 @@ weight = 3
 Use [Helm](https://helm.sh/) to provide guidance for the installation of ShardingSphere-Proxy instance in Kubernetes cluster.
 
 ## Quick Start
-
+Attention: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm pull shardingsphere/apache-shardingsphere-proxy
-tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-# Modify the serverConfig section in apache-shardingsphere-proxy/values.yaml
-helm install shardingsphere-proxy apache-shardingsphere-proxy
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
 ```
 
 ## Step By Step

--- a/shardingsphere-charts/README.md
+++ b/shardingsphere-charts/README.md
@@ -34,11 +34,18 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 Install ShardingSphere-Proxy charts:
+⚠️: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
+
+```shell
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+```
+
+To modify the configuration:
 
 ```shell
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-Modify the serverConfig section in values.yaml
+# Modify the serverConfig section in apache-shardingsphere-proxy/values.yaml
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 

--- a/shardingsphere-charts/README.md
+++ b/shardingsphere-charts/README.md
@@ -3,13 +3,10 @@
 Use [Helm](https://helm.sh/) to provide guidance for the installation of ShardingSphere-Proxy instance in Kubernetes cluster.
 
 ## Quick Start
-
+Attention: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm pull shardingsphere/apache-shardingsphere-proxy
-tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-Modify the serverConfig section in values.yaml
-helm install shardingsphere-proxy apache-shardingsphere-proxy
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
 ```
 
 ## Step By Step

--- a/shardingsphere-charts/README.md
+++ b/shardingsphere-charts/README.md
@@ -6,7 +6,10 @@ Use [Helm](https://helm.sh/) to provide guidance for the installation of Shardin
 
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+Modify the serverConfig section in values.yaml
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 ## Step By Step
@@ -33,7 +36,10 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 Install ShardingSphere-Proxy charts:
 
 ```shell
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+Modify the serverConfig section in values.yaml
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 #### Source installation
@@ -98,6 +104,29 @@ Delete all release records by default, add `--keep-history` to keep them.
 | `compute.service.port`              | ShardingSphere-Proxy expose port                             | `3307`                        |
 | `compute.mysqlConnector.version`    | MySQL connector version                                      | `5.1.49`                      |
 | `compute.startPort`                 | ShardingSphere-Proxy start port                              | `3307`                        |
-| `compute.serverConfig`              | ServerConfiguration file for ShardingSphere-Proxy            | `""`                          |
+
+
+### Compute-Node ShardingSphere-Proxy ServerConfiguration authority parameters
+
+| Name                                               | Description                                                                                                                                    | Value                      |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `compute.serverConfig.authority.privilege.type`    | authority provider for storage node, the default value is ALL_PERMITTED                                                                        | `ALL_PRIVILEGES_PERMITTED` |
+| `compute.serverConfig.authority.users[0].password` | Password for compute node.                                                                                                                     | `root`                     |
+| `compute.serverConfig.authority.users[0].user`     | Username,authorized host for compute node. Format: <username>@<hostname> hostname is % or empty string means do not care about authorized host | `root@%`                   |
+
+
+### Compute-Node ShardingSphere-Proxy ServerConfiguration mode Configuration parameters
+
+| Name                                                                      | Description                                                         | Value                                                                  |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| `compute.serverConfig.mode.type`                                          | Type of mode configuration. Now only support Cluster mode           | `Cluster`                                                              |
+| `compute.serverConfig.mode.repository.props.namespace`                    | Namespace of registry center                                        | `governance_ds`                                                        |
+| `compute.serverConfig.mode.repository.props.server-lists`                 | Server lists of registry center                                     | `{{ printf "%s-zookeeper.%s:2181" .Release.Name .Release.Namespace }}` |
+| `compute.serverConfig.mode.repository.props.maxRetries`                   | Max retries of client connection                                    | `3`                                                                    |
+| `compute.serverConfig.mode.repository.props.operationTimeoutMilliseconds` | Milliseconds of operation timeout                                   | `5000`                                                                 |
+| `compute.serverConfig.mode.repository.props.retryIntervalMilliseconds`    | Milliseconds of retry interval                                      | `500`                                                                  |
+| `compute.serverConfig.mode.repository.props.timeToLiveSeconds`            | Seconds of ephemeral data live                                      | `60`                                                                   |
+| `compute.serverConfig.mode.repository.type`                               | Type of persist repository. Now only support ZooKeeper              | `ZooKeeper`                                                            |
+| `compute.serverConfig.mode.overwrite`                                     | Whether overwrite persistent configuration with local configuration | `true`                                                                 |
 
 

--- a/shardingsphere-charts/README.md
+++ b/shardingsphere-charts/README.md
@@ -34,7 +34,7 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 Install ShardingSphere-Proxy charts:
-⚠️: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
+Attention: The following installation method will start ShardingSphere-Proxy with the default server.yaml configuration
 
 ```shell
 helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy

--- a/shardingsphere-charts/README_ZH.md
+++ b/shardingsphere-charts/README_ZH.md
@@ -6,7 +6,10 @@
 
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+修改 values.yaml 中 serverConfig 部分
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 ## 操作步骤
@@ -34,7 +37,10 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 以 ShardingSphere-Proxy 命名安装 charts：
 
 ```shell
-helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+helm pull shardingsphere/apache-shardingsphere-proxy
+tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
+修改 values 中 serverConfig 部分
+helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
 #### 源码安装
@@ -99,4 +105,28 @@ helm uninstall shardingsphere-proxy
 | `compute.service.port`             | ShardingSphere-Proxy 暴露端口         | `3307`                        |
 | `compute.mysqlConnector.version`   | MySQL 驱动版本                        | `5.1.49`                      |
 | `compute.startPort`                | ShardingSphere-Proxy 启动端口         | `3307`                        |
-| `compute.serverConfig`             | ShardingSphere-Proxy 模式配置文件       | `""`                          |
+
+### 计算节点--ShardingSphere-Proxy Server配置 权限配置项
+
+| Name                                               | Description                                                               | Value                      |
+| -------------------------------------------------- |---------------------------------------------------------------------------| -------------------------- |
+| `compute.serverConfig.authority.privilege.type`    | 存储节点数据授权的权限提供者类型，缺省值为 ALL_PERMITTED                                       | `ALL_PRIVILEGES_PERMITTED` |
+| `compute.serverConfig.authority.users[0].password` | 用于登录计算节点的密码                                                               | `root`                     |
+| `compute.serverConfig.authority.users[0].user`     | 用于登录计算节点的用户名，授权主机。格式: <username>@<hostname> hostname 为 % 或空字符串表示不限制授权主机   | `root@%`                   |
+
+
+### 计算节点--ShardingSphere-Proxy Server配置 模式配置项
+
+| Name                                                                      | Description               | Value                                                                 |
+| ------------------------------------------------------------------------- |---------------------------| --------------------------------------------------------------------- |
+| `compute.serverConfig.mode.type`                                          | 运行模式类型。 现阶段仅支持 Cluster 模式 | `Cluster`                                                             |
+| `compute.serverConfig.mode.repository.props.namespace`                    | 注册中心命名空间                  | `governance_ds`                                                       |
+| `compute.serverConfig.mode.repository.props.server-lists`                 | 注册中心连接地址                  | `{{ printf "%s-zookeeper.%s:2181" .Release.Name .Release.Namespace }}` |
+| `compute.serverConfig.mode.repository.props.maxRetries`                   | 客户端连接最大重试次数               | `3`                                                                   |
+| `compute.serverConfig.mode.repository.props.operationTimeoutMilliseconds` | 客户端操作超时的毫秒数               | `5000`                                                                |
+| `compute.serverConfig.mode.repository.props.retryIntervalMilliseconds`    | 重试间隔毫秒数                   | `500`                                                                 |
+| `compute.serverConfig.mode.repository.props.timeToLiveSeconds`            | 临时数据失效的秒数                 | `60`                                                                  |
+| `compute.serverConfig.mode.repository.type`                               | 持久化仓库类型。 现阶段仅支持 ZooKeeper | `ZooKeeper`                                                           |
+| `compute.serverConfig.mode.overwrite`                                     | 是否使用本地配置覆盖持久化配置           | `true`                                                                |
+
+

--- a/shardingsphere-charts/README_ZH.md
+++ b/shardingsphere-charts/README_ZH.md
@@ -8,7 +8,7 @@
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-修改 values.yaml 中 serverConfig 部分
+# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 
@@ -35,11 +35,18 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 以 ShardingSphere-Proxy 命名安装 charts：
+⚠️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
+
+```shell
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
+```
+
+如需修改配置，请执行以下操作:
 
 ```shell
 helm pull shardingsphere/apache-shardingsphere-proxy
 tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-修改 values 中 serverConfig 部分
+# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
 helm install shardingsphere-proxy apache-shardingsphere-proxy
 ```
 

--- a/shardingsphere-charts/README_ZH.md
+++ b/shardingsphere-charts/README_ZH.md
@@ -35,7 +35,7 @@ helm repo add shardingsphere https://shardingsphere.apache.org/charts
 ```
 
 以 ShardingSphere-Proxy 命名安装 charts：
-⚠️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
+注意️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
 
 ```shell
 helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy

--- a/shardingsphere-charts/README_ZH.md
+++ b/shardingsphere-charts/README_ZH.md
@@ -3,13 +3,10 @@
 使用 [Helm](https://helm.sh/) 在 Kubernetes 集群中引导 ShardingSphere-Proxy 实例进行安装。
 
 ## 快速入门
-
+注意️：以下安装方式将使用默认的 server.yaml 配置启动 ShardingSphere-Proxy
 ```shell
 helm repo add shardingsphere https://shardingsphere.apache.org/charts
-helm pull shardingsphere/apache-shardingsphere-proxy
-tar -zxvf apache-shardingsphere-proxy-1.1.0-chart.tgz
-# 修改 apache-shardingsphere-proxy/values.yaml 中 serverConfig 部分
-helm install shardingsphere-proxy apache-shardingsphere-proxy
+helm install shardingsphere-proxy shardingsphere/apache-shardingsphere-proxy
 ```
 
 ## 操作步骤

--- a/shardingsphere-charts/apache-shardingsphere-proxy/values.yaml
+++ b/shardingsphere-charts/apache-shardingsphere-proxy/values.yaml
@@ -108,34 +108,51 @@ compute:
   ## ref: https://shardingsphere.apache.org/document/current/en/user-manual/shardingsphere-proxy/startup/docker/
   ##
   startPort: 3307
-  ## @param compute.serverConfig ServerConfiguration file for ShardingSphere-Proxy
+  ## @section Compute-Node ShardingSphere-Proxy ServerConfiguration parameters
   ## NOTE: If you use the sub-charts to deploy Zookeeper, the server-lists field must be "{{ printf \"%s-zookeeper.%s:2181\" .Release.Name .Release.Namespace }}",
   ## otherwise please fill in the correct zookeeper address
   ## The server.yaml is auto-generated based on this parameter.
   ## If it is empty, the server.yaml is also empty.
   ## ref: https://shardingsphere.apache.org/document/current/en/user-manual/shardingsphere-jdbc/yaml-config/mode/
-  ## ref: https://shardingsphere.apache.org/document/current/cn/user-manual/shardingsphere-jdbc/builtin-algorithm/metadata-repository/
-  ## e.g:
-  ## serverConfig:
-  ##   authority:
-  ##    privilege:
-  ##      type: ALL_PRIVILEGES_PERMITTED
-  ##    users:
-  ##    - password: root
-  ##      user: root@%
-  ##   mode:
-  ##    overwrite: true
-  ##    repository:
-  ##      props:
-  ##        maxRetries: 3
-  ##        namespace: governance_ds
-  ##        operationTimeoutMilliseconds: 5000
-  ##        retryIntervalMilliseconds: 500
-  ##        server-lists: "{{ printf \"%s-zookeeper.%s:2181\" .Release.Name .Release.Namespace }}"
-  ##        timeToLiveSeconds: 600
-  ##      type: ZooKeeper
-  ##    type: Cluster
+  ## ref: https://shardingsphere.apache.org/document/current/en/user-manual/shardingsphere-jdbc/builtin-algorithm/metadata-repository/
   ##
-  serverConfig: ""
+  serverConfig:
+    ## @section Compute-Node ShardingSphere-Proxy ServerConfiguration authority parameters
+    ## NOTE: It is used to set up initial user to login compute node, and authority data of storage node.
+    ## ref: https://shardingsphere.apache.org/document/current/en/user-manual/shardingsphere-proxy/yaml-config/authentication/
+    ## @param compute.serverConfig.authority.privilege.type authority provider for storage node, the default value is ALL_PERMITTED
+    ## @param compute.serverConfig.authority.users[0].password Password for compute node.
+    ## @param compute.serverConfig.authority.users[0].user Username,authorized host for compute node. Format: <username>@<hostname> hostname is % or empty string means do not care about authorized host
+    ##
+    authority:
+      privilege:
+        type: ALL_PRIVILEGES_PERMITTED
+      users:
+      - password: root
+        user: root@%
+    ## @section Compute-Node ShardingSphere-Proxy ServerConfiguration mode Configuration parameters
+    ## @param compute.serverConfig.mode.type Type of mode configuration. Now only support Cluster mode
+    ## @param compute.serverConfig.mode.repository.props.namespace Namespace of registry center
+    ## @param compute.serverConfig.mode.repository.props.server-lists Server lists of registry center
+    ## @param compute.serverConfig.mode.repository.props.maxRetries Max retries of client connection
+    ## @param compute.serverConfig.mode.repository.props.operationTimeoutMilliseconds Milliseconds of operation timeout
+    ## @param compute.serverConfig.mode.repository.props.retryIntervalMilliseconds Milliseconds of retry interval
+    ## @param compute.serverConfig.mode.repository.props.timeToLiveSeconds Seconds of ephemeral data live
+    ## @param compute.serverConfig.mode.repository.type Type of persist repository. Now only support ZooKeeper
+    ## @param compute.serverConfig.mode.overwrite Whether overwrite persistent configuration with local configuration
+    ##
+    mode:
+      type: Cluster
+      repository:
+        type: ZooKeeper
+        props:
+          maxRetries: 3
+          namespace: governance_ds
+          operationTimeoutMilliseconds: 5000
+          retryIntervalMilliseconds: 500
+          server-lists: "{{ printf \"%s-zookeeper.%s:2181\" .Release.Name .Release.Namespace }}"
+          timeToLiveSeconds: 60
+      overwrite: true
+
 
 


### PR DESCRIPTION
Changes proposed in this pull request:
- feat(helm): add default serverConfig in helm charts
- feat(helm): Added some documentation about helm
