### PR TITLE
Show write_data_source_query_enabled query results in READWRITE_SPLITTING RULES 

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/readwrite-splitting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/readwrite-splitting.cn.md
@@ -15,6 +15,7 @@ SHOW READWRITE_SPLITTING RULES [FROM databaseName]
 | --------------------------- | ------------------------------------ |
 | name                        | 规则名称                               |
 | auto_aware_data_source_name | 自动发现数据源名称（配置动态读写分离规则显示）|
+| write_data_source_query_enabled | 读库全部下线，主库是否承担读流量      |
 | write_data_source_name      | 写数据源名称                            |
 | read_data_source_names      | 读数据源名称列表                         |
 | load_balancer_type          | 负载均衡算法类型                         |
@@ -37,9 +38,9 @@ mysql> show readwrite_splitting rules;
 ```sql
 mysql> show readwrite_splitting rules from readwrite_splitting_db;
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| name         | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+| name         | auto_aware_data_source_name | write_data_source_query_enabled | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| readwrite_ds | ms_group_0                  |                        |                        | random             | read_weight=2:1     |
+| readwrite_ds | ms_group_0                  |                                 |                        |                        | random             | read_weight=2:1     |
 +-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
 1 row in set (0.01 sec)
 ```
@@ -48,9 +49,9 @@ mysql> show readwrite_splitting rules from readwrite_splitting_db;
 ```sql
 mysql> show readwrite_splitting rules from readwrite_splitting_db;
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| name         | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+| name         | auto_aware_data_source_name | write_data_source_query_enabled | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| readwrite_ds | ms_group_0                  | write_ds               | read_ds_0, read_ds_1   | random             | read_weight=2:1     |
+| readwrite_ds | ms_group_0                  |                                 | write_ds               | read_ds_0, read_ds_1   | random             | read_weight=2:1     |
 +-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
 1 row in set (0.00 sec)
 ```

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/readwrite-splitting.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/readwrite-splitting.en.md
@@ -15,6 +15,7 @@ SHOW READWRITE_SPLITTING RULES [FROM databaseName]
 | --------------------------- | ------------------------------------ |
 | name                        | Rule name                            |
 | auto_aware_data_source_name | Auto-Aware discovery data source name (Display configuration dynamic readwrite splitting rules) |
+| write_data_source_query_enabled | All read data source are offline, write data source whether the data source is responsible for read traffic |
 | write_data_source_name      | Write data source name                |
 | read_data_source_names      | Read data source name list            |
 | load_balancer_type          | Load balance algorithm type           |
@@ -37,9 +38,9 @@ mysql> show readwrite_splitting rules;
 ```sql
 mysql> show readwrite_splitting rules from readwrite_splitting_db;
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| name         | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+| name         | auto_aware_data_source_name | write_data_source_query_enabled | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| readwrite_ds | ms_group_0                  |                        |                        | random             | read_weight=2:1     |
+| readwrite_ds | ms_group_0                  |                                 |                        |                        | random             | read_weight=2:1     |
 +-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
 1 row in set (0.01 sec)
 ```
@@ -48,9 +49,9 @@ mysql> show readwrite_splitting rules from readwrite_splitting_db;
 ```sql
 mysql> show readwrite_splitting rules from readwrite_splitting_db;
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| name         | auto_aware_data_source_name | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
+| name         | auto_aware_data_source_name | write_data_source_query_enabled | write_data_source_name | read_data_source_names | load_balancer_type | load_balancer_props |
 +--------------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
-| readwrite_ds | ms_group_0                  | write_ds               | read_ds_0, read_ds_1   | random             | read_weight=2:1     |
+| readwrite_ds | ms_group_0                  |                                 | write_ds               | read_ds_0, read_ds_1   | random             | read_weight=2:1     |
 +-------+-----------------------------+------------------------+------------------------+--------------------+---------------------+
 1 row in set (0.00 sec)
 ```

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSet.java
@@ -83,6 +83,7 @@ public final class ReadwriteSplittingRuleQueryResultSet implements DistSQLResult
         Optional<ShardingSphereAlgorithmConfiguration> loadBalancer = Optional.ofNullable(loadBalancers.get(dataSourceRuleConfig.getLoadBalancerName()));
         return Arrays.asList(name,
                 getAutoAwareDataSourceName(dataSourceRuleConfig),
+                getWriteDataSourceQueryEnabled(dataSourceRuleConfig),
                 getWriteDataSourceName(dataSourceRuleConfig, exportDataSources),
                 getReadDataSourceNames(dataSourceRuleConfig, exportDataSources),
                 loadBalancer.map(ShardingSphereAlgorithmConfiguration::getType).orElse(""),
@@ -101,6 +102,13 @@ public final class ReadwriteSplittingRuleQueryResultSet implements DistSQLResult
         return dataSourceRuleConfig.getDynamicStrategy().getAutoAwareDataSourceName();
     }
     
+    private String getWriteDataSourceQueryEnabled(final ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig) {
+        if (null == dataSourceRuleConfig.getDynamicStrategy()) {
+            return "";
+        }
+        return dataSourceRuleConfig.getDynamicStrategy().getWriteDataSourceQueryEnabled();
+    }
+
     private String getWriteDataSourceName(final ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig, final Map<String, String> exportDataSources) {
         if (null != exportDataSources) {
             return exportDataSources.get(ExportableItemConstants.PRIMARY_DATA_SOURCE_NAME);
@@ -117,7 +125,7 @@ public final class ReadwriteSplittingRuleQueryResultSet implements DistSQLResult
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList("name", "auto_aware_data_source_name", "write_data_source_name", "read_data_source_names", "load_balancer_type", "load_balancer_props");
+        return Arrays.asList("name", "auto_aware_data_source_name", "write_data_source_query_enabled", "write_data_source_name", "read_data_source_names", "load_balancer_type", "load_balancer_props");
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-distsql/shardingsphere-readwrite-splitting-distsql-handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ReadwriteSplittingRuleQueryResultSetTest.java
@@ -58,7 +58,7 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
         ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
         resultSet.init(database, mock(ShowReadwriteSplittingRulesStatement.class));
         Collection<Object> actual = resultSet.getRowData();
-        assertThat(actual.size(), is(6));
+        assertThat(actual.size(), is(7));
         assertTrue(actual.contains("readwrite_ds"));
         assertTrue(actual.contains("ds_primary"));
         assertTrue(actual.contains("ds_slave_0,ds_slave_1"));
@@ -92,7 +92,7 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
         ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
         resultSet.init(database, mock(ShowReadwriteSplittingRulesStatement.class));
         Collection<Object> actual = resultSet.getRowData();
-        assertThat(actual.size(), is(6));
+        assertThat(actual.size(), is(7));
         assertTrue(actual.contains("readwrite_ds"));
         assertTrue(actual.contains("write_ds"));
         assertTrue(actual.contains("read_ds_0,read_ds_1"));
@@ -115,9 +115,10 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
         ReadwriteSplittingRuleQueryResultSet resultSet = new ReadwriteSplittingRuleQueryResultSet();
         resultSet.init(metaData, mock(ShowReadwriteSplittingRulesStatement.class));
         Collection<Object> actual = resultSet.getRowData();
-        assertThat(actual.size(), is(6));
+        assertThat(actual.size(), is(7));
         assertTrue(actual.contains("readwrite_ds"));
         assertTrue(actual.contains("rd_rs"));
+        assertTrue(actual.contains("false"));
         assertTrue(actual.contains("write_ds"));
         assertTrue(actual.contains("read_ds_0,read_ds_1"));
     }
@@ -154,7 +155,7 @@ public final class ReadwriteSplittingRuleQueryResultSetTest {
     
     private RuleConfiguration createRuleConfigurationWithAutoAwareDataSource() {
         ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig = new ReadwriteSplittingDataSourceRuleConfiguration("readwrite_ds", null,
-                new DynamicReadwriteSplittingStrategyConfiguration("rd_rs"), "");
+                new DynamicReadwriteSplittingStrategyConfiguration("rd_rs", "false"), "");
         return new ReadwriteSplittingRuleConfiguration(Collections.singleton(dataSourceRuleConfig), null);
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/alter_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/alter_readwrite_splitting_rules.xml
@@ -19,11 +19,12 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| | encrypt_write_ds_1| encrypt_read_ds_1,encrypt_read_ds_2| RANDOM| read_weight='2:1'" />
+    <row values="readwrite_ds_0| | | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| | | encrypt_write_ds_1| encrypt_read_ds_1,encrypt_read_ds_2| RANDOM| read_weight='2:1'" />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/create_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/create_readwrite_splitting_rules.xml
@@ -19,11 +19,12 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| | encrypt_write_ds_1| encrypt_read_ds_1| ROUND_ROBIN| " />
+    <row values="readwrite_ds_0| | | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| | | encrypt_write_ds_1| encrypt_read_ds_1| ROUND_ROBIN| " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/drop_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rdl/dataset/empty_rules/drop_readwrite_splitting_rules.xml
@@ -19,6 +19,7 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_readwrite_splitting_rules.xml
@@ -19,19 +19,20 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| | write_ds_0| read_ds_0| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| | write_ds_1| read_ds_1| ROUND_ROBIN| " />
-    <row values="readwrite_ds_2| | write_ds_2| read_ds_2| ROUND_ROBIN| " />
-    <row values="readwrite_ds_3| | write_ds_3| read_ds_3| ROUND_ROBIN| " />
-    <row values="readwrite_ds_4| | write_ds_4| read_ds_4| ROUND_ROBIN| " />
-    <row values="readwrite_ds_5| | write_ds_5| read_ds_5| ROUND_ROBIN| " />
-    <row values="readwrite_ds_6| | write_ds_6| read_ds_6| ROUND_ROBIN| " />
-    <row values="readwrite_ds_7| | write_ds_7| read_ds_7| ROUND_ROBIN| " />
-    <row values="readwrite_ds_8| | write_ds_8| read_ds_8| ROUND_ROBIN| " />
-    <row values="readwrite_ds_9| | write_ds_9| read_ds_9| ROUND_ROBIN| " />
+    <row values="readwrite_ds_0| | | write_ds_0| read_ds_0| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| | | write_ds_1| read_ds_1| ROUND_ROBIN| " />
+    <row values="readwrite_ds_2| | | write_ds_2| read_ds_2| ROUND_ROBIN| " />
+    <row values="readwrite_ds_3| | | write_ds_3| read_ds_3| ROUND_ROBIN| " />
+    <row values="readwrite_ds_4| | | write_ds_4| read_ds_4| ROUND_ROBIN| " />
+    <row values="readwrite_ds_5| | | write_ds_5| read_ds_5| ROUND_ROBIN| " />
+    <row values="readwrite_ds_6| | | write_ds_6| read_ds_6| ROUND_ROBIN| " />
+    <row values="readwrite_ds_7| | | write_ds_7| read_ds_7| ROUND_ROBIN| " />
+    <row values="readwrite_ds_8| | | write_ds_8| read_ds_8| ROUND_ROBIN| " />
+    <row values="readwrite_ds_9| | | write_ds_9| read_ds_9| ROUND_ROBIN| " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_readwrite_splitting_rules.xml
@@ -19,19 +19,20 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="readwrite_ds_0| | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
-    <row values="readwrite_ds_1| | encrypt_write_ds_1| encrypt_read_ds_1| ROUND_ROBIN| " />
-    <row values="readwrite_ds_2| | encrypt_write_ds_2| encrypt_read_ds_2| ROUND_ROBIN| " />
-    <row values="readwrite_ds_3| | encrypt_write_ds_3| encrypt_read_ds_3| ROUND_ROBIN| " />
-    <row values="readwrite_ds_4| | encrypt_write_ds_4| encrypt_read_ds_4| ROUND_ROBIN| " />
-    <row values="readwrite_ds_5| | encrypt_write_ds_5| encrypt_read_ds_5| ROUND_ROBIN| " />
-    <row values="readwrite_ds_6| | encrypt_write_ds_6| encrypt_read_ds_6| ROUND_ROBIN| " />
-    <row values="readwrite_ds_7| | encrypt_write_ds_7| encrypt_read_ds_7| ROUND_ROBIN| " />
-    <row values="readwrite_ds_8| | encrypt_write_ds_8| encrypt_read_ds_8| ROUND_ROBIN| " />
-    <row values="readwrite_ds_9| | encrypt_write_ds_9| encrypt_read_ds_9| ROUND_ROBIN| " />
+    <row values="readwrite_ds_0| | | encrypt_write_ds_0| encrypt_read_ds_0| ROUND_ROBIN| " />
+    <row values="readwrite_ds_1| | | encrypt_write_ds_1| encrypt_read_ds_1| ROUND_ROBIN| " />
+    <row values="readwrite_ds_2| | | encrypt_write_ds_2| encrypt_read_ds_2| ROUND_ROBIN| " />
+    <row values="readwrite_ds_3| | | encrypt_write_ds_3| encrypt_read_ds_3| ROUND_ROBIN| " />
+    <row values="readwrite_ds_4| | | encrypt_write_ds_4| encrypt_read_ds_4| ROUND_ROBIN| " />
+    <row values="readwrite_ds_5| | | encrypt_write_ds_5| encrypt_read_ds_5| ROUND_ROBIN| " />
+    <row values="readwrite_ds_6| | | encrypt_write_ds_6| encrypt_read_ds_6| ROUND_ROBIN| " />
+    <row values="readwrite_ds_7| | | encrypt_write_ds_7| encrypt_read_ds_7| ROUND_ROBIN| " />
+    <row values="readwrite_ds_8| | | encrypt_write_ds_8| encrypt_read_ds_8| ROUND_ROBIN| " />
+    <row values="readwrite_ds_9| | | encrypt_write_ds_9| encrypt_read_ds_9| ROUND_ROBIN| " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_readwrite_splitting_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_readwrite_splitting_rules.xml
@@ -19,10 +19,11 @@
     <metadata>
         <column name="name" />
         <column name="auto_aware_data_source_name" />
+        <column name="write_data_source_query_enabled" />
         <column name="write_data_source_name" />
         <column name="read_data_source_names" />
         <column name="load_balancer_type" />
         <column name="load_balancer_props" />
     </metadata>
-    <row values="write-read-ds| | write_ds| read_0,read_1| | " />
+    <row values="write-read-ds| | | write_ds| read_0,read_1| | " />
 </dataset>


### PR DESCRIPTION
Fixes #18687.

Changes proposed in this pull request:

- Add `write_data_source_query_enabled` parameter in `ReadwriteSplittingRuleQueryResultSet.class` .
- Fix `ReadwriteSplittingRuleQueryResultSetTest.class` unit test.
- Fix `shardingsphere-integration-test` module.
- Modify `rule-query/readwrite-splitting.cn/readwrite-splitting.en` document.