### PR TITLE
Verify Suite CI Run in IT

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -85,6 +85,8 @@ jobs:
           java-version: 8
       - name: Build IT image
         run: ./mvnw -B clean install -am -pl shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite -Pit.env.docker -DskipTests -Dspotless.apply.skip=true
+      - name: Verify Suite CI Run
+        run: ./mvnw -B install -pl shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite -Dspotless.apply.skip=true --offline
       - name: Save IT image
         run: docker save -o /tmp/shardingsphere-proxy-test.tar apache/shardingsphere-proxy-test:latest
       - name: Upload IT image


### PR DESCRIPTION
Purpose:
- When Integration Test workflow is changed (it.yml), it might cause `shardingsphere-integration-test-suite` module run Integration Test in Continuous Integration, but this module's Continuous Integration won't be triggered for now. So if we do not check it, then it might cause issue after PR is merged, e.g. #20556.

Changes proposed in this pull request:
- Verify Suite CI Run in IT
