### PR TITLE
Impl create/alter/show ProcessConfiguration in pipeline job API

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineProcessConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineProcessConfiguration.java
@@ -36,4 +36,26 @@ public final class YamlPipelineProcessConfiguration implements YamlConfiguration
     private YamlPipelineWriteConfiguration write;
     
     private YamlAlgorithmConfiguration streamChannel;
+    
+    /**
+     * Copy non-null fields from another.
+     *
+     * @param another another configuration
+     */
+    // TODO add unit test
+    public void copyNonNullFields(final YamlPipelineProcessConfiguration another) {
+        if (null == read) {
+            read = another.getRead();
+        } else {
+            read.copyNonNullFields(another.getRead());
+        }
+        if (null == write) {
+            write = another.getWrite();
+        } else {
+            write.copyNonNullFields(another.getWrite());
+        }
+        if (null == streamChannel) {
+            streamChannel = another.getStreamChannel();
+        }
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineReadConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineReadConfiguration.java
@@ -64,4 +64,27 @@ public final class YamlPipelineReadConfiguration implements YamlConfiguration {
             shardingSize = DEFAULT_SHARDING_SIZE;
         }
     }
+    
+    /**
+     * Copy non-null fields from another.
+     *
+     * @param another another configuration
+     */
+    public void copyNonNullFields(final YamlPipelineReadConfiguration another) {
+        if (null == another) {
+            return;
+        }
+        if (null != another.getWorkerThread()) {
+            workerThread = another.getWorkerThread();
+        }
+        if (null != another.getBatchSize()) {
+            batchSize = another.getBatchSize();
+        }
+        if (null != another.getShardingSize()) {
+            shardingSize = another.getShardingSize();
+        }
+        if (null != another.getRateLimiter()) {
+            rateLimiter = another.getRateLimiter();
+        }
+    }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineWriteConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineWriteConfiguration.java
@@ -57,4 +57,24 @@ public final class YamlPipelineWriteConfiguration implements YamlConfiguration {
             batchSize = DEFAULT_BATCH_SIZE;
         }
     }
+    
+    /**
+     * Copy non-null fields from another.
+     *
+     * @param another another configuration
+     */
+    public void copyNonNullFields(final YamlPipelineWriteConfiguration another) {
+        if (null == another) {
+            return;
+        }
+        if (null != another.getWorkerThread()) {
+            workerThread = another.workerThread;
+        }
+        if (null != another.getBatchSize()) {
+            batchSize = another.getBatchSize();
+        }
+        if (null != another.getRateLimiter()) {
+            rateLimiter = another.getRateLimiter();
+        }
+    }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/MigrationJobPublicAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/MigrationJobPublicAPI.java
@@ -114,14 +114,14 @@ public interface MigrationJobPublicAPI extends PipelineJobPublicAPI, RequiredSPI
     void reset(String jobId);
     
     /**
-     * Update migration source resource.
+     * Add migration source resources.
      *
-     * @param sourcePropertiesMap source properties map
+     * @param dataSourcePropsMap data source properties map
      */
-    void addMigrationSourceResources(Map<String, DataSourceProperties> sourcePropertiesMap);
+    void addMigrationSourceResources(Map<String, DataSourceProperties> dataSourcePropsMap);
     
     /**
-     * Drop migration source resource.
+     * Drop migration source resources.
      *
      * @param resourceNames resource names
      */

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobPublicAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobPublicAPI.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.api;
 
 import org.apache.shardingsphere.data.pipeline.api.pojo.PipelineJobInfo;
+import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPI;
 
 import java.util.List;
@@ -26,6 +27,27 @@ import java.util.List;
  * Pipeline job public API.
  */
 public interface PipelineJobPublicAPI extends TypedSPI {
+    
+    /**
+     * Create process configuration.
+     *
+     * @param processConfig process configuration
+     */
+    void createProcessConfiguration(PipelineProcessConfiguration processConfig);
+    
+    /**
+     * Alter process configuration.
+     *
+     * @param processConfig process configuration
+     */
+    void alterProcessConfiguration(PipelineProcessConfiguration processConfig);
+    
+    /**
+     * Show process configuration.
+     *
+     * @return process configuration
+     */
+    PipelineProcessConfiguration showProcessConfiguration();
     
     /**
      * Start disabled job.

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/GovernanceRepositoryAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/GovernanceRepositoryAPI.java
@@ -110,18 +110,18 @@ public interface GovernanceRepositoryAPI {
     List<Integer> getShardingItems(String jobId);
     
     /**
-     * Get migration source data source.
+     * Get meta data data sources.
      *
      * @param jobType job type
-     * @return migration source data source
+     * @return data source properties
      */
-    String getMetaDataDataSource(JobType jobType);
+    String getMetaDataDataSources(JobType jobType);
     
     /**
-     * Persist meta data data source.
+     * Persist meta data data sources.
      *
      * @param jobType job type
-     * @param metaDataDataSource meta data data source
+     * @param metaDataDataSources data source properties
      */
-    void persistMetaDataDataSource(JobType jobType, String metaDataDataSource);
+    void persistMetaDataDataSources(JobType jobType, String metaDataDataSources);
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/GovernanceRepositoryAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/GovernanceRepositoryAPI.java
@@ -124,4 +124,20 @@ public interface GovernanceRepositoryAPI {
      * @param metaDataDataSources data source properties
      */
     void persistMetaDataDataSources(JobType jobType, String metaDataDataSources);
+    
+    /**
+     * Get meta data process configuration.
+     *
+     * @param jobType job type, nullable
+     * @return process configuration YAML text
+     */
+    String getMetaDataProcessConfiguration(JobType jobType);
+    
+    /**
+     * Persist meta data process configuration.
+     *
+     * @param jobType job type, nullable
+     * @param processConfigYamlText process configuration YAML text
+     */
+    void persistMetaDataProcessConfiguration(JobType jobType, String processConfigYamlText);
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/PipelineMetaDataPersistService.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/PipelineMetaDataPersistService.java
@@ -18,28 +18,27 @@
 package org.apache.shardingsphere.data.pipeline.core.api;
 
 import org.apache.shardingsphere.data.pipeline.api.job.JobType;
-import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
-
-import java.util.Map;
 
 /**
- * Pipeline resource API.
+ * Pipeline meta data persist service.
+ *
+ * @param <T> type of configuration
  */
-public interface PipelineResourceAPI {
+public interface PipelineMetaDataPersistService<T> {
     
     /**
-     * Get meta data data source.
+     * Load meta data.
      *
-     * @param jobType job type
-     * @return meta data data source
+     * @param jobType job type, nullable
+     * @return configurations
      */
-    Map<String, DataSourceProperties> getMetaDataDataSource(JobType jobType);
+    T load(JobType jobType);
     
     /**
-     * Persist meta data data source.
+     * Persist meta data.
      *
-     * @param jobType job type
-     * @param dataSource data source
+     * @param jobType job type, nullable
+     * @param configs configurations
      */
-    void persistMetaDataDataSource(JobType jobType, Map<String, DataSourceProperties> dataSource);
+    void persist(JobType jobType, T configs);
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
@@ -18,12 +18,10 @@
 package org.apache.shardingsphere.data.pipeline.core.api.impl;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.job.PipelineJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.config.job.yaml.YamlPipelineJobConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.api.job.PipelineJobId;
 import org.apache.shardingsphere.data.pipeline.api.pojo.PipelineJobInfo;
 import org.apache.shardingsphere.data.pipeline.core.api.GovernanceRepositoryAPI;
@@ -32,20 +30,28 @@ import org.apache.shardingsphere.data.pipeline.core.api.PipelineJobAPI;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobCreationException;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineJobNotFoundException;
+import org.apache.shardingsphere.data.pipeline.core.exception.PipelineMetaDataException;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineVerifyFailedException;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.core.metadata.node.PipelineMetaDataNode;
 import org.apache.shardingsphere.data.pipeline.core.util.PipelineDistributedBarrier;
+import org.apache.shardingsphere.data.pipeline.core.util.PipelineProcessConfigurationUtils;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.MigrationJob;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.elasticjob.lite.lifecycle.domain.JobBriefInfo;
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
+import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rule.data.pipeline.YamlPipelineProcessConfigurationSwapper;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Abstract pipeline job API impl.
@@ -55,7 +61,40 @@ public abstract class AbstractPipelineJobAPIImpl implements PipelineJobAPI {
     
     protected static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     
+    private static final YamlPipelineProcessConfigurationSwapper PROCESS_CONFIG_SWAPPER = new YamlPipelineProcessConfigurationSwapper();
+    
+    private final PipelineProcessConfigurationPersistService processConfigPersistService = new PipelineProcessConfigurationPersistService();
+    
     private final PipelineDistributedBarrier pipelineDistributedBarrier = PipelineDistributedBarrier.getInstance();
+    
+    protected abstract JobType getJobType();
+    
+    @Override
+    public void createProcessConfiguration(final PipelineProcessConfiguration processConfig) {
+        PipelineProcessConfiguration existingProcessConfig = processConfigPersistService.load(getJobType());
+        if (null != existingProcessConfig) {
+            throw new PipelineMetaDataException("Process configuration already exists");
+        }
+        processConfigPersistService.persist(getJobType(), processConfig);
+    }
+    
+    @Override
+    public void alterProcessConfiguration(final PipelineProcessConfiguration processConfig) {
+        PipelineProcessConfiguration existingProcessConfig = processConfigPersistService.load(getJobType());
+        if (null == existingProcessConfig) {
+            throw new PipelineMetaDataException("Process configuration does not exists");
+        }
+        YamlPipelineProcessConfiguration targetYamlProcessConfig = PROCESS_CONFIG_SWAPPER.swapToYamlConfiguration(existingProcessConfig);
+        targetYamlProcessConfig.copyNonNullFields(PROCESS_CONFIG_SWAPPER.swapToYamlConfiguration(processConfig));
+        processConfigPersistService.persist(getJobType(), PROCESS_CONFIG_SWAPPER.swapToObject(targetYamlProcessConfig));
+    }
+    
+    @Override
+    public PipelineProcessConfiguration showProcessConfiguration() {
+        PipelineProcessConfiguration result = processConfigPersistService.load(getJobType());
+        result = PipelineProcessConfigurationUtils.convertWithDefaultValue(result);
+        return result;
+    }
     
     @Override
     public final String marshalJobId(final PipelineJobId pipelineJobId) {

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -95,12 +95,12 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     }
     
     @Override
-    public String getMetaDataDataSource(final JobType jobType) {
+    public String getMetaDataDataSources(final JobType jobType) {
         return repository.get(PipelineMetaDataNode.getMetaDataDataSourcesPath(jobType));
     }
     
     @Override
-    public void persistMetaDataDataSource(final JobType jobType, final String metaDataDataSource) {
-        repository.persist(PipelineMetaDataNode.getMetaDataDataSourcesPath(jobType), metaDataDataSource);
+    public void persistMetaDataDataSources(final JobType jobType, final String metaDataDataSources) {
+        repository.persist(PipelineMetaDataNode.getMetaDataDataSourcesPath(jobType), metaDataDataSources);
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -103,4 +103,14 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     public void persistMetaDataDataSources(final JobType jobType, final String metaDataDataSources) {
         repository.persist(PipelineMetaDataNode.getMetaDataDataSourcesPath(jobType), metaDataDataSources);
     }
+    
+    @Override
+    public String getMetaDataProcessConfiguration(final JobType jobType) {
+        return repository.get(PipelineMetaDataNode.getMetaDataProcessConfigPath(jobType));
+    }
+    
+    @Override
+    public void persistMetaDataProcessConfiguration(final JobType jobType, final String processConfigYamlText) {
+        repository.persist(PipelineMetaDataNode.getMetaDataProcessConfigPath(jobType), processConfigYamlText);
+    }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineDataSourcePersistService.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineDataSourcePersistService.java
@@ -40,7 +40,7 @@ public final class PipelineDataSourcePersistService implements PipelineMetaDataP
     @Override
     @SuppressWarnings("unchecked")
     public Map<String, DataSourceProperties> load(final JobType jobType) {
-        String dataSourcesProperties = PipelineAPIFactory.getGovernanceRepositoryAPI().getMetaDataDataSource(jobType);
+        String dataSourcesProperties = PipelineAPIFactory.getGovernanceRepositoryAPI().getMetaDataDataSources(jobType);
         if (StringUtils.isBlank(dataSourcesProperties)) {
             return Collections.emptyMap();
         }
@@ -56,6 +56,6 @@ public final class PipelineDataSourcePersistService implements PipelineMetaDataP
         for (Entry<String, DataSourceProperties> entry : dataSourcePropsMap.entrySet()) {
             dataSourceMap.put(entry.getKey(), DATA_SOURCE_CONFIG_SWAPPER.swapToMap(entry.getValue()));
         }
-        PipelineAPIFactory.getGovernanceRepositoryAPI().persistMetaDataDataSource(jobType, YamlEngine.marshal(dataSourceMap));
+        PipelineAPIFactory.getGovernanceRepositoryAPI().persistMetaDataDataSources(jobType, YamlEngine.marshal(dataSourceMap));
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineDataSourcePersistService.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineDataSourcePersistService.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.api.impl;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.shardingsphere.data.pipeline.api.job.JobType;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
-import org.apache.shardingsphere.data.pipeline.core.api.PipelineResourceAPI;
+import org.apache.shardingsphere.data.pipeline.core.api.PipelineMetaDataPersistService;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.config.swapper.resource.YamlDataSourceConfigurationSwapper;
@@ -31,15 +31,15 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
- * Pipeline resource API implementation.
+ * Pipeline data source persist service.
  */
-public final class PipelineResourceAPIImpl implements PipelineResourceAPI {
+public final class PipelineDataSourcePersistService implements PipelineMetaDataPersistService<Map<String, DataSourceProperties>> {
     
     private static final YamlDataSourceConfigurationSwapper DATA_SOURCE_CONFIG_SWAPPER = new YamlDataSourceConfigurationSwapper();
     
     @Override
     @SuppressWarnings("unchecked")
-    public Map<String, DataSourceProperties> getMetaDataDataSource(final JobType jobType) {
+    public Map<String, DataSourceProperties> load(final JobType jobType) {
         String dataSourcesProperties = PipelineAPIFactory.getGovernanceRepositoryAPI().getMetaDataDataSource(jobType);
         if (StringUtils.isBlank(dataSourcesProperties)) {
             return Collections.emptyMap();
@@ -51,9 +51,9 @@ public final class PipelineResourceAPIImpl implements PipelineResourceAPI {
     }
     
     @Override
-    public void persistMetaDataDataSource(final JobType jobType, final Map<String, DataSourceProperties> dataSourceConfigs) {
-        Map<String, Map<String, Object>> dataSourceMap = new LinkedHashMap<>(dataSourceConfigs.size());
-        for (Entry<String, DataSourceProperties> entry : dataSourceConfigs.entrySet()) {
+    public void persist(final JobType jobType, final Map<String, DataSourceProperties> dataSourcePropsMap) {
+        Map<String, Map<String, Object>> dataSourceMap = new LinkedHashMap<>(dataSourcePropsMap.size());
+        for (Entry<String, DataSourceProperties> entry : dataSourcePropsMap.entrySet()) {
             dataSourceMap.put(entry.getKey(), DATA_SOURCE_CONFIG_SWAPPER.swapToMap(entry.getValue()));
         }
         PipelineAPIFactory.getGovernanceRepositoryAPI().persistMetaDataDataSource(jobType, YamlEngine.marshal(dataSourceMap));

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineProcessConfigurationPersistService.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineProcessConfigurationPersistService.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.api.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
+import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
+import org.apache.shardingsphere.data.pipeline.core.api.PipelineMetaDataPersistService;
+import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rule.data.pipeline.YamlPipelineProcessConfigurationSwapper;
+
+/**
+ * Pipeline process configuration persist service.
+ */
+public final class PipelineProcessConfigurationPersistService implements PipelineMetaDataPersistService<PipelineProcessConfiguration> {
+    
+    private static final YamlPipelineProcessConfigurationSwapper PROCESS_CONFIG_SWAPPER = new YamlPipelineProcessConfigurationSwapper();
+    
+    @Override
+    public PipelineProcessConfiguration load(final JobType jobType) {
+        String yamlText = PipelineAPIFactory.getGovernanceRepositoryAPI().getMetaDataProcessConfiguration(jobType);
+        if (StringUtils.isBlank(yamlText)) {
+            return null;
+        }
+        return PROCESS_CONFIG_SWAPPER.swapToObject(YamlEngine.unmarshal(yamlText, YamlPipelineProcessConfiguration.class, true));
+    }
+    
+    @Override
+    public void persist(final JobType jobType, final PipelineProcessConfiguration processConfig) {
+        String yamlText = YamlEngine.marshal(PROCESS_CONFIG_SWAPPER.swapToYamlConfiguration(processConfig));
+        PipelineAPIFactory.getGovernanceRepositoryAPI().persistMetaDataProcessConfiguration(jobType, yamlText);
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/PipelineMetaDataException.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/PipelineMetaDataException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.exception;
+
+/**
+ * Pipeline meta data exception.
+ */
+public final class PipelineMetaDataException extends RuntimeException {
+    
+    private static final long serialVersionUID = 1L;
+    
+    public PipelineMetaDataException(final String message) {
+        super(message);
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNode.java
@@ -47,7 +47,11 @@ public final class PipelineMetaDataNode {
     }
     
     private static String getMetaDataRootPath(final JobType jobType) {
-        return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobType.getLowercaseTypeName(), "metadata");
+        if (null != jobType) {
+            return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, jobType.getLowercaseTypeName(), "metadata");
+        } else {
+            return String.join("/", DataPipelineConstants.DATA_PIPELINE_ROOT, "metadata");
+        }
     }
     
     /**

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtils.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory.MemoryPipelineChannelCreator;
+import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineReadConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineWriteConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rule.data.pipeline.YamlPipelineProcessConfigurationSwapper;
+
+import java.util.Properties;
+
+/**
+ * Pipeline process configuration utils.
+ */
+public final class PipelineProcessConfigurationUtils {
+    
+    private static final YamlPipelineProcessConfigurationSwapper SWAPPER = new YamlPipelineProcessConfigurationSwapper();
+    
+    /**
+     * Convert with default value.
+     *
+     * @param originalConfig original process configuration, nullable
+     * @return process configuration
+     */
+    public static PipelineProcessConfiguration convertWithDefaultValue(final PipelineProcessConfiguration originalConfig) {
+        if (null != originalConfig && null != originalConfig.getRead() && null != originalConfig.getWrite() && null != originalConfig.getStreamChannel()) {
+            return originalConfig;
+        }
+        YamlPipelineProcessConfiguration yamlConfig = null != originalConfig ? SWAPPER.swapToYamlConfiguration(originalConfig) : new YamlPipelineProcessConfiguration();
+        if (null == yamlConfig.getRead()) {
+            yamlConfig.setRead(YamlPipelineReadConfiguration.buildWithDefaultValue());
+        } else {
+            yamlConfig.getRead().fillInNullFieldsWithDefaultValue();
+        }
+        if (null == yamlConfig.getWrite()) {
+            yamlConfig.setWrite(YamlPipelineWriteConfiguration.buildWithDefaultValue());
+        } else {
+            yamlConfig.getWrite().fillInNullFieldsWithDefaultValue();
+        }
+        if (null == yamlConfig.getStreamChannel()) {
+            yamlConfig.setStreamChannel(new YamlAlgorithmConfiguration(MemoryPipelineChannelCreator.TYPE, new Properties()));
+        }
+        return SWAPPER.swapToObject(yamlConfig);
+    }
+}

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
@@ -401,11 +401,11 @@ public final class MigrationJobAPIImpl extends AbstractPipelineJobAPIImpl implem
     }
     
     @Override
-    public void addMigrationSourceResources(final Map<String, DataSourceProperties> dataSourceProperties) {
-        log.info("Add migration source resources {}", dataSourceProperties.keySet());
+    public void addMigrationSourceResources(final Map<String, DataSourceProperties> dataSourcePropsMap) {
+        log.info("Add migration source resources {}", dataSourcePropsMap.keySet());
         Map<String, DataSourceProperties> existDataSources = dataSourcePersistService.load(JobType.MIGRATION);
-        Collection<String> duplicateDataSourceNames = new HashSet<>(dataSourceProperties.size(), 1);
-        for (Entry<String, DataSourceProperties> entry : dataSourceProperties.entrySet()) {
+        Collection<String> duplicateDataSourceNames = new HashSet<>(dataSourcePropsMap.size(), 1);
+        for (Entry<String, DataSourceProperties> entry : dataSourcePropsMap.entrySet()) {
             if (existDataSources.containsKey(entry.getKey())) {
                 duplicateDataSourceNames.add(entry.getKey());
             }
@@ -414,7 +414,7 @@ public final class MigrationJobAPIImpl extends AbstractPipelineJobAPIImpl implem
             throw new AddMigrationSourceResourceException(String.format("Duplicate resource names %s.", duplicateDataSourceNames));
         }
         Map<String, DataSourceProperties> result = new LinkedHashMap<>(existDataSources);
-        result.putAll(dataSourceProperties);
+        result.putAll(dataSourcePropsMap);
         dataSourcePersistService.persist(JobType.MIGRATION, result);
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
@@ -51,6 +51,19 @@ public final class MigrationJobAPIFixture implements MigrationJobAPI {
     }
     
     @Override
+    public void createProcessConfiguration(final PipelineProcessConfiguration processConfig) {
+    }
+    
+    @Override
+    public void alterProcessConfiguration(final PipelineProcessConfiguration processConfig) {
+    }
+    
+    @Override
+    public PipelineProcessConfiguration showProcessConfiguration() {
+        return null;
+    }
+    
+    @Override
     public void startDisabledJob(final String jobId) {
     }
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
@@ -146,7 +146,7 @@ public final class MigrationJobAPIFixture implements MigrationJobAPI {
     }
     
     @Override
-    public void addMigrationSourceResources(final Map<String, DataSourceProperties> sourcePropertiesMap) {
+    public void addMigrationSourceResources(final Map<String, DataSourceProperties> dataSourcePropsMap) {
     }
     
     @Override

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/api/impl/MigrationJobAPIImplTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/api/impl/MigrationJobAPIImplTest.java
@@ -31,7 +31,6 @@ import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncreme
 import org.apache.shardingsphere.data.pipeline.api.pojo.PipelineJobInfo;
 import org.apache.shardingsphere.data.pipeline.core.api.GovernanceRepositoryAPI;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
-import org.apache.shardingsphere.data.pipeline.core.api.PipelineResourceAPI;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DefaultPipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.datasource.creator.PipelineDataSourceCreatorFactory;
 import org.apache.shardingsphere.data.pipeline.core.exception.PipelineVerifyFailedException;
@@ -278,8 +277,8 @@ public final class MigrationJobAPIImplTest {
         Map<String, DataSourceProperties> expect = new LinkedHashMap<>(1, 1);
         expect.put("ds_0", new DataSourceProperties("com.zaxxer.hikari.HikariDataSource", props));
         jobAPI.addMigrationSourceResources(expect);
-        PipelineResourceAPI pipelineResourceAPI = new PipelineResourceAPIImpl();
-        Map<String, DataSourceProperties> actual = pipelineResourceAPI.getMetaDataDataSource(JobType.MIGRATION);
+        PipelineDataSourcePersistService persistService = new PipelineDataSourcePersistService();
+        Map<String, DataSourceProperties> actual = persistService.load(JobType.MIGRATION);
         assertTrue(actual.containsKey("ds_0"));
     }
 }

--- a/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineProcessConfigurationPersistServiceTest.java
+++ b/shardingsphere-test/shardingsphere-pipeline-test/src/test/java/org/apache/shardingsphere/data/pipeline/core/api/impl/PipelineProcessConfigurationPersistServiceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.api.impl;
+
+import org.apache.shardingsphere.data.pipeline.api.job.JobType;
+import org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory.MemoryPipelineChannelCreator;
+import org.apache.shardingsphere.data.pipeline.core.util.PipelineContextUtil;
+import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
+import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineProcessConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineReadConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineWriteConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rule.data.pipeline.YamlPipelineProcessConfigurationSwapper;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class PipelineProcessConfigurationPersistServiceTest {
+    
+    private static final YamlPipelineProcessConfigurationSwapper PROCESS_CONFIG_SWAPPER = new YamlPipelineProcessConfigurationSwapper();
+    
+    @BeforeClass
+    public static void beforeClass() {
+        PipelineContextUtil.mockModeConfigAndContextManager();
+    }
+    
+    @Test
+    public void assertLoadAndPersist() {
+        YamlPipelineProcessConfiguration yamlProcessConfig = new YamlPipelineProcessConfiguration();
+        YamlPipelineReadConfiguration yamlReadConfig = YamlPipelineReadConfiguration.buildWithDefaultValue();
+        yamlReadConfig.fillInNullFieldsWithDefaultValue();
+        yamlReadConfig.setShardingSize(10);
+        yamlProcessConfig.setRead(yamlReadConfig);
+        YamlPipelineWriteConfiguration yamlWriteConfig = YamlPipelineWriteConfiguration.buildWithDefaultValue();
+        yamlProcessConfig.setWrite(yamlWriteConfig);
+        YamlAlgorithmConfiguration yamlStreamChannel = new YamlAlgorithmConfiguration(MemoryPipelineChannelCreator.TYPE, new Properties());
+        yamlProcessConfig.setStreamChannel(yamlStreamChannel);
+        String expectedYamlText = YamlEngine.marshal(yamlProcessConfig);
+        PipelineProcessConfiguration processConfig = PROCESS_CONFIG_SWAPPER.swapToObject(yamlProcessConfig);
+        PipelineProcessConfigurationPersistService persistService = new PipelineProcessConfigurationPersistService();
+        JobType jobType = JobType.MIGRATION;
+        persistService.persist(jobType, processConfig);
+        String actualYamlText = YamlEngine.marshal(PROCESS_CONFIG_SWAPPER.swapToYamlConfiguration(persistService.load(jobType)));
+        assertThat(actualYamlText, is(expectedYamlText));
+    }
+}


### PR DESCRIPTION
Part of #19421. And also to implement new feature for migration job.

Changes proposed in this pull request:
- Extract PipelineMetaDataPersistService interface, used for `dataSources` and `processConfig` impl; Refactor dataSources impl; Add processConfig impl PipelineProcessConfigurationPersistService
- Impl create/alter/show ProcessConfiguration in pipeline job API
