### PR TITLE
Separate schedule CI from ci.yml

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
       - name: Build with Maven
         run: ./mvnw -B -ntp clean install
@@ -60,6 +61,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Build Project
         run: ./mvnw -B -ntp clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -DskipITs -DskipTests -Dspotless.apply.skip=true
@@ -75,6 +77,7 @@ jobs:
       - name: Set up JDK 8
         uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
         run: ./mvnw -B -ntp clean install cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -23,6 +23,8 @@ name: Daily Continuous Integration
 on:
   schedule:
     - cron: '0 18 */1 * *'  # once a day. UTC time
+  pull_request:
+    branches: [ master ]
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -1,0 +1,82 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Daily Continuous Integration
+
+on:
+  schedule:
+    - cron: '0 18 */1 * *'  # once a day. UTC time
+
+env:
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+
+jobs:
+  ci:
+    if: github.repository == 'apache/shardingsphere'
+    name: JDK ${{ matrix.java_version }} - on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        java_version: [ 8, 17, 18 ]
+    steps:
+      - name: Support longpaths in Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --system core.longpaths true
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java_version }}
+      - name: Build with Maven
+        run: ./mvnw -B -ntp clean install
+      - name: Build examples with Maven
+        run: ./mvnw -B -f examples/pom.xml clean package
+  
+  shardingsphere-example-generator:
+    if: github.repository == 'apache/shardingsphere'
+    name: ShardingSphere example generator
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+      - name: Build Project
+        run: ./mvnw -B -ntp clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -DskipITs -DskipTests -Dspotless.apply.skip=true
+      - name: Run Example generator
+        run: ./mvnw -B test -f examples/shardingsphere-example-generator/pom.xml -Pexample-generator
+
+  test-coverage-report:
+    if: github.repository == 'apache/shardingsphere'
+    runs-on: ubuntu-latest
+    name: ShardingSphere test coverage report
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: 8
+      - name: Test with Maven
+        run: ./mvnw -B -ntp clean install cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true
+      - name: Upload to Codecov
+        run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -23,8 +23,6 @@ name: Daily Continuous Integration
 on:
   schedule:
     - cron: '0 18 */1 * *'  # once a day. UTC time
-  pull_request:
-    branches: [ master ]
 
 env:
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,6 @@ on:
       - '!*.md'
   repository_dispatch:
     types: [rerun-ci]
-  schedule:
-    - cron: '0 16 */1 * *'  # once a day. UTC time
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
@@ -70,76 +68,19 @@ jobs:
           key: maven-cache-checkstyle-and-apache-rat-${{ hashFiles('**/pom.xml') }}
       - name: Run Checkstyle and Apache Rat
         run: ./mvnw checkstyle:check apache-rat:check -T1C
-  windows:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere')
-    runs-on: windows-latest
-    timeout-minutes: 60
-    steps:
-      - name: Cache Maven Repos
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Support longpaths
-        run: git config --system core.longpaths true
-      - uses: actions/checkout@v2
-      - name: Dump concurrency group
-        env:
-          CON_GROUP: ${{ github.workflow }}-${{ github.ref }}
-        run: echo "$CON_GROUP"
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 8
-      - name: Build with Maven
-        shell: cmd
-        run: |
-          .\mvnw -B --no-transfer-progress clean -D"maven.javadoc.skip"=true -D"rat.skip"=true -D"spotless.apply.skip"=true install < nul
-          echo "mvnw exited"
-      - name: Build examples with Maven
-        run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
 
-  ubuntu:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere')
-    name: JDK 8 - on ubuntu-latest
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v2
-      - name: Maven resolve ranges
-        run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
-      - name: Cache Maven Repos
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: 8
-      - name: Build with Maven
-        run: echo y | ./mvnw -B --no-transfer-progress clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true
-      - name: Build examples with Maven
-        run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
-
-  unix:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere') || (github.event_name != 'schedule')
-    name: JDK ${{ matrix.java.version }} - on ${{ matrix.os }}
+  linux:
+    if: github.repository == 'apache/shardingsphere'
+    name: JDK ${{ matrix.java_version }} - on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: checkstyle-and-apache-rat
     timeout-minutes: 60
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        java_version: [ 11, 17, 18 ]
+        java_version: [ 8, 17, 18 ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v2
         with:
@@ -155,49 +96,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build with Maven
-        run: echo y | ./mvnw -B --no-transfer-progress clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dspotless.apply.skip=true
+        run: ./mvnw -B -ntp clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dspotless.apply.skip=true
       - name: Build examples with Maven
-        run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
+        run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
   
-  macos:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere')
-    name: macos
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
-    strategy:
-      matrix:
-        os: [ macos-latest ]
-        java:
-          - {
-            version: 8,
-            maven_args: "-Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true"
-          }
-    steps:
-      - name: Cache Maven Repos
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - uses: actions/checkout@v2
-      - name: Set up JDK ${{ matrix.java.version }}
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java.version }}
-      - name: Build with Maven
-        run: echo y | ./mvnw -B --no-transfer-progress clean install ${{ matrix.java.maven_args }}
-      - name: Build examples with Maven
-        run: echo y | ./mvnw -B -f examples/pom.xml clean package -DskipTests
   
   shardingsphere-example-generator:
-    if: (github.event_name == 'schedule' && github.repository == 'apache/shardingsphere') || (github.event_name != 'schedule')
-    name: shardingsphere example generator
+    if: github.repository == 'apache/shardingsphere'
+    name: ShardingSphere example generator
     runs-on: ubuntu-latest
     needs: checkstyle-and-apache-rat
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Cache Maven Repos
@@ -213,16 +123,17 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Build Project
-        run: ./mvnw -B --no-transfer-progress clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -DskipITs -DskipTests -Dspotless.apply.skip=true
+        run: ./mvnw -B -ntp clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true -DskipITs -DskipTests -Dspotless.apply.skip=true
       - name: Run Example generator
-        run: echo y | ./mvnw -B test -f examples/shardingsphere-example-generator/pom.xml -Pexample-generator
+        run: ./mvnw -B test -f examples/shardingsphere-example-generator/pom.xml -Pexample-generator
 
   test-coverage-report:
+    if: github.repository == 'apache/shardingsphere'
     runs-on: ubuntu-latest
-    name: shardingsphere test coverage report
+    name: ShardingSphere test coverage report
     needs: checkstyle-and-apache-rat
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache Maven Repos
         uses: actions/cache@v2
         with:
@@ -236,6 +147,6 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -B --no-transfer-progress clean install cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true
+        run: ./mvnw -B -ntp clean install cobertura:cobertura -Dmaven.javadoc.skip=true -Drat.skip=true -Dcheckstyle.skip=true
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- There are too many skipped CI when we create a Pull Request.
- There are too much redundancies in ci.yml.

![image](https://user-images.githubusercontent.com/20503072/182559975-fdb1b8ad-a1e1-4805-917c-8e0b045873f9.png)
