### PR TITLE
Improve unit test of MySQLInventoryDumper

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumperTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumperTest.java
@@ -46,9 +46,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class MySQLInventoryDumperTest {
-
+    
     private MySQLInventoryDumper mysqlJdbcDumper;
-
+    
     @Before
     public void setUp() {
         PipelineDataSourceManager dataSourceManager = new PipelineDataSourceManager();
@@ -57,7 +57,7 @@ public final class MySQLInventoryDumperTest {
         mysqlJdbcDumper = new MySQLInventoryDumper(mockInventoryDumperConfiguration(), new SimpleMemoryPipelineChannel(100), dataSource, new PipelineTableMetaDataLoader(dataSource));
         initTableData(dataSource);
     }
-
+    
     private InventoryDumperConfiguration mockInventoryDumperConfiguration() {
         DumperConfiguration dumperConfig = mockDumperConfiguration();
         InventoryDumperConfiguration result = new InventoryDumperConfiguration(dumperConfig);
@@ -65,13 +65,13 @@ public final class MySQLInventoryDumperTest {
         result.setLogicTableName("t_order");
         return result;
     }
-
+    
     private DumperConfiguration mockDumperConfiguration() {
         DumperConfiguration result = new DumperConfiguration();
         result.setDataSourceConfig(new StandardPipelineDataSourceConfiguration("jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL", "root", "root"));
         return result;
     }
-
+    
     @SneakyThrows(SQLException.class)
     private void initTableData(final DataSource dataSource) {
         try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
@@ -80,7 +80,7 @@ public final class MySQLInventoryDumperTest {
             statement.execute("INSERT INTO t_order (order_id, user_id) VALUES (1, 'xxx'), (999, 'yyy')");
         }
     }
-
+    
     @Test
     public void assertReadValue() throws SQLException {
         String mockDateString = "2022-6-30";
@@ -107,7 +107,7 @@ public final class MySQLInventoryDumperTest {
         verify(resultSet).getObject(2);
         verify(resultSet).getObject(3);
     }
-
+    
     @Test
     public void assertCreatePreparedStatement() throws SQLException {
         Connection connection = mock(Connection.class);

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumperTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-dialect/shardingsphere-data-pipeline-mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/MySQLInventoryDumperTest.java
@@ -54,8 +54,7 @@ public final class MySQLInventoryDumperTest {
         PipelineDataSourceManager dataSourceManager = new PipelineDataSourceManager();
         InventoryDumperConfiguration dumperConfig = mockInventoryDumperConfiguration();
         PipelineDataSourceWrapper dataSource = dataSourceManager.getDataSource(dumperConfig.getDataSourceConfig());
-        mysqlJdbcDumper = new MySQLInventoryDumper(mockInventoryDumperConfiguration(), new SimpleMemoryPipelineChannel(100),
-                dataSource, new PipelineTableMetaDataLoader(dataSource));
+        mysqlJdbcDumper = new MySQLInventoryDumper(mockInventoryDumperConfiguration(), new SimpleMemoryPipelineChannel(100), dataSource, new PipelineTableMetaDataLoader(dataSource));
         initTableData(dataSource);
     }
 
@@ -75,9 +74,7 @@ public final class MySQLInventoryDumperTest {
 
     @SneakyThrows(SQLException.class)
     private void initTableData(final DataSource dataSource) {
-        try (
-                Connection connection = dataSource.getConnection();
-                Statement statement = connection.createStatement()) {
+        try (Connection connection = dataSource.getConnection(); Statement statement = connection.createStatement()) {
             statement.execute("DROP TABLE IF EXISTS t_order");
             statement.execute("CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id VARCHAR(12))");
             statement.execute("INSERT INTO t_order (order_id, user_id) VALUES (1, 'xxx'), (999, 'yyy')");


### PR DESCRIPTION

Fixes #15707.

Changes proposed in this pull request:
- rename MySQLJdbcDumperTest to MySQLInventoryDumperTest
- add more test case for YEAR_DATE_TYPE in MySQLInventoryDumper

