### PR TITLE
feat: add Gitpod support

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image: gitpod/workspace-java-17
+
+# List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - init: mvn clean install -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Drat.skip=true -Djacoco.skip=true -DskipITs -DskipTests -Prelease
+
+# Learn More https://www.gitpod.io/docs/ides-and-editors/vscode-extensions#vs-code-extensions
+vscode:
+  extensions:
+    - vscjava.vscode-java-pack

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5394/badge)](https://bestpractices.coreinfrastructure.org/projects/5394)
 [![OpenTracing-1.0 Badge](https://img.shields.io/badge/OpenTracing--1.0-enabled-blue.svg)](http://opentracing.io)
 [![Skywalking Tracing](https://img.shields.io/badge/Skywalking%20Tracing-enable-brightgreen.svg)](https://github.com/apache/skywalking)
+[![Contribute with Gitpod](https://img.shields.io/badge/Contribute%20with-Gitpod-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/apache/shardingsphere)
 
 [![Twitter](https://img.shields.io/twitter/url/https/twitter.com/ShardingSphere.svg?style=social&label=Follow%20%40ShardingSphere)](https://twitter.com/ShardingSphere)
 [![Slack](https://img.shields.io/badge/%20Slack-ShardingSphere%20Channel-blueviolet)](https://join.slack.com/t/apacheshardingsphere/shared_invite/zt-sbdde7ie-SjDqo9~I4rYcR18bq0SYTg)
@@ -40,7 +41,7 @@ The concepts at the core of the project are `Connect`, `Enhance` and `Pluggable`
 Virtually all databases are [supported](https://shardingsphere.apache.org/document/current/en/dev-manual/data-source/) including [MySQL](https://www.mysql.com), [PostgreSQL](https://www.postgresql.org), [SQL Server](https://www.microsoft.com/en-us/sql-server/sql-server-downloads), [Oracle Database](https://www.oracle.com/database/), [MariaDB](https://mariadb.org) or any other SQL-92 database.
 
 ShardingSphere became an [Apache](https://apache.org/index.html#projects-list) Top-Level Project on April 16, 2020.
- 
+
 ### DOCUMENTATION📜
 
 <hr>
@@ -96,13 +97,13 @@ Keep an eye on the [milestones page](https://github.com/apache/shardingsphere/mi
 [comment]: <> (##)
 
 [comment]: <> (### NIGHTLY BUILDS:)
- 
+
 [comment]: <> (<hr>)
 
 [comment]: <> (A nightly build of ShardingSphere from the latest master branch is available. )
 
 [comment]: <> (The package is updated daily and is available [here]&#40;http://117.48.121.24:8080&#41;.)
- 
+
 [comment]: <> (##)
 
 [comment]: <> (**‼️ Notice:**)
@@ -114,7 +115,7 @@ Keep an eye on the [milestones page](https://github.com/apache/shardingsphere/mi
 [comment]: <> (The branch is not always fully tested. )
 
 [comment]: <> (The nightly build may contain bugs, and there may be new features added which may cause problems with your environment. )
- 
+
 ##
 
 ### How it Works

--- a/docs/community/content/contribute/contributor.cn.md
+++ b/docs/community/content/contribute/contributor.cn.md
@@ -20,6 +20,10 @@ chapter = true
 
 **1. 准备仓库**
 
+> 您也可以通过单击以下按钮跳过以下步骤并直接从浏览器中贡献
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/shardingsphere)
+
 到 [ShardingSphere GitHub Repo]( https://github.com/apache/shardingsphere ) fork 仓库到你的 GitHub 账号。
 
 克隆到本地。

--- a/docs/community/content/contribute/contributor.en.md
+++ b/docs/community/content/contribute/contributor.en.md
@@ -18,6 +18,10 @@ You can report a bug, submit a new function enhancement suggestion, or submit a 
 
 ## Developer Flow
 
+> You Can also Skip the following steps & directly contribute from your browser by clicking on the following button 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/shardingsphere)
+
 **1. Prepare repository**
 
 Go to [ShardingSphere GitHub Repo]( https://github.com/apache/shardingsphere ) and fork repository to your account.

--- a/docs/community/content/contribute/establish-project.cn.md
+++ b/docs/community/content/contribute/establish-project.cn.md
@@ -4,6 +4,10 @@ weight = 2
 chapter = true
 +++
 
+> 您也可以通过单击以下按钮跳过以下步骤并直接从浏览器中贡献
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/shardingsphere)
+
 ## 安装 Git
 
 使用最新版。

--- a/docs/community/content/contribute/establish-project.en.md
+++ b/docs/community/content/contribute/establish-project.en.md
@@ -4,6 +4,11 @@ weight = 2
 chapter = true
 +++
 
+> You Can also Skip the following steps & directly contribute from your browser by clicking on the following button 
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/apache/shardingsphere)
+
+
 ## Git Installation
 
 Use the latest version.


### PR DESCRIPTION
Hello, Siddhant here from [Gitpod](https://www.gitpod.io) 👋

Goal for this PR is to make it easier to get started contributing to `apache/shardingsphere`. Ongoing contributors will find something like this useful too, Because, with this PR they can directly start contributing to this project directly from browser without any manual installation. Also, Since I've wrote the build commands in [**_init-tasks_**](https://www.gitpod.io/docs/config-start-tasks#:~:text=global%20project%20dependencies.-,init,-%3A%20Use%20this%20for) it will directly create a workspace something like this:

![image](https://user-images.githubusercontent.com/55068936/179730501-fd5813e4-1cb8-4475-983c-adb33bf1b7a5.png)

You can also use your favorite IDEs, because [_**Gitpod supports various editors & IDEs**_](https://www.gitpod.io/docs/ides-and-editors#supported-ideeditors)

**_Testit now by clicking on the following button, you will get (in a matter of seconds) a development environment with a compiled version of the binary files_**: 

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/gitpod-forks/apache-shardingsphere) 

**_To use the benefits of [Gitpod Prebuilds](https://www.gitpod.io/docs/prebuilds) will require installing [the Gitpod app](https://github.com/apps/gitpod-io) to this repository_**


