### PR TITLE
Fix wrong encrypt rewrite result due to incorrect order of metadata

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/show/EncryptShowColumnsMergedResult.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/merge/dal/show/EncryptShowColumnsMergedResult.java
@@ -76,7 +76,7 @@ public abstract class EncryptShowColumnsMergedResult implements MergedResult {
             if (!encryptTable.isPresent()) {
                 return columnName;
             }
-            Optional<String> logicColumn = encryptTable.get().isCipherColumn(columnName) ? Optional.of(encryptTable.get().getLogicColumn(columnName)) : Optional.empty();
+            Optional<String> logicColumn = encryptTable.get().isCipherColumn(columnName) ? Optional.of(encryptTable.get().getLogicColumnByCipherColumn(columnName)) : Optional.empty();
             return logicColumn.orElse(columnName);
         }
         return getOriginalValue(columnIndex, type);

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptSchemaMetaDataDecorator.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/metadata/EncryptSchemaMetaDataDecorator.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.Tab
 
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -56,16 +57,20 @@ public final class EncryptSchemaMetaDataDecorator implements RuleBasedSchemaMeta
     }
     
     private Collection<ColumnMetaData> getEncryptColumnMetaDataList(final EncryptTable encryptTable, final Collection<ColumnMetaData> originalColumnMetaDataList) {
-        Collection<ColumnMetaData> result = new LinkedList<>();
+        Collection<ColumnMetaData> result = new LinkedHashSet<>();
         Collection<String> plainColumns = encryptTable.getPlainColumns();
         Collection<String> assistedQueryColumns = encryptTable.getAssistedQueryColumns();
         for (ColumnMetaData each : originalColumnMetaDataList) {
             String columnName = each.getName();
-            if (encryptTable.isCipherColumn(columnName)) {
-                result.add(createColumnMetaData(encryptTable.getLogicColumn(columnName), each));
+            if (plainColumns.contains(columnName)) {
+                result.add(createColumnMetaData(encryptTable.getLogicColumnByPlainColumn(columnName), each));
                 continue;
             }
-            if (!plainColumns.contains(columnName) && !assistedQueryColumns.contains(columnName)) {
+            if (encryptTable.isCipherColumn(columnName)) {
+                result.add(createColumnMetaData(encryptTable.getLogicColumnByCipherColumn(columnName), each));
+                continue;
+            }
+            if (!assistedQueryColumns.contains(columnName)) {
                 result.add(each);
             }
         }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptTable.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptTable.java
@@ -77,18 +77,33 @@ public final class EncryptTable {
     }
     
     /**
-     * Get logic column.
+     * Get logic column by cipher column.
      * 
      * @param cipherColumn cipher column
      * @return logic column
      */
-    public String getLogicColumn(final String cipherColumn) {
+    public String getLogicColumnByCipherColumn(final String cipherColumn) {
         for (Entry<String, EncryptColumn> entry : columns.entrySet()) {
             if (entry.getValue().getCipherColumn().equals(cipherColumn)) {
                 return entry.getKey();
             }
         }
         throw new ShardingSphereException("Can not find logic column by %s.", cipherColumn);
+    }
+    
+    /**
+     * Get logic column by plain column.
+     *
+     * @param plainColumn plain column
+     * @return logic column
+     */
+    public String getLogicColumnByPlainColumn(final String plainColumn) {
+        for (Entry<String, EncryptColumn> entry : columns.entrySet()) {
+            if (entry.getValue().getPlainColumn().isPresent() && entry.getValue().getPlainColumn().get().equals(plainColumn)) {
+                return entry.getKey();
+            }
+        }
+        throw new ShardingSphereException("Can not find logic column by %s.", plainColumn);
     }
     
     /**

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowColumnsMergedResultTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/merge/dal/show/MergedEncryptShowColumnsMergedResultTest.java
@@ -76,7 +76,7 @@ public final class MergedEncryptShowColumnsMergedResultTest {
         when(result.findEncryptTable("test")).thenReturn(Optional.of(encryptTable));
         when(encryptTable.getAssistedQueryColumns()).thenReturn(Collections.singleton("assistedQuery"));
         when(encryptTable.isCipherColumn("cipher")).thenReturn(true);
-        when(encryptTable.getLogicColumn("cipher")).thenReturn("id");
+        when(encryptTable.getLogicColumnByCipherColumn("cipher")).thenReturn("id");
         return result;
     }
     

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptSchemaMetaDataDecoratorTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptSchemaMetaDataDecoratorTest.java
@@ -64,7 +64,8 @@ public final class EncryptSchemaMetaDataDecoratorTest {
         when(encryptTable.getAssistedQueryColumns()).thenReturn(Collections.emptyList());
         when(encryptTable.getPlainColumns()).thenReturn(Collections.singleton("pwd_plain"));
         when(encryptTable.isCipherColumn("pwd_cipher")).thenReturn(true);
-        when(encryptTable.getLogicColumn("pwd_cipher")).thenReturn("pwd");
+        when(encryptTable.getLogicColumnByCipherColumn("pwd_cipher")).thenReturn("pwd");
+        when(encryptTable.getLogicColumnByPlainColumn("pwd_plain")).thenReturn("pwd");
         return result;
     }
     

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptTableTest.java
@@ -58,13 +58,23 @@ public final class EncryptTableTest {
     }
     
     @Test
-    public void assertGetLogicColumn() {
-        assertNotNull(encryptTable.getLogicColumn("cipherColumn"));
+    public void assertGetLogicColumnByCipherColumn() {
+        assertNotNull(encryptTable.getLogicColumnByCipherColumn("cipherColumn"));
     }
     
     @Test(expected = ShardingSphereException.class)
-    public void assertGetLogicColumnWhenNotFind() {
-        encryptTable.getLogicColumn("invalidColumn");
+    public void assertGetLogicColumnByCipherColumnWhenNotFind() {
+        encryptTable.getLogicColumnByCipherColumn("invalidColumn");
+    }
+    
+    @Test
+    public void assertGetLogicColumnByPlainColumn() {
+        assertNotNull(encryptTable.getLogicColumnByPlainColumn("plainColumn"));
+    }
+    
+    @Test(expected = ShardingSphereException.class)
+    public void assertGetLogicColumnByPlainColumnWhenNotFind() {
+        encryptTable.getLogicColumnByPlainColumn("invalidColumn");
     }
     
     @Test

--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/SpringBootStarterTest.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/SpringBootStarterTest.java
@@ -157,7 +157,7 @@ public class SpringBootStarterTest {
     }
     
     private void assertEncryptTable(final EncryptTable actual) {
-        assertThat(actual.getLogicColumn("pwd_cipher"), is("pwd"));
+        assertThat(actual.getLogicColumnByCipherColumn("pwd_cipher"), is("pwd"));
         assertThat(actual.getPlainColumns(), is(Collections.singletonList("pwd_plain")));
         assertThat(actual.getAssistedQueryColumns(), is(Collections.singletonList("pwd_assisted_query_cipher")));
     }


### PR DESCRIPTION
Fixes #19418.

Changes proposed in this pull request:
- fix wrong encrypt rewrite result due to incorrect order of metadata
- add unit test
