### PR TITLE
Ignore vscode's configuration file in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ cobertura.ser
 *.iml
 *.iws
 
+# vscode ignore
+.vscode/
+
 # temp ignore
 logs/
 *.log


### PR DESCRIPTION
For #19536.

Changes proposed in this pull request:
- Ignore vscode's configuration file in .gitignore.
- This will improve the experience of using the VS Code-based IDE and avoid passing personal configuration files into other PRs.
