### PR TITLE
Fix NullPointerException when execute select union statement contains subquery

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtil.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtil.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.sql.parser.sql.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.SubqueryType;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BetweenExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExistsSubqueryExpression;
@@ -63,6 +64,13 @@ public final class SubqueryExtractUtil {
         extractSubquerySegmentsFromTableSegment(result, selectStatement.getFrom());
         if (selectStatement.getWhere().isPresent()) {
             extractSubquerySegmentsFromExpression(result, selectStatement.getWhere().get().getExpr());
+        }
+        extractSubquerySegmentsFromCombines(result, selectStatement.getCombines());
+    }
+    
+    private static void extractSubquerySegmentsFromCombines(final List<SubquerySegment> result, final Collection<CombineSegment> combineSegments) {
+        for (CombineSegment each : combineSegments) {
+            extractSubquerySegments(result, each.getSelectStatement());
         }
     }
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilTest.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.sql.parser.sql.common.util;
 
 import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
+import org.apache.shardingsphere.sql.parser.sql.common.constant.CombineType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.InExpression;
@@ -163,5 +165,21 @@ public final class SubqueryExtractUtilTest {
         selectStatement.setWhere(new WhereSegment(0, 0, new InExpression(0, 0,
                 left, new SubqueryExpressionSegment(new SubquerySegment(0, 0, new MySQLSelectStatement())), false)));
         return new SubquerySegment(0, 0, selectStatement);
+    }
+    
+    @Test
+    public void assertGetSubquerySegmentsWithCombineSegment() {
+        SelectStatement selectStatement = new MySQLSelectStatement();
+        selectStatement.getCombines().add(new CombineSegment(0, 0, CombineType.UNION, createSelectStatementForCombineSegment()));
+        Collection<SubquerySegment> actual = SubqueryExtractUtil.getSubquerySegments(selectStatement);
+        assertThat(actual.size(), is(1));
+    }
+    
+    private SelectStatement createSelectStatementForCombineSegment() {
+        SelectStatement result = new MySQLSelectStatement();
+        ExpressionSegment left = new ColumnSegment(0, 0, new IdentifierValue("order_id"));
+        result.setWhere(new WhereSegment(0, 0, new InExpression(0, 0,
+                left, new SubqueryExpressionSegment(new SubquerySegment(0, 0, new MySQLSelectStatement())), false)));
+        return result;
     }
 }


### PR DESCRIPTION
Fixes #17466.

Changes proposed in this pull request:
- fix NullPointerException when execute select union statement contains subquery
- add unit test
