### PR TITLE
Refactor pipeline job path in registry center

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/JobType.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/job/JobType.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.api.job;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -40,10 +41,14 @@ public enum JobType {
     
     private final String typeName;
     
+    private final String lowercaseTypeName;
+    
     private final String typeCode;
     
     JobType(final String typeName, final String typeCode) {
+        Preconditions.checkArgument(StringUtils.isAlpha(typeName), "type name must be character of [a-z]");
         this.typeName = typeName;
+        this.lowercaseTypeName = typeName.toLowerCase();
         Preconditions.checkArgument(typeCode.length() == 2, "code length is not 2");
         this.typeCode = typeCode;
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/PipelineAPIFactory.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/PipelineAPIFactory.java
@@ -25,8 +25,8 @@ import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.core.api.impl.GovernanceRepositoryAPIImpl;
-import org.apache.shardingsphere.data.pipeline.core.constant.DataPipelineConstants;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
+import org.apache.shardingsphere.data.pipeline.core.metadata.node.PipelineMetaDataNode;
 import org.apache.shardingsphere.data.pipeline.core.registry.CoordinatorRegistryCenterInitializer;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobAPIFactory;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.api.JobConfigurationAPI;
@@ -126,7 +126,7 @@ public final class PipelineAPIFactory {
         
         private ElasticJobAPIHolder() {
             ClusterPersistRepositoryConfiguration repositoryConfig = (ClusterPersistRepositoryConfiguration) PipelineContext.getModeConfig().getRepository();
-            String namespace = repositoryConfig.getNamespace() + DataPipelineConstants.DATA_PIPELINE_ROOT;
+            String namespace = repositoryConfig.getNamespace() + PipelineMetaDataNode.getElasticJobNamespace();
             jobStatisticsAPI = JobAPIFactory.createJobStatisticsAPI(repositoryConfig.getServerLists(), namespace, null);
             jobConfigurationAPI = JobAPIFactory.createJobConfigurationAPI(repositoryConfig.getServerLists(), namespace, null);
             jobOperateAPI = JobAPIFactory.createJobOperateAPI(repositoryConfig.getServerLists(), namespace, null);
@@ -162,7 +162,7 @@ public final class PipelineAPIFactory {
         private static CoordinatorRegistryCenter createRegistryCenter() {
             CoordinatorRegistryCenterInitializer registryCenterInitializer = new CoordinatorRegistryCenterInitializer();
             ModeConfiguration modeConfig = PipelineContext.getModeConfig();
-            return registryCenterInitializer.createRegistryCenter(modeConfig, DataPipelineConstants.DATA_PIPELINE_ROOT);
+            return registryCenterInitializer.createRegistryCenter(modeConfig, PipelineMetaDataNode.getElasticJobNamespace());
         }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -45,30 +45,30 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     
     @Override
     public void persistJobItemProgress(final String jobId, final int shardingItem, final String progressValue) {
-        repository.persist(PipelineMetaDataNode.getScalingJobOffsetPath(jobId, shardingItem), progressValue);
+        repository.persist(PipelineMetaDataNode.getJobOffsetItemPath(jobId, shardingItem), progressValue);
     }
     
     @Override
     public String getJobItemProgress(final String jobId, final int shardingItem) {
-        return repository.get(PipelineMetaDataNode.getScalingJobOffsetPath(jobId, shardingItem));
+        return repository.get(PipelineMetaDataNode.getJobOffsetItemPath(jobId, shardingItem));
     }
     
     @Override
     public void persistJobCheckResult(final String jobId, final boolean checkSuccess) {
         log.info("persist job check result '{}' for job {}", checkSuccess, jobId);
-        repository.persist(PipelineMetaDataNode.getScalingCheckResultPath(jobId), String.valueOf(checkSuccess));
+        repository.persist(PipelineMetaDataNode.getJobCheckResultPath(jobId), String.valueOf(checkSuccess));
     }
     
     @Override
     public Optional<Boolean> getJobCheckResult(final String jobId) {
-        String data = repository.get(PipelineMetaDataNode.getScalingCheckResultPath(jobId));
+        String data = repository.get(PipelineMetaDataNode.getJobCheckResultPath(jobId));
         return Strings.isNullOrEmpty(data) ? Optional.empty() : Optional.of(Boolean.parseBoolean(data));
     }
     
     @Override
     public void deleteJob(final String jobId) {
         log.info("delete job {}", jobId);
-        repository.delete(PipelineMetaDataNode.getScalingJobPath(jobId));
+        repository.delete(PipelineMetaDataNode.getJobRootPath(jobId));
     }
     
     @Override
@@ -88,7 +88,7 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     
     @Override
     public List<Integer> getShardingItems(final String jobId) {
-        List<String> result = getChildrenKeys(PipelineMetaDataNode.getScalingJobOffsetPath(jobId));
+        List<String> result = getChildrenKeys(PipelineMetaDataNode.getJobOffsetPath(jobId));
         log.info("getShardingItems, jobId={}, offsetKeys={}", jobId, result);
         return result.stream().map(Integer::parseInt).collect(Collectors.toList());
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/constant/DataPipelineConstants.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/constant/DataPipelineConstants.java
@@ -29,8 +29,7 @@ public final class DataPipelineConstants {
     /**
      * Data pipeline node name.
      */
-    // TODO change to pipeline after job configuration structure completed
-    public static final String DATA_PIPELINE_NODE_NAME = "scaling";
+    public static final String DATA_PIPELINE_NODE_NAME = "pipeline";
     
     /**
      * Data pipeline root path.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
@@ -19,9 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.metadata.node;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.core.constant.DataPipelineConstants;
-import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
 
 import java.util.regex.Pattern;
 
@@ -31,11 +29,25 @@ import java.util.regex.Pattern;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PipelineMetaDataNode {
     
-    private static final String JOB_PATTERN_PREFIX = DataPipelineConstants.DATA_PIPELINE_ROOT + "/[a-z]+/jobs/(j\\d{2}[0-9a-f]+)";
+    private static final String JOB_PATTERN_PREFIX = DataPipelineConstants.DATA_PIPELINE_ROOT + "/jobs/(j\\d{2}[0-9a-f]+)";
     
     public static final Pattern CONFIG_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/config");
     
     public static final Pattern BARRIER_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/barrier/(enable|disable)/\\d+");
+    
+    /**
+     * Get ElasticJob namespace.
+     *
+     * @return namespace
+     */
+    public static String getElasticJobNamespace() {
+        // ElasticJob will persist job to namespace
+        return getJobsPath();
+    }
+    
+    private static String getJobsPath() {
+        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, "jobs");
+    }
     
     /**
      * Get job root path.
@@ -44,8 +56,7 @@ public final class PipelineMetaDataNode {
      * @return root path
      */
     public static String getJobRootPath(final String jobId) {
-        JobType jobType = PipelineJobIdUtils.parseJobType(jobId);
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobType.getLowercaseTypeName(), "jobs", jobId);
+        return String.join("/", getJobsPath(), jobId);
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
@@ -19,13 +19,55 @@ package org.apache.shardingsphere.data.pipeline.core.metadata.node;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.core.constant.DataPipelineConstants;
+import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
+
+import java.util.regex.Pattern;
 
 /**
- * Scaling meta data node.
+ * Pipeline meta data node.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class PipelineMetaDataNode {
+    
+    private static final String JOB_PATTERN_PREFIX = DataPipelineConstants.DATA_PIPELINE_ROOT + "/[a-z]+/jobs/(j\\d{2}[0-9a-f]+)";
+    
+    public static final Pattern CONFIG_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/config");
+    
+    public static final Pattern BARRIER_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/barrier/(enable|disable)/\\d+");
+    
+    /**
+     * Get job root path.
+     *
+     * @param jobId job id.
+     * @return root path
+     */
+    public static String getJobRootPath(final String jobId) {
+        JobType jobType = PipelineJobIdUtils.parseJobType(jobId);
+        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobType.getLowercaseTypeName(), "jobs", jobId);
+    }
+    
+    /**
+     * Get job offset item path.
+     *
+     * @param jobId job id
+     * @param shardingItem sharding item
+     * @return job offset path
+     */
+    public static String getJobOffsetItemPath(final String jobId, final int shardingItem) {
+        return String.join("/", getJobOffsetPath(jobId), Integer.toString(shardingItem));
+    }
+    
+    /**
+     * Get job offset path.
+     *
+     * @param jobId job id
+     * @return job offset path
+     */
+    public static String getJobOffsetPath(final String jobId) {
+        return String.join("/", getJobRootPath(jobId), "offset");
+    }
     
     /**
      * Get job config path.
@@ -34,77 +76,36 @@ public final class PipelineMetaDataNode {
      * @return job config path.
      */
     public static String getJobConfigPath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "config");
+        return String.join("/", getJobRootPath(jobId), "config");
     }
     
     /**
-     * Get scaling root path.
-     *
-     * @param jobId job id.
-     * @return root path
-     */
-    public static String getScalingJobPath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId);
-    }
-    
-    /**
-     * Get scaling job offset path, include job id and sharding item.
-     *
-     * @param jobId job id.
-     * @param shardingItem sharding item.
-     * @return job offset path.
-     */
-    public static String getScalingJobOffsetPath(final String jobId, final int shardingItem) {
-        return String.join("/", getScalingJobOffsetPath(jobId), Integer.toString(shardingItem));
-    }
-    
-    /**
-     * Get scaling job offset path.
-     *
-     * @param jobId job id.
-     * @return job offset path.
-     */
-    public static String getScalingJobOffsetPath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "offset");
-    }
-    
-    /**
-     * Get scaling job config path.
+     * Get job check result path.
      *
      * @param jobId job id.
      * @return job config path.
      */
-    public static String getScalingJobConfigPath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "config");
+    public static String getJobCheckResultPath(final String jobId) {
+        return String.join("/", getJobRootPath(jobId), "check", "result");
     }
     
     /**
-     * Get scaling job config path.
-     *
-     * @param jobId job id.
-     * @return job config path.
-     */
-    public static String getScalingCheckResultPath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "check", "result");
-    }
-    
-    /**
-     * Get scaling job barrier enable path.
+     * Get job barrier enable path.
      *
      * @param jobId job id
-     * @return job barrier path.
+     * @return job barrier enable path
      */
-    public static String getScalingJobBarrierEnablePath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "barrier", "enable");
+    public static String getJobBarrierEnablePath(final String jobId) {
+        return String.join("/", getJobRootPath(jobId), "barrier", "enable");
     }
     
     /**
-     * Get scaling job barrier disable path.
+     * Get job barrier disable path.
      *
      * @param jobId job id
-     * @return job barrier path.
+     * @return job barrier disable path
      */
-    public static String getScalingJobBarrierDisablePath(final String jobId) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobId, "barrier", "disable");
+    public static String getJobBarrierDisablePath(final String jobId) {
+        return String.join("/", getJobRootPath(jobId), "barrier", "disable");
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
@@ -76,7 +76,7 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
         });
         getTasksRunnerMap().put(shardingItem, tasksRunner);
         PipelineJobProgressPersistService.addJobProgressPersistContext(getJobId(), shardingItem);
-        pipelineDistributedBarrier.persistEphemeralChildrenNode(PipelineMetaDataNode.getScalingJobBarrierEnablePath(getJobId()), shardingItem);
+        pipelineDistributedBarrier.persistEphemeralChildrenNode(PipelineMetaDataNode.getJobBarrierEnablePath(getJobId()), shardingItem);
     }
     
     private void prepare(final MigrationJobItemContext jobItemContext) {
@@ -110,7 +110,7 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
             return;
         }
         log.info("stop tasks runner, jobId={}", getJobId());
-        String scalingJobBarrierDisablePath = PipelineMetaDataNode.getScalingJobBarrierDisablePath(getJobId());
+        String scalingJobBarrierDisablePath = PipelineMetaDataNode.getJobBarrierDisablePath(getJobId());
         for (PipelineTasksRunner each : getTasksRunnerMap().values()) {
             each.stop();
             pipelineDistributedBarrier.persistEphemeralChildrenNode(scalingJobBarrierDisablePath, each.getJobItemContext().getShardingItem());

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
@@ -24,21 +24,42 @@ import static org.junit.Assert.assertThat;
 
 public final class PipelineMetaDataNodeTest {
     
+    private final String jobId = "j01001";
+    
+    private final String jobRootPath = "/pipeline/migration/jobs/j01001";
+    
+    @Test
+    public void assertGetJobRootPath() {
+        assertThat(PipelineMetaDataNode.getJobRootPath(jobId), is(jobRootPath));
+    }
+    
+    @Test
+    public void assertGetJobOffsetPath() {
+        assertThat(PipelineMetaDataNode.getJobOffsetPath(jobId), is(jobRootPath + "/offset"));
+    }
+    
+    @Test
+    public void assertGetJobOffsetItemPath() {
+        assertThat(PipelineMetaDataNode.getJobOffsetItemPath(jobId, 0), is(jobRootPath + "/offset/0"));
+    }
+    
     @Test
     public void assertGetJobConfigPath() {
-        String actualOffsetPath = PipelineMetaDataNode.getScalingJobOffsetPath("0130317c30317c3054317c7368617264696e675f6462");
-        assertThat(actualOffsetPath, is("/scaling/0130317c30317c3054317c7368617264696e675f6462/offset"));
-        actualOffsetPath = PipelineMetaDataNode.getScalingJobOffsetPath("0130317c30317c3054317c7368617264696e675f6462", 1);
-        assertThat(actualOffsetPath, is("/scaling/0130317c30317c3054317c7368617264696e675f6462/offset/1"));
+        assertThat(PipelineMetaDataNode.getJobConfigPath(jobId), is(jobRootPath + "/config"));
     }
     
     @Test
-    public void assertGetScalingJobConfigPath() {
-        assertThat(PipelineMetaDataNode.getScalingJobConfigPath("0130317c30317c3054317c7368617264696e675f6462"), is("/scaling/0130317c30317c3054317c7368617264696e675f6462/config"));
+    public void assertGetCheckResultPath() {
+        assertThat(PipelineMetaDataNode.getJobCheckResultPath(jobId), is(jobRootPath + "/check/result"));
     }
     
     @Test
-    public void assertGetScalingCheckResultPath() {
-        assertThat(PipelineMetaDataNode.getScalingCheckResultPath("0130317c30317c3054317c7368617264696e675f6462"), is("/scaling/0130317c30317c3054317c7368617264696e675f6462/check/result"));
+    public void assertGetJobBarrierEnablePath() {
+        assertThat(PipelineMetaDataNode.getJobBarrierEnablePath(jobId), is(jobRootPath + "/barrier/enable"));
+    }
+    
+    @Test
+    public void assertGetJobBarrierDisablePath() {
+        assertThat(PipelineMetaDataNode.getJobBarrierDisablePath(jobId), is(jobRootPath + "/barrier/disable"));
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
@@ -26,7 +26,14 @@ public final class PipelineMetaDataNodeTest {
     
     private final String jobId = "j01001";
     
-    private final String jobRootPath = "/pipeline/migration/jobs/j01001";
+    private final String jobsPath = "/pipeline/jobs";
+    
+    private final String jobRootPath = jobsPath + "/j01001";
+    
+    @Test
+    public void assertGetElasticJobNamespace() {
+        assertThat(PipelineMetaDataNode.getElasticJobNamespace(), is(jobsPath));
+    }
     
     @Test
     public void assertGetJobRootPath() {


### PR DESCRIPTION

Changes proposed in this pull request:
- Refactor pipeline job path in registry center; Compatible with ejob namespace
- Improve PipelineMetaDataNode and unit test, PipelineJobExecutor pattern

```
pipeline/
    jobs/
```
