### PR TITLE
Optimize PostgreSQL, openGauss order by item parse and convert to SqlNode

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/dialect/OracleSchemaMetaDataLoader.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/dialect/OracleSchemaMetaDataLoader.java
@@ -67,7 +67,7 @@ public final class OracleSchemaMetaDataLoader implements DialectSchemaMetaDataLo
     private static final int COLLATION_START_MINOR_VERSION = 2;
     
     private static final int IDENTITY_COLUMN_START_MINOR_VERSION = 1;
-
+    
     private static final int HIDDEN_COLUMN_START_MINOR_VERSION = 1;
     
     private static final int MAX_EXPRESSION_SIZE = 1000;
@@ -144,7 +144,7 @@ public final class OracleSchemaMetaDataLoader implements DialectSchemaMetaDataLo
         return tables.isEmpty() ? String.format(TABLE_META_DATA_SQL, collation)
                 : String.format(TABLE_META_DATA_SQL_IN_TABLES, collation, tables.stream().map(each -> String.format("'%s'", each)).collect(Collectors.joining(",")));
     }
-
+    
     private boolean versionContainsHiddenColumn(final DatabaseMetaData databaseMetaData) throws SQLException {
         return databaseMetaData.getDatabaseMajorVersion() >= COLLATION_START_MAJOR_VERSION && databaseMetaData.getDatabaseMinorVersion() >= HIDDEN_COLUMN_START_MINOR_VERSION;
     }

--- a/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/converter/segment/orderby/item/ExpressionOrderByItemConverter.java
+++ b/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/converter/segment/orderby/item/ExpressionOrderByItemConverter.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.federation.optimizer.converter.segment.o
 
 import org.apache.calcite.sql.SqlNode;
 import org.apache.shardingsphere.infra.federation.optimizer.converter.segment.SQLSegmentConverter;
+import org.apache.shardingsphere.infra.federation.optimizer.converter.segment.expression.ExpressionConverter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.ExpressionOrderByItemSegment;
 
 import java.util.Optional;
@@ -30,7 +31,6 @@ public final class ExpressionOrderByItemConverter implements SQLSegmentConverter
     
     @Override
     public Optional<SqlNode> convert(final ExpressionOrderByItemSegment segment) {
-        // TODO
-        return Optional.empty();
+        return null == segment ? Optional.empty() : new ExpressionConverter().convert(segment.getExpr());
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/converter/segment/orderby/item/OrderByItemConverterUtil.java
+++ b/shardingsphere-infra/shardingsphere-infra-federation/shardingsphere-infra-federation-optimizer/src/main/java/org/apache/shardingsphere/infra/federation/optimizer/converter/segment/orderby/item/OrderByItemConverterUtil.java
@@ -47,7 +47,7 @@ public final class OrderByItemConverterUtil {
             if (each instanceof ColumnOrderByItemSegment) {
                 new ColumnOrderByItemConverter().convert((ColumnOrderByItemSegment) each).ifPresent(result::add);
             } else if (each instanceof ExpressionOrderByItemSegment) {
-                throw new UnsupportedOperationException("unsupported ExpressionOrderByItemSegment");
+                new ExpressionOrderByItemConverter().convert((ExpressionOrderByItemSegment) each).ifPresent(result::add);
             } else if (each instanceof IndexOrderByItemSegment) {
                 new IndexOrderByItemConverter().convert((IndexOrderByItemSegment) each).ifPresent(result::add);
             } else if (each instanceof TextOrderByItemSegment) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineDistributedBarrier.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineDistributedBarrier.java
@@ -42,6 +42,7 @@ public final class PipelineDistributedBarrier {
     private static final PipelineDistributedBarrier INSTANCE = new PipelineDistributedBarrier();
     
     private static final LazyInitializer<ClusterPersistRepository> REPOSITORY_LAZY_INITIALIZER = new LazyInitializer<ClusterPersistRepository>() {
+        
         @Override
         protected ClusterPersistRepository initialize() {
             return (ClusterPersistRepository) PipelineContext.getContextManager().getMetaDataContexts().getPersistService().getRepository();

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
@@ -298,18 +298,38 @@ public abstract class OpenGaussStatementSQLVisitor extends OpenGaussStatementBas
         if (null != ctx.patternMatchingOperator()) {
             return createPatternMatchingOperationSegment(ctx);
         }
-        if (null != ctx.comparisonOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.comparisonOperator().getText());
-        }
-        if (null != ctx.andOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.andOperator().getText());
-        }
-        if (null != ctx.orOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.orOperator().getText());
+        Optional<String> commonBinaryOperator = findCommonBinaryOperator(ctx);
+        if (commonBinaryOperator.isPresent()) {
+            return createCommonBinaryOperationSegment(ctx, commonBinaryOperator.get());
         }
         super.visitAExpr(ctx);
         String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
         return new CommonExpressionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), text);
+    }
+    
+    private Optional<String> findCommonBinaryOperator(final AExprContext ctx) {
+        if (null != ctx.comparisonOperator()) {
+            return Optional.of(ctx.comparisonOperator().getText());
+        }
+        if (null != ctx.andOperator()) {
+            return Optional.of(ctx.andOperator().getText());
+        }
+        if (null != ctx.orOperator()) {
+            return Optional.of(ctx.orOperator().getText());
+        }
+        if (null != ctx.PLUS_()) {
+            return Optional.of(ctx.PLUS_().getText());
+        }
+        if (null != ctx.MINUS_()) {
+            return Optional.of(ctx.MINUS_().getText());
+        }
+        if (null != ctx.ASTERISK_()) {
+            return Optional.of(ctx.ASTERISK_().getText());
+        }
+        if (null != ctx.SLASH_()) {
+            return Optional.of(ctx.SLASH_().getText());
+        }
+        return Optional.empty();
     }
     
     private BinaryOperationExpression createPatternMatchingOperationSegment(final AExprContext ctx) {

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -296,18 +296,38 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementP
         if (null != ctx.patternMatchingOperator()) {
             return createPatternMatchingOperationSegment(ctx);
         }
-        if (null != ctx.comparisonOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.comparisonOperator().getText());
-        }
-        if (null != ctx.andOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.andOperator().getText());
-        }
-        if (null != ctx.orOperator()) {
-            return createCommonBinaryOperationSegment(ctx, ctx.orOperator().getText());
+        Optional<String> commonBinaryOperator = findCommonBinaryOperator(ctx);
+        if (commonBinaryOperator.isPresent()) {
+            return createCommonBinaryOperationSegment(ctx, commonBinaryOperator.get());
         }
         super.visitAExpr(ctx);
         String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
         return new CommonExpressionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), text);
+    }
+    
+    private Optional<String> findCommonBinaryOperator(final AExprContext ctx) {
+        if (null != ctx.comparisonOperator()) {
+            return Optional.of(ctx.comparisonOperator().getText());
+        }
+        if (null != ctx.andOperator()) {
+            return Optional.of(ctx.andOperator().getText());
+        }
+        if (null != ctx.orOperator()) {
+            return Optional.of(ctx.orOperator().getText());
+        }
+        if (null != ctx.PLUS_()) {
+            return Optional.of(ctx.PLUS_().getText());
+        }
+        if (null != ctx.MINUS_()) {
+            return Optional.of(ctx.MINUS_().getText());
+        }
+        if (null != ctx.ASTERISK_()) {
+            return Optional.of(ctx.ASTERISK_().getText());
+        }
+        if (null != ctx.SLASH_()) {
+            return Optional.of(ctx.SLASH_().getText());
+        }
+        return Optional.empty();
     }
     
     private BinaryOperationExpression createPatternMatchingOperationSegment(final AExprContext ctx) {

--- a/shardingsphere-test/shardingsphere-optimize-test/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConvertEngineParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-optimize-test/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConvertEngineParameterizedTest.java
@@ -99,6 +99,8 @@ public final class SQLNodeConvertEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_count_with_binding_tables_with_join");
         SUPPORTED_SQL_CASE_IDS.add("select_join_using");
         SUPPORTED_SQL_CASE_IDS.add("select_count_with_escape_character");
+        SUPPORTED_SQL_CASE_IDS.add("select_group_by_with_order_by_and_limit");
+        SUPPORTED_SQL_CASE_IDS.add("select_count_with_sub");
     }
     
     private final String sqlCaseId;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-aggregate.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-aggregate.xml
@@ -74,7 +74,6 @@
                                 <literal-expression value="1" start-index="64" stop-index="64" />
                             </right>
                         </binary-operation-expression>
-                        <common-expression text="1-1" start-index="62" stop-index="64" />
                     </right>
                 </binary-operation-expression>
             </expr>


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/19580.

Changes proposed in this pull request:
- optimize PostgreSQL, openGauss order by item parse logic
- support convert order by item segment to SqlNode
- add test case
