### PR TITLE
fix DatabaseDiscoveryRuleTest NPE

### DIFF
--- a/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
+++ b/shardingsphere-features/shardingsphere-db-discovery/shardingsphere-db-discovery-core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
@@ -21,9 +21,13 @@ import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleCon
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryHeartBeatConfiguration;
 import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
+import org.apache.shardingsphere.infra.config.mode.PersistRepositoryConfiguration;
 import org.apache.shardingsphere.infra.distsql.constant.ExportableConstants;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.schedule.core.ScheduleContextFactory;
 import org.apache.shardingsphere.test.mock.MockedDataSource;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.sql.DataSource;
@@ -45,7 +49,12 @@ import static org.mockito.Mockito.when;
 public final class DatabaseDiscoveryRuleTest {
     
     private final Map<String, DataSource> dataSourceMap = Collections.singletonMap("primary_ds", new MockedDataSource());
-    
+
+    @Before
+    public void init() {
+        ScheduleContextFactory.getInstance().init("foo_id", new ModeConfiguration("Cluster", mock(PersistRepositoryConfiguration.class), false));
+    }
+
     @Test
     public void assertFindDataSourceRule() {
         Optional<DatabaseDiscoveryDataSourceRule> actual = createRule().findDataSourceRule("replica_ds");


### PR DESCRIPTION
Fixes NPE when DatabaseDiscoveryRuleTest running alone.

ScheduleContextFactory.getInstance() return null when ScheduleContextFactory.init not be called.

![image](https://user-images.githubusercontent.com/87062136/182020745-1b0e7e34-0203-46af-8676-f736e377eaa0.png)


![image](https://user-images.githubusercontent.com/87062136/182020853-af4ca6f4-5279-499e-9470-4e15274f973d.png)
