### PR TITLE
Rename tryLock to persistLock in ClusterPersistRepository

### DIFF
--- a/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-namespace/src/test/java/org/apache/shardingsphere/spring/namespace/fixture/FixtureClusterPersistRepository.java
+++ b/shardingsphere-jdbc/shardingsphere-jdbc-spring/shardingsphere-jdbc-core-spring/shardingsphere-jdbc-core-spring-namespace/src/test/java/org/apache/shardingsphere/spring/namespace/fixture/FixtureClusterPersistRepository.java
@@ -70,7 +70,7 @@ public final class FixtureClusterPersistRepository implements ClusterPersistRepo
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return false;
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterLockPersistService.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterLockPersistService.java
@@ -33,7 +33,7 @@ public final class ClusterLockPersistService implements LockPersistService {
     
     @Override
     public boolean tryLock(final LockDefinition lockDefinition, final long timeoutMillis) {
-        return repository.tryLock(lockDefinition.getLockKey(), timeoutMillis);
+        return repository.persistLock(lockDefinition.getLockKey(), timeoutMillis);
     }
     
     @Override

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/fixture/ClusterPersistRepositoryFixture.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/fixture/ClusterPersistRepositoryFixture.java
@@ -62,7 +62,7 @@ public final class ClusterPersistRepositoryFixture implements ClusterPersistRepo
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return false;
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/process/ProcessListClusterPersistRepositoryFixture.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/process/ProcessListClusterPersistRepositoryFixture.java
@@ -69,7 +69,7 @@ public final class ProcessListClusterPersistRepositoryFixture implements Cluster
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return false;
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-api/src/main/java/org/apache/shardingsphere/mode/repository/cluster/ClusterPersistRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-api/src/main/java/org/apache/shardingsphere/mode/repository/cluster/ClusterPersistRepository.java
@@ -42,6 +42,15 @@ public interface ClusterPersistRepository extends PersistRepository {
     void persistEphemeral(String key, String value);
     
     /**
+     * Persist lock.
+     *
+     * @param lockKey lock key
+     * @param timeoutMillis timeout millis
+     * @return is locked or not
+     */
+    boolean persistLock(String lockKey, long timeoutMillis);
+    
+    /**
      * Watch key or path of governance server.
      *
      * @param key key of data
@@ -55,13 +64,4 @@ public interface ClusterPersistRepository extends PersistRepository {
      * @param instanceContext instance context
      */
     void watchSessionConnection(InstanceContext instanceContext);
-    
-    /**
-     * Try lock.
-     *
-     * @param lockKey lock key
-     * @param timeoutMillis timeout millis
-     * @return is locked or not
-     */
-    boolean tryLock(String lockKey, long timeoutMillis);
 }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/EtcdRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/EtcdRepository.java
@@ -145,7 +145,7 @@ public final class EtcdRepository implements ClusterPersistRepository {
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return etcdInternalLockHolder.getInternalLock(lockKey).tryLock(timeoutMillis);
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/lock/EtcdInternalLockHolder.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/lock/EtcdInternalLockHolder.java
@@ -62,7 +62,7 @@ public final class EtcdInternalLockHolder implements InternalLockHolder {
             // CHECKSTYLE:OFF
         } catch (final Exception ex) {
             // CHECKSTYLE:ON
-            log.error("EtcdRepository tryLock error, lockName:{}", lockKey, ex);
+            log.error("Create etcd internal lock failed, lockName:{}", lockKey, ex);
         }
         return null;
     }
@@ -87,7 +87,7 @@ public final class EtcdInternalLockHolder implements InternalLockHolder {
                 // CHECKSTYLE:OFF
             } catch (final Exception ex) {
                 // CHECKSTYLE:ON
-                log.error("EtcdRepository tryLock error, lockName:{}", lockKey, ex);
+                log.error("Etcd internal lock try lock failed", ex);
                 return false;
             }
         }
@@ -99,7 +99,7 @@ public final class EtcdInternalLockHolder implements InternalLockHolder {
                 // CHECKSTYLE:OFF
             } catch (final Exception ex) {
                 // CHECKSTYLE:ON
-                log.error("EtcdRepository unlock error, lockName:{}", lockKey, ex);
+                log.error("Etcd internal lock unlock failed", ex);
             }
         }
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/CuratorZookeeperRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/CuratorZookeeperRepository.java
@@ -255,7 +255,7 @@ public final class CuratorZookeeperRepository implements ClusterPersistRepositor
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return internalLockHolder.getInternalLock(lockKey).tryLock(timeoutMillis);
     }
     

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/test/java/org/apache/shardingsphere/proxy/fixture/ClusterPersistRepositoryFixture.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/src/test/java/org/apache/shardingsphere/proxy/fixture/ClusterPersistRepositoryFixture.java
@@ -68,7 +68,7 @@ public final class ClusterPersistRepositoryFixture implements ClusterPersistRepo
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return false;
     }
     

--- a/shardingsphere-test/shardingsphere-integration-driver-test/src/test/java/org/apache/shardingsphere/driver/fixture/TestClusterPersistRepository.java
+++ b/shardingsphere-test/shardingsphere-integration-driver-test/src/test/java/org/apache/shardingsphere/driver/fixture/TestClusterPersistRepository.java
@@ -70,7 +70,7 @@ public final class TestClusterPersistRepository implements ClusterPersistReposit
     }
     
     @Override
-    public boolean tryLock(final String lockKey, final long timeoutMillis) {
+    public boolean persistLock(final String lockKey, final long timeoutMillis) {
         return false;
     }
     


### PR DESCRIPTION
## Rename tryLock to persistLock in ClusterPersistRepository

Changes proposed in this pull request:
- Rename tryLock to persistLock in ClusterPersistRepository

