### PR TITLE
Reduce foreach call times and object create times

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessUnit.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessUnit.java
@@ -18,17 +18,19 @@
 package org.apache.shardingsphere.infra.executor.sql.process.model;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 
 /**
  * Execute process unit.
  */
 @Getter
+@Setter
 public final class ExecuteProcessUnit {
     
     private final String unitID;
     
-    private final ExecuteProcessConstants status;
+    private volatile ExecuteProcessConstants status;
     
     public ExecuteProcessUnit(final ExecutionUnit executionUnit, final ExecuteProcessConstants status) {
         this.unitID = String.valueOf(executionUnit.hashCode());

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/BatchYamlExecuteProcessContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/BatchYamlExecuteProcessContext.java
@@ -20,8 +20,10 @@ package org.apache.shardingsphere.infra.executor.sql.process.model.yaml;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 
 import java.util.Collection;
+import java.util.LinkedList;
 
 /**
  * Batch execute process context for YAML.
@@ -33,7 +35,15 @@ public final class BatchYamlExecuteProcessContext {
     
     private Collection<YamlExecuteProcessContext> contexts;
     
-    public BatchYamlExecuteProcessContext(final Collection<YamlExecuteProcessContext> contexts) {
-        this.contexts = contexts;
+    public BatchYamlExecuteProcessContext(final Collection<ExecuteProcessContext> processContexts) {
+        this.contexts = getYamlProcessContexts(processContexts);
+    }
+    
+    private Collection<YamlExecuteProcessContext> getYamlProcessContexts(final Collection<ExecuteProcessContext> processContexts) {
+        Collection<YamlExecuteProcessContext> result = new LinkedList<>();
+        for (ExecuteProcessContext each : processContexts) {
+            result.add(new YamlExecuteProcessContext(each));
+        }
+        return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessContext.java
+++ b/shardingsphere-infra/shardingsphere-infra-executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessContext.java
@@ -17,14 +17,15 @@
 
 package org.apache.shardingsphere.infra.executor.sql.process.model.yaml;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessUnit;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * Execute process context for YAML.
@@ -55,8 +56,8 @@ public final class YamlExecuteProcessContext {
         username = executeProcessContext.getUsername();
         hostname = executeProcessContext.getHostname();
         sql = executeProcessContext.getSql();
-        unitStatuses = new ArrayList<>(executeProcessContext.getUnitStatuses().size());
-        for (ExecuteProcessUnit each : executeProcessContext.getUnitStatuses()) {
+        unitStatuses = new ArrayList<>(executeProcessContext.getProcessUnits().size());
+        for (ExecuteProcessUnit each : executeProcessContext.getProcessUnits().values()) {
             unitStatuses.add(new YamlExecuteProcessUnit(each));
         }
         startTimeMillis = executeProcessContext.getStartTimeMillis();

--- a/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/process/ShowProcessListManager.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/main/java/org/apache/shardingsphere/mode/process/ShowProcessListManager.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.mode.process;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 import org.apache.shardingsphere.mode.process.lock.ShowProcessListSimpleLock;
 
 import java.sql.Statement;
@@ -38,7 +38,7 @@ public final class ShowProcessListManager {
     private static final ShowProcessListManager INSTANCE = new ShowProcessListManager();
     
     @Getter
-    private final Map<String, YamlExecuteProcessContext> processContexts = new ConcurrentHashMap<>();
+    private final Map<String, ExecuteProcessContext> processContexts = new ConcurrentHashMap<>();
     
     @Getter
     private final Map<String, Collection<Statement>> processStatements = new ConcurrentHashMap<>();
@@ -61,7 +61,7 @@ public final class ShowProcessListManager {
      * @param executionId execution id
      * @param processContext process context
      */
-    public void putProcessContext(final String executionId, final YamlExecuteProcessContext processContext) {
+    public void putProcessContext(final String executionId, final ExecuteProcessContext processContext) {
         processContexts.put(executionId, processContext);
     }
     
@@ -84,7 +84,7 @@ public final class ShowProcessListManager {
      * @param executionId execution id
      * @return execute process context
      */
-    public YamlExecuteProcessContext getProcessContext(final String executionId) {
+    public ExecuteProcessContext getProcessContext(final String executionId) {
         return processContexts.get(executionId);
     }
     
@@ -121,7 +121,7 @@ public final class ShowProcessListManager {
      * 
      * @return collection execute process context
      */
-    public Collection<YamlExecuteProcessContext> getAllProcessContext() {
+    public Collection<ExecuteProcessContext> getAllProcessContext() {
         return processContexts.values();
     }
 }

--- a/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/process/GovernanceExecuteProcessReporterTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-core/src/test/java/org/apache/shardingsphere/mode/process/GovernanceExecuteProcessReporterTest.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupConte
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
-import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -74,21 +74,11 @@ public final class GovernanceExecuteProcessReporterTest {
         SQLExecutionUnit sqlExecutionUnit = mock(SQLExecutionUnit.class);
         ExecutionUnit executionUnit = mock(ExecutionUnit.class);
         when(sqlExecutionUnit.getExecutionUnit()).thenReturn(executionUnit);
-        YamlExecuteProcessContext yamlExecuteProcessContext = mock(YamlExecuteProcessContext.class);
-        when(yamlExecuteProcessContext.getUnitStatuses()).thenReturn(Collections.emptyList());
-        when(showProcessListManager.getProcessContext("foo_id")).thenReturn(yamlExecuteProcessContext);
+        ExecuteProcessContext executeProcessContext = mock(ExecuteProcessContext.class);
+        when(executeProcessContext.getProcessUnits()).thenReturn(Collections.emptyMap());
+        when(showProcessListManager.getProcessContext("foo_id")).thenReturn(executeProcessContext);
         reporter.report("foo_id", sqlExecutionUnit, ExecuteProcessConstants.EXECUTE_ID, EventBusContextHolderFixture.EVENT_BUS_CONTEXT);
         verify(showProcessListManager, times(1)).getProcessContext(eq("foo_id"));
-    }
-    
-    @Test
-    public void assertReportComplete() {
-        YamlExecuteProcessContext yamlExecuteProcessContext = mock(YamlExecuteProcessContext.class);
-        when(yamlExecuteProcessContext.getUnitStatuses()).thenReturn(Collections.emptyList());
-        when(showProcessListManager.getProcessContext("foo_id")).thenReturn(yamlExecuteProcessContext);
-        reporter.report("foo_id", ExecuteProcessConstants.EXECUTE_STATUS_DONE, EventBusContextHolderFixture.EVENT_BUS_CONTEXT);
-        verify(showProcessListManager, times(1)).getProcessContext(eq("foo_id"));
-        verify(showProcessListManager, times(1)).removeProcessContext(eq("foo_id"));
     }
     
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinator.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinator.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.mode.manager.cluster.coordinator;
 import com.google.common.eventbus.Subscribe;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
 import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.BatchYamlExecuteProcessContext;
-import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.metadata.database.schema.QualifiedDatabase;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -62,7 +62,6 @@ import org.apache.shardingsphere.mode.process.node.ProcessNode;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -291,10 +290,10 @@ public final class ClusterContextManagerCoordinator {
         if (!event.getInstanceId().equals(contextManager.getInstanceContext().getInstance().getMetaData().getId())) {
             return;
         }
-        Collection<YamlExecuteProcessContext> processContexts = ShowProcessListManager.getInstance().getAllProcessContext();
+        Collection<ExecuteProcessContext> processContexts = ShowProcessListManager.getInstance().getAllProcessContext();
         if (!processContexts.isEmpty()) {
             registryCenter.getRepository().persist(ProcessNode.getProcessListInstancePath(event.getProcessListId(), event.getInstanceId()),
-                    YamlEngine.marshal(new BatchYamlExecuteProcessContext(new LinkedList<>(processContexts))));
+                    YamlEngine.marshal(new BatchYamlExecuteProcessContext(processContexts)));
         }
         registryCenter.getRepository().delete(ComputeNode.getProcessTriggerInstanceIdNodePath(event.getInstanceId(), event.getProcessListId()));
     }

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinatorTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/ClusterContextManagerCoordinatorTest.java
@@ -28,7 +28,6 @@ import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.datasource.props.DataSourcePropertiesCreator;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
-import org.apache.shardingsphere.infra.executor.sql.process.model.yaml.YamlExecuteProcessContext;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.instance.metadata.proxy.ProxyInstanceMetaData;
@@ -361,7 +360,7 @@ public final class ClusterContextManagerCoordinatorTest {
     @Test
     public void assertTriggerShowProcessList() throws NoSuchFieldException, IllegalAccessException {
         String instanceId = contextManager.getInstanceContext().getInstance().getMetaData().getId();
-        ShowProcessListManager.getInstance().putProcessContext("foo_execution_id", new YamlExecuteProcessContext(mock(ExecuteProcessContext.class)));
+        ShowProcessListManager.getInstance().putProcessContext("foo_execution_id", mock(ExecuteProcessContext.class));
         String processListId = "foo_process_id";
         coordinator.triggerShowProcessList(new ShowProcessListTriggerEvent(instanceId, processListId));
         ClusterPersistRepository repository = ReflectionUtil.getFieldValue(coordinator, "registryCenter", RegistryCenter.class).getRepository();


### PR DESCRIPTION
Ref #20531.

Changes proposed in this pull request:
- use Map instead of Collection to optimize processUnits call performance
- move processStatements foreach to ExecuteProcessContext
- use ExecuteProcessContext instead of YamlExecuteProcessContext in ShowProcessListManager
- remove useless logic for report method after sql units execute
