### PR TITLE
Fix CI error in windows, ExportDatabaseConfigurationHandler use System.lineSeparator instead of '\n'

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
@@ -91,14 +91,14 @@ public final class ExportDatabaseConfigurationHandler extends QueryableRALBacken
         if (database.getResource().getDataSources().isEmpty()) {
             return;
         }
-        stringBuilder.append("dataSources").append(":\n");
+        stringBuilder.append("dataSources:").append(System.lineSeparator());
         for (Entry<String, DataSource> entry : database.getResource().getDataSources().entrySet()) {
             appendDataSourceConfiguration(entry.getKey(), entry.getValue(), stringBuilder);
         }
     }
     
     private void appendDataSourceConfiguration(final String name, final DataSource dataSource, final StringBuilder stringBuilder) {
-        stringBuilder.append("  ").append(name).append(":\n");
+        stringBuilder.append("  ").append(name).append(":").append(System.lineSeparator());
         DataSourceProperties dataSourceProps = DataSourcePropertiesCreator.create(dataSource);
         dataSourceProps.getConnectionPropertySynonyms().getStandardProperties()
                 .forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append(System.lineSeparator()));

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandler.java
@@ -84,7 +84,7 @@ public final class ExportDatabaseConfigurationHandler extends QueryableRALBacken
     }
     
     private void appendDatabaseName(final String databaseName, final StringBuilder stringBuilder) {
-        stringBuilder.append("databaseName").append(": ").append(databaseName).append("\n");
+        stringBuilder.append("databaseName").append(": ").append(databaseName).append(System.lineSeparator());
     }
     
     private void appendDataSourceConfigurations(final ShardingSphereDatabase database, final StringBuilder stringBuilder) {
@@ -100,8 +100,9 @@ public final class ExportDatabaseConfigurationHandler extends QueryableRALBacken
     private void appendDataSourceConfiguration(final String name, final DataSource dataSource, final StringBuilder stringBuilder) {
         stringBuilder.append("  ").append(name).append(":\n");
         DataSourceProperties dataSourceProps = DataSourcePropertiesCreator.create(dataSource);
-        dataSourceProps.getConnectionPropertySynonyms().getStandardProperties().forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append("\n"));
-        dataSourceProps.getPoolPropertySynonyms().getStandardProperties().forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append("\n"));
+        dataSourceProps.getConnectionPropertySynonyms().getStandardProperties()
+                .forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append(System.lineSeparator()));
+        dataSourceProps.getPoolPropertySynonyms().getStandardProperties().forEach((key, value) -> stringBuilder.append("    ").append(key).append(": ").append(value).append(System.lineSeparator()));
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -109,7 +110,7 @@ public final class ExportDatabaseConfigurationHandler extends QueryableRALBacken
         if (ruleConfigs.isEmpty()) {
             return;
         }
-        stringBuilder.append("rules").append(":\n");
+        stringBuilder.append("rules:").append(System.lineSeparator());
         for (Entry<RuleConfiguration, YamlRuleConfigurationSwapper> entry : YamlRuleConfigurationSwapperFactory.getInstanceMapByRuleConfigurations(ruleConfigs).entrySet()) {
             stringBuilder.append(YamlEngine.marshal(Collections.singletonList(entry.getValue().swapToYamlConfiguration(entry.getKey()))));
         }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandlerTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/queryable/ExportDatabaseConfigurationHandlerTest.java
@@ -205,7 +205,7 @@ public final class ExportDatabaseConfigurationHandlerTest extends ProxyContextRe
         assertTrue(handler.next());
         Collection<Object> rowData = handler.getRowData();
         assertThat(rowData.size(), is(1));
-        assertThat(rowData.iterator().next(), is("databaseName: empty_db\n"));
+        assertThat(rowData.iterator().next(), is("databaseName: empty_db" + System.lineSeparator()));
         assertFalse(handler.next());
     }
     


### PR DESCRIPTION
ExportDatabaseConfigurationHandler use System.lineSeparator instead of '\n'
-
-
-
