### PR TITLE
Recover RAL backend handler class name and checkDatabaseName

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
@@ -18,6 +18,8 @@
 package org.apache.shardingsphere.migration.distsql.handler.update;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.api.MigrationJobPublicAPI;
+import org.apache.shardingsphere.data.pipeline.api.PipelineJobPublicAPIFactory;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
 
@@ -26,6 +28,8 @@ import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceR
  */
 @Slf4j
 public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMigrationSourceResourceStatement> {
+    
+    private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
     public void executeUpdate(final String databaseName, final AddMigrationSourceResourceStatement sqlStatement) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.metadata.node;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.core.constant.DataPipelineConstants;
 
 import java.util.regex.Pattern;
@@ -34,6 +35,30 @@ public final class PipelineMetaDataNode {
     public static final Pattern CONFIG_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/config");
     
     public static final Pattern BARRIER_PATTERN = Pattern.compile(JOB_PATTERN_PREFIX + "/barrier/(enable|disable)/\\d+");
+    
+    /**
+     * Get metadata data sources path.
+     *
+     * @param jobType job type
+     * @return data sources path
+     */
+    public static String getMetaDataDataSourcesPath(final JobType jobType) {
+        return String.join("/", getMetaDataRootPath(jobType), "dataSources");
+    }
+    
+    private static String getMetaDataRootPath(final JobType jobType) {
+        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobType.getLowercaseTypeName(), "metadata");
+    }
+    
+    /**
+     * Get metadata process configuration path.
+     *
+     * @param jobType job type
+     * @return data sources path
+     */
+    public static String getMetaDataProcessConfigPath(final JobType jobType) {
+        return String.join("/", getMetaDataRootPath(jobType), "processConfig");
+    }
     
     /**
      * Get ElasticJob namespace.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.metadata.node;
 
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -24,11 +25,23 @@ import static org.junit.Assert.assertThat;
 
 public final class PipelineMetaDataNodeTest {
     
+    private final String migrationMetaDataRootPath = "/pipeline/migration/metadata";
+    
     private final String jobId = "j01001";
     
     private final String jobsPath = "/pipeline/jobs";
     
     private final String jobRootPath = jobsPath + "/j01001";
+    
+    @Test
+    public void assertGetMetaDataDataSourcesPath() {
+        assertThat(PipelineMetaDataNode.getMetaDataDataSourcesPath(JobType.MIGRATION), is(migrationMetaDataRootPath + "/dataSources"));
+    }
+    
+    @Test
+    public void assertGetMetaDataProcessConfigPath() {
+        assertThat(PipelineMetaDataNode.getMetaDataProcessConfigPath(JobType.MIGRATION), is(migrationMetaDataRootPath + "/processConfig"));
+    }
     
     @Test
     public void assertGetElasticJobNamespace() {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
@@ -54,9 +54,9 @@ import org.apache.shardingsphere.infra.distsql.query.DatabaseDistSQLResultSet;
 import org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.hint.HintRALBackendHandler;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.query.QueryableMigrationRALBackendHandler;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.query.QueryableMigrationRALBackendHandlerFactory;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.update.UpdatableMigrationRALBackendHandler;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.query.QueryableScalingRALBackendHandler;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.query.QueryableScalingRALBackendHandlerFactory;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.update.UpdatableScalingRALBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ConvertYamlConfigurationHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ExportDatabaseConfigurationHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowAllVariableHandler;
@@ -145,11 +145,11 @@ public final class RALBackendHandlerFactory {
             return new HintRALBackendHandler((HintRALStatement) sqlStatement, connectionSession);
         }
         if (sqlStatement instanceof QueryableScalingRALStatement) {
-            DistSQLResultSet resultSet = QueryableMigrationRALBackendHandlerFactory.newInstance((QueryableScalingRALStatement) sqlStatement);
-            return new QueryableMigrationRALBackendHandler(sqlStatement, connectionSession, (DatabaseDistSQLResultSet) resultSet);
+            DistSQLResultSet resultSet = QueryableScalingRALBackendHandlerFactory.newInstance((QueryableScalingRALStatement) sqlStatement);
+            return new QueryableScalingRALBackendHandler(sqlStatement, connectionSession, (DatabaseDistSQLResultSet) resultSet);
         }
         if (sqlStatement instanceof UpdatableScalingRALStatement) {
-            return new UpdatableMigrationRALBackendHandler((UpdatableScalingRALStatement) sqlStatement, connectionSession);
+            return new UpdatableScalingRALBackendHandler((UpdatableScalingRALStatement) sqlStatement, connectionSession);
         }
         if (sqlStatement instanceof QueryableGlobalRuleRALStatement) {
             return QueryableGlobalRuleRALBackendHandlerFactory.newInstance((QueryableGlobalRuleRALStatement) sqlStatement);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandler.java
@@ -34,13 +34,13 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Queryable migration RAL backend handler.
+ * Queryable scaling RAL backend handler.
  */
-public final class QueryableMigrationRALBackendHandler extends DatabaseRequiredBackendHandler<RALStatement> {
+public final class QueryableScalingRALBackendHandler extends DatabaseRequiredBackendHandler<RALStatement> {
     
     private final DatabaseDistSQLResultSet resultSet;
     
-    public QueryableMigrationRALBackendHandler(final RALStatement sqlStatement, final ConnectionSession connectionSession, final DatabaseDistSQLResultSet resultSet) {
+    public QueryableScalingRALBackendHandler(final RALStatement sqlStatement, final ConnectionSession connectionSession, final DatabaseDistSQLResultSet resultSet) {
         super(sqlStatement, connectionSession);
         this.resultSet = resultSet;
     }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandlerFactory.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandlerFactory.java
@@ -27,10 +27,10 @@ import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPIRegistry;
 import java.util.Properties;
 
 /**
- * Queryable migration RAL backend handler factory.
+ * Queryable scaling RAL backend handler factory.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class QueryableMigrationRALBackendHandlerFactory {
+public final class QueryableScalingRALBackendHandlerFactory {
     
     static {
         ShardingSphereServiceLoader.register(DistSQLResultSet.class);

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
@@ -19,11 +19,8 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.up
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.apache.shardingsphere.dialect.exception.syntax.database.NoDatabaseSelectedException;
-import org.apache.shardingsphere.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdaterFactory;
-import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.handler.ProxyBackendHandler;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
@@ -44,21 +41,11 @@ public final class UpdatableScalingRALBackendHandler implements ProxyBackendHand
     @Override
     public ResponseHeader execute() {
         String databaseName = getDatabaseName(connectionSession);
-        checkDatabaseName(databaseName);
         RALUpdaterFactory.getInstance(sqlStatement.getClass()).executeUpdate(databaseName, sqlStatement);
         return new UpdateResponseHeader(sqlStatement);
     }
     
     private String getDatabaseName(final ConnectionSession connectionSession) {
         return connectionSession.getDatabaseName();
-    }
-    
-    private void checkDatabaseName(final String databaseName) {
-        if (null == databaseName) {
-            throw new NoDatabaseSelectedException();
-        }
-        if (!ProxyContext.getInstance().databaseExists(databaseName)) {
-            throw new UnknownDatabaseException(databaseName);
-        }
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
@@ -30,12 +30,11 @@ import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResp
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
 /**
- * Updatable migration RAL backend handler factory.
+ * Updatable scaling RAL backend handler factory.
  */
 @RequiredArgsConstructor
 @Setter
-// TODO rename, and also similar ones
-public final class UpdatableMigrationRALBackendHandler implements ProxyBackendHandler {
+public final class UpdatableScalingRALBackendHandler implements ProxyBackendHandler {
     
     private final UpdatableScalingRALStatement sqlStatement;
     

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandlerFactoryTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandlerFactoryTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
-public final class QueryableMigrationRALBackendHandlerFactoryTest {
+public final class QueryableScalingRALBackendHandlerFactoryTest {
     
     @Test
     public void assertNewInstance() {
-        assertThat(QueryableMigrationRALBackendHandlerFactory.newInstance(new QueryableScalingFixtureRALStatement()), instanceOf(QueryableScalingFixtureQueryResultSet.class));
+        assertThat(QueryableScalingRALBackendHandlerFactory.newInstance(new QueryableScalingFixtureRALStatement()), instanceOf(QueryableScalingFixtureQueryResultSet.class));
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
- Recover RAL backend handler class name
- Remove checkDatabaseName in UpdatableScalingRALBackendHandler. Reivse previous PR 20286
