### PR TITLE
Fix parse tableName with back quotes

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -107,6 +107,7 @@ identifier
     | identifierKeywordsAmbiguous4SystemVariables
     | customKeyword
     | DOUBLE_QUOTED_TEXT
+    | BACK_QUOTED_TEXT
     | UNDERSCORE_CHARSET
     ;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/Literals.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-mysql/src/main/antlr4/imports/mysql/Literals.g4
@@ -31,6 +31,10 @@ DOUBLE_QUOTED_TEXT
     : DQ_ ( '\\'. | '""' | ~('"'| '\\') )* DQ_
     ;
 
+BACK_QUOTED_TEXT
+    : BQ_ ( '\\'. | '``' | ~('`'| '\\') )* BQ_
+    ;
+
 NCHAR_TEXT
     : N SINGLE_QUOTED_TEXT
     ;


### PR DESCRIPTION
Fixes #18697.

Changes proposed in this pull request:
- Fix parse tableName with back quotes
