### PR TITLE
Update strategy result of `SHOW SHARDING TABLE RULES`

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/ComplexShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/ComplexShardingStrategyConfiguration.java
@@ -37,4 +37,9 @@ public final class ComplexShardingStrategyConfiguration implements ShardingStrat
         this.shardingColumns = shardingColumns;
         this.shardingAlgorithmName = shardingAlgorithmName;
     }
+    
+    @Override
+    public String getType() {
+        return "COMPLEX";
+    }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/HintShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/HintShardingStrategyConfiguration.java
@@ -32,4 +32,9 @@ public final class HintShardingStrategyConfiguration implements ShardingStrategy
         Preconditions.checkNotNull(shardingAlgorithmName, "Sharding algorithm name is required.");
         this.shardingAlgorithmName = shardingAlgorithmName;
     }
+    
+    @Override
+    public String getType() {
+        return "HINT";
+    }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/NoneShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/NoneShardingStrategyConfiguration.java
@@ -26,4 +26,9 @@ public final class NoneShardingStrategyConfiguration implements ShardingStrategy
     public String getShardingAlgorithmName() {
         return "";
     }
+    
+    @Override
+    public String getType() {
+        return "NONE";
+    }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/NoneShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/NoneShardingStrategyConfiguration.java
@@ -29,6 +29,6 @@ public final class NoneShardingStrategyConfiguration implements ShardingStrategy
     
     @Override
     public String getType() {
-        return "NONE";
+        return "";
     }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/ShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/ShardingStrategyConfiguration.java
@@ -28,4 +28,11 @@ public interface ShardingStrategyConfiguration {
      * @return sharding algorithm name
      */
     String getShardingAlgorithmName();
+    
+    /**
+     * Get type.
+     * 
+     * @return type
+     */
+    String getType();
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/StandardShardingStrategyConfiguration.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-api/src/main/java/org/apache/shardingsphere/sharding/api/config/strategy/sharding/StandardShardingStrategyConfiguration.java
@@ -35,4 +35,9 @@ public final class StandardShardingStrategyConfiguration implements ShardingStra
         this.shardingColumn = shardingColumn;
         this.shardingAlgorithmName = shardingAlgorithmName;
     }
+    
+    @Override
+    public String getType() {
+        return "STANDARD";
+    }
 }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRuleQueryResultSet.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableRuleQueryResultSet.java
@@ -93,14 +93,14 @@ public final class ShardingTableRuleQueryResultSet implements DistSQLResultSet {
         result.add(shardingTableRuleConfig.getLogicTable());
         result.add(shardingTableRuleConfig.getActualDataNodes());
         result.add("");
-        result.add(getDatabaseStrategyType(shardingTableRuleConfig));
-        result.add(getDatabaseShardingColumn(shardingTableRuleConfig));
         Optional<ShardingStrategyConfiguration> databaseShardingStrategyConfig = getDatabaseShardingStrategy(shardingTableRuleConfig);
+        result.add(databaseShardingStrategyConfig.map(this::getStrategyType).orElse(""));
+        result.add(databaseShardingStrategyConfig.map(this::getShardingColumn).orElse(""));
         result.add(databaseShardingStrategyConfig.map(this::getAlgorithmType).orElse(""));
         result.add(databaseShardingStrategyConfig.map(this::getAlgorithmProperties).orElse(""));
-        result.add(getTableStrategyType(shardingTableRuleConfig.getTableShardingStrategy()));
-        result.add(getTableShardingColumn(shardingTableRuleConfig.getTableShardingStrategy()));
         Optional<ShardingStrategyConfiguration> tableShardingStrategyConfig = getTableShardingStrategy(shardingTableRuleConfig.getTableShardingStrategy());
+        result.add(tableShardingStrategyConfig.map(this::getStrategyType).orElse(""));
+        result.add(tableShardingStrategyConfig.map(this::getShardingColumn).orElse(""));
         result.add(tableShardingStrategyConfig.map(this::getAlgorithmType).orElse(""));
         result.add(tableShardingStrategyConfig.map(this::getAlgorithmProperties).orElse(""));
         result.add(getKeyGenerateColumn(shardingTableRuleConfig.getKeyGenerateStrategy()));
@@ -118,27 +118,15 @@ public final class ShardingTableRuleQueryResultSet implements DistSQLResultSet {
         result.add("");
         result.add("");
         result.add("");
-        result.add(getTableStrategyType(shardingAutoTableRuleConfig.getShardingStrategy()));
-        result.add(getTableShardingColumn(shardingAutoTableRuleConfig.getShardingStrategy()));
         Optional<ShardingStrategyConfiguration> tableShardingStrategyConfig = getTableShardingStrategy(shardingAutoTableRuleConfig.getShardingStrategy());
+        result.add(tableShardingStrategyConfig.map(this::getStrategyType).orElse(""));
+        result.add(tableShardingStrategyConfig.map(this::getShardingColumn).orElse(""));
         result.add(tableShardingStrategyConfig.map(this::getAlgorithmType).orElse(""));
         result.add(tableShardingStrategyConfig.map(this::getAlgorithmProperties).orElse(""));
         result.add(getKeyGenerateColumn(shardingAutoTableRuleConfig.getKeyGenerateStrategy()));
         result.add(getKeyGeneratorType(shardingAutoTableRuleConfig.getKeyGenerateStrategy()));
         result.add(getKeyGeneratorProps(shardingAutoTableRuleConfig.getKeyGenerateStrategy()));
         return result;
-    }
-    
-    private String getDatabaseStrategyType(final ShardingTableRuleConfiguration shardingTableRuleConfig) {
-        Optional<ShardingStrategyConfiguration> databaseShardingStrategy = getDatabaseShardingStrategy(shardingTableRuleConfig);
-        return databaseShardingStrategy.isPresent() && !(databaseShardingStrategy.get() instanceof NoneShardingStrategyConfiguration)
-                ? getAlgorithmConfiguration(databaseShardingStrategy.get().getShardingAlgorithmName()).getType()
-                : "";
-    }
-    
-    private String getDatabaseShardingColumn(final ShardingTableRuleConfiguration shardingTableRuleConfig) {
-        Optional<ShardingStrategyConfiguration> databaseShardingStrategy = getDatabaseShardingStrategy(shardingTableRuleConfig);
-        return databaseShardingStrategy.isPresent() ? getShardingColumn(databaseShardingStrategy.get()) : "";
     }
     
     private String getShardingColumn(final ShardingStrategyConfiguration shardingStrategyConfig) {
@@ -151,14 +139,14 @@ public final class ShardingTableRuleQueryResultSet implements DistSQLResultSet {
         return "";
     }
     
-    private String getAlgorithmType(final ShardingStrategyConfiguration databaseShardingStrategy) {
-        return databaseShardingStrategy instanceof NoneShardingStrategyConfiguration ? "" : getAlgorithmConfiguration(databaseShardingStrategy.getShardingAlgorithmName()).getType();
+    private String getAlgorithmType(final ShardingStrategyConfiguration shardingStrategyConfig) {
+        return shardingStrategyConfig instanceof NoneShardingStrategyConfiguration ? "" : getAlgorithmConfiguration(shardingStrategyConfig.getShardingAlgorithmName()).getType();
     }
     
-    private String getAlgorithmProperties(final ShardingStrategyConfiguration databaseShardingStrategy) {
-        return databaseShardingStrategy instanceof NoneShardingStrategyConfiguration
+    private String getAlgorithmProperties(final ShardingStrategyConfiguration shardingStrategyConfig) {
+        return shardingStrategyConfig instanceof NoneShardingStrategyConfiguration
                 ? ""
-                : PropertiesConverter.convert(getAlgorithmConfiguration(databaseShardingStrategy.getShardingAlgorithmName()).getProps());
+                : PropertiesConverter.convert(getAlgorithmConfiguration(shardingStrategyConfig.getShardingAlgorithmName()).getProps());
     }
     
     private Optional<ShardingStrategyConfiguration> getDatabaseShardingStrategy(final ShardingTableRuleConfiguration shardingTableRuleConfig) {
@@ -171,22 +159,12 @@ public final class ShardingTableRuleQueryResultSet implements DistSQLResultSet {
         return shardingRuleConfig.getShardingAlgorithms().get(algorithmName);
     }
     
-    private String getTableStrategyType(final ShardingStrategyConfiguration shardingStrategyConfig) {
-        Optional<ShardingStrategyConfiguration> tableShardingStrategy = getTableShardingStrategy(shardingStrategyConfig);
-        return tableShardingStrategy.isPresent() ? getStrategyType(tableShardingStrategy.get()) : "";
-    }
-    
     private String getStrategyType(final ShardingStrategyConfiguration shardingStrategyConfig) {
-        return shardingStrategyConfig instanceof NoneShardingStrategyConfiguration ? "none" : getAlgorithmConfiguration(shardingStrategyConfig.getShardingAlgorithmName()).getType();
+        return shardingStrategyConfig.getType();
     }
     
     private Optional<ShardingStrategyConfiguration> getTableShardingStrategy(final ShardingStrategyConfiguration shardingStrategyConfig) {
         return null == shardingStrategyConfig ? Optional.ofNullable(shardingRuleConfig.getDefaultTableShardingStrategy()) : Optional.of(shardingStrategyConfig);
-    }
-    
-    private String getTableShardingColumn(final ShardingStrategyConfiguration shardingStrategyConfig) {
-        Optional<ShardingStrategyConfiguration> tableShardingStrategy = getTableShardingStrategy(shardingStrategyConfig);
-        return tableShardingStrategy.isPresent() ? getShardingColumn(tableShardingStrategy.get()) : "";
     }
     
     private String getKeyGenerateColumn(final KeyGenerateStrategyConfiguration keyGenerateStrategyConfig) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingTableRuleQueryResultSetTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShardingTableRuleQueryResultSetTest.java
@@ -53,11 +53,11 @@ public final class ShardingTableRuleQueryResultSetTest {
         assertThat(actual.get(0), is("t_order"));
         assertThat(actual.get(1), is("ds_${0..1}.t_order_${0..1}"));
         assertThat(actual.get(2), is(""));
-        assertThat(actual.get(3), is("INLINE"));
+        assertThat(actual.get(3), is("STANDARD"));
         assertThat(actual.get(4), is("user_id"));
         assertThat(actual.get(5), is("INLINE"));
         assertThat(actual.get(6), is("algorithm-expression=ds_${user_id % 2}"));
-        assertThat(actual.get(7), is("INLINE"));
+        assertThat(actual.get(7), is("STANDARD"));
         assertThat(actual.get(8), is("order_id"));
         assertThat(actual.get(9), is("INLINE"));
         assertThat(actual.get(10), is("algorithm-expression=t_order_${order_id % 2}"));

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_rules.xml
@@ -35,6 +35,6 @@
     <row values="t_order| ds_${0..9}.t_order| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | | | " />
     <row values="t_order_item| ds_${0..9}.t_order_item| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | item_id| IT.FIXTURE| " />
     <row values="t_order_details| ds_${0..9}.t_order_details| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | | " />
-    <row values="t_order_federate_sharding| ds_${0..1}.t_order_federate_sharding| | INLINE| order_id_sharding| INLINE| algorithm-expression=ds_${order_id_sharding % 2}| | | | | | | " />
-    <row values="t_order_item_federate_sharding| ds_${0..1}.t_order_item_federate_sharding| | INLINE| item_id| INLINE| algorithm-expression=ds_${db_inline_item_id % 2}| | | | | | | " />
+    <row values="t_order_federate_sharding| ds_${0..1}.t_order_federate_sharding| | STANDARD| order_id_sharding| INLINE| algorithm-expression=ds_${order_id_sharding % 2}| | | | | | | " />
+    <row values="t_order_item_federate_sharding| ds_${0..1}.t_order_item_federate_sharding| | STANDARD| item_id| INLINE| algorithm-expression=ds_${db_inline_item_id % 2}| | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_rules.xml
@@ -32,9 +32,9 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| ds_${0..9}.t_order| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | | | | | | | " />
-    <row values="t_order_item| ds_${0..9}.t_order_item| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | | | | | item_id| IT.FIXTURE| " />
-    <row values="t_order_details| ds_${0..9}.t_order_details| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | | | | | | " />
+    <row values="t_order| ds_${0..9}.t_order| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | | | " />
+    <row values="t_order_item| ds_${0..9}.t_order_item| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | item_id| IT.FIXTURE| " />
+    <row values="t_order_details| ds_${0..9}.t_order_details| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | | " />
     <row values="t_order_federate_sharding| ds_${0..1}.t_order_federate_sharding| | INLINE| order_id_sharding| INLINE| algorithm-expression=ds_${order_id_sharding % 2}| | | | | | | " />
     <row values="t_order_item_federate_sharding| ds_${0..1}.t_order_item_federate_sharding| | INLINE| item_id| INLINE| algorithm-expression=ds_${db_inline_item_id % 2}| | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/db/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| ds_${0..9}.t_order| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | | | | | | | " />
+    <row values="t_order| ds_${0..9}.t_order| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_rules.xml
@@ -32,9 +32,9 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| readwrite_ds_${0..9}.t_order_${0..9}| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
-    <row values="t_order_item| readwrite_ds_${0..9}.t_order_item_${0..9}| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
-    <row values="t_order_details| readwrite_ds_${0..9}.t_order_details_${0..9}| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order| readwrite_ds_${0..9}.t_order_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order_item| readwrite_ds_${0..9}.t_order_item_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
+    <row values="t_order_details| readwrite_ds_${0..9}.t_order_details_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
     <row values="t_order_item_federate_sharding | readwrite_ds_1.t_order_item_federate_sharding_${0..1}| | | | | | INLINE| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
     <row values="t_order_federate_sharding | readwrite_ds_1.t_order_federate_sharding_${0..1}| | | | | | INLINE| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2}| | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_rules.xml
@@ -35,6 +35,6 @@
     <row values="t_order| readwrite_ds_${0..9}.t_order_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
     <row values="t_order_item| readwrite_ds_${0..9}.t_order_item_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
     <row values="t_order_details| readwrite_ds_${0..9}.t_order_details_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
-    <row values="t_order_item_federate_sharding | readwrite_ds_1.t_order_item_federate_sharding_${0..1}| | | | | | INLINE| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
-    <row values="t_order_federate_sharding | readwrite_ds_1.t_order_federate_sharding_${0..1}| | | | | | INLINE| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2}| | | " />
+    <row values="t_order_item_federate_sharding | readwrite_ds_1.t_order_item_federate_sharding_${0..1}| | | | | | STANDARD| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
+    <row values="t_order_federate_sharding | readwrite_ds_1.t_order_federate_sharding_${0..1}| | | | | | STANDARD| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2}| | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| readwrite_ds_${0..9}.t_order_${0..9}| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order| readwrite_ds_${0..9}.t_order_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_rules.xml
@@ -32,10 +32,10 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_user_item| readwrite_ds_${0..9}.t_user_item_${0..9}| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| item_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
-    <row values="t_user| readwrite_ds_${0..9}.t_user_${0..9}| | IT.STANDARD.FIXTURE| address_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | user_id| IT.FIXTURE| " />
-    <row values="t_user_details| readwrite_ds_${0..9}.t_user_details_${0..9}| | IT.STANDARD.FIXTURE| address_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | | | " />
-    <row values="t_order_item_federate_sharding| readwrite_ds_1.t_order_item_federate_sharding_${0..1}| | | | | | INLINE| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
-    <row values="t_order_federate_sharding| readwrite_ds_1.t_order_federate_sharding_${0..1}| | | | | | INLINE| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2}| | | " />
-    <row values="t_user_encrypt_federate_sharding| readwrite_ds_1.t_user_encrypt_federate_sharding_${0..1}| | | | | | INLINE| user_id| INLINE| algorithm-expression=t_user_encrypt_federate_sharding_${user_id % 2},allow-range-query-with-inline-sharding=true| | | " />
+    <row values="t_user_item| readwrite_ds_${0..9}.t_user_item_${0..9}| | STANDARD| user_id| IT.STANDARD.FIXTURE| | STANDARD| item_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
+    <row values="t_user| readwrite_ds_${0..9}.t_user_${0..9}| | STANDARD| address_id| IT.STANDARD.FIXTURE| | STANDARD| user_id| IT.STANDARD.FIXTURE| | user_id| IT.FIXTURE| " />
+    <row values="t_user_details| readwrite_ds_${0..9}.t_user_details_${0..9}| | STANDARD| address_id| IT.STANDARD.FIXTURE| | STANDARD| user_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order_item_federate_sharding| readwrite_ds_1.t_order_item_federate_sharding_${0..1}| | | | | | STANDARD| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
+    <row values="t_order_federate_sharding| readwrite_ds_1.t_order_federate_sharding_${0..1}| | | | | | STANDARD| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2}| | | " />
+    <row values="t_user_encrypt_federate_sharding| readwrite_ds_1.t_user_encrypt_federate_sharding_${0..1}| | | | | | STANDARD| user_id| INLINE| algorithm-expression=t_user_encrypt_federate_sharding_${user_id % 2},allow-range-query-with-inline-sharding=true| | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/dbtbl_with_readwrite_splitting_and_encrypt/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_user| readwrite_ds_${0..9}.t_user_${0..9}| | IT.STANDARD.FIXTURE| address_id| IT.STANDARD.FIXTURE| | IT.STANDARD.FIXTURE| user_id| IT.STANDARD.FIXTURE| | user_id| IT.FIXTURE| " />
+    <row values="t_user| readwrite_ds_${0..9}.t_user_${0..9}| | STANDARD| address_id| IT.STANDARD.FIXTURE| | STANDARD| user_id| IT.STANDARD.FIXTURE| | user_id| IT.FIXTURE| " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_rules.xml
@@ -32,7 +32,7 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| write-read-ds.t_order| | | | | | none| | | | | | " />
-    <row values="t_order_item| write-read-ds.t_order_item| | | | | | none| | | | | | " />
-    <row values="t_order_details| write-read-ds.t_order_details| | | | | | none| | | | | | " />
+    <row values="t_order| write-read-ds.t_order| | | | | | | | | | | | " />
+    <row values="t_order_item| write-read-ds.t_order_item| | | | | | | | | | | | " />
+    <row values="t_order_details| write-read-ds.t_order_details| | | | | | | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| write-read-ds.t_order| | | | | | none| | | | | | " />
+    <row values="t_order| write-read-ds.t_order| | | | | | | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/sharding_governance/mysql/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/sharding_governance/mysql/show_rules.xml
@@ -32,6 +32,6 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| governance_db.t_order| | | | | | none| | | | | | " />
-    <row values="t_order_details| governance_db.t_order_details| | | | | | none| | | | | | " />
+    <row values="t_order| governance_db.t_order| | | | | | | | | | | | " />
+    <row values="t_order_details| governance_db.t_order_details| | | | | | | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/sharding_governance/mysql/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/sharding_governance/mysql/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| governance_db.t_order| | | | | | none| | | | | | " />
+    <row values="t_order| governance_db.t_order| | | | | | | | | | | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/tbl/show_rules.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/tbl/show_rules.xml
@@ -32,9 +32,9 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| tbl.t_order_${0..9}| | | | | | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
-    <row values="t_order_item| tbl.t_order_item_${0..9}| | | | | | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
-    <row values="t_order_details| tbl.t_order_details_${0..9}| | | | | | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
-    <row values="t_order_federate_sharding| tbl.t_order_federate_sharding_${0..1}| | | | | | INLINE| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2},allow-range-query-with-inline-sharding=true| | | " />
-    <row values="t_order_item_federate_sharding | tbl.t_order_item_federate_sharding_${0..1}| | | | | | INLINE| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
+    <row values="t_order| tbl.t_order_${0..9}| | | | | | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order_item| tbl.t_order_item_${0..9}| | | | | | STANDARD| order_id| IT.STANDARD.FIXTURE| | item_id| IT.FIXTURE| " />
+    <row values="t_order_details| tbl.t_order_details_${0..9}| | | | | | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order_federate_sharding| tbl.t_order_federate_sharding_${0..1}| | | | | | STANDARD| order_id_sharding| INLINE| algorithm-expression=t_order_federate_sharding_${order_id_sharding % 2},allow-range-query-with-inline-sharding=true| | | " />
+    <row values="t_order_item_federate_sharding | tbl.t_order_item_federate_sharding_${0..1}| | | | | | STANDARD| item_id| INLINE| algorithm-expression=t_order_item_federate_sharding_${item_id % 2}| | | " />
 </dataset>

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/tbl/show_table_rule.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/rql/dataset/tbl/show_table_rule.xml
@@ -32,5 +32,5 @@
         <column name="key_generator_type" />
         <column name="key_generator_props" />
     </metadata>
-    <row values="t_order| tbl.t_order_${0..9}| | | | | | IT.STANDARD.FIXTURE| order_id| IT.STANDARD.FIXTURE| | | | " />
+    <row values="t_order| tbl.t_order_${0..9}| | | | | | STANDARD| order_id| IT.STANDARD.FIXTURE| | | | " />
 </dataset>


### PR DESCRIPTION
### Before
The `xxx_strategy_type` is incorrect, `inline` is not a type of strategy.
```sq
mysql> show sharding table rules\G;
*************************** 1. row ***************************
                            table: t_order_item
                actual_data_nodes: ds_${0..1}.t_order_item_${0..1}
              actual_data_sources:
           database_strategy_type: inline
         database_sharding_column: user_id
 database_sharding_algorithm_type: inline
database_sharding_algorithm_props: algorithm-expression=t_order_item_${user_id % 2}
              table_strategy_type: inline
            table_sharding_column: order_id
    table_sharding_algorithm_type: inline
   table_sharding_algorithm_props: algorithm-expression=t_order_item_${order_id % 2}
              key_generate_column: id
               key_generator_type: snowflake
              key_generator_props:


```

### After
```sql
mysql> show sharding table rules\G;
*************************** 1. row ***************************
                            table: t_order_item
                actual_data_nodes: ds_${0..1}.t_order_item_${0..1}
              actual_data_sources:
           database_strategy_type: STANDARD
         database_sharding_column: user_id
 database_sharding_algorithm_type: inline
database_sharding_algorithm_props: algorithm-expression=t_order_item_${user_id % 2}
              table_strategy_type: STANDARD
            table_sharding_column: order_id
    table_sharding_algorithm_type: inline
   table_sharding_algorithm_props: algorithm-expression=t_order_item_${order_id % 2}
              key_generate_column: id
               key_generator_type: snowflake
              key_generator_props:
```

