### PR TITLE
Support Parsing `ALTER SUBSCRIPTION` in PostgreSQL

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -1070,6 +1070,8 @@ alterSubscription
     | CONNECTION STRING_
     | REFRESH PUBLICATION (WITH definition)?
     | SET PUBLICATION publicationNameList (WITH definition)?
+    | ADD PUBLICATION publicationNameList (WITH definition)?
+    | DROP PUBLICATION publicationNameList (WITH definition)?
     | (ENABLE | DISABLE))
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/PostgreSQLStatementParser.g4
@@ -172,5 +172,6 @@ execute
     | createForeignTable
     | alterStatistics
     | createGroup
+    | alterSubscription
     ) SEMI_? EOF
     ;

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLDDLStatementSQLVisitor.java
@@ -43,6 +43,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Al
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterPolicyContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterProcedureContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterPublicationContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterSubscriptionContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterRenameViewContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterRoutineContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AlterRuleContext;
@@ -215,6 +216,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterPolicyStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterProcedureStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterPublicationStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterSubscriptionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterRoutineStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterRuleStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl.PostgreSQLAlterSchemaStatement;
@@ -493,6 +495,11 @@ public final class PostgreSQLDDLStatementSQLVisitor extends PostgreSQLStatementS
     @Override
     public ASTNode visitAlterPublication(final AlterPublicationContext ctx) {
         return new PostgreSQLAlterPublicationStatement();
+    }
+    
+    @Override
+    public ASTNode visitAlterSubscription(final AlterSubscriptionContext ctx) {
+        return new PostgreSQLAlterSubscriptionStatement();
     }
     
     @Override

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/visitor/SQLVisitorRule.java
@@ -94,6 +94,8 @@ public enum SQLVisitorRule {
     
     ALTER_PUBLICATION("AlterPublication", SQLStatementType.DDL),
     
+    ALTER_SUBSCRIPTION("AlterSubscription", SQLStatementType.DDL),
+    
     ALTER_PROCEDURE("AlterProcedure", SQLStatementType.DDL),
     
     ALTER_STATEMENT("AlterStatement", SQLStatementType.DDL),

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterSubscriptionStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterSubscriptionStatement.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.statement.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
+
+/**
+ * Alter subscription statement.
+ */
+@ToString(callSuper = true)
+public abstract class AlterSubscriptionStatement extends AbstractSQLStatement implements DDLStatement {
+}

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterSubscriptionStatement.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/postgresql/ddl/PostgreSQLAlterSubscriptionStatement.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.ddl;
+
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterSubscriptionStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
+
+/**
+ * PostgreSQL alter subscription statement.
+ */
+@ToString(callSuper = true)
+public final class PostgreSQLAlterSubscriptionStatement extends AlterSubscriptionStatement implements PostgreSQLStatement {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -139,6 +139,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSequenceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterServerStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterStatisticsStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSubscriptionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterServiceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSessionStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl.AlterSynonymStatementTestCase;
@@ -656,6 +657,9 @@ public final class SQLParserTestCases {
     
     @XmlElement(name = "alter-statistics")
     private final List<AlterStatisticsStatementTestCase> alterStatisticsTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "alter-subscription")
+    private final List<AlterSubscriptionStatementTestCase> alterSubscriptionTestCases = new LinkedList<>();
     
     @XmlElement(name = "alter-session")
     private final List<AlterSessionStatementTestCase> alterSessionTestCases = new LinkedList<>();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/AlterSubscriptionStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/ddl/AlterSubscriptionStatementTestCase.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.ddl;
+
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+/**
+ * Alter subscription statement test case.
+ */
+public final class AlterSubscriptionStatementTestCase extends SQLParserTestCase {
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-subscription.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ddl/alter-subscription.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-parser-test-cases>
+    <alter-subscription sql-case-id="alter_subscription_set_publication" />
+    <alter-subscription sql-case-id="alter_subscription_add_publication" />
+    <alter-subscription sql-case-id="alter_subscription_drop_publication" />
+    <alter-subscription sql-case-id="alter_subscription_connection" />
+    <alter-subscription sql-case-id="alter_subscription_disable" />
+    <alter-subscription sql-case-id="alter_subscription_enable" />
+    <alter-subscription sql-case-id="alter_subscription_transfer_ownership" />
+    <alter-subscription sql-case-id="alter_subscription_rename" />
+    <alter-subscription sql-case-id="alter_subscription_set" />
+</sql-parser-test-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-subscription.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ddl/alter-subscription.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<sql-cases>
+    <sql-case id="alter_subscription_set_publication" value="ALTER SUBSCRIPTION regress_testsub SET PUBLICATION testpub2, testpub3 WITH (refresh = false);" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_add_publication" value="ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub WITH (refresh = false);" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_drop_publication" value="ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub1, testpub1 WITH (refresh = false);" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_connection" value="ALTER SUBSCRIPTION regress_test CONNECTION 'host=192.168.1.50 port=5432 user=foo dbname=foodb';" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_disable" value="ALTER SUBSCRIPTION regress_testsub DISABLE;" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_enable" value="ALTER SUBSCRIPTION regress_testsub ENABLE;" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_transfer_ownership" value="ALTER SUBSCRIPTION regress_testsub OWNER TO regress_subscription_user2;" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_rename" value="ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub_foo;" db-types="PostgreSQL" />
+    <sql-case id="alter_subscription_set" value="ALTER SUBSCRIPTION regress_testsub SET (binary = false);" db-types="PostgreSQL" />
+</sql-cases>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/unsupported/unsupported.xml
@@ -3264,46 +3264,6 @@
     <sql-case id="alter_by_postgresql_source_test_case214" value="ALTER OPERATOR FAMILY alt_opf7 USING btree DROP OPERATOR 1 (int4, int2, int8);" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case215" value="ALTER OPERATOR FAMILY alt_opf8 USING btree ADD OPERATOR 1 &lt; (int4, int4);" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case216" value="ALTER OPERATOR FAMILY alt_opf9 USING gist ADD OPERATOR 1 &lt; (int4, int4) FOR ORDER BY float_ops;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case327" value="ALTER SUBSCRIPTION regress_doesnotexist CONNECTION &apos;dbname=regress_doesnotexist2&apos;;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case328" value="ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case329" value="ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub1 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case330" value="ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub2 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case331" value="ALTER SUBSCRIPTION regress_testsub ADD PUBLICATION testpub1, testpub2 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case332" value="ALTER SUBSCRIPTION regress_testsub CONNECTION &apos;dbname=regress_doesnotexist2&apos;;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case333" value="ALTER SUBSCRIPTION regress_testsub CONNECTION &apos;foobar&apos;;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case334" value="ALTER SUBSCRIPTION regress_testsub DISABLE;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case335" value="ALTER SUBSCRIPTION regress_testsub DISABLE;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case336" value="ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub, testpub1, testpub2 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case337" value="ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub1, testpub1 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case338" value="ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub1, testpub2 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case339" value="ALTER SUBSCRIPTION regress_testsub DROP PUBLICATION testpub3 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case340" value="ALTER SUBSCRIPTION regress_testsub ENABLE;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case341" value="ALTER SUBSCRIPTION regress_testsub ENABLE;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case342" value="ALTER SUBSCRIPTION regress_testsub OWNER TO regress_subscription_user2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case343" value="ALTER SUBSCRIPTION regress_testsub OWNER TO regress_subscription_user2;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case344" value="ALTER SUBSCRIPTION regress_testsub REFRESH PUBLICATION;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case345" value="ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub_dummy;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case346" value="ALTER SUBSCRIPTION regress_testsub RENAME TO regress_testsub_foo;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case347" value="ALTER SUBSCRIPTION regress_testsub SET (binary = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case348" value="ALTER SUBSCRIPTION regress_testsub SET (create_slot = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case349" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = &apos;&apos;);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case350" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = &apos;newname&apos;);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case351" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case352" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case353" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case354" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case355" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case356" value="ALTER SUBSCRIPTION regress_testsub SET (slot_name = NONE);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case357" value="ALTER SUBSCRIPTION regress_testsub SET (streaming = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case358" value="ALTER SUBSCRIPTION regress_testsub SET (streaming = true);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case359" value="ALTER SUBSCRIPTION regress_testsub SET (two_phase = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case360" value="ALTER SUBSCRIPTION regress_testsub SET PUBLICATION mypub WITH (refresh = true);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case361" value="ALTER SUBSCRIPTION regress_testsub SET PUBLICATION testpub2, testpub3 WITH (refresh = false);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case362" value="ALTER SUBSCRIPTION regress_testsub3 ENABLE;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case363" value="ALTER SUBSCRIPTION regress_testsub3 REFRESH PUBLICATION;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case364" value="ALTER SUBSCRIPTION regress_testsub_foo RENAME TO regress_testsub;" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case365" value="ALTER SUBSCRIPTION regress_testsub_foo SET (synchronous_commit = foobar);" db-types="PostgreSQL" />
-    <sql-case id="alter_by_postgresql_source_test_case366" value="ALTER SUBSCRIPTION regress_testsub_foo SET (synchronous_commit = local);" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case367" value="ALTER TABLE ONLY gtest30 ALTER COLUMN b DROP EXPRESSION;" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case368" value="ALTER TABLE ab1 ALTER a SET STATISTICS -1;" db-types="PostgreSQL" />
     <sql-case id="alter_by_postgresql_source_test_case369" value="ALTER TABLE am_partitioned SET ACCESS METHOD heap2;" db-types="PostgreSQL" />


### PR DESCRIPTION
Ref #17848 .
Sub-issue of  #14015

Changes proposed in this pull request:
- Proofread `ALTER SUBSCRIPTION` grammar
- Support parsing `ALTER SUBSCRIPTION` in PostgreSQL
- Add tests

✅ Builds locally

