### PR TITLE
Improve job progress swapper

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlJobItemIncrementalTasksProgressSwapper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlJobItemIncrementalTasksProgressSwapper.java
@@ -35,7 +35,7 @@ public final class YamlJobItemIncrementalTasksProgressSwapper {
      */
     public YamlJobItemIncrementalTasksProgress swapToYaml(final JobItemIncrementalTasksProgress progress) {
         if (null == progress) {
-            return null;
+            return new YamlJobItemIncrementalTasksProgress();
         }
         return progress.getIncrementalTaskProgressMap()
                 .entrySet().stream()
@@ -45,7 +45,7 @@ public final class YamlJobItemIncrementalTasksProgressSwapper {
                     result.setPosition(entry.getValue().getPosition().toString());
                     result.setDelay(entry.getValue().getIncrementalTaskDelay());
                     return result;
-                }).findAny().orElse(null);
+                }).findAny().orElse(new YamlJobItemIncrementalTasksProgress());
     }
     
     /**
@@ -57,7 +57,7 @@ public final class YamlJobItemIncrementalTasksProgressSwapper {
      */
     public JobItemIncrementalTasksProgress swapToObject(final String databaseType, final YamlJobItemIncrementalTasksProgress yamlProgress) {
         if (null == yamlProgress) {
-            return null;
+            return new JobItemIncrementalTasksProgress(Collections.emptyMap());
         }
         IncrementalTaskProgress taskProgress = new IncrementalTaskProgress();
         // TODO databaseType

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlJobItemInventoryTasksProgressSwapper.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlJobItemInventoryTasksProgressSwapper.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.data.pipeline.api.job.progress.JobItemInventory
 import org.apache.shardingsphere.data.pipeline.api.task.progress.InventoryTaskProgress;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -43,7 +44,7 @@ public final class YamlJobItemInventoryTasksProgressSwapper {
      */
     public YamlJobItemInventoryTasksProgress swapToYaml(final JobItemInventoryTasksProgress progress) {
         YamlJobItemInventoryTasksProgress result = new YamlJobItemInventoryTasksProgress();
-        if (progress != null) {
+        if (null != progress) {
             result.setFinished(getFinished(progress));
             result.setUnfinished(getUnfinished(progress));
         }
@@ -70,7 +71,7 @@ public final class YamlJobItemInventoryTasksProgressSwapper {
      */
     public JobItemInventoryTasksProgress swapToObject(final YamlJobItemInventoryTasksProgress yamlProgress) {
         if (null == yamlProgress) {
-            return null;
+            return new JobItemInventoryTasksProgress(Collections.emptyMap());
         }
         Map<String, InventoryTaskProgress> taskProgressMap = new LinkedHashMap<>();
         taskProgressMap.putAll(Arrays.stream(yamlProgress.getFinished()).collect(Collectors.toMap(key -> key, value -> new InventoryTaskProgress(new FinishedPosition()))));

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/job-progress-failure.yaml
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/resources/job-progress-failure.yaml
@@ -15,11 +15,5 @@
 # limitations under the License.
 #
 #
-incremental:
-  dataSourceName: ds0
-  delay:
-    lastEventTimestamps: 0
-    latestActiveTimeMillis: 0
-  position: ''
 sourceDatabaseType: H2
-status: RUNNING
+status: PREPARING_FAILURE


### PR DESCRIPTION
Related to #19940.

Changes proposed in this pull request:
- Improve job item tasks progress swapper, make it compatible with null value, avoid possible NPE in ShowScalingJobStatusQueryResultSet
- Improve YamlJobProgressSwapperTest, 1) test swapToYaml and swapToObject, 2) test job-progress-failure.yaml secenario
