### PR TITLE
Fix the failed conversion of Month related classes on IntervalShardingAlgorithm

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -317,7 +317,7 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
     }
     
     private Month parseMonth(final Comparable<?> endpoint) {
-        return (Month) endpoint;
+        return Month.of(Integer.parseInt(getDateTimeText(endpoint).substring(0, dateTimePatternLength)));
     }
     
     private YearMonth parseYearMonth(final Comparable<?> endpoint) {

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -444,5 +444,8 @@ public final class IntervalShardingAlgorithmTest {
         Collection<String> actualAsMonth = shardingAlgorithmByMonthInJSR310.doSharding(availableTablesForMonthInJSR310DataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed(Month.of(4), Month.of(10))));
         assertThat(actualAsMonth.size(), is(4));
+        Collection<String> actualAsMonthString = shardingAlgorithmByMonthInJSR310.doSharding(availableTablesForMonthInJSR310DataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("04", "10")));
+        assertThat(actualAsMonthString.size(), is(4));
     }
 }


### PR DESCRIPTION
Fixes #19636.

Changes proposed in this pull request:
- Refactor `org.apache.shardingsphere.sharding.algorithm.sharding.datetime.IntervalShardingAlgorithm#parseMonth` .
- Update unit tests.
