### PR TITLE
fix shardingsphere-jdbc-example module runtime exception

### DIFF
--- a/examples/shardingsphere-jdbc-example/pom.xml
+++ b/examples/shardingsphere-jdbc-example/pom.xml
@@ -34,6 +34,14 @@
         <module>single-feature-example</module>
     </modules>
 
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2.version}</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Fixes #19398 .

Changes proposed in this pull request:
- Added h2 dependency for shardingsphere-jdbc-example module
-
-
