### PR TITLE
Add duplicate datasource check logic for ReadwriteSplitting

### DIFF
--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/checker/AbstractReadwriteSplittingRuleConfigurationChecker.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/main/java/org/apache/shardingsphere/readwritesplitting/checker/AbstractReadwriteSplittingRuleConfigurationChecker.java
@@ -21,8 +21,11 @@ import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.infra.config.RuleConfiguration;
 import org.apache.shardingsphere.infra.config.checker.RuleConfigurationChecker;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
+import org.apache.shardingsphere.readwritesplitting.api.strategy.StaticReadwriteSplittingStrategyConfiguration;
 
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Optional;
 
 /**
  * Abstract readwrite-splitting rule configuration checker.
@@ -37,8 +40,20 @@ public abstract class AbstractReadwriteSplittingRuleConfigurationChecker<T exten
     }
     
     private void checkDataSources(final String databaseName, final Collection<ReadwriteSplittingDataSourceRuleConfiguration> dataSources) {
-        dataSources.forEach(each -> Preconditions.checkState(null != each.getStaticStrategy() || null != each.getDynamicStrategy(),
-                "No available readwrite-splitting rule configuration in database `%s`.", databaseName));
+        Collection<String> writeDataSourceNames = new HashSet<>();
+        Collection<String> readDataSourceNames = new HashSet<>();
+        for (ReadwriteSplittingDataSourceRuleConfiguration each : dataSources) {
+            Preconditions.checkState(null != each.getStaticStrategy() || null != each.getDynamicStrategy(),
+                    "No available readwrite-splitting rule configuration in database `%s`.", databaseName);
+            Optional.ofNullable(each.getStaticStrategy()).ifPresent(optional -> checkStaticStrategy(writeDataSourceNames, readDataSourceNames, optional));
+        }
+    }
+    
+    private void checkStaticStrategy(final Collection<String> writeDataSourceNames, final Collection<String> readDataSourceNames, final StaticReadwriteSplittingStrategyConfiguration strategyConfig) {
+        Preconditions.checkState(writeDataSourceNames.add(strategyConfig.getWriteDataSourceName()),
+                "Can not config duplicate write dataSource `%s` in multi readwrite-splitting rule configurations.", strategyConfig.getWriteDataSourceName());
+        Preconditions.checkState(readDataSourceNames.addAll(strategyConfig.getReadDataSourceNames()),
+                "Can not config duplicate read dataSources `%s` in multi readwrite-splitting rule configurations.", strategyConfig.getReadDataSourceNames());
     }
     
     protected abstract Collection<ReadwriteSplittingDataSourceRuleConfiguration> getDataSources(T config);

--- a/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
+++ b/shardingsphere-features/shardingsphere-readwrite-splitting/shardingsphere-readwrite-splitting-core/src/test/java/org/apache/shardingsphere/readwritesplitting/checker/ReadwriteSplittingRuleConfigurationCheckerTest.java
@@ -22,9 +22,12 @@ import org.apache.shardingsphere.infra.config.checker.RuleConfigurationCheckerFa
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.strategy.DynamicReadwriteSplittingStrategyConfiguration;
+import org.apache.shardingsphere.readwritesplitting.api.strategy.StaticReadwriteSplittingStrategyConfiguration;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -67,6 +70,41 @@ public final class ReadwriteSplittingRuleConfigurationCheckerTest {
         ReadwriteSplittingRuleConfiguration result = mock(ReadwriteSplittingRuleConfiguration.class);
         ReadwriteSplittingDataSourceRuleConfiguration dataSourceConfig = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
         when(result.getDataSources()).thenReturn(Collections.singleton(dataSourceConfig));
+        return result;
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckWhenConfigInvalidWriteDataSource() {
+        ReadwriteSplittingRuleConfiguration config = mock(ReadwriteSplittingRuleConfiguration.class);
+        List<ReadwriteSplittingDataSourceRuleConfiguration> configurations = Arrays.asList(createDataSourceRuleConfig(
+                "write_ds", Collections.emptyList()), createDataSourceRuleConfig("write_ds", Collections.emptyList()));
+        when(config.getDataSources()).thenReturn(configurations);
+        Optional<RuleConfigurationChecker> checker = RuleConfigurationCheckerFactory.findInstance(config);
+        assertTrue(checker.isPresent());
+        assertThat(checker.get(), instanceOf(ReadwriteSplittingRuleConfigurationChecker.class));
+        checker.get().check("test", config);
+    }
+    
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Test(expected = IllegalStateException.class)
+    public void assertCheckWhenConfigInvalidReadDataSource() {
+        ReadwriteSplittingRuleConfiguration config = mock(ReadwriteSplittingRuleConfiguration.class);
+        List<ReadwriteSplittingDataSourceRuleConfiguration> configurations = Arrays.asList(createDataSourceRuleConfig(
+                "write_ds_0", Arrays.asList("read_ds_0", "read_ds_0")), createDataSourceRuleConfig("write_ds_1", Arrays.asList("read_ds_0", "read_ds_0")));
+        when(config.getDataSources()).thenReturn(configurations);
+        Optional<RuleConfigurationChecker> checker = RuleConfigurationCheckerFactory.findInstance(config);
+        assertTrue(checker.isPresent());
+        assertThat(checker.get(), instanceOf(ReadwriteSplittingRuleConfigurationChecker.class));
+        checker.get().check("test", config);
+    }
+    
+    private ReadwriteSplittingDataSourceRuleConfiguration createDataSourceRuleConfig(final String writeDataSource, final List<String> readDataSources) {
+        ReadwriteSplittingDataSourceRuleConfiguration result = mock(ReadwriteSplittingDataSourceRuleConfiguration.class);
+        StaticReadwriteSplittingStrategyConfiguration readwriteSplittingStrategy = mock(StaticReadwriteSplittingStrategyConfiguration.class);
+        when(readwriteSplittingStrategy.getWriteDataSourceName()).thenReturn(writeDataSource);
+        when(readwriteSplittingStrategy.getReadDataSourceNames()).thenReturn(readDataSources);
+        when(result.getStaticStrategy()).thenReturn(readwriteSplittingStrategy);
         return result;
     }
 }


### PR DESCRIPTION
Fixes #19102.

Changes proposed in this pull request:
- add duplicate datasource check logic for ReadwriteSplitting
- add unit test
