### PR TITLE
feat(integration-test): create new run mode

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -123,7 +123,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Standalone -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   it-single-rule:
     name: single rule
@@ -158,7 +158,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Standalone -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   it-mixture-rule:
     name: mixture rule
@@ -193,7 +193,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Standalone -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   mysql-proxy-agent:
     name: Agent Metrics & OpenTelemetry

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -123,7 +123,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Cluster -Dit.scenarios=${{ matrix.scenario }} -Dit.cluster.adapters=${{ matrix.adapter }} -Dit.cluster.databases=${{ matrix.database }} -Dit.cluster.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   it-single-rule:
     name: single rule
@@ -158,7 +158,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Cluster -Dit.scenarios=${{ matrix.scenario }} -Dit.cluster.adapters=${{ matrix.adapter }} -Dit.culster.databases=${{ matrix.database }} -Dit.cluster.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   it-mixture-rule:
     name: mixture rule
@@ -193,7 +193,7 @@ jobs:
         if: matrix.adapter == 'proxy'
         run: docker load -i /tmp/shardingsphere-proxy-test.tar
       - name: Run Integration Test
-        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Cluster -Dit.scenarios=${{ matrix.scenario }} -Dit.cluster.adapters=${{ matrix.adapter }} -Dit.cluster.databases=${{ matrix.database }} -Dit.cluster.env.type=DOCKER
+        run: ./mvnw -nsu -B install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dit.run.modes=Singleton -Dit.scenarios=${{ matrix.scenario }} -Dit.node.adapters=${{ matrix.adapter }} -Dit.node.databases=${{ matrix.database }} -Dit.node.env.type=DOCKER
   
   mysql-proxy-agent:
     name: Agent Metrics & OpenTelemetry

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -134,7 +134,7 @@ jobs:
       matrix:
         env: [ docker ]
         adapter: [ proxy, jdbc ]
-        database: [ MySQL, PostgreSQL ]
+        database: [ MySQL ]
         scenario: [ db, tbl, encrypt, readwrite_splitting, shadow ]
     steps:
       - uses: actions/checkout@v2

--- a/docs/document/content/reference/test/integration-test/_index.cn.md
+++ b/docs/document/content/reference/test/integration-test/_index.cn.md
@@ -132,12 +132,12 @@ it.scenarios=db,tbl,dbtbl_with_replica_query,replica_query
 it.run.additional.cases=false
 
 # 配置环境类型，只支持单值。可选值：docker或空，默认值：空
-it.cluster.env.type=${it.env}
+it.node.env.type=${it.env}
 # 待测试的接入端类型，多个值可用逗号分隔。可选值：jdbc, proxy, 默认值：jdbc
-it.cluster.adapters=jdbc
+it.node.adapters=jdbc
 
 # 场景类型，多个值可用逗号分隔。可选值：H2, MySQL, Oracle, SQLServer, PostgreSQL
-it.cluster.databases=H2,MySQL,Oracle,SQLServer,PostgreSQL
+it.node.databases=H2,MySQL,Oracle,SQLServer,PostgreSQL
 ```
 
 #### 运行调试模式
@@ -155,13 +155,13 @@ it.cluster.databases=H2,MySQL,Oracle,SQLServer,PostgreSQL
 #### 运行 Docker 模式
 
 ```bash
-./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/pom.xml -Pit.env.docker -Dit.cluster.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.cluster.databases=MySQL
+./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/pom.xml -Pit.env.docker -Dit.node.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.node.databases=MySQL
 ```
 运行以上命令会构建出一个用于集成测试的 Docker 镜像 `apache/shardingsphere-proxy-test:latest`。
 如果仅修改了测试代码，可以复用已有的测试镜像，无须重新构建。使用以下命令可以跳过镜像构建，直接运行集成测试：
 
 ```bash
-./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Pit.env.docker -Dit.cluster.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.cluster.databases=MySQL
+./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Pit.env.docker -Dit.node.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.node.databases=MySQL
 ```
 
 #### 注意事项

--- a/docs/document/content/reference/test/integration-test/_index.en.md
+++ b/docs/document/content/reference/test/integration-test/_index.en.md
@@ -38,7 +38,7 @@ it.run.additional.cases=false
 it.scenarios=db,tbl,dbtbl_with_replica_query,replica_query
 
 # database type, could define multiple databases(H2,MySQL,Oracle,SQLServer,PostgreSQL)
-it.cluster.databases=MySQL,PostgreSQL
+it.node.databases=MySQL,PostgreSQL
 
 # MySQL configuration
 it.mysql.host=127.0.0.1
@@ -129,14 +129,14 @@ This will reduce the difficulty for ShardingSphere testing.
 #### Run with Docker
 
 ```bash
-./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/pom.xml -Pit.env.docker -Dit.cluster.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.cluster.databases=MySQL
+./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/pom.xml -Pit.env.docker -Dit.node.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.node.databases=MySQL
 ```
 Running the above command will build a Docker image `apache/shardingsphere-proxy-test:latest` for integration testing.
 The existing test Docker image can be reused without rebuilding if only the test code is modified.
 Use the following command to skip the image building and run the integration tests directly:
 
 ```bash
-./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Pit.env.docker -Dit.cluster.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.cluster.databases=MySQL
+./mvnw -B clean install -f shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/pom.xml -Pit.env.docker -Dit.node.adapters=proxy,jdbc -Dit.scenarios=${scenario_name_1,scenario_name_1,scenario_name_n} -Dit.node.databases=MySQL
 ```
 
 ## Notice

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/cluster/NodeEnvironment.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/cluster/NodeEnvironment.java
@@ -28,10 +28,10 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**
- * Cluster environment.
+ * ShardingSphere node environment.
  */
 @Getter
-public final class ClusterEnvironment {
+public final class NodeEnvironment {
     
     private final Type type;
     
@@ -39,14 +39,14 @@ public final class ClusterEnvironment {
     
     private final Collection<DatabaseType> databaseTypes;
     
-    public ClusterEnvironment(final Properties props) {
+    public NodeEnvironment(final Properties props) {
         type = getType(props);
         adapters = getAdapters(props);
         databaseTypes = getDatabaseTypes(props);
     }
     
     private Type getType(final Properties props) {
-        String value = props.getProperty("it.cluster.env.type");
+        String value = props.getProperty("it.node.env.type");
         if (null == value) {
             return Type.NATIVE;
         }
@@ -58,11 +58,11 @@ public final class ClusterEnvironment {
     }
     
     private Collection<String> getAdapters(final Properties props) {
-        return Splitter.on(",").trimResults().splitToList(props.getProperty("it.cluster.adapters"));
+        return Splitter.on(",").trimResults().splitToList(props.getProperty("it.node.adapters"));
     }
     
     private Collection<DatabaseType> getDatabaseTypes(final Properties props) {
-        return Arrays.stream(props.getProperty("it.cluster.databases").split(",")).map(each -> DatabaseTypeFactory.getInstance(each.trim())).collect(Collectors.toSet());
+        return Arrays.stream(props.getProperty("it.node.databases").split(",")).map(each -> DatabaseTypeFactory.getInstance(each.trim())).collect(Collectors.toSet());
     }
     
     /**

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/node/NodeEnvironment.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/node/NodeEnvironment.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.integration.env.cluster;
+package org.apache.shardingsphere.test.integration.env.node;
 
 import com.google.common.base.Splitter;
 import lombok.Getter;
@@ -66,7 +66,7 @@ public final class NodeEnvironment {
     }
     
     /**
-     * Cluster environment type.
+     * Node environment type.
      */
     public enum Type {
         

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/pom.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-fixture/pom.xml
@@ -108,7 +108,7 @@
         <profile>
             <id>it.env.docker</id>
             <properties>
-                <it.cluster.env.type>DOCKER</it.cluster.env.type>
+                <it.node.env.type>DOCKER</it.node.env.type>
             </properties>
             <build>
                 <plugins>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
@@ -41,7 +41,7 @@ public final class TotalSuitesCountCalculator {
     
     /**
      * Calculate total test suites count.
-     * 
+     *
      * @return total test suites count
      */
     public static int calculate() {
@@ -60,10 +60,10 @@ public final class TotalSuitesCountCalculator {
     }
     
     private static boolean isRunDCL() {
-        return ENV.getRunModes().contains("Cluster");
+        return ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Singleton");
     }
     
     private static boolean isRunProxy() {
-        return ENV.getRunModes().contains("Cluster") && ENV.getNodeEnvironment().getAdapters().contains("proxy");
+        return (ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Singleton")) && ENV.getNodeEnvironment().getAdapters().contains("proxy");
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
@@ -64,6 +64,6 @@ public final class TotalSuitesCountCalculator {
     }
     
     private static boolean isRunProxy() {
-        return ENV.getRunModes().contains("Cluster") && ENV.getClusterEnvironment().getAdapters().contains("proxy");
+        return ENV.getRunModes().contains("Cluster") && ENV.getNodeEnvironment().getAdapters().contains("proxy");
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/TotalSuitesCountCalculator.java
@@ -60,10 +60,10 @@ public final class TotalSuitesCountCalculator {
     }
     
     private static boolean isRunDCL() {
-        return ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Singleton");
+        return ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Standalone");
     }
     
     private static boolean isRunProxy() {
-        return (ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Singleton")) && ENV.getNodeEnvironment().getAdapters().contains("proxy");
+        return (ENV.getRunModes().contains("Cluster") || ENV.getRunModes().contains("Standalone")) && ENV.getNodeEnvironment().getAdapters().contains("proxy");
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/env/IntegrationTestEnvironment.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/env/IntegrationTestEnvironment.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.integration.env;
 
 import com.google.common.base.Splitter;
 import lombok.Getter;
-import org.apache.shardingsphere.test.integration.env.cluster.ClusterEnvironment;
+import org.apache.shardingsphere.test.integration.env.cluster.NodeEnvironment;
 import org.apache.shardingsphere.test.integration.env.scenario.path.ScenarioCommonPath;
 
 import java.io.IOException;
@@ -41,14 +41,14 @@ public final class IntegrationTestEnvironment {
     
     private final Collection<String> scenarios;
     
-    private final ClusterEnvironment clusterEnvironment;
+    private final NodeEnvironment nodeEnvironment;
     
     private IntegrationTestEnvironment() {
         Properties props = loadProperties();
         runModes = Splitter.on(",").trimResults().splitToList(props.getProperty("it.run.modes"));
         runAdditionalTestCases = Boolean.parseBoolean(props.getProperty("it.run.additional.cases"));
         scenarios = getScenarios(props);
-        clusterEnvironment = new ClusterEnvironment(props);
+        nodeEnvironment = new NodeEnvironment(props);
     }
     
     @SuppressWarnings("AccessOfSystemProperties")

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/env/IntegrationTestEnvironment.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/env/IntegrationTestEnvironment.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.integration.env;
 
 import com.google.common.base.Splitter;
 import lombok.Getter;
-import org.apache.shardingsphere.test.integration.env.cluster.NodeEnvironment;
+import org.apache.shardingsphere.test.integration.env.node.NodeEnvironment;
 import org.apache.shardingsphere.test.integration.env.scenario.path.ScenarioCommonPath;
 
 import java.io.IOException;

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/container/compose/ComposedContainerRegistry.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/container/compose/ComposedContainerRegistry.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.test.integration.framework.container.compose;
 
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.test.integration.framework.container.compose.mode.ClusterComposedContainer;
-import org.apache.shardingsphere.test.integration.framework.container.compose.mode.MemoryComposedContainer;
+import org.apache.shardingsphere.test.integration.framework.container.compose.mode.DefaultComposedContainer;
 import org.apache.shardingsphere.test.integration.framework.param.model.ParameterizedArray;
 
 import javax.sql.DataSource;
@@ -53,12 +53,12 @@ public final class ComposedContainerRegistry implements AutoCloseable {
     }
     
     private ComposedContainer createComposedContainer(final ParameterizedArray parameterizedArray) {
-        return isMemoryMode(parameterizedArray) ? new MemoryComposedContainer(parameterizedArray) : new ClusterComposedContainer(parameterizedArray);
+        return isClusterMode(parameterizedArray) ? new ClusterComposedContainer(parameterizedArray) : new DefaultComposedContainer(parameterizedArray);
     }
     
-    private boolean isMemoryMode(final ParameterizedArray parameterizedArray) {
+    private boolean isClusterMode(final ParameterizedArray parameterizedArray) {
         // TODO cluster mode often throw exception sometimes, issue is #15517
-        return true;
+        return false;
         // return "H2".equals(parameterizedArray.getDatabaseType().getName());
     }
     

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/container/compose/mode/DefaultComposedContainer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/container/compose/mode/DefaultComposedContainer.java
@@ -31,9 +31,9 @@ import javax.sql.DataSource;
 import java.util.Map;
 
 /**
- * Memory composed container.
+ * The default composed container.
  */
-public final class MemoryComposedContainer implements ComposedContainer {
+public final class DefaultComposedContainer implements ComposedContainer {
     
     private final ITContainers containers;
     
@@ -41,7 +41,7 @@ public final class MemoryComposedContainer implements ComposedContainer {
     
     private final AdapterContainer adapterContainer;
     
-    public MemoryComposedContainer(final ParameterizedArray parameterizedArray) {
+    public DefaultComposedContainer(final ParameterizedArray parameterizedArray) {
         String scenario = parameterizedArray.getScenario();
         containers = new ITContainers(scenario);
         storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(parameterizedArray.getDatabaseType(), scenario),

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
@@ -46,8 +46,8 @@ public final class ParameterizedArrayFactory {
         for (String each : ENV.getRunModes()) {
             if ("Memory".equalsIgnoreCase(each)) {
                 result.addAll(MemoryParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
-            } else if ("Singleton".equalsIgnoreCase(each)) {
-                result.addAll(SingletonParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
+            } else if ("Standalone".equalsIgnoreCase(each)) {
+                result.addAll(StandaloneParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
             } else if ("Cluster".equalsIgnoreCase(each)) {
                 result.addAll(ClusterParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
             }
@@ -66,8 +66,8 @@ public final class ParameterizedArrayFactory {
         for (String each : ENV.getRunModes()) {
             if ("Memory".equalsIgnoreCase(each)) {
                 result.addAll(MemoryParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
-            } else if ("Singleton".equalsIgnoreCase(each)) {
-                result.addAll(SingletonParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
+            } else if ("Standalone".equalsIgnoreCase(each)) {
+                result.addAll(StandaloneParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             } else if ("Cluster".equalsIgnoreCase(each)) {
                 result.addAll(ClusterParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
@@ -67,7 +67,7 @@ public final class ParameterizedArrayFactory {
             if ("Memory".equalsIgnoreCase(each)) {
                 result.addAll(MemoryParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             } else if ("Singleton".equalsIgnoreCase(each)) {
-                result.addAll(SingletonParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
+                result.addAll(SingletonParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             } else if ("Cluster".equalsIgnoreCase(each)) {
                 result.addAll(ClusterParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/ParameterizedArrayFactory.java
@@ -46,6 +46,8 @@ public final class ParameterizedArrayFactory {
         for (String each : ENV.getRunModes()) {
             if ("Memory".equalsIgnoreCase(each)) {
                 result.addAll(MemoryParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
+            } else if ("Singleton".equalsIgnoreCase(each)) {
+                result.addAll(SingletonParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
             } else if ("Cluster".equalsIgnoreCase(each)) {
                 result.addAll(ClusterParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
             }
@@ -64,6 +66,8 @@ public final class ParameterizedArrayFactory {
         for (String each : ENV.getRunModes()) {
             if ("Memory".equalsIgnoreCase(each)) {
                 result.addAll(MemoryParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
+            } else if ("Singleton".equalsIgnoreCase(each)) {
+                result.addAll(SingletonParameterizedArrayGenerator.getAssertionParameterized(sqlCommandType));
             } else if ("Cluster".equalsIgnoreCase(each)) {
                 result.addAll(ClusterParameterizedArrayGenerator.getCaseParameterized(sqlCommandType));
             }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/SingletonParameterizedArrayGenerator.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/SingletonParameterizedArrayGenerator.java
@@ -27,10 +27,10 @@ import org.apache.shardingsphere.test.integration.framework.param.model.Paramete
 import java.util.Collection;
 
 /**
- * Parameterized array generator for cluster mode.
+ * Parameterized array generator for singleton mode.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ClusterParameterizedArrayGenerator {
+public final class SingletonParameterizedArrayGenerator {
     
     private static final IntegrationTestEnvironment ENV = IntegrationTestEnvironment.getInstance();
     

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/StandaloneParameterizedArrayGenerator.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/param/array/StandaloneParameterizedArrayGenerator.java
@@ -27,10 +27,10 @@ import org.apache.shardingsphere.test.integration.framework.param.model.Paramete
 import java.util.Collection;
 
 /**
- * Parameterized array generator for singleton mode.
+ * Parameterized array generator for standalone mode.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class SingletonParameterizedArrayGenerator {
+public final class StandaloneParameterizedArrayGenerator {
     
     private static final IntegrationTestEnvironment ENV = IntegrationTestEnvironment.getInstance();
     

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/runner/ShardingSphereIntegrationTestParameterized.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/runner/ShardingSphereIntegrationTestParameterized.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.test.integration.framework.runner;
 
 import org.apache.shardingsphere.test.integration.env.IntegrationTestEnvironment;
-import org.apache.shardingsphere.test.integration.env.cluster.ClusterEnvironment;
+import org.apache.shardingsphere.test.integration.env.cluster.NodeEnvironment;
 import org.apache.shardingsphere.test.integration.framework.runner.parallel.ParallelRunnerScheduler;
 import org.apache.shardingsphere.test.integration.framework.runner.parallel.annotaion.ParallelRuntimeStrategy;
 import org.junit.runners.Parameterized;
@@ -32,7 +32,7 @@ public final class ShardingSphereIntegrationTestParameterized extends Parameteri
     public ShardingSphereIntegrationTestParameterized(final Class<?> clazz) throws Throwable {
         // CHECKSTYLE:ON
         super(clazz);
-        if (ClusterEnvironment.Type.DOCKER != IntegrationTestEnvironment.getInstance().getClusterEnvironment().getType()) {
+        if (NodeEnvironment.Type.DOCKER != IntegrationTestEnvironment.getInstance().getNodeEnvironment().getType()) {
             ParallelRuntimeStrategy parallelRuntimeStrategy = clazz.getAnnotation(ParallelRuntimeStrategy.class);
             if (null != parallelRuntimeStrategy) {
                 setScheduler(new ParallelRunnerScheduler(parallelRuntimeStrategy.value()));

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/runner/ShardingSphereIntegrationTestParameterized.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/framework/runner/ShardingSphereIntegrationTestParameterized.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.test.integration.framework.runner;
 
 import org.apache.shardingsphere.test.integration.env.IntegrationTestEnvironment;
-import org.apache.shardingsphere.test.integration.env.cluster.NodeEnvironment;
+import org.apache.shardingsphere.test.integration.env.node.NodeEnvironment;
 import org.apache.shardingsphere.test.integration.framework.runner.parallel.ParallelRunnerScheduler;
 import org.apache.shardingsphere.test.integration.framework.runner.parallel.annotaion.ParallelRuntimeStrategy;
 import org.junit.runners.Parameterized;

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
@@ -15,18 +15,18 @@
 # limitations under the License.
 #
 
-#it.modes=Memory,Cluster
-it.run.modes=Memory
+#it.modes=Memory,Singleton,Cluster
+it.run.modes=Singleton
 it.run.additional.cases=false
 
 #it.scenarios=db,tbl,readwrite_splitting,encrypt,shadow,dbtbl_with_readwrite_splitting,dbtbl_with_readwrite_splitting_and_encrypt,empty_rules
 it.scenarios=db,tbl,readwrite_splitting,encrypt,shadow,dbtbl_with_readwrite_splitting,dbtbl_with_readwrite_splitting_and_encrypt,empty_rules
 
-# it.cluster.env.type=DOCKER,NATIVE
-it.cluster.env.type=DOCKER
+# it.node.env.type=DOCKER,NATIVE
+it.node.env.type=DOCKER
 
-# it.cluster.adapters=jdbc,proxy
-it.cluster.adapters=proxy
+# it.node.adapters=jdbc,proxy
+it.node.adapters=proxy
 
-# it.cluster.databases=MySQL,PostgreSQL
-it.cluster.databases=MySQL
+# it.node.databases=MySQL,PostgreSQL
+it.node.databases=MySQL

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
@@ -16,7 +16,7 @@
 #
 
 #it.modes=Memory,Singleton,Cluster
-it.run.modes=Singleton
+it.run.modes=Memory
 it.run.additional.cases=false
 
 #it.scenarios=db,tbl,readwrite_splitting,encrypt,shadow,dbtbl_with_readwrite_splitting,dbtbl_with_readwrite_splitting_and_encrypt,empty_rules

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/env/it-env.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-#it.modes=Memory,Singleton,Cluster
+#it.modes=Memory,Standalone,Cluster
 it.run.modes=Memory
 it.run.additional.cases=false
 


### PR DESCRIPTION
After this PR, we will have three run modes.

1. Memory: Execute integration tests via jdbc+H2.
2. Standalone: Perform single ShardingSphere(JDBC,Proxy) integration tests based on database (MySQL, PG) containers.
3. Cluster: Add more ShardingSphere(JDBC,Proxy) nodes based on standalone and import registry services such as zookeeper and ETCD.

In fact, the PostgreSQL database scenario test always had problems, but the single-rule integration test had not been opened before.
![image](https://user-images.githubusercontent.com/76552510/177586780-e6769aed-b095-419c-a646-c24542f0d3d3.png)
![image](https://user-images.githubusercontent.com/76552510/177587317-a68a7925-7173-4d0c-adfc-8e8e3e8ea5a1.png)

So i close the PG single-rule integration test
