### PR TITLE
Return `false` for `isDelay` check when delay threshold is not set

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/main/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm.java
@@ -123,7 +123,9 @@ public final class MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm impl
                 Connection connection = replicaDataSource.getConnection();
                 Statement statement = connection.createStatement()) {
             long replicationDelayMilliseconds = queryReplicationDelayMilliseconds(statement);
-            boolean isDelay = replicationDelayMilliseconds >= Long.parseLong(getProps().getProperty("delay-milliseconds-threshold"));
+            boolean isDelay = getProps().containsKey("delay-milliseconds-threshold")
+                    ? replicationDelayMilliseconds >= Long.parseLong(getProps().getProperty("delay-milliseconds-threshold"))
+                    : false;
             return new ReplicaDataSourceStatus(!isDelay, replicationDelayMilliseconds);
         }
     }

--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/test/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-provider/shardingsphere-db-discovery-mysql/src/test/java/org/apache/shardingsphere/dbdiscovery/mysql/type/MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithmTest.java
@@ -74,6 +74,16 @@ public final class MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithmTest 
         assertTrue(actual.isOnline());
         assertThat(actual.getReplicationDelayMilliseconds(), is(10000L));
     }
+
+    @Test
+    public void assertLoadReplicaStatusWhenDelayThreshldIsNotSet() throws SQLException {
+        Properties props = new Properties();
+        DatabaseDiscoveryProviderAlgorithm algorithm = new MySQLNormalReplicationDatabaseDiscoveryProviderAlgorithm();
+        algorithm.init(props);
+        DataSource dataSource = mockDataSourceForReplicaStatus();
+        ReplicaDataSourceStatus actual = algorithm.loadReplicaStatus(dataSource);
+        assertTrue(actual.isOnline());
+    }
     
     private DataSource mockDataSourceForReplicaStatus() throws SQLException {
         ResultSet resultSet = mock(ResultSet.class);


### PR DESCRIPTION
Fixes #18914.

Changes proposed in this pull request:
- If the delay threshold is not set, then return `false` for `isDelay` check.

