### PR TITLE
Update Gson to 2.9.1 to avoid CVE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         
         <antlr4.version>4.9.2</antlr4.version>
         <snakeyaml.version>1.30</snakeyaml.version>
-        <gson.version>2.8.6</gson.version>
+        <gson.version>2.9.1</gson.version>
         <groovy.version>4.0.3</groovy.version>
         
         <jaxb.version>2.3.0</jaxb.version>

--- a/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
+++ b/shardingsphere-distribution/shardingsphere-proxy-distribution/src/main/release-docs/LICENSE
@@ -249,7 +249,7 @@ The text of each license is the standard Apache 2.0 license.
     grpc-protobuf 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-protobuf-lite 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-stub 1.27.1: https://github.com/grpc/grpc-java, Apache 2.0
-    gson 2.8.6: https://github.com/google/gson, Apache 2.0
+    gson 2.9.1: https://github.com/google/gson, Apache 2.0
     guava 30.0-jre: https://github.com/google/guava, Apache 2.0
     HikariCP 3.4.2: https://github.com/brettwooldridge/HikariCP, Apache 2.0
     httpclient 4.5.9: http://hc.apache.org/httpcomponents-client, Apache 2.0


### PR DESCRIPTION
Fixes #20120.

Changes proposed in this pull request:
- update pom.xml and LICENSE.
