### PR TITLE
Use byte stream to load config file when use ShardingSphere Driver with SpringBoot fatjar

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/DriverDataSourceCache.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/DriverDataSourceCache.java
@@ -46,7 +46,7 @@ public final class DriverDataSourceCache {
         }
         DataSource dataSource;
         try {
-            dataSource = YamlShardingSphereDataSourceFactory.createDataSource(new ShardingSphereDriverURL(url).toConfigurationFile());
+            dataSource = YamlShardingSphereDataSourceFactory.createDataSource(new ShardingSphereDriverURL(url).toConfigurationBytes());
         } catch (final IOException ex) {
             throw new SQLException(ex);
         }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURL.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURL.java
@@ -18,8 +18,12 @@
 package org.apache.shardingsphere.driver.jdbc.core.driver;
 
 import com.google.common.base.Preconditions;
+import lombok.SneakyThrows;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Objects;
 
 /**
@@ -46,13 +50,16 @@ public final class ShardingSphereDriverURL {
     }
     
     /**
-     * Generate to configuration file.
+     * Generate to configuration bytes.
      * 
-     * @return generated configuration file
+     * @return generated configuration bytes
      */
-    public File toConfigurationFile() {
-        return new File(inClasspath
-                ? Objects.requireNonNull(ShardingSphereDriverURL.class.getResource("/" + file), String.format("Can not find configuration file `%s` in classpath.", file)).getFile()
-                : file);
+    @SneakyThrows(IOException.class)
+    public byte[] toConfigurationBytes() {
+        try (InputStream stream = inClasspath ? ShardingSphereDriverURL.class.getResourceAsStream("/" + file) : Files.newInputStream(new File(file).toPath())) {
+            byte[] result = new byte[null == stream ? 0 : stream.available()];
+            Objects.requireNonNull(stream, String.format("Can not find configuration file `%s`.", file)).read(result);
+            return result;
+        }
     }
 }

--- a/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURLTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURLTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.driver.jdbc.core.driver;
 
 import org.junit.Test;
 
-import java.io.File;
+import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -34,18 +34,20 @@ public final class ShardingSphereDriverURLTest {
     @Test
     public void assertToClasspathConfigurationFile() {
         ShardingSphereDriverURL actual = new ShardingSphereDriverURL("jdbc:shardingsphere:classpath:config/driver/foo-driver-fixture.yaml");
-        assertThat(actual.toConfigurationFile().getName(), is("foo-driver-fixture.yaml"));
+        assertThat(actual.toConfigurationBytes().length, is(822));
     }
     
     @Test
     public void assertToConfigurationFile() {
-        ShardingSphereDriverURL actual = new ShardingSphereDriverURL("jdbc:shardingsphere:config/driver/foo-driver-fixture.yaml");
-        assertThat(actual.toConfigurationFile(), is(new File("config/driver/foo-driver-fixture.yaml")));
+        String absolutePath = Objects.requireNonNull(ShardingSphereDriverURLTest.class.getClassLoader().getResource("config/driver/foo-driver-fixture.yaml")).getPath();
+        ShardingSphereDriverURL actual = new ShardingSphereDriverURL("jdbc:shardingsphere:" + absolutePath);
+        assertThat(actual.toConfigurationBytes().length, is(822));
     }
     
     @Test
     public void assertToConfigurationFileWithOtherParameters() {
-        ShardingSphereDriverURL actual = new ShardingSphereDriverURL("jdbc:shardingsphere:config/driver/foo-driver-fixture.yaml?xxx=xxx&yyy=yyy");
-        assertThat(actual.toConfigurationFile(), is(new File("config/driver/foo-driver-fixture.yaml")));
+        String absolutePath = Objects.requireNonNull(ShardingSphereDriverURLTest.class.getClassLoader().getResource("config/driver/foo-driver-fixture.yaml")).getPath();
+        ShardingSphereDriverURL actual = new ShardingSphereDriverURL("jdbc:shardingsphere:" + absolutePath + "?xxx=xxx&yyy=yyy");
+        assertThat(actual.toConfigurationBytes().length, is(822));
     }
 }


### PR DESCRIPTION
Fixes #18968.

Changes proposed in this pull request:
- use byte stream to load config file when use ShardingSphere Driver with SpringBoot fatjar
- update unit test
