### PR TITLE
Fix wrong parameter rewrite when use sharding and encrypt

### DIFF
--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptAssignmentParameterRewriter.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptAssignmentParameterRewriter.java
@@ -105,7 +105,7 @@ public final class EncryptAssignmentParameterRewriter implements ParameterRewrit
             addedParameters.add(originalValue);
         }
         if (!addedParameters.isEmpty()) {
-            parameterBuilder.addAddedParameters(parameterMarkerIndex + 1, addedParameters);
+            parameterBuilder.addAddedParameters(parameterMarkerIndex, addedParameters);
         }
     }
 }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter.java
@@ -86,10 +86,10 @@ public final class EncryptInsertOnDuplicateKeyUpdateValueParameterRewriter imple
                     addedParameters.add(plainColumnValue);
                 }
                 if (!addedParameters.isEmpty()) {
-                    if (!groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().containsKey(columnIndex + 1)) {
-                        groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().put(columnIndex + 1, new LinkedList<>());
+                    if (!groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().containsKey(columnIndex)) {
+                        groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().put(columnIndex, new LinkedList<>());
                     }
-                    groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().get(columnIndex + 1).addAll(addedParameters);
+                    groupedParameterBuilder.getGenericParameterBuilder().getAddedIndexAndParameters().get(columnIndex).addAll(addedParameters);
                 }
             });
         }

--- a/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertValueParameterRewriter.java
+++ b/shardingsphere-features/shardingsphere-encrypt/shardingsphere-encrypt-core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertValueParameterRewriter.java
@@ -118,10 +118,10 @@ public final class EncryptInsertValueParameterRewriter implements ParameterRewri
             addedParameters.add(originalValue);
         }
         if (!addedParameters.isEmpty()) {
-            if (!parameterBuilder.getAddedIndexAndParameters().containsKey(parameterIndex + 1)) {
-                parameterBuilder.getAddedIndexAndParameters().put(parameterIndex + 1, new LinkedList<>());
+            if (!parameterBuilder.getAddedIndexAndParameters().containsKey(parameterIndex)) {
+                parameterBuilder.getAddedIndexAndParameters().put(parameterIndex, new LinkedList<>());
             }
-            parameterBuilder.getAddedIndexAndParameters().get(parameterIndex + 1).addAll(addedParameters);
+            parameterBuilder.getAddedIndexAndParameters().get(parameterIndex).addAll(addedParameters);
         }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/StandardParameterBuilder.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/StandardParameterBuilder.java
@@ -43,8 +43,6 @@ public final class StandardParameterBuilder implements ParameterBuilder {
     
     private final Map<Integer, Object> replacedIndexAndParameters = new LinkedHashMap<>();
     
-    private final List<Integer> removeIndexAndParameters = new ArrayList<>();
-    
     /**
      * Add added parameters.
      * 
@@ -65,31 +63,31 @@ public final class StandardParameterBuilder implements ParameterBuilder {
         replacedIndexAndParameters.put(index, parameter);
     }
     
-    /**
-     * Add removed parameter.
-     *
-     * @param index parameter index to be removed
-     */
-    public void addRemovedParameters(final int index) {
-        removeIndexAndParameters.add(index);
-    }
-    
     @Override
     public List<Object> getParameters() {
-        List<Object> result = new LinkedList<>(originalParameters);
+        List<Object> replacedParameters = new ArrayList<>(originalParameters);
         for (Entry<Integer, Object> entry : replacedIndexAndParameters.entrySet()) {
-            result.set(entry.getKey(), entry.getValue());
+            replacedParameters.set(entry.getKey(), entry.getValue());
         }
-        for (Entry<Integer, Collection<Object>> entry : ((TreeMap<Integer, Collection<Object>>) addedIndexAndParameters).descendingMap().entrySet()) {
-            if (entry.getKey() > result.size()) {
-                result.addAll(entry.getValue());
-            } else {
-                result.addAll(entry.getKey(), entry.getValue());
+        int maxParameterIndex = getMaxParameterIndex(originalParameters, addedIndexAndParameters);
+        List<Object> result = new LinkedList<>();
+        for (int index = 0; index <= maxParameterIndex; index++) {
+            List<Object> currentIndexParameters = new LinkedList<>();
+            if (replacedParameters.size() > index) {
+                currentIndexParameters.add(replacedParameters.get(index));
             }
-        }
-        for (int index : removeIndexAndParameters) {
-            result.remove(index);
+            if (addedIndexAndParameters.containsKey(index)) {
+                currentIndexParameters.addAll(addedIndexAndParameters.get(index));
+            }
+            result.addAll(currentIndexParameters);
         }
         return result;
+    }
+    
+    private int getMaxParameterIndex(final List<Object> originalParameters, final Map<Integer, Collection<Object>> addedIndexAndParameters) {
+        if (addedIndexAndParameters.isEmpty()) {
+            return originalParameters.size() - 1;
+        }
+        return Math.max(originalParameters.size() - 1, ((TreeMap<Integer, Collection<Object>>) addedIndexAndParameters).descendingMap().firstKey());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/GroupedParameterBuilderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/GroupedParameterBuilderTest.java
@@ -49,8 +49,7 @@ public final class GroupedParameterBuilderTest {
         actual.getGenericParameterBuilder().addReplacedParameters(1, 88);
         actual.getGenericParameterBuilder().addAddedParameters(0, Arrays.asList(66, -1));
         actual.getGenericParameterBuilder().addAddedParameters(2, Arrays.asList(99, 110));
-        actual.getGenericParameterBuilder().addRemovedParameters(1);
-        assertThat(actual.getGenericParameterBuilder().getParameters(), is(Arrays.<Object>asList(66, 77, 88, 99, 110)));
+        assertThat(actual.getGenericParameterBuilder().getParameters(), is(Arrays.<Object>asList(66, -1, 77, 88, 99, 110)));
     }
     
     @Test

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/GroupedParameterBuilderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/GroupedParameterBuilderTest.java
@@ -49,7 +49,7 @@ public final class GroupedParameterBuilderTest {
         actual.getGenericParameterBuilder().addReplacedParameters(1, 88);
         actual.getGenericParameterBuilder().addAddedParameters(0, Arrays.asList(66, -1));
         actual.getGenericParameterBuilder().addAddedParameters(2, Arrays.asList(99, 110));
-        assertThat(actual.getGenericParameterBuilder().getParameters(), is(Arrays.<Object>asList(66, -1, 77, 88, 99, 110)));
+        assertThat(actual.getGenericParameterBuilder().getParameters(), is(Arrays.<Object>asList(77, 66, -1, 88, 99, 110)));
     }
     
     @Test

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/StandardParameterBuilderTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/parameter/builder/impl/StandardParameterBuilderTest.java
@@ -37,11 +37,10 @@ public final class StandardParameterBuilderTest {
     public void setUp() {
         parameterBuilder = new StandardParameterBuilder(parameters);
         parameterBuilder.addAddedParameters(4, Collections.singleton(7));
-        parameterBuilder.addRemovedParameters(1);
     }
     
     @Test
     public void assertGetParameters() {
-        assertThat(parameterBuilder.getParameters(), is(Arrays.<Object>asList(1, 1, 5, 7)));
+        assertThat(parameterBuilder.getParameters(), is(Arrays.<Object>asList(1, 2, 1, 5, 7)));
     }
 }

--- a/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/query-with-cipher/dml/insert/insert-column.xml
+++ b/shardingsphere-test/shardingsphere-rewrite-test/src/test/resources/scenario/mix/case/query-with-cipher/dml/insert/insert-column.xml
@@ -105,11 +105,10 @@
         <output sql="INSERT INTO t_account_bak_0(account_id, cipher_password, assisted_query_password, plain_password, cipher_amount, plain_amount) VALUES (2, 'encrypt_bbb', 'assisted_query_bbb', 'bbb', 'encrypt_2000', 2000), (4, 'encrypt_ddd', 'assisted_query_ddd', 'ddd', 'encrypt_4000', 4000)" />
     </rewrite-assertion>
     
-    <!-- TODO FIX parameter rewrite logic when use sharding and encrypt -->
-    <!--<rewrite-assertion id="insert_values_without_columns_with_plain_without_id_for_parameters" db-types="MySQL">
+    <rewrite-assertion id="insert_values_without_columns_with_plain_without_id_for_parameters" db-types="MySQL">
         <input sql="INSERT INTO t_account_bak VALUES (?, ?), ('bbb', 2000), (?, ?), ('ddd', 4000)" parameters="aaa, 1000, ccc, 3000" />
         <output sql="INSERT INTO t_account_bak_1(cipher_password, assisted_query_password, plain_password, cipher_amount, plain_amount, account_id) VALUES (?, ?, ?, ?, ?, ?), ('encrypt_bbb', 'assisted_query_bbb', 'bbb', 'encrypt_2000', 2000, 1), (?, ?, ?, ?, ?, ?), ('encrypt_ddd', 'assisted_query_ddd', 'ddd', 'encrypt_4000', 4000, 1)" parameters="encrypt_aaa, assisted_query_aaa, aaa, encrypt_1000, 1000, 1, encrypt_ccc, assisted_query_ccc, ccc, encrypt_3000, 3000, 1" />
-    </rewrite-assertion>-->
+    </rewrite-assertion>
     
     <rewrite-assertion id="insert_values_without_columns_with_plain_without_id_for_literals" db-types="MySQL">
         <input sql="INSERT INTO t_account_bak VALUES ('aaa', 1000), ('bbb', 2000), ('ccc', 3000), ('ddd', 4000)" />


### PR DESCRIPTION
Fixes #19888.

Changes proposed in this pull request:
- optimize logic of StandardParameterBuilder#getParameters to group by parameters by original index
- add rewrite test case
- remove useless removeIndexAndParameters
