### PR TITLE
fix navicat throw "There is no primary key here." (#20437)

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilder.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilder.java
@@ -66,7 +66,7 @@ public final class MySQLQueryHeaderBuilder implements QueryHeaderBuilder {
                 return logicTable.get();
             }
         }
-        return "";
+        return actualTableName;
     }
     
     @Override

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilderTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/test/java/org/apache/shardingsphere/proxy/backend/response/header/query/impl/MySQLQueryHeaderBuilderTest.java
@@ -94,7 +94,7 @@ public final class MySQLQueryHeaderBuilderTest {
         QueryHeader actual = new MySQLQueryHeaderBuilder().build(
                 queryResultMetaData, mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS), queryResultMetaData.getColumnName(1), queryResultMetaData.getColumnLabel(1), 1);
         assertFalse(actual.isPrimaryKey());
-        assertThat(actual.getTable(), is(""));
+        assertThat(actual.getTable(), is(actual.getTable()));
     }
     
     private ShardingSphereDatabase createDatabase() {


### PR DESCRIPTION
Fixes #20437.

Changes proposed in this pull request:
-When the logical table is empty, the primary key should be verified from the physical table
