### PR TITLE
Add and update IDEA code style schema

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,7 +15,7 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
  - Make sure the test coverage rate is not lower than the master branch.
  - Careful consideration for each `pull request`; Small and frequent `pull request` with complete unit function is welcomed.
  - Conform to `Contributor Covenant Code of Conduct` below.
- - If using IDEA，you can import the recommended [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar).
+ - If using IDEA，you can import the recommended [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar), or `src/resources/code-style-idea.xml`.
 
 ## Contributor Covenant Code of Conduct
 

--- a/docs/community/content/contribute/code-conduct.cn.md
+++ b/docs/community/content/contribute/code-conduct.cn.md
@@ -22,7 +22,7 @@ chapter = true
  - 确保覆盖率不低于 master 分支。
  - 应尽量将设计精细化拆分；做到小幅度修改，多次数提交，但应保证提交的完整性。
  - 确保遵守编码规范。
- - 如果您使用 IDEA，可导入推荐的 [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar)。
+ - 如果您使用 IDEA，可导入推荐的 [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar)，或者 `src/resources/code-style-idea.xml`。
  - 通过 Spotless 统一代码风格，执行 `mvn spotless:apply` 格式化代码。
  
 ## 编码规范

--- a/docs/community/content/contribute/code-conduct.en.md
+++ b/docs/community/content/contribute/code-conduct.en.md
@@ -19,7 +19,7 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
  - Make sure the test coverage rate is not lower than the master branch.
  - Careful consideration for each `pull request`; Small and frequent `pull request` with complete unit function is welcomed.
  - Conform to `Contributor Covenant Code of Conduct` below.
- - If using IDEA, you can import the recommended [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar).
+ - If using IDEA, you can import the recommended [Settings](https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar), or `src/resources/code-style-idea.xml`.
  - Through the uniform code style of spotless, execute the `mvn spotless:apply` formatted code.
 
 ## Contributor Covenant Code of Conduct

--- a/src/resources/code-style-idea.xml
+++ b/src/resources/code-style-idea.xml
@@ -1,0 +1,62 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<code_scheme name="ShardingSphere" version="173">
+  <option name="LINE_SEPARATOR" value="&#xA;" />
+  <JavaCodeStyleSettings>
+    <option name="GENERATE_FINAL_LOCALS" value="true" />
+    <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+    <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+  </JavaCodeStyleSettings>
+  <codeStyleSettings language="JAVA">
+    <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <indentOptions>
+      <option name="KEEP_INDENTS_ON_EMPTY_LINES" value="true" />
+    </indentOptions>
+    <arrangement>
+      <groups>
+        <group>
+          <type>GETTERS_AND_SETTERS</type>
+          <order>KEEP</order>
+        </group>
+        <group>
+          <type>OVERRIDDEN_METHODS</type>
+          <order>KEEP</order>
+        </group>
+        <group>
+          <type>DEPENDENT_METHODS</type>
+          <order>BREADTH_FIRST</order>
+        </group>
+      </groups>
+    </arrangement>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="KEEP_INDENTS_ON_EMPTY_LINES" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="yaml">
+    <indentOptions>
+      <option name="KEEP_INDENTS_ON_EMPTY_LINES" value="true" />
+    </indentOptions>
+  </codeStyleSettings>
+</code_scheme>


### PR DESCRIPTION
Purpose:
- Easier to import code style schema in IDEA
- Keep unified code style on original files even users format code; Java importing and line breaks might be changed if code style is not set up
- Easier to update code style schema

Process:
1. Download [shardingsphere-settings.jar]( https://shardingsphere.apache.org/community/data/shardingsphere-settings.jar ) and unzip, import `codestyles/Default _1_.xml`
2. Do some testing for a long time
3. Export it as `code-style-idea.xml`

Changes proposed in this pull request:
- Add `code-style-idea.xml`

Changes in `code-style-idea.xml` comparing to original `codestyles/Default _1_.xml`:

1, Add `LINE_SEPARATOR` option, limit to `\n`
<img width="348" alt="图片" src="https://user-images.githubusercontent.com/42492540/183245762-e5022906-7137-46e8-9f4c-1f0818e590df.png">

2, Remove `<option name="KEEP_LINE_BREAKS" value="false" />` and `<option name="KEEP_MULTIPLE_EXPRESSIONS_IN_ONE_LINE" value="true" />`.

Settings is like this:
<img width="403" alt="图片" src="https://user-images.githubusercontent.com/42492540/183246239-ae05819e-7d32-41be-ade0-6149bdfd4d2d.png">

Since it might remove line breaks:

1) One line might exceed maximum length.
e.g.
<img width="1216" alt="图片" src="https://user-images.githubusercontent.com/42492540/183245922-4bca91d4-2e2d-448d-a835-c092999a8ea8.png">

2), Several lines into one line. e.g.
<img width="1360" alt="图片" src="https://user-images.githubusercontent.com/42492540/183246180-0afc192e-0637-4e45-b3e3-45b8a08832d3.png">


