### PR TITLE
Optimize worker-id generate when proxy is re-registered in cluster mode

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstance.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/instance/ComputeNodeInstance.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.infra.instance;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.state.StateContext;
@@ -30,7 +29,6 @@ import java.util.Collection;
 /**
  * Instance of compute node.
  */
-@RequiredArgsConstructor
 @Getter
 @Setter
 public final class ComputeNodeInstance {
@@ -42,6 +40,11 @@ public final class ComputeNodeInstance {
     private Collection<String> labels = new ArrayList<>();
     
     private volatile long workerId;
+    
+    public ComputeNodeInstance(final InstanceMetaData metaData) {
+        this.metaData = metaData;
+        workerId = -1L;
+    }
     
     /**
      * Set labels.

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/listener/SessionConnectionListener.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-zookeeper-curator/src/main/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/listener/SessionConnectionListener.java
@@ -58,7 +58,9 @@ public final class SessionConnectionListener implements ConnectionStateListener 
     private boolean reRegister(final CuratorFramework client) {
         try {
             if (client.getZookeeperClient().blockUntilConnectedOrTimedOut()) {
-                instanceContext.generateWorkerId(new Properties());
+                if (isNeedGenerateWorkerId()) {
+                    instanceContext.generateWorkerId(new Properties());
+                }
                 repository.persistEphemeral(ComputeNode.getOnlineInstanceNodePath(instanceContext.getInstance().getCurrentInstanceId(),
                         instanceContext.getInstance().getMetaData().getType()), instanceContext.getInstance().getMetaData().getAttributes());
                 return true;
@@ -69,6 +71,10 @@ public final class SessionConnectionListener implements ConnectionStateListener 
             CuratorZookeeperExceptionHandler.handleException(ex);
             return true;
         }
+    }
+    
+    private boolean isNeedGenerateWorkerId() {
+        return -1L != instanceContext.getInstance().getWorkerId();
     }
     
     @SneakyThrows(InterruptedException.class)


### PR DESCRIPTION
## Optimize worker-id generate when proxy is re-registered in cluster mode

Fixes #20155.

Changes proposed in this pull request:
- Optimize worker-id generate when proxy is re-registered in cluster mode

