### PR TITLE
Fix wrong singleTableDataNodes when execute reloadRules

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabase.java
@@ -33,7 +33,6 @@ import org.apache.shardingsphere.infra.metadata.database.schema.builder.SystemSc
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.builder.database.DatabaseRulesBuilder;
-import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 
 import javax.sql.DataSource;
@@ -43,7 +42,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * ShardingSphere database.
@@ -184,14 +182,7 @@ public final class ShardingSphereDatabase {
         RuleConfiguration config = toBeReloadedRules.stream().map(ShardingSphereRule::getConfiguration).findFirst().orElse(null);
         toBeReloadedRules.stream().findFirst().ifPresent(optional -> {
             ruleMetaData.getRules().removeAll(toBeReloadedRules);
-            ruleMetaData.getRules().addAll(reloadRules(config, (MutableDataNodeRule) optional));
+            ruleMetaData.getRules().add(((MutableDataNodeRule) optional).reloadRule(config, name, resource.getDataSources(), ruleMetaData.getRules()));
         });
-    }
-    
-    private Collection<ShardingSphereRule> reloadRules(final RuleConfiguration config, final MutableDataNodeRule mutableDataNodeRule) {
-        Collection<ShardingSphereRule> result = new LinkedList<>();
-        Collection<ShardingSphereRule> dataSourceContainedRules = ruleMetaData.getRules().stream().filter(each -> each instanceof DataSourceContainedRule).collect(Collectors.toList());
-        result.add(mutableDataNodeRule.reloadRule(config, name, resource.getDataSources(), dataSourceContainedRules));
-        return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/test/java/org/apache/shardingsphere/infra/metadata/database/ShardingSphereDatabaseTest.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.infra.rule.identifier.type.MutableDataNodeRule;
 import org.apache.shardingsphere.infra.metadata.database.resource.ShardingSphereResource;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
 import org.apache.shardingsphere.test.mock.MockedDataSource;
 import org.junit.Test;
 
@@ -69,9 +70,10 @@ public final class ShardingSphereDatabaseTest {
         Collection<ShardingSphereRule> rules = new LinkedList<>();
         rules.add(mock(MutableDataNodeRule.class, RETURNS_DEEP_STUBS));
         rules.add(mock(DataSourceContainedRule.class, RETURNS_DEEP_STUBS));
+        rules.add(mock(TableContainedRule.class, RETURNS_DEEP_STUBS));
         ShardingSphereRuleMetaData ruleMetaData = new ShardingSphereRuleMetaData(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase("foo_db", mock(DatabaseType.class), resource, ruleMetaData, Collections.emptyMap());
         database.reloadRules(MutableDataNodeRule.class);
-        assertThat(database.getRuleMetaData().getRules().size(), is(2));
+        assertThat(database.getRuleMetaData().getRules().size(), is(3));
     }
 }


### PR DESCRIPTION
Fixes #20287.

Changes proposed in this pull request:
- fix wrong singleTableDataNodes when execute reloadRules
- update unit test
