### PR TITLE
fix issue #18528

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/MySQLAdminExecutorCreator.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/text/admin/mysql/MySQLAdminExecutorCreator.java
@@ -51,6 +51,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLShowProcessListStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dal.MySQLShowTablesStatement;
 
+import java.util.Iterator;
 import java.util.Optional;
 
 /**
@@ -128,8 +129,10 @@ public final class MySQLAdminExecutorCreator implements DatabaseAdminExecutorCre
     }
     
     private boolean isShowSpecialFunction(final SelectStatement sqlStatement, final String functionName) {
-        ProjectionSegment firstProjection = sqlStatement.getProjections().getProjections().iterator().next();
-        return firstProjection instanceof ExpressionProjectionSegment && functionName.equalsIgnoreCase(((ExpressionProjectionSegment) firstProjection).getText());
+        Iterator<ProjectionSegment> segmentIterator = sqlStatement.getProjections().getProjections().iterator();
+        ProjectionSegment firstProjection = segmentIterator.next();
+        return !segmentIterator.hasNext() && firstProjection instanceof ExpressionProjectionSegment
+                && functionName.equalsIgnoreCase(((ExpressionProjectionSegment) firstProjection).getText());
     }
     
     private boolean isQueryInformationSchema(final SelectStatement sqlStatement) {


### PR DESCRIPTION
Fixes #18528 

Changes proposed in this pull request:
- modify  method ```create()``` in MySQLAdminExecutorCreator, add logic about checking count of params , not just consider the first parameter.
-
My test case as follow in my code:
```
mysql> select version(), @@sql_mode;
```

##### before

<img width="394" alt="image" src="https://user-images.githubusercontent.com/33018640/181413979-c5b6aacd-eac9-429e-821d-23f02f2d55d2.png">

###### now
<img width="956" alt="image" src="https://user-images.githubusercontent.com/33018640/181414045-556f31f0-e755-4993-8941-04339a3f6743.png">

```
mysql> select current_user(), @@sql_mode;
```

##### before
<img width="367" alt="image" src="https://user-images.githubusercontent.com/33018640/181414169-6ecef06d-2d6f-4002-94df-0f80a241e74f.png">

##### now
<img width="984" alt="image" src="https://user-images.githubusercontent.com/33018640/181414259-86d8422a-482e-439c-98c1-1559bfdaa74c.png">

and it doesn't affect the existing logic

<img width="263" alt="image" src="https://user-images.githubusercontent.com/33018640/181414368-06b338d7-53c2-4bce-b2d2-2f80277f4d09.png">

<img width="399" alt="image" src="https://user-images.githubusercontent.com/33018640/181414730-4a85917e-1556-4eba-9997-cbe6cbb8b546.png">



