### PR TITLE
Add DROP MIGRATION PROCESS CONFIGURATION DistSQL and api impl

### DIFF
--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/imports/RALStatement.g4
@@ -119,6 +119,10 @@ alterMigrationProcessConfiguration
     : ALTER MIGRATION PROCESS CONFIGURATION migrationProcessConfiguration?
     ;
 
+dropMigrationProcessConfiguration
+    : DROP MIGRATION PROCESS CONFIGURATION confPath
+    ;
+
 migrationProcessConfiguration
     : LP readDefinition? (COMMA? writeDefinition)? (COMMA? streamChannel)? RP
     ;
@@ -149,6 +153,10 @@ rateLimiter
 
 streamChannel
     : STREAM_CHANNEL LP algorithmDefinition RP
+    ;
+
+confPath
+    : STRING
     ;
 
 filePath

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/KernelDistSQLStatement.g4
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/antlr4/org/apache/shardingsphere/distsql/parser/autogen/KernelDistSQLStatement.g4
@@ -61,5 +61,6 @@ execute
     | showMigrationProcessConfiguration
     | createMigrationProcessConfiguration
     | alterMigrationProcessConfiguration
+    | dropMigrationProcessConfiguration
     ) SEMI?
     ;

--- a/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-parser/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.distsql.parser.core.kernel;
 
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.shardingsphere.distsql.parser.autogen.KernelDistSQLStatementBaseVisitor;
+import org.apache.shardingsphere.distsql.parser.autogen.KernelDistSQLStatementParser;
 import org.apache.shardingsphere.distsql.parser.autogen.KernelDistSQLStatementParser.AddResourceContext;
 import org.apache.shardingsphere.distsql.parser.autogen.KernelDistSQLStatementParser.AlgorithmDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.autogen.KernelDistSQLStatementParser.AlterDefaultSingleTableRuleContext;
@@ -108,6 +109,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.AlterTra
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.ApplyDistSQLStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.CreateMigrationProcessConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.DiscardDistSQLStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.DropMigrationProcessConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.ImportDatabaseConfigurationStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.LabelInstanceStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.PrepareDistSQLStatement;
@@ -433,6 +435,11 @@ public final class KernelDistSQLStatementVisitor extends KernelDistSQLStatementB
     public ASTNode visitAlterMigrationProcessConfiguration(final AlterMigrationProcessConfigurationContext ctx) {
         MigrationProcessConfigurationSegment segment = null == ctx.migrationProcessConfiguration() ? null : (MigrationProcessConfigurationSegment) visit(ctx.migrationProcessConfiguration());
         return new AlterMigrationProcessConfigurationStatement(segment);
+    }
+    
+    @Override
+    public ASTNode visitDropMigrationProcessConfiguration(final KernelDistSQLStatementParser.DropMigrationProcessConfigurationContext ctx) {
+        return new DropMigrationProcessConfigurationStatement(getIdentifierValue(ctx.confPath()));
     }
     
     @Override

--- a/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/updatable/DropMigrationProcessConfigurationStatement.java
+++ b/shardingsphere-distsql/shardingsphere-distsql-statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/updatable/DropMigrationProcessConfigurationStatement.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.distsql.parser.statement.ral.updatable;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
+
+/**
+ * Drop migration process configuration statement.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class DropMigrationProcessConfigurationStatement extends UpdatableScalingRALStatement {
+    
+    private final String confPath;
+}

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineProcessConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineProcessConfiguration.java
@@ -47,9 +47,6 @@ public final class YamlPipelineProcessConfiguration implements YamlConfiguration
         if (null == another) {
             return;
         }
-        if (isAllFieldsNull(another)) {
-            setAllFieldsNull(this);
-        }
         if (null == read) {
             read = another.read;
         } else {
@@ -65,13 +62,33 @@ public final class YamlPipelineProcessConfiguration implements YamlConfiguration
         }
     }
     
-    private boolean isAllFieldsNull(final YamlPipelineProcessConfiguration config) {
-        return null == config.read && null == config.write && null == config.streamChannel;
+    /**
+     * Set all fields null.
+     */
+    public void setAllFieldsNull() {
+        read = null;
+        write = null;
+        streamChannel = null;
     }
     
-    private void setAllFieldsNull(final YamlPipelineProcessConfiguration config) {
-        config.read = null;
-        config.write = null;
-        config.streamChannel = null;
+    /**
+     * Set field to null.
+     *
+     * @param nodeName node name
+     */
+    public void setFieldNull(final String nodeName) {
+        switch (nodeName.toUpperCase()) {
+            case "READ":
+                read = null;
+                break;
+            case "WRITE":
+                write = null;
+                break;
+            case "STREAM_CHANNEL":
+                streamChannel = null;
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineReadConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineReadConfiguration.java
@@ -33,11 +33,11 @@ public final class YamlPipelineReadConfiguration implements YamlConfiguration {
     
     private static final Integer DEFAULT_SHARDING_SIZE = 1000_0000;
     
-    private Integer workerThread = DEFAULT_WORKER_THREAD;
+    private Integer workerThread;
     
-    private Integer batchSize = DEFAULT_BATCH_SIZE;
+    private Integer batchSize;
     
-    private Integer shardingSize = DEFAULT_SHARDING_SIZE;
+    private Integer shardingSize;
     
     private YamlAlgorithmConfiguration rateLimiter;
     
@@ -47,7 +47,11 @@ public final class YamlPipelineReadConfiguration implements YamlConfiguration {
      * @return read configuration
      */
     public static YamlPipelineReadConfiguration buildWithDefaultValue() {
-        return new YamlPipelineReadConfiguration();
+        YamlPipelineReadConfiguration result = new YamlPipelineReadConfiguration();
+        result.workerThread = DEFAULT_WORKER_THREAD;
+        result.batchSize = DEFAULT_BATCH_SIZE;
+        result.shardingSize = DEFAULT_SHARDING_SIZE;
+        return result;
     }
     
     /**
@@ -74,9 +78,6 @@ public final class YamlPipelineReadConfiguration implements YamlConfiguration {
         if (null == another) {
             return;
         }
-        if (isAllFieldsNull(another)) {
-            setAllFieldsNull(this);
-        }
         if (null != another.workerThread) {
             workerThread = another.workerThread;
         }
@@ -91,14 +92,27 @@ public final class YamlPipelineReadConfiguration implements YamlConfiguration {
         }
     }
     
-    private boolean isAllFieldsNull(final YamlPipelineReadConfiguration config) {
-        return null == config.workerThread && null == config.batchSize && null == config.shardingSize && null == config.rateLimiter;
-    }
-    
-    private void setAllFieldsNull(final YamlPipelineReadConfiguration config) {
-        config.workerThread = null;
-        config.batchSize = null;
-        config.shardingSize = null;
-        config.rateLimiter = null;
+    /**
+     * Set field to null.
+     *
+     * @param nodeName node name
+     */
+    public void setFieldNull(final String nodeName) {
+        switch (nodeName.toUpperCase()) {
+            case "WORKER_THREAD":
+                workerThread = null;
+                break;
+            case "BATCH_SIZE":
+                batchSize = null;
+                break;
+            case "SHARDING_SIZE":
+                shardingSize = null;
+                break;
+            case "RATE_LIMITER":
+                rateLimiter = null;
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineWriteConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/data/pipeline/YamlPipelineWriteConfiguration.java
@@ -31,9 +31,9 @@ public final class YamlPipelineWriteConfiguration implements YamlConfiguration {
     
     private static final Integer DEFAULT_BATCH_SIZE = 1000;
     
-    private Integer workerThread = DEFAULT_WORKER_THREAD;
+    private Integer workerThread;
     
-    private Integer batchSize = DEFAULT_BATCH_SIZE;
+    private Integer batchSize;
     
     private YamlAlgorithmConfiguration rateLimiter;
     
@@ -43,7 +43,10 @@ public final class YamlPipelineWriteConfiguration implements YamlConfiguration {
      * @return write configuration
      */
     public static YamlPipelineWriteConfiguration buildWithDefaultValue() {
-        return new YamlPipelineWriteConfiguration();
+        YamlPipelineWriteConfiguration result = new YamlPipelineWriteConfiguration();
+        result.workerThread = DEFAULT_WORKER_THREAD;
+        result.batchSize = DEFAULT_BATCH_SIZE;
+        return result;
     }
     
     /**
@@ -67,9 +70,6 @@ public final class YamlPipelineWriteConfiguration implements YamlConfiguration {
         if (null == another) {
             return;
         }
-        if (isAllFieldsNull(another)) {
-            setAllFieldsNull(this);
-        }
         if (null != another.workerThread) {
             workerThread = another.workerThread;
         }
@@ -81,13 +81,24 @@ public final class YamlPipelineWriteConfiguration implements YamlConfiguration {
         }
     }
     
-    private boolean isAllFieldsNull(final YamlPipelineWriteConfiguration config) {
-        return null == config.workerThread && null == config.batchSize && null == config.rateLimiter;
-    }
-    
-    private void setAllFieldsNull(final YamlPipelineWriteConfiguration config) {
-        config.workerThread = null;
-        config.batchSize = null;
-        config.rateLimiter = null;
+    /**
+     * Set field to null.
+     *
+     * @param nodeName node name
+     */
+    public void setFieldNull(final String nodeName) {
+        switch (nodeName.toUpperCase()) {
+            case "WORKER_THREAD":
+                workerThread = null;
+                break;
+            case "BATCH_SIZE":
+                batchSize = null;
+                break;
+            case "RATE_LIMITER":
+                rateLimiter = null;
+                break;
+            default:
+                break;
+        }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobPublicAPI.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-api/src/main/java/org/apache/shardingsphere/data/pipeline/api/PipelineJobPublicAPI.java
@@ -43,6 +43,13 @@ public interface PipelineJobPublicAPI extends TypedSPI {
     void alterProcessConfiguration(PipelineProcessConfiguration processConfig);
     
     /**
+     * Drop process configuration.
+     *
+     * @param confPath configuration path. e.g. <code>/</code>, <code>/READ</code>, <code>/READ/RATE_LIMITER</code>
+     */
+    void dropProcessConfiguration(String confPath);
+    
+    /**
      * Show process configuration.
      *
      * @return process configuration, non-null

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtils.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtils.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.util;
 
+import com.google.common.base.Splitter;
 import org.apache.shardingsphere.data.pipeline.core.ingest.channel.memory.MemoryPipelineChannelCreator;
 import org.apache.shardingsphere.infra.config.rule.data.pipeline.PipelineProcessConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
@@ -25,7 +26,9 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipeli
 import org.apache.shardingsphere.infra.yaml.config.pojo.data.pipeline.YamlPipelineWriteConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.rule.data.pipeline.YamlPipelineProcessConfigurationSwapper;
 
+import java.util.List;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /**
  * Pipeline process configuration utils.
@@ -34,6 +37,10 @@ public final class PipelineProcessConfigurationUtils {
     
     private static final YamlPipelineProcessConfigurationSwapper SWAPPER = new YamlPipelineProcessConfigurationSwapper();
     
+    private static final String CONF_PATH_REGEX = "^/|(/[a-zA-Z_]+)+$";
+    
+    private static final Pattern CONF_PATH_PATTERN = Pattern.compile(CONF_PATH_REGEX);
+    
     /**
      * Convert with default value.
      *
@@ -41,9 +48,6 @@ public final class PipelineProcessConfigurationUtils {
      * @return process configuration
      */
     public static PipelineProcessConfiguration convertWithDefaultValue(final PipelineProcessConfiguration originalConfig) {
-        if (null != originalConfig && null != originalConfig.getRead() && null != originalConfig.getWrite() && null != originalConfig.getStreamChannel()) {
-            return originalConfig;
-        }
         YamlPipelineProcessConfiguration yamlConfig = null != originalConfig ? SWAPPER.swapToYamlConfiguration(originalConfig) : new YamlPipelineProcessConfiguration();
         fillInDefaultValue(yamlConfig);
         return SWAPPER.swapToObject(yamlConfig);
@@ -69,6 +73,44 @@ public final class PipelineProcessConfigurationUtils {
             Properties props = new Properties();
             props.put(MemoryPipelineChannelCreator.BLOCK_QUEUE_SIZE_KEY, MemoryPipelineChannelCreator.BLOCK_QUEUE_SIZE_DEFAULT_VALUE);
             yamlConfig.setStreamChannel(new YamlAlgorithmConfiguration(MemoryPipelineChannelCreator.TYPE, props));
+        }
+    }
+    
+    /**
+     * Verify configuration path valid or not.
+     *
+     * @param confPath configuration path
+     * @throws IllegalArgumentException if path doesn't match pattern
+     */
+    public static void verifyConfPath(final String confPath) {
+        if (!CONF_PATH_PATTERN.matcher(confPath).matches()) {
+            throw new IllegalArgumentException("Invalid confPath, it doesn't match pattern: " + CONF_PATH_REGEX);
+        }
+    }
+    
+    /**
+     * Set fields to null by configuration path.
+     *
+     * @param targetYamlProcessConfig target YAML process configuration
+     * @param confPath configuration path, e.g. <code>/</code>, <code>/READ</code>, <code>/READ/RATE_LIMITER</code>
+     */
+    public static void setFieldsNullByConfPath(final YamlPipelineProcessConfiguration targetYamlProcessConfig, final String confPath) {
+        List<String> confPathNodes = Splitter.on('/').splitToList(confPath);
+        if (2 == confPathNodes.size()) {
+            String levelOne = confPathNodes.get(1).toUpperCase();
+            if (levelOne.isEmpty()) {
+                targetYamlProcessConfig.setAllFieldsNull();
+            } else {
+                targetYamlProcessConfig.setFieldNull(levelOne);
+            }
+        } else if (3 == confPathNodes.size()) {
+            String levelOne = confPathNodes.get(1).toUpperCase();
+            String levelTwo = confPathNodes.get(2).toUpperCase();
+            if ("READ".equals(levelOne) && null != targetYamlProcessConfig.getRead()) {
+                targetYamlProcessConfig.getRead().setFieldNull(levelTwo);
+            } else if ("WRITE".equals(levelOne) && null != targetYamlProcessConfig.getWrite()) {
+                targetYamlProcessConfig.getWrite().setFieldNull(levelTwo);
+            }
         }
     }
 }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/fixture/MigrationJobAPIFixture.java
@@ -60,6 +60,10 @@ public final class MigrationJobAPIFixture implements MigrationJobAPI {
     }
     
     @Override
+    public void dropProcessConfiguration(final String confPath) {
+    }
+    
+    @Override
     public PipelineProcessConfiguration showProcessConfiguration() {
         return null;
     }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtilsTest.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/test/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineProcessConfigurationUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class PipelineProcessConfigurationUtilsTest {
+    
+    @Test
+    public void assertVerifyConfPathSuccess() {
+        for (String each : Arrays.asList("/", "/READ", "/READ/RATE_LIMITER")) {
+            PipelineProcessConfigurationUtils.verifyConfPath(each);
+        }
+    }
+    
+    @Test
+    public void assertVerifyConfPathFailed() {
+        Collection<String> confPaths = Arrays.asList("", "//", "READ", "/READ/");
+        int failCount = 0;
+        for (String each : confPaths) {
+            try {
+                PipelineProcessConfigurationUtils.verifyConfPath(each);
+            } catch (final IllegalArgumentException ex) {
+                ++failCount;
+            }
+        }
+        assertThat(failCount, is(confPaths.size()));
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/DropMigrationProcessConfigurationUpdater.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/DropMigrationProcessConfigurationUpdater.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable;
+
+import org.apache.shardingsphere.data.pipeline.api.MigrationJobPublicAPI;
+import org.apache.shardingsphere.data.pipeline.api.PipelineJobPublicAPIFactory;
+import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.DropMigrationProcessConfigurationStatement;
+import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
+
+/**
+ * Drop migration process configuration updater.
+ */
+public final class DropMigrationProcessConfigurationUpdater implements RALUpdater<DropMigrationProcessConfigurationStatement> {
+    
+    private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
+    
+    @Override
+    public void executeUpdate(final String databaseName, final DropMigrationProcessConfigurationStatement sqlStatement) {
+        JOB_API.dropProcessConfiguration(sqlStatement.getConfPath());
+    }
+    
+    @Override
+    public String getType() {
+        return DropMigrationProcessConfigurationStatement.class.getName();
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.CreateMigrationProcessConfigurationUpdater
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.AlterMigrationProcessConfigurationUpdater
+org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.DropMigrationProcessConfigurationUpdater

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/UpdatableScalingRALStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/UpdatableScalingRALStatementAssert.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.DropMigrationProcessConfigurationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
 import org.apache.shardingsphere.migration.distsql.statement.CleanMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.DropMigrationSourceResourceStatement;
@@ -30,6 +31,7 @@ import org.apache.shardingsphere.migration.distsql.statement.StopMigrationStatem
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.AddMigrationSourceResourceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.CleanMigrationStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.DropMigrationProcessConfigurationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.DropMigrationSourceResourceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.MigrateTableStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.ResetMigrationStatementAssert;
@@ -38,6 +40,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.AddMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CleanMigrationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationProcessConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.MigrateTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ResetMigrationStatementTestCase;
@@ -61,6 +64,9 @@ public final class UpdatableScalingRALStatementAssert {
         // TODO add more test case
         if (actual instanceof MigrateTableStatement) {
             MigrateTableStatementAssert.assertIs(assertContext, (MigrateTableStatement) actual, (MigrateTableStatementTestCase) expected);
+        } else if (actual instanceof DropMigrationProcessConfigurationStatement) {
+            DropMigrationProcessConfigurationStatementAssert.assertIs(assertContext, (DropMigrationProcessConfigurationStatement) actual,
+                    (DropMigrationProcessConfigurationStatementTestCase) expected);
         } else if (actual instanceof StopMigrationStatement) {
             StopMigrationStatementAssert.assertIs(assertContext, (StopMigrationStatement) actual, (StopMigrationStatementTestCase) expected);
         } else if (actual instanceof ResetMigrationStatement) {

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/DropMigrationProcessConfigurationStatementAssert.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/DropMigrationProcessConfigurationStatementAssert.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update;
+
+import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.DropMigrationProcessConfigurationStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationProcessConfigurationStatementTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Drop migration process configuration statement assert.
+ */
+public final class DropMigrationProcessConfigurationStatementAssert {
+    
+    /**
+     * Assert drop migration process configuration statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual statement
+     * @param expected expected statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final DropMigrationProcessConfigurationStatement actual, final DropMigrationProcessConfigurationStatementTestCase expected) {
+        assertThat(assertContext.getText("conf path does not match"), actual.getConfPath(), is(expected.getConfPath()));
+    }
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -309,6 +309,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.AddMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CheckMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CleanMigrationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationProcessConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.MigrateTableStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ResetMigrationStatementTestCase;
@@ -1018,6 +1019,9 @@ public final class SQLParserTestCases {
     
     @XmlElement(name = "start-migration")
     private final List<StartMigrationStatementTestCase> startMigrationTestCases = new LinkedList<>();
+    
+    @XmlElement(name = "drop-migration-process-configuration")
+    private final List<DropMigrationProcessConfigurationStatementTestCase> dropMigrationProcessConfigurationStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "migrate-table")
     private final List<MigrateTableStatementTestCase> migrateTableTestCases = new LinkedList<>();

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/DropMigrationProcessConfigurationStatementTestCase.java
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/DropMigrationProcessConfigurationStatementTestCase.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Drop migration process configuration test case.
+ */
+@Getter
+@Setter
+public final class DropMigrationProcessConfigurationStatementTestCase extends SQLParserTestCase {
+    
+    @XmlElement(name = "conf-path")
+    private String confPath;
+}

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/ral/migration.xml
@@ -38,6 +38,14 @@
         <job-id>123</job-id>
     </show-migration-status>
     
+    <drop-migration-process-configuration sql-case-id="drop-migration-process-configuration-read">
+        <conf-path>/READ</conf-path>
+    </drop-migration-process-configuration>
+    
+    <drop-migration-process-configuration sql-case-id="drop-migration-process-configuration-read-rate-limiter">
+        <conf-path>/READ/RATE_LIMITER</conf-path>
+    </drop-migration-process-configuration>
+    
     <migrate-table sql-case-id="migrate-table-without-schema-target-db">
         <source-resource-name>ds_0</source-resource-name>
         <source-table-name>t_order</source-table-name>

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/migration.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/ral/migration.xml
@@ -24,6 +24,8 @@
     <distsql-case id="show-migration-status" value="SHOW MIGRATION STATUS 123;" />
     <distsql-case id="check-migration-with-type" value="CHECK MIGRATION 123 by TYPE(name='DEFAULT', PROPERTIES('test-property'='4'));" />
     
+    <distsql-case id="drop-migration-process-configuration-read" value="DROP MIGRATION PROCESS CONFIGURATION '/READ';" />
+    <distsql-case id="drop-migration-process-configuration-read-rate-limiter" value="DROP MIGRATION PROCESS CONFIGURATION '/READ/RATE_LIMITER';" />
     <distsql-case id="migrate-table-without-schema-target-db" value="MIGRATE TABLE ds_0.t_order INTO t_order;" />
     <distsql-case id="migrate-table-with-schema" value="MIGRATE TABLE ds_0.public.t_order INTO t_order;" />
     <distsql-case id="migrate-table-with-target-db" value="MIGRATE TABLE ds_0.t_order INTO sharding_db.t_order;" />


### PR DESCRIPTION

Changes proposed in this pull request:
- Add DROP MIGRATION PROCESS CONFIGURATION DistSQL parsing, e.g. `DROP MIGRATION PROCESS CONFIGURATION '/READ/RATE_LIMITER';`
- Add API impl
