### PR TITLE
ExpressionProjection add parameters field to support expression aggregation

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.infra.binder.segment.select.projection.impl;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
@@ -35,7 +34,6 @@ import java.util.Optional;
 /**
  * Aggregation projection.
  */
-@RequiredArgsConstructor
 @Getter
 @EqualsAndHashCode
 @ToString
@@ -45,7 +43,8 @@ public class AggregationProjection implements Projection {
     
     private final String innerExpression;
     
-    private final String alias;
+    @Setter
+    private String alias;
     
     private final DatabaseType databaseType;
     
@@ -53,6 +52,13 @@ public class AggregationProjection implements Projection {
     
     @Setter
     private int index = -1;
+    
+    public AggregationProjection(final AggregationType type, final String innerExpression, final String alias, final DatabaseType databaseType) {
+        this.type = type;
+        this.innerExpression = innerExpression;
+        this.alias = alias;
+        this.databaseType = databaseType;
+    }
     
     @Override
     public final String getExpression() {

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
@@ -23,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Optional;
 
 /**
@@ -37,6 +39,8 @@ public final class ExpressionProjection implements Projection {
     private final String expression;
     
     private final String alias;
+    
+    private final Collection<Projection> parameters = new LinkedList<>();
     
     @Override
     public Optional<String> getAlias() {

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
@@ -105,6 +105,22 @@ public final class ProjectionsContextTest {
     }
     
     @Test
+    public void assertGetExpressionProjectionInsideAggregationProjections() {
+        ExpressionProjection expressionProjection = getContainsParametersExpressionProjection();
+        Collection<AggregationProjection> items = getProjectionsContext(expressionProjection).getAggregationProjections();
+        expressionProjection.getParameters().forEach(parameter -> {
+            if (parameter instanceof AggregationProjection) {
+                assertTrue(items.contains(parameter));
+            }
+        });
+        assertThat(items.size(), is(2));
+    }
+    
+    private ProjectionsContext getProjectionsContext(final ExpressionProjection expressionProjection) {
+        return new ProjectionsContext(0, 0, true, Arrays.asList(expressionProjection, getColumnProjection(), getAggregationProjection()));
+    }
+    
+    @Test
     public void assertGetAggregationDistinctProjections() {
         Projection projection = getAggregationDistinctProjection();
         Collection<AggregationDistinctProjection> items = new ProjectionsContext(0, 0, true, Arrays.asList(projection, getColumnProjection())).getAggregationDistinctProjections();
@@ -126,6 +142,13 @@ public final class ProjectionsContextTest {
     
     private AggregationProjection getAggregationProjection() {
         return new AggregationProjection(AggregationType.COUNT, "(column)", "c", mock(DatabaseType.class));
+    }
+    
+    private ExpressionProjection getContainsParametersExpressionProjection() {
+        AggregationProjection aggregationProjection = new AggregationProjection(AggregationType.MAX, "(status)", "IFNULL(MAX(status), 0)", mock(DatabaseType.class));
+        ExpressionProjection expressionProjection = new ExpressionProjection("IFNULL(MAX(status), 0)", null);
+        expressionProjection.getParameters().add(aggregationProjection);
+        return expressionProjection;
     }
     
     private AggregationDistinctProjection getAggregationDistinctProjection() {

--- a/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
@@ -135,18 +135,16 @@ public final class ProjectionEngineTest {
     }
     
     private List<ExpressionSegment> getExpressionSegments() {
-        List<ExpressionSegment> list = new ArrayList<>();
+        List<ExpressionSegment> result = new ArrayList<>();
         FunctionSegment functionSegment = new FunctionSegment(7, 28, "IFNULL", "IFNULL(MAX(status), 0)");
         AggregationProjectionSegment parameter = new AggregationProjectionSegment(14, 24, AggregationType.MAX, "(status)");
         functionSegment.getParameters().add(parameter);
-        list.add(functionSegment);
-        
+        result.add(functionSegment);
         ExpressionSegment right = new LiteralExpressionSegment(25, 25, 1);
         ExpressionSegment binaryOperationExpression = new BinaryOperationExpression(7, 25, parameter, right, "+", "IFNULL(status, 0)+1");
-        list.add(binaryOperationExpression);
-        
-        list.add(null);
-        return list;
+        result.add(binaryOperationExpression);
+        result.add(null);
+        return result;
     }
     
     @Test

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -628,4 +628,20 @@
         <assertion parameters="1:int" expected-data-source-name="prod_dataset" />
         <assertion parameters="0:int" expected-data-source-name="shadow_dataset" />
     </test-case>
+    
+    <test-case sql="SELECT IFNULL(status, 0) FROM t_order" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting" db-types="MySQL">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT IFNULL(MAX(status), 0) FROM t_order" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting" db-types="MySQL">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT IFNULL(MAX(status)+1, 0) FROM t_order" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting" db-types="MySQL">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
+    <test-case sql="SELECT IFNULL(MAX(DISTINCT status), 0) FROM t_order" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting" db-types="MySQL">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
 </integration-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/segment/expression/ExpressionAssert.java
@@ -58,6 +58,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedParameterMarkerExpression;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedSubquery;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.function.ExpectedFunction;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.aggregation.ExpectedAggregationProjection;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.sql.SQLCaseType;
 
 import java.util.Iterator;
@@ -378,8 +379,12 @@ public final class ExpressionAssert {
             ProjectionAssert.assertProjection(assertContext,
                     (ExpressionProjectionSegment) actual, expected.getExpressionProjection());
         } else if (actual instanceof AggregationProjectionSegment) {
+            ExpectedAggregationProjection expectedAggregationProjection = expected.getAggregationProjection();
+            if (null == expectedAggregationProjection) {
+                expectedAggregationProjection = expected.getAggregationDistinctProjection();
+            }
             ProjectionAssert.assertProjection(assertContext,
-                    (AggregationProjectionSegment) actual, expected.getAggregationProjection());
+                    (AggregationProjectionSegment) actual, expectedAggregationProjection);
         } else if (actual instanceof FunctionSegment) {
             assertFunction(assertContext, (FunctionSegment) actual, expected.getFunction());
         } else if (actual instanceof CollateExpression) {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExpression.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/segment/impl/expr/ExpectedExpression.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.expr.simple.ExpectedSubquery;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.function.ExpectedFunction;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.generic.ExpectedDataType;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.aggregation.ExpectedAggregationDistinctProjection;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.aggregation.ExpectedAggregationProjection;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.projection.impl.expression.ExpectedExpressionProjection;
 
@@ -83,6 +84,9 @@ public final class ExpectedExpression extends AbstractExpectedSQLSegment {
     
     @XmlElement(name = "aggregation-projection")
     private ExpectedAggregationProjection aggregationProjection;
+    
+    @XmlElement(name = "aggregation-distinct-projection")
+    private ExpectedAggregationDistinctProjection aggregationDistinctProjection;
     
     @XmlElement(name = "collate-expression")
     private ExpectedCollateExpression collateExpression;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-special-function.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-special-function.xml
@@ -211,4 +211,92 @@
             <simple-table name="t_order" start-index="29" stop-index="35" />
         </from>
     </select>
+    
+    <select sql-case-id="select_ifnull">
+        <from>
+            <simple-table name="t_order" start-index="30" stop-index="36"/>
+        </from>
+        <projections start-index="7" stop-index="23">
+            <expression-projection text="IFNULL(status, 0)" start-index="7" stop-index="23">
+                <expr>
+                    <function function-name="IFNULL" start-index="7" stop-index="23" text="IFNULL(status, 0)">
+                        <parameter>
+                            <column name="status" start-index="14" stop-index="19"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="0" start-index="22" stop-index="22"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_ifnull_max">
+        <from>
+            <simple-table name="t_order" start-index="35" stop-index="41"/>
+        </from>
+        <projections start-index="7" stop-index="28">
+            <expression-projection text="IFNULL(MAX(status), 0)" start-index="7" stop-index="28">
+                <expr>
+                    <function function-name="IFNULL" start-index="7" stop-index="28" text="IFNULL(MAX(status), 0)">
+                        <parameter>
+                            <aggregation-projection type="MAX" inner-expression="(status)" start-index="14" stop-index="24"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="0" start-index="27" stop-index="27"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_ifnull_max_add">
+        <from>
+            <simple-table name="t_order" start-index="37" stop-index="43"/>
+        </from>
+        <projections start-index="7" stop-index="30">
+            <expression-projection text="IFNULL(MAX(status)+1, 0)" start-index="7" stop-index="30">
+                <expr>
+                    <function function-name="IFNULL" start-index="7" stop-index="30" text="IFNULL(MAX(status)+1, 0)">
+                        <parameter>
+                            <binary-operation-expression start-index="14" stop-index="26" text="MAX(status)+1">
+                                <left>
+                                    <aggregation-projection type="MAX" inner-expression="(status)" start-index="14" stop-index="24"/>
+                                </left>
+                                <operator>+</operator>
+                                <right>
+                                    <literal-expression value="1" start-index="26" stop-index="26" />
+                                </right>
+                            </binary-operation-expression>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="0" start-index="29" stop-index="29"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
+    
+    <select sql-case-id="select_ifnull_max_distinct">
+        <from>
+            <simple-table name="t_order" start-index="44" stop-index="50"/>
+        </from>
+        <projections start-index="7" stop-index="37">
+            <expression-projection text="IFNULL(MAX(DISTINCT status), 0)" start-index="7" stop-index="37">
+                <expr>
+                    <function function-name="IFNULL" start-index="7" stop-index="37" text="IFNULL(MAX(DISTINCT status), 0)">
+                        <parameter>
+                            <aggregation-distinct-projection type="MAX" inner-expression="(DISTINCT status)" distinct-expression="status" start-index="14" stop-index="33"/>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="0" start-index="36" stop-index="36"/>
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -33,4 +33,8 @@
     <sql-case id="select_current_user_brackets" value="SELECT CURRENT_USER()" db-types="MySQL" />
     <sql-case id="select_extract_function" value="SELECT EXTRACT(YEAR FROM TIMESTAMP '2001-02-16 20:38:40')" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_mod_function" value="SELECT MOD(order_id, 1) from t_order" db-types="PostgreSQL,openGauss" />
+    <sql-case id="select_ifnull" value="SELECT IFNULL(status, 0) FROM t_order" db-types="MySQL" />
+    <sql-case id="select_ifnull_max" value="SELECT IFNULL(MAX(status), 0) FROM t_order" db-types="MySQL" />
+    <sql-case id="select_ifnull_max_add" value="SELECT IFNULL(MAX(status)+1, 0) FROM t_order" db-types="MySQL" />
+    <sql-case id="select_ifnull_max_distinct" value="SELECT IFNULL(MAX(DISTINCT status), 0) FROM t_order" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Support #17402 .
Support #18261  but not NULLIF

Changes proposed in this pull request:
- ExpressionProjection add parameters field
- AggregationProjection alias field add setter method
- Add AggregationProjection constructor method
- Modify ProjectionsContext#getAggregationProjections
- Modify ProjectionEngine#createProjection
- Add sql case about MySQL ifnull
- Add more unit test for ProjectionsContext
- Add more unit test for ProjectionEngine
- Add MySQL dql integration test case