### PR TITLE
Reduce redundant overhead in AuthorityChecker

### DIFF
--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/checker/AuthorityChecker.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/main/java/org/apache/shardingsphere/authority/checker/AuthorityChecker.java
@@ -47,7 +47,6 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQ
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 
@@ -78,8 +77,11 @@ public final class AuthorityChecker implements SQLChecker<AuthorityRule> {
             return new SQLCheckResult(false, String.format("Unknown database '%s'", currentDatabase));
         }
         PrivilegeType privilegeType = getPrivilege(sqlStatementContext.getSqlStatement());
-        String errorMessage = Objects.isNull(privilegeType) ? "" : String.format("Access denied for operation %s", privilegeType.name());
-        return privileges.map(optional -> new SQLCheckResult(optional.hasPrivileges(Collections.singletonList(privilegeType)), errorMessage)).orElseGet(() -> new SQLCheckResult(false, ""));
+        return privileges.map(optional -> {
+            boolean isPassed = optional.hasPrivileges(Collections.singletonList(privilegeType));
+            String errorMessage = isPassed || null == privilegeType ? "" : String.format("Access denied for operation %s", privilegeType.name());
+            return new SQLCheckResult(isPassed, errorMessage);
+        }).orElseGet(() -> new SQLCheckResult(false, ""));
     }
     
     @Override

--- a/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/checker/AuthorityCheckerTest.java
+++ b/shardingsphere-kernel/shardingsphere-authority/shardingsphere-authority-core/src/test/java/org/apache/shardingsphere/authority/checker/AuthorityCheckerTest.java
@@ -25,14 +25,9 @@ import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementConte
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.executor.check.SQLChecker;
 import org.apache.shardingsphere.infra.executor.check.SQLCheckerFactory;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Answers;
-import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -43,11 +38,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-@RunWith(MockitoJUnitRunner.class)
 public final class AuthorityCheckerTest {
-    
-    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-    private ShardingSphereDatabase database;
     
     @SuppressWarnings("unchecked")
     @Test


### PR DESCRIPTION
Revise #14161.

The overhead of construct error message is always present even the check passed.

![image](https://user-images.githubusercontent.com/20503072/181411062-48fb1c41-9367-4ad7-9975-1e933abebd87.png)
