### PR TITLE
[Doc Error]correct [dev list]link

### DIFF
--- a/docs/community/content/contribute/contributor.en.md
+++ b/docs/community/content/contribute/contributor.en.md
@@ -44,7 +44,7 @@ When you pull the latest code from ShardingSphere and create new branch later, y
 
  - Please choose the issue to be edited. If it is a new issue discovered or a new function enhancement to offer, please create an issue and set the right label for it.
  - After choosing the relevant issue, please reply with a deadline to indicate that you are working on it.
- - Find a mentor from the [Developer List](/en/contribute/contributor/) and he/she will give you feedback about the design and the implementation of function in time.
+ - Find a mentor from the [Developer List](en/team) and he/she will give you feedback about the design and the implementation of function in time.
 
 **3. Create Branch**
 


### PR DESCRIPTION
correct [dev list]link to `TEAM`

Fixes https://github.com/apache/shardingsphere/issues/20405

Changes proposed in this pull request:
- Fix `Developer List` link error in https://shardingsphere.apache.org/community/en/contribute/contributor/#developer-flow 
-
-
