### PR TITLE
Support create index if not exists statement for PostgreSQL and openGauss

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/impl/ShardingCreateIndexStatementValidator.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/impl/ShardingCreateIndexStatementValidator.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.route.context.RouteContext;
 import org.apache.shardingsphere.sharding.route.engine.validator.ddl.ShardingDDLStatementValidator;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl.CreateIndexStatementHandler;
 
 import java.util.Collections;
 import java.util.List;
@@ -40,13 +41,16 @@ public final class ShardingCreateIndexStatementValidator extends ShardingDDLStat
     @Override
     public void preValidate(final ShardingRule shardingRule, final SQLStatementContext<CreateIndexStatement> sqlStatementContext,
                             final List<Object> parameters, final ShardingSphereDatabase database) {
+        if (CreateIndexStatementHandler.ifNotExists(sqlStatementContext.getSqlStatement())) {
+            return;
+        }
         String defaultSchemaName = DatabaseTypeEngine.getDefaultSchemaName(sqlStatementContext.getDatabaseType(), database.getName());
         ShardingSphereSchema schema = sqlStatementContext.getTablesContext().getSchemaName()
                 .map(optional -> database.getSchemas().get(optional)).orElseGet(() -> database.getSchemas().get(defaultSchemaName));
         validateTableExist(schema, Collections.singletonList(sqlStatementContext.getSqlStatement().getTable()));
         String tableName = sqlStatementContext.getSqlStatement().getTable().getTableName().getIdentifier().getValue();
         String indexName = ((IndexAvailable) sqlStatementContext).getIndexes().stream().map(each -> each.getIndexName().getIdentifier().getValue()).findFirst().orElse(null);
-        if (schema.get(tableName).getIndexes().containsKey(indexName)) {
+        if (schema.containsIndex(tableName, indexName)) {
             throw new ShardingSphereException("Index '%s' already exists.", indexName);
         }
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateIndexStatementValidatorTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/ShardingCreateIndexStatementValidatorTest.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.sharding.route.engine.validator.ddl;
 import org.apache.shardingsphere.infra.binder.statement.ddl.CreateIndexStatementContext;
 import org.apache.shardingsphere.infra.exception.ShardingSphereException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
 import org.apache.shardingsphere.sharding.route.engine.exception.NoSuchTableException;
 import org.apache.shardingsphere.sharding.route.engine.validator.ddl.impl.ShardingCreateIndexStatementValidator;
@@ -39,8 +38,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -56,21 +53,18 @@ public final class ShardingCreateIndexStatementValidatorTest {
     
     @Test
     public void assertPreValidateCreateIndexWhenTableExistIndexNotExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.setIndex(new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("t_order_index"))));
         when(database.getSchemas().get("public").containsTable("t_order")).thenReturn(true);
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchemas().get("public").get("t_order")).thenReturn(table);
-        Map<String, ShardingSphereIndex> indexes = mock(HashMap.class);
-        when(table.getIndexes()).thenReturn(indexes);
-        when(indexes.containsKey("t_order_index")).thenReturn(false);
         new ShardingCreateIndexStatementValidator().preValidate(shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database);
     }
     
     @Test(expected = NoSuchTableException.class)
     public void assertPreValidateCreateIndexWhenTableNotExistIndexNotExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.setIndex(new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("t_order_index"))));
         when(database.getSchemas().get("public").containsTable("t_order")).thenReturn(false);
@@ -79,35 +73,31 @@ public final class ShardingCreateIndexStatementValidatorTest {
     
     @Test(expected = ShardingSphereException.class)
     public void assertPreValidateCreateIndexWhenTableExistIndexExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.setIndex(new IndexSegment(0, 0, new IndexNameSegment(0, 0, new IdentifierValue("t_order_index"))));
         when(database.getSchemas().get("public").containsTable("t_order")).thenReturn(true);
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchemas().get("public").get("t_order")).thenReturn(table);
-        Map<String, ShardingSphereIndex> indexes = mock(HashMap.class);
-        when(table.getIndexes()).thenReturn(indexes);
-        when(indexes.containsKey("t_order_index")).thenReturn(true);
+        when(database.getSchemas().get("public").containsIndex("t_order", "t_order_index")).thenReturn(true);
         new ShardingCreateIndexStatementValidator().preValidate(shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database);
     }
     
     @Test
     public void assertPreValidateCreateIndexWithoutIndexNameWhenTableExistIndexNotExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("content")));
         sqlStatement.setGeneratedIndexStartIndex(10);
         when(database.getSchemas().get("public").containsTable("t_order")).thenReturn(true);
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchemas().get("public").get("t_order")).thenReturn(table);
-        Map<String, ShardingSphereIndex> indexes = mock(HashMap.class);
-        when(table.getIndexes()).thenReturn(indexes);
         new ShardingCreateIndexStatementValidator().preValidate(shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database);
     }
     
     @Test(expected = NoSuchTableException.class)
     public void assertPreValidateCreateIndexWithoutIndexNameWhenTableNotExistIndexNotExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("content")));
         sqlStatement.setGeneratedIndexStartIndex(10);
@@ -117,16 +107,14 @@ public final class ShardingCreateIndexStatementValidatorTest {
     
     @Test(expected = ShardingSphereException.class)
     public void assertPreValidateCreateIndexWithoutIndexNameWhenTableExistIndexExistForPostgreSQL() {
-        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement sqlStatement = new PostgreSQLCreateIndexStatement(false);
         sqlStatement.setTable(new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order"))));
         sqlStatement.getColumns().add(new ColumnSegment(0, 0, new IdentifierValue("content")));
         sqlStatement.setGeneratedIndexStartIndex(10);
         when(database.getSchemas().get("public").containsTable("t_order")).thenReturn(true);
         ShardingSphereTable table = mock(ShardingSphereTable.class);
         when(database.getSchemas().get("public").get("t_order")).thenReturn(table);
-        Map<String, ShardingSphereIndex> indexes = mock(HashMap.class);
-        when(table.getIndexes()).thenReturn(indexes);
-        when(indexes.containsKey("content_idx")).thenReturn(true);
+        when(database.getSchemas().get("public").containsIndex("t_order", "content_idx")).thenReturn(true);
         new ShardingCreateIndexStatementValidator().preValidate(shardingRule, new CreateIndexStatementContext(sqlStatement), Collections.emptyList(), database);
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/decorator/model/ShardingSphereSchema.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/decorator/model/ShardingSphereSchema.java
@@ -115,6 +115,17 @@ public final class ShardingSphereSchema {
     }
     
     /**
+     * Judge whether contains index name.
+     *
+     * @param tableName table name
+     * @param indexName index name
+     * @return whether contains index name or not
+     */
+    public boolean containsIndex(final String tableName, final String indexName) {
+        return containsTable(tableName) && get(tableName).getIndexes().containsKey(indexName.toLowerCase());
+    }
+    
+    /**
      * Get all column names via table.
      *
      * @param tableName table name

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/ShardingSphereSchemaTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/ShardingSphereSchemaTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.metadata.database.schema;
 
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereColumn;
+import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereIndex;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
 import org.junit.Test;
@@ -83,5 +84,11 @@ public final class ShardingSphereSchemaTest {
         ShardingSphereTable table = new ShardingSphereTable("tbl", Collections.singletonList(
                 new ShardingSphereColumn("col", 0, false, false, false)), Collections.emptyList(), Collections.emptyList());
         assertThat(new ShardingSphereSchema(Collections.singletonMap("tbl1", table)).getAllColumnNames("tbl2"), is(Collections.<String>emptyList()));
+    }
+    
+    @Test
+    public void assertContainsIndex() {
+        ShardingSphereTable table = new ShardingSphereTable("tbl", Collections.emptyList(), Collections.singletonList(new ShardingSphereIndex("col_idx")), Collections.emptyList());
+        assertTrue(new ShardingSphereSchema(Collections.singletonMap("tbl", table)).containsIndex("tbl", "col_idx"));
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/constant/DistSQLScriptConstants.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/distsql/ral/common/constant/DistSQLScriptConstants.java
@@ -42,8 +42,8 @@ public final class DistSQLScriptConstants {
     
     public static final String KEY_PASSWORD = "password";
     
-    public static final String RESOURCE_DEFINITION = " %s (" 
-            + System.lineSeparator() 
+    public static final String RESOURCE_DEFINITION = " %s ("
+            + System.lineSeparator()
             + "URL=\"%s\","
             + System.lineSeparator()
             + "USER=%s,"

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussDDLStatementSQLVisitor.java
@@ -507,7 +507,7 @@ public final class OpenGaussDDLStatementSQLVisitor extends OpenGaussStatementSQL
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitCreateIndex(final CreateIndexContext ctx) {
-        OpenGaussCreateIndexStatement result = new OpenGaussCreateIndexStatement();
+        OpenGaussCreateIndexStatement result = new OpenGaussCreateIndexStatement(null != ctx.ifNotExists());
         result.setTable((SimpleTableSegment) visit(ctx.tableName()));
         result.getColumns().addAll(((CollectionValue<ColumnSegment>) visit(ctx.indexParams())).getValue());
         if (null != ctx.indexName()) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -616,7 +616,7 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @SuppressWarnings("unchecked")
     @Override
     public ASTNode visitCreateIndex(final CreateIndexContext ctx) {
-        PostgreSQLCreateIndexStatement result = new PostgreSQLCreateIndexStatement();
+        PostgreSQLCreateIndexStatement result = new PostgreSQLCreateIndexStatement(null != ctx.ifNotExists());
         result.setTable((SimpleTableSegment) visit(ctx.tableName()));
         result.getColumns().addAll(((CollectionValue<ColumnSegment>) visit(ctx.indexParams())).getValue());
         if (null != ctx.indexName()) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandler.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandler.java
@@ -49,4 +49,20 @@ public final class CreateIndexStatementHandler implements SQLStatementHandler {
         }
         return Optional.empty();
     }
+    
+    /**
+     * Judge whether contains if not exists or not.
+     *
+     * @param createIndexStatement create index statement
+     * @return whether contains if not exists or not
+     */
+    public static boolean ifNotExists(final CreateIndexStatement createIndexStatement) {
+        if (createIndexStatement instanceof PostgreSQLStatement) {
+            return ((PostgreSQLCreateIndexStatement) createIndexStatement).isIfNotExists();
+        }
+        if (createIndexStatement instanceof OpenGaussStatement) {
+            return ((OpenGaussCreateIndexStatement) createIndexStatement).isIfNotExists();
+        }
+        return false;
+    }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandler.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandler.java
@@ -43,10 +43,10 @@ import java.util.Optional;
 public final class CreateTableStatementHandler implements SQLStatementHandler {
     
     /**
-     * Judge whether if not exists.
+     * Judge whether contains if not exists or not.
      *
      * @param createTableStatement create table statement
-     * @return if not exists or not
+     * @return whether contains if not exists or not
      */
     public static boolean ifNotExists(final CreateTableStatement createTableStatement) {
         if (createTableStatement instanceof MySQLStatement) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateIndexStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/opengauss/ddl/OpenGaussCreateIndexStatement.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
@@ -27,9 +29,13 @@ import java.util.Optional;
 /**
  * OpenGauss create index statement.
  */
+@RequiredArgsConstructor
+@Getter
 @Setter
 @ToString(callSuper = true)
 public final class OpenGaussCreateIndexStatement extends CreateIndexStatement implements OpenGaussStatement {
+    
+    private final boolean ifNotExists;
     
     private Integer generatedIndexStartIndex;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLCreateIndexStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLCreateIndexStatement.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateIndexStatement;
@@ -27,9 +29,13 @@ import java.util.Optional;
 /**
  * PostgreSQL create index statement.
  */
+@RequiredArgsConstructor
+@Getter
 @Setter
 @ToString(callSuper = true)
 public final class PostgreSQLCreateIndexStatement extends CreateIndexStatement implements PostgreSQLStatement {
+    
+    private final boolean ifNotExists;
     
     private Integer generatedIndexStartIndex;
     

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandlerTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateIndexStatementHandlerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
+
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.ddl.MySQLCreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLCreateIndexStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.ddl.SQLServerCreateIndexStatement;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class CreateIndexStatementHandlerTest {
+    
+    @Test
+    public void assertIfNotExists() {
+        assertFalse(CreateIndexStatementHandler.ifNotExists(new MySQLCreateIndexStatement()));
+        assertTrue(CreateIndexStatementHandler.ifNotExists(new PostgreSQLCreateIndexStatement(true)));
+        assertTrue(CreateIndexStatementHandler.ifNotExists(new OpenGaussCreateIndexStatement(true)));
+        assertFalse(CreateIndexStatementHandler.ifNotExists(new OracleCreateIndexStatement()));
+        assertFalse(CreateIndexStatementHandler.ifNotExists(new SQLServerCreateIndexStatement()));
+    }
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandlerTest.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/ddl/CreateTableStatementHandlerTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sql.parser.sql.dialect.handler.ddl;
 
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.ddl.MySQLCreateTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.ddl.OracleCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sql92.ddl.SQL92CreateTableStatement;
@@ -30,37 +31,15 @@ import static org.junit.Assert.assertTrue;
 public final class CreateTableStatementHandlerTest {
     
     @Test
-    public void assertContainsIfNotExistsForMySQL() {
+    public void assertIfNotExists() {
         assertTrue(CreateTableStatementHandler.ifNotExists(new MySQLCreateTableStatement(true)));
-    }
-    
-    @Test
-    public void assertContainsIfNotExistsForPostgreSQL() {
-        assertTrue(CreateTableStatementHandler.ifNotExists(new PostgreSQLCreateTableStatement(true)));
-    }
-    
-    @Test
-    public void assertNotContainsIfNotExistsForMySQL() {
         assertFalse(CreateTableStatementHandler.ifNotExists(new MySQLCreateTableStatement(false)));
-    }
-    
-    @Test
-    public void assertNotContainsIfNotExistsForOracle() {
-        assertFalse(CreateTableStatementHandler.ifNotExists(new OracleCreateTableStatement()));
-    }
-    
-    @Test
-    public void assertNotContainsIfNotExistsForPostgreSQL() {
+        assertTrue(CreateTableStatementHandler.ifNotExists(new PostgreSQLCreateTableStatement(true)));
         assertFalse(CreateTableStatementHandler.ifNotExists(new PostgreSQLCreateTableStatement(false)));
-    }
-    
-    @Test
-    public void assertNotContainsIfNotExistsForSQL92() {
-        assertFalse(CreateTableStatementHandler.ifNotExists(new SQL92CreateTableStatement()));
-    }
-    
-    @Test
-    public void assertNotContainsIfNotExistsForSQLServer() {
+        assertTrue(CreateTableStatementHandler.ifNotExists(new OpenGaussCreateTableStatement(true)));
+        assertFalse(CreateTableStatementHandler.ifNotExists(new OpenGaussCreateTableStatement(false)));
+        assertFalse(CreateTableStatementHandler.ifNotExists(new OracleCreateTableStatement()));
         assertFalse(CreateTableStatementHandler.ifNotExists(new SQLServerCreateTableStatement()));
+        assertFalse(CreateTableStatementHandler.ifNotExists(new SQL92CreateTableStatement()));
     }
 }


### PR DESCRIPTION
Fixes #19104.

Changes proposed in this pull request:
- support create index if not exists statement for PostgreSQL and openGauss
- add unit test
