### PR TITLE
Remove nonexistent parameter from maven-javadoc-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -960,7 +960,6 @@
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <charset>${project.build.sourceEncoding}</charset>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <docencoding>${project.build.sourceEncoding}</docencoding>
@@ -1202,7 +1201,6 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
-                    <aggregate>true</aggregate>
                     <charset>${project.build.sourceEncoding}</charset>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <docencoding>${project.build.sourceEncoding}</docencoding>


### PR DESCRIPTION
Revise #11629.

The parameter `aggregate` has been deprecated since 2.5 and removed in 3.x.

https://github.com/apache/maven-javadoc-plugin/blob/95f7724c0b8382256caaa294e1a36e6e3a466aab/src/main/java/org/apache/maven/plugin/javadoc/AbstractJavadocMojo.java#L441-L448