### PR TITLE
fix navicat throw "There is no primary key here." (#20437)

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilder.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilder.java
@@ -44,7 +44,7 @@ public final class MySQLQueryHeaderBuilder implements QueryHeaderBuilder {
             tableName = getLogicTableName(database, actualTableName);
             ShardingSphereSchema schema = database.getSchema(schemaName);
             primaryKey = null != schema
-                    && Optional.ofNullable(schema.get(tableName)).map(optional -> optional.getColumns().get(columnName.toLowerCase())).map(ShardingSphereColumn::isPrimaryKey).orElse(false);
+                    && Optional.ofNullable(schema.get(actualTableName)).map(optional -> optional.getColumns().get(columnName.toLowerCase())).map(ShardingSphereColumn::isPrimaryKey).orElse(false);
         } else {
             tableName = actualTableName;
             primaryKey = false;


### PR DESCRIPTION
.Verify whether the column is a primary key. The field list should be obtained from the real table

Fixes #20437.

Changes proposed in this pull request:
- Verify whether the column is a primary key. The field list should be obtained from the real table.
-
-
