### PR TITLE
Refactor RALUpdater, add databaseName parameter

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceR
 public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMigrationSourceResourceStatement> {
     
     @Override
-    public void executeUpdate(final AddMigrationSourceResourceStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final AddMigrationSourceResourceStatement sqlStatement) {
         // TODO add migration source resource later
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/ApplyMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/ApplyMigrationUpdater.java
@@ -30,7 +30,7 @@ public final class ApplyMigrationUpdater implements RALUpdater<ApplyMigrationSta
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final ApplyMigrationStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final ApplyMigrationStatement sqlStatement) {
         JOB_API.switchClusterConfiguration(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/DropMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/DropMigrationUpdater.java
@@ -30,7 +30,7 @@ public final class DropMigrationUpdater implements RALUpdater<DropMigrationState
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final DropMigrationStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final DropMigrationStatement sqlStatement) {
         JOB_API.remove(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
@@ -30,7 +30,7 @@ public final class MigrateTableUpdater implements RALUpdater<MigrateTableStateme
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final MigrateTableStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final MigrateTableStatement sqlStatement) {
         // TODO implement migrate table
         JOB_API.getType();
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/ResetMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/ResetMigrationUpdater.java
@@ -30,7 +30,7 @@ public final class ResetMigrationUpdater implements RALUpdater<ResetMigrationSta
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final ResetMigrationStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final ResetMigrationStatement sqlStatement) {
         JOB_API.reset(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RestoreMigrationSourceWritingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RestoreMigrationSourceWritingUpdater.java
@@ -30,7 +30,7 @@ public final class RestoreMigrationSourceWritingUpdater implements RALUpdater<Re
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final RestoreMigrationSourceWritingStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final RestoreMigrationSourceWritingStatement sqlStatement) {
         JOB_API.restoreClusterWriteDB(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StartMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StartMigrationUpdater.java
@@ -30,7 +30,7 @@ public final class StartMigrationUpdater implements RALUpdater<StartMigrationSta
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final StartMigrationStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final StartMigrationStatement sqlStatement) {
         JOB_API.startDisabledJob(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StopMigrationSourceWritingUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StopMigrationSourceWritingUpdater.java
@@ -30,7 +30,7 @@ public final class StopMigrationSourceWritingUpdater implements RALUpdater<StopM
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final StopMigrationSourceWritingStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final StopMigrationSourceWritingStatement sqlStatement) {
         JOB_API.stopClusterWriteDB(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StopMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/StopMigrationUpdater.java
@@ -30,7 +30,7 @@ public final class StopMigrationUpdater implements RALUpdater<StopMigrationState
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final StopMigrationStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final StopMigrationStatement sqlStatement) {
         JOB_API.stop(sqlStatement.getJobId());
     }
     

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/distsql/update/RALUpdater.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/distsql/update/RALUpdater.java
@@ -31,8 +31,9 @@ public interface RALUpdater<T extends SQLStatement> extends TypedSPI {
     
     /**
      * Execute update.
-     * 
+     *
+     * @param databaseName database name
      * @param sqlStatement updatable RAL statement
      */
-    void executeUpdate(T sqlStatement);
+    void executeUpdate(String databaseName, T sqlStatement);
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/fixture/FixtureRALUpdater.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/fixture/FixtureRALUpdater.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 public final class FixtureRALUpdater implements RALUpdater<FixtureRALStatement> {
     
     @Override
-    public void executeUpdate(final FixtureRALStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final FixtureRALStatement sqlStatement) {
     }
     
     @Override

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
@@ -149,7 +149,7 @@ public final class RALBackendHandlerFactory {
             return new QueryableMigrationRALBackendHandler(sqlStatement, connectionSession, (DatabaseDistSQLResultSet) resultSet);
         }
         if (sqlStatement instanceof UpdatableScalingRALStatement) {
-            return new UpdatableMigrationRALBackendHandler((UpdatableScalingRALStatement) sqlStatement);
+            return new UpdatableMigrationRALBackendHandler((UpdatableScalingRALStatement) sqlStatement, connectionSession);
         }
         if (sqlStatement instanceof QueryableGlobalRuleRALStatement) {
             return QueryableGlobalRuleRALBackendHandlerFactory.newInstance((QueryableGlobalRuleRALStatement) sqlStatement);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableMigrationRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableMigrationRALBackendHandler.java
@@ -19,25 +19,47 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.up
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.apache.shardingsphere.dialect.exception.syntax.database.NoDatabaseSelectedException;
+import org.apache.shardingsphere.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdaterFactory;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
-import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
 /**
  * Updatable migration RAL backend handler factory.
  */
 @RequiredArgsConstructor
 @Setter
+// TODO rename, and also similar ones
 public final class UpdatableMigrationRALBackendHandler implements ProxyBackendHandler {
     
     private final UpdatableScalingRALStatement sqlStatement;
     
+    private final ConnectionSession connectionSession;
+    
     @SuppressWarnings("unchecked")
     @Override
     public ResponseHeader execute() {
-        RALUpdaterFactory.getInstance(sqlStatement.getClass()).executeUpdate(sqlStatement);
+        String databaseName = getDatabaseName(connectionSession);
+        checkDatabaseName(databaseName);
+        RALUpdaterFactory.getInstance(sqlStatement.getClass()).executeUpdate(databaseName, sqlStatement);
         return new UpdateResponseHeader(sqlStatement);
+    }
+    
+    private String getDatabaseName(final ConnectionSession connectionSession) {
+        return connectionSession.getDatabaseName();
+    }
+    
+    private void checkDatabaseName(final String databaseName) {
+        if (null == databaseName) {
+            throw new NoDatabaseSelectedException();
+        }
+        if (!ProxyContext.getInstance().databaseExists(databaseName)) {
+            throw new UnknownDatabaseException(databaseName);
+        }
     }
 }


### PR DESCRIPTION
Purpose:
- Support `add migration source resource` and `migrate table` DistSQL to get current logical database

Changes proposed in this pull request:
- RALUpdater, add databaseName parameter; And also UpdatableMigrationRALBackendHandler, RALBackendHandlerFactory
