### PR TITLE
MIGRATE TABLE DistSQL support define schema name

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
@@ -40,8 +40,8 @@ public final class MigrateTableUpdater implements RALUpdater<MigrateTableStateme
     public void executeUpdate(final String databaseName, final MigrateTableStatement sqlStatement) {
         log.info("start migrate job by {}", sqlStatement);
         String targetDatabaseName = ObjectUtils.defaultIfNull(sqlStatement.getTargetDatabaseName(), databaseName);
-        CreateMigrationJobParameter createMigrationJobParameter = new CreateMigrationJobParameter(sqlStatement.getSourceDatabaseName(), sqlStatement.getSourceTableName(),
-                targetDatabaseName, sqlStatement.getTargetTableName());
+        CreateMigrationJobParameter createMigrationJobParameter = new CreateMigrationJobParameter(sqlStatement.getSourceDatabaseName(), sqlStatement.getSourceSchemaName(),
+                sqlStatement.getSourceTableName(), targetDatabaseName, sqlStatement.getTargetTableName());
         JOB_API.createJobAndStart(createMigrationJobParameter);
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/MigrateTableUpdater.java
@@ -40,7 +40,7 @@ public final class MigrateTableUpdater implements RALUpdater<MigrateTableStateme
     public void executeUpdate(final String databaseName, final MigrateTableStatement sqlStatement) {
         log.info("start migrate job by {}", sqlStatement);
         String targetDatabaseName = ObjectUtils.defaultIfNull(sqlStatement.getTargetDatabaseName(), databaseName);
-        CreateMigrationJobParameter createMigrationJobParameter = new CreateMigrationJobParameter(sqlStatement.getSourceDatabaseName(), sqlStatement.getSourceSchemaName(),
+        CreateMigrationJobParameter createMigrationJobParameter = new CreateMigrationJobParameter(sqlStatement.getSourceResourceName(), sqlStatement.getSourceSchemaName(),
                 sqlStatement.getSourceTableName(), targetDatabaseName, sqlStatement.getTargetTableName());
         JOB_API.createJobAndStart(createMigrationJobParameter);
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/migration/RALStatement.g4
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/antlr4/imports/migration/RALStatement.g4
@@ -72,7 +72,7 @@ jobId
     ;
 
 sourceTableName
-    : (owner DOT)? name
+    : owner DOT (schema DOT)? name
     ;
 
 targetTableName
@@ -80,6 +80,10 @@ targetTableName
     ;
 
 owner
+    : identifier
+    ;
+
+schema
     : identifier
     ;
 

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
@@ -100,7 +100,12 @@ public final class MigrationDistSQLStatementVisitor extends MigrationDistSQLStat
     public ASTNode visitMigrateTable(final MigrateTableContext ctx) {
         List<String> source = Splitter.on('.').splitToList(getIdentifierValue(ctx.sourceTableName()));
         List<String> target = Splitter.on('.').splitToList(getIdentifierValue(ctx.targetTableName()));
-        return new MigrateTableStatement(source.size() > 1 ? source.get(0) : null, source.get(source.size() - 1), target.size() > 1 ? target.get(0) : null, target.get(target.size() - 1));
+        String sourceDatabaseName = source.get(0);
+        String sourceSchemaName = 3 == source.size() ? source.get(1) : null;
+        String sourceTableName = source.get(source.size() - 1);
+        String targetDatabaseName = target.size() > 1 ? target.get(0) : null;
+        String targetTableName = target.get(target.size() - 1);
+        return new MigrateTableStatement(sourceDatabaseName, sourceSchemaName, sourceTableName, targetDatabaseName, targetTableName);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
@@ -100,12 +100,12 @@ public final class MigrationDistSQLStatementVisitor extends MigrationDistSQLStat
     public ASTNode visitMigrateTable(final MigrateTableContext ctx) {
         List<String> source = Splitter.on('.').splitToList(getIdentifierValue(ctx.sourceTableName()));
         List<String> target = Splitter.on('.').splitToList(getIdentifierValue(ctx.targetTableName()));
-        String sourceDatabaseName = source.get(0);
+        String sourceResourceName = source.get(0);
         String sourceSchemaName = 3 == source.size() ? source.get(1) : null;
         String sourceTableName = source.get(source.size() - 1);
         String targetDatabaseName = target.size() > 1 ? target.get(0) : null;
         String targetTableName = target.get(target.size() - 1);
-        return new MigrateTableStatement(sourceDatabaseName, sourceSchemaName, sourceTableName, targetDatabaseName, targetTableName);
+        return new MigrateTableStatement(sourceResourceName, sourceSchemaName, sourceTableName, targetDatabaseName, targetTableName);
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/MigrateTableStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/MigrateTableStatement.java
@@ -32,6 +32,8 @@ public final class MigrateTableStatement extends UpdatableScalingRALStatement {
     
     private final String sourceDatabaseName;
     
+    private final String sourceSchemaName;
+    
     private final String sourceTableName;
     
     private final String targetDatabaseName;

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/MigrateTableStatement.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/MigrateTableStatement.java
@@ -30,7 +30,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableS
 @ToString
 public final class MigrateTableStatement extends UpdatableScalingRALStatement {
     
-    private final String sourceDatabaseName;
+    private final String sourceResourceName;
     
     private final String sourceSchemaName;
     

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/pojo/CreateMigrationJobParameter.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/pojo/CreateMigrationJobParameter.java
@@ -26,6 +26,8 @@ public final class CreateMigrationJobParameter {
     
     private final String sourceResourceName;
     
+    private final String sourceSchemaName;
+    
     private final String sourceTableName;
     
     private final String targetDatabaseName;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/MigrateTableStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/MigrateTableStatementAssert.java
@@ -37,7 +37,7 @@ public final class MigrateTableStatementAssert {
      * @param expected expected migrate table statement test case
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final MigrateTableStatement actual, final MigrateTableStatementTestCase expected) {
-        assertThat(assertContext.getText("source database name does not match"), actual.getSourceDatabaseName(), is(expected.getSourceDatabaseName()));
+        assertThat(assertContext.getText("source database name does not match"), actual.getSourceResourceName(), is(expected.getSourceResourceName()));
         assertThat(assertContext.getText("source schema name does not match"), actual.getSourceSchemaName(), is(expected.getSourceSchemaName()));
         assertThat(assertContext.getText("source table name does not match"), actual.getSourceTableName(), is(expected.getSourceTableName()));
         assertThat(assertContext.getText("target database name does not match"), actual.getTargetDatabaseName(), is(expected.getTargetDatabaseName()));

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/MigrateTableStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/MigrateTableStatementAssert.java
@@ -38,6 +38,7 @@ public final class MigrateTableStatementAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final MigrateTableStatement actual, final MigrateTableStatementTestCase expected) {
         assertThat(assertContext.getText("source database name does not match"), actual.getSourceDatabaseName(), is(expected.getSourceDatabaseName()));
+        assertThat(assertContext.getText("source schema name does not match"), actual.getSourceSchemaName(), is(expected.getSourceSchemaName()));
         assertThat(assertContext.getText("source table name does not match"), actual.getSourceTableName(), is(expected.getSourceTableName()));
         assertThat(assertContext.getText("target database name does not match"), actual.getTargetDatabaseName(), is(expected.getTargetDatabaseName()));
         assertThat(assertContext.getText("target table name does not match"), actual.getTargetTableName(), is(expected.getTargetTableName()));

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/MigrateTableStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/MigrateTableStatementTestCase.java
@@ -36,6 +36,9 @@ public final class MigrateTableStatementTestCase extends SQLParserTestCase {
     @XmlElement(name = "source-table-name")
     private String sourceTableName;
     
+    @XmlElement(name = "source-schema-name")
+    private String sourceSchemaName;
+    
     @XmlElement(name = "target-database-name")
     private String targetDatabaseName;
     

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/MigrateTableStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/MigrateTableStatementTestCase.java
@@ -30,8 +30,8 @@ import javax.xml.bind.annotation.XmlElement;
 @Setter
 public final class MigrateTableStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "source-database-name")
-    private String sourceDatabaseName;
+    @XmlElement(name = "source-resource-name")
+    private String sourceResourceName;
     
     @XmlElement(name = "source-table-name")
     private String sourceTableName;

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
@@ -37,14 +37,29 @@
         <job-id>123</job-id>
     </show-migration-status>
     
-    <migrate-table sql-case-id="migrate-table-without-target-db">
+    <migrate-table sql-case-id="migrate-table-without-schema-target-db">
         <source-database-name>ds_0</source-database-name>
+        <source-table-name>t_order</source-table-name>
+        <target-table-name>t_order</target-table-name>
+    </migrate-table>
+    
+    <migrate-table sql-case-id="migrate-table-with-schema">
+        <source-database-name>ds_0</source-database-name>
+        <source-schema-name>public</source-schema-name>
         <source-table-name>t_order</source-table-name>
         <target-table-name>t_order</target-table-name>
     </migrate-table>
     
     <migrate-table sql-case-id="migrate-table-with-target-db">
         <source-database-name>ds_0</source-database-name>
+        <source-table-name>t_order</source-table-name>
+        <target-database-name>sharding_db</target-database-name>
+        <target-table-name>t_order</target-table-name>
+    </migrate-table>
+    
+    <migrate-table sql-case-id="migrate-table-with-schema-target-db">
+        <source-database-name>ds_0</source-database-name>
+        <source-schema-name>public</source-schema-name>
         <source-table-name>t_order</source-table-name>
         <target-database-name>sharding_db</target-database-name>
         <target-table-name>t_order</target-table-name>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
@@ -38,27 +38,27 @@
     </show-migration-status>
     
     <migrate-table sql-case-id="migrate-table-without-schema-target-db">
-        <source-database-name>ds_0</source-database-name>
+        <source-resource-name>ds_0</source-resource-name>
         <source-table-name>t_order</source-table-name>
         <target-table-name>t_order</target-table-name>
     </migrate-table>
     
     <migrate-table sql-case-id="migrate-table-with-schema">
-        <source-database-name>ds_0</source-database-name>
+        <source-resource-name>ds_0</source-resource-name>
         <source-schema-name>public</source-schema-name>
         <source-table-name>t_order</source-table-name>
         <target-table-name>t_order</target-table-name>
     </migrate-table>
     
     <migrate-table sql-case-id="migrate-table-with-target-db">
-        <source-database-name>ds_0</source-database-name>
+        <source-resource-name>ds_0</source-resource-name>
         <source-table-name>t_order</source-table-name>
         <target-database-name>sharding_db</target-database-name>
         <target-table-name>t_order</target-table-name>
     </migrate-table>
     
     <migrate-table sql-case-id="migrate-table-with-schema-target-db">
-        <source-database-name>ds_0</source-database-name>
+        <source-resource-name>ds_0</source-resource-name>
         <source-schema-name>public</source-schema-name>
         <source-table-name>t_order</source-table-name>
         <target-database-name>sharding_db</target-database-name>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/migration.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/migration.xml
@@ -23,8 +23,10 @@
     <distsql-case id="show-migration-status" value="SHOW MIGRATION STATUS 123;" />
     <distsql-case id="check-migration-with-type" value="CHECK MIGRATION 123 by TYPE(name='DEFAULT', PROPERTIES('test-property'='4'));" />
     
-    <distsql-case id="migrate-table-without-target-db" value="MIGRATE TABLE ds_0.t_order INTO t_order;" />
+    <distsql-case id="migrate-table-without-schema-target-db" value="MIGRATE TABLE ds_0.t_order INTO t_order;" />
+    <distsql-case id="migrate-table-with-schema" value="MIGRATE TABLE ds_0.public.t_order INTO t_order;" />
     <distsql-case id="migrate-table-with-target-db" value="MIGRATE TABLE ds_0.t_order INTO sharding_db.t_order;" />
+    <distsql-case id="migrate-table-with-schema-target-db" value="MIGRATE TABLE ds_0.public.t_order INTO sharding_db.t_order;" />
     <distsql-case id="stop-migration-source-writing" value="STOP MIGRATION SOURCE WRITING 123;" />
     <distsql-case id="restore-migration-source-writing" value="RESTORE MIGRATION SOURCE WRITING 123;" />
     <distsql-case id="apply-migration" value="APPLY MIGRATION 123;" />


### PR DESCRIPTION
Related to #20270.

e.g.
```
MIGRATE TABLE ds_0.public.t_order INTO sharding_db.t_order;
```

Changes proposed in this pull request:
- Add schema support for MIGRATE TABLE DistSQL
