### PR TITLE
Update Anltr to 4.10 to support Hibernate 6 integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-codec.version>1.15</commons-codec.version>
         
-        <antlr4.version>4.9.2</antlr4.version>
+        <antlr4.version>4.10</antlr4.version>
         <snakeyaml.version>1.30</snakeyaml.version>
         <gson.version>2.8.6</gson.version>
         <groovy.version>4.0.3</groovy.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -317,7 +317,7 @@ BSD licenses
 The following components are provided under a BSD license. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    antlr4-runtime 4.9.2: https://github.com/antlr/antlr4, BSD-3-Clause
+    antlr4-runtime 4.10: https://github.com/antlr/antlr4, BSD-3-Clause
     asm 5.0.4: https://github.com/llbit/ow2-asm, BSD-3-Clause
     commons-compiler 3.0.11: https://github.com/janino-compiler/janino, New BSD License
     janino 3.0.11: https://github.com/janino-compiler/janino, New BSD License

--- a/shardingsphere-infra/shardingsphere-infra-merge/src/main/java/org/apache/shardingsphere/infra/merge/engine/merger/impl/TransparentResultMerger.java
+++ b/shardingsphere-infra/shardingsphere-infra-merge/src/main/java/org/apache/shardingsphere/infra/merge/engine/merger/impl/TransparentResultMerger.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class TransparentResultMerger implements ResultMerger {
     
     @Override
-    public MergedResult merge(final List<QueryResult> queryResults, final SQLStatementContext<?> sqlStatementContext, 
+    public MergedResult merge(final List<QueryResult> queryResults, final SQLStatementContext<?> sqlStatementContext,
                               final ShardingSphereDatabase database, final ConnectionContext connectionContext) {
         return new TransparentMergedResult(queryResults.get(0));
     }

--- a/shardingsphere-infra/shardingsphere-infra-merge/src/main/java/org/apache/shardingsphere/infra/merge/engine/merger/impl/TransparentResultMerger.java
+++ b/shardingsphere-infra/shardingsphere-infra-merge/src/main/java/org/apache/shardingsphere/infra/merge/engine/merger/impl/TransparentResultMerger.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class TransparentResultMerger implements ResultMerger {
     
     @Override
-    public MergedResult merge(final List<QueryResult> queryResults, final SQLStatementContext<?> sqlStatementContext,
+    public MergedResult merge(final List<QueryResult> queryResults, final SQLStatementContext<?> sqlStatementContext, 
                               final ShardingSphereDatabase database, final ConnectionContext connectionContext) {
         return new TransparentMergedResult(queryResults.get(0));
     }


### PR DESCRIPTION
Fixes #19990.

Changes proposed in this pull request:
- Update pom.xml and LICENSE.
- Drop support for Hibrenate 5 in favor of Hibernate 6 integration.
- Also fixes #20008 .
