### PR TITLE
add md5 support for openGauss

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/ShardingSphereUser.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/ShardingSphereUser.java
@@ -31,8 +31,15 @@ public final class ShardingSphereUser {
     
     private final String password;
     
+    private final String authType;
+    
     public ShardingSphereUser(final String username, final String password, final String hostname) {
+        this(username, password, hostname, null);
+    }
+    
+    public ShardingSphereUser(final String username, final String password, final String hostname, final String authType) {
         grantee = new Grantee(username, hostname);
         this.password = password;
+        this.authType = authType;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUserConfiguration.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUserConfiguration.java
@@ -34,8 +34,14 @@ public final class YamlUserConfiguration implements YamlConfiguration {
     
     private String password;
     
+    private String authorityType;
+    
     @Override
     public String toString() {
-        return username + "@" + (null == hostname ? "%" : hostname) + ":" + password;
+        String result = username + "@" + (null == hostname ? "%" : hostname) + ":" + password;
+        if (authorityType != null && !"".equals(authorityType.trim())) {
+            result += ":" + authorityType;
+        }
+        return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUsersConfigurationConverter.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUsersConfigurationConverter.java
@@ -79,13 +79,30 @@ public final class YamlUsersConfigurationConverter {
                 "user configuration `%s` is invalid, the configuration format should be like `username@hostname:password`", yamlUser);
         Preconditions.checkArgument(yamlUser.indexOf("@") < yamlUser.indexOf(":"),
                 "user configuration `%s` is invalid, the configuration format should be like `username@hostname:password`", yamlUser);
-        String username = yamlUser.substring(0, yamlUser.indexOf("@"));
-        String hostname = yamlUser.substring(yamlUser.indexOf("@") + 1, yamlUser.indexOf(":"));
-        String password = yamlUser.substring(yamlUser.indexOf(":") + 1);
+        // Match for user@host:pwd:authType, but authType is optional.
+        String[] splitOrders = {"@", ":", ":" };
+        String[] splitValues = {null, null, null, null};
+        int previousPosition = 0;
+        int postPosition = 0;
+        
+        for (int i = 0; i < splitOrders.length; i++) {
+            postPosition = yamlUser.indexOf(splitOrders[i], previousPosition);
+            if (postPosition == -1) {
+                splitValues[i] = yamlUser.substring(previousPosition);
+                postPosition = yamlUser.length();
+                break;
+            }
+            splitValues[i] = yamlUser.substring(previousPosition, postPosition);
+            previousPosition = postPosition + 1;
+        }
+        if (postPosition < yamlUser.length()) {
+            splitValues[splitOrders.length] = yamlUser.substring(previousPosition);
+        }
         YamlUserConfiguration result = new YamlUserConfiguration();
-        result.setUsername(username);
-        result.setHostname(hostname);
-        result.setPassword(password);
+        result.setUsername(splitValues[0]);
+        result.setHostname(splitValues[1]);
+        result.setPassword(splitValues[2]);
+        result.setAuthorityType(splitValues[3]);
         return result;
     }
 }

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/swapper/YamlUserSwapper.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/swapper/YamlUserSwapper.java
@@ -37,6 +37,9 @@ public final class YamlUserSwapper implements YamlConfigurationSwapper<YamlUserC
         result.setUsername(data.getGrantee().getUsername());
         result.setHostname(data.getGrantee().getHostname());
         result.setPassword(data.getPassword());
+        if (null != data.getAuthType()) {
+            result.setAuthorityType(data.getAuthType());
+        }
         return result;
     }
     
@@ -45,6 +48,8 @@ public final class YamlUserSwapper implements YamlConfigurationSwapper<YamlUserC
         if (Objects.isNull(yamlConfig)) {
             return null;
         }
-        return new ShardingSphereUser(yamlConfig.getUsername(), yamlConfig.getPassword(), null == yamlConfig.getHostname() ? "%" : yamlConfig.getHostname());
+        return new ShardingSphereUser(yamlConfig.getUsername(), yamlConfig.getPassword(),
+                null == yamlConfig.getHostname() ? "%" : yamlConfig.getHostname(),
+                yamlConfig.getAuthorityType());
     }
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-bootstrap/pom.xml
+++ b/shardingsphere-proxy/shardingsphere-proxy-bootstrap/pom.xml
@@ -112,6 +112,11 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
+            <groupId>org.opengauss</groupId>
+            <artifactId>opengauss-jdbc</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <scope>runtime</scope>

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationHelper.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationHelper.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.opengauss.authentication;
+
+import lombok.Getter;
+import org.apache.shardingsphere.authority.rule.AuthorityRule;
+import org.apache.shardingsphere.db.protocol.opengauss.packet.authentication.OpenGaussAuthenticationSCRAMSha256Packet;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLPasswordMessagePacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLRandomGenerator;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.authentication.PostgreSQLMD5PasswordAuthenticationPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
+import org.apache.shardingsphere.infra.metadata.user.Grantee;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.PostgreSQLAuthenticationHandler;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.PostgreSQLLoginResult;
+
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Authentication helper for openGauss.
+ */
+public final class OpenGaussAuthenticationHelper {
+    
+    private static final String MD5 = "md5";
+    
+    @Getter
+    private final String saltHexString;
+    
+    @Getter
+    private final String nonceHexString;
+    
+    @Getter
+    private final int serverIteration;
+    
+    @Getter
+    private byte[] md5Salt;
+    
+    @Getter
+    private final boolean md5AuthorityType;
+    
+    public OpenGaussAuthenticationHelper(final String user) {
+        if (isMd5User(user)) {
+            md5AuthorityType = true;
+            saltHexString = null;
+            nonceHexString = null;
+        } else {
+            md5AuthorityType = false;
+            saltHexString = generateRandomHexString(64);
+            nonceHexString = generateRandomHexString(8);
+        }
+        serverIteration = 1000;
+    }
+    
+    /**
+     * Select the algorithm according to the configuration.
+     *
+     * @return the identifier packet
+     */
+    public PostgreSQLIdentifierPacket createIdentifierPacket() {
+        if (md5AuthorityType) {
+            md5Salt = PostgreSQLRandomGenerator.getInstance().generateRandomBytes(4);
+            return new PostgreSQLMD5PasswordAuthenticationPacket(md5Salt);
+        } else {
+            return new OpenGaussAuthenticationSCRAMSha256Packet(saltHexString.getBytes(), nonceHexString.getBytes(), serverIteration);
+        }
+    }
+    
+    /**
+     * Process password authention in openGauss connecting.
+     * @param username the user name
+     * @param databaseName database name
+     * @param passwordMessagePacket receive password package
+     * @return the login result
+     */
+    public PostgreSQLLoginResult processPassword(final String username, final String databaseName, final PostgreSQLPasswordMessagePacket passwordMessagePacket) {
+        if (md5AuthorityType) {
+            return new PostgreSQLAuthenticationHandler().login(username, databaseName, md5Salt, passwordMessagePacket);
+        } else {
+            return OpenGaussAuthenticationHandler.loginWithSCRAMSha256Password(username,
+                    databaseName, saltHexString, nonceHexString, serverIteration, passwordMessagePacket);
+        }
+    }
+    
+    private String generateRandomHexString(final int length) {
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        StringBuilder result = new StringBuilder(length);
+        for (int i = 0; i < result.capacity(); i++) {
+            result.append(Integer.toString(random.nextInt(0x10), 0x10));
+        }
+        return result.toString();
+    }
+    
+    private static boolean isMd5User(final String user) {
+        Optional<AuthorityRule> rule;
+        try {
+            rule = ProxyContext.getInstance().getContextManager()
+                    .getMetaDataContexts().getMetaData().getGlobalRuleMetaData().findSingleRule(AuthorityRule.class);
+            if (!rule.isPresent()) {
+                return false;
+            }
+            Grantee grantee = new Grantee(user, "%");
+            Optional<ShardingSphereUser> shardingSphereUser = rule.get().findUser(grantee);
+            if (!shardingSphereUser.isPresent()) {
+                return false;
+            }
+            return MD5.equalsIgnoreCase(shardingSphereUser.get().getAuthType());
+        } catch (NullPointerException npe) {
+            // in test case, maybe proxy context not inited.
+            return false;
+        }
+    }
+}

--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationHelperTest.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/authentication/OpenGaussAuthenticationHelperTest.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.opengauss.authentication;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.buffer.UnpooledHeapByteBuf;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.authority.config.AuthorityRuleConfiguration;
+import org.apache.shardingsphere.authority.rule.AuthorityRule;
+import org.apache.shardingsphere.authority.rule.builder.AuthorityRuleBuilder;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.handshake.PostgreSQLPasswordMessagePacket;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.apache.shardingsphere.dialect.postgresql.vendor.PostgreSQLVendorError;
+import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.database.DefaultDatabase;
+import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.resource.ShardingSphereResource;
+import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
+import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.proxy.frontend.opengauss.ProxyContextRestorer;
+import org.apache.shardingsphere.proxy.frontend.opengauss.authentication.fixture.OpenGaussAuthenticationAlgorithm;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.PostgreSQLLoginResult;
+import org.apache.shardingsphere.proxy.frontend.postgresql.authentication.authenticator.PostgreSQLMD5PasswordAuthenticator;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class OpenGaussAuthenticationHelperTest extends ProxyContextRestorer {
+    
+    private static final String SCHEMA_PATTERN = "schema_%s";
+    
+    private final String username = "gaussdb";
+    
+    private final String password = "P@ssw0rd";
+    
+    private final String database = "schema_0";
+    
+    private PostgreSQLPasswordMessagePacket passwordMessagePacket;
+    
+    private OpenGaussAuthenticationHelper helper;
+    
+    @Test
+    public void testDefaultUserSuccess() {
+        initProxyContext(new ShardingSphereUser(username, password, "%"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String digest = encodeDigest(password, helper.getSaltHexString(), helper.getNonceHexString(), helper.getServerIteration());
+        payload.writeInt4(4 + digest.length() + 1);
+        payload.writeStringNul(digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.SUCCESSFUL_COMPLETION));
+    }
+    
+    @Test
+    public void testDefaultUserFalse() {
+        initProxyContext(new ShardingSphereUser(username, password, "%"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String digest = encodeDigest(password + "random", helper.getSaltHexString(), helper.getNonceHexString(), helper.getServerIteration());
+        payload.writeInt4(4 + digest.length() + 1);
+        payload.writeStringNul(digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.INVALID_PASSWORD));
+    }
+    
+    @Test
+    public void testSha256UserSuccess() {
+        initProxyContext(new ShardingSphereUser(username, password, "%", "sha256"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String digest = encodeDigest(password, helper.getSaltHexString(), helper.getNonceHexString(), helper.getServerIteration());
+        payload.writeInt4(4 + digest.length() + 1);
+        payload.writeStringNul(digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.SUCCESSFUL_COMPLETION));
+    }
+    
+    @Test
+    public void testSha256UserFalse() {
+        initProxyContext(new ShardingSphereUser(username, password, "%", "sha256"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String digest = encodeDigest(password + "random", helper.getSaltHexString(), helper.getNonceHexString(), helper.getServerIteration());
+        payload.writeInt4(4 + digest.length() + 1);
+        payload.writeStringNul(digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.INVALID_PASSWORD));
+    }
+    
+    @Test
+    public void testMD5UserSuccess() {
+        initProxyContext(new ShardingSphereUser(username, password, "%", "md5"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        helper.createIdentifierPacket();
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String md5Digest = md5Encode(username, password, helper.getMd5Salt());
+        payload.writeInt4(5);
+        payload.writeStringNul(md5Digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.SUCCESSFUL_COMPLETION));
+    }
+    
+    @Test
+    public void testMD5UserFalse() {
+        initProxyContext(new ShardingSphereUser(username, password, "%", "md5"));
+        helper = new OpenGaussAuthenticationHelper(username);
+        helper.createIdentifierPacket();
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(createByteBuf(16, 128), StandardCharsets.UTF_8);
+        String md5Digest = md5Encode(username, password + "bbb", helper.getMd5Salt());
+        payload.writeInt4(5);
+        payload.writeStringNul(md5Digest);
+        passwordMessagePacket = new PostgreSQLPasswordMessagePacket(payload);
+        PostgreSQLLoginResult postgreSQLLoginResult = helper.processPassword(username, database, passwordMessagePacket);
+        assertThat(postgreSQLLoginResult.getVendorError(), is(PostgreSQLVendorError.INVALID_PASSWORD));
+    }
+    
+    @SneakyThrows(ReflectiveOperationException.class)
+    private String md5Encode(final String username, final String password, final byte[] md5Salt) {
+        Method method = PostgreSQLMD5PasswordAuthenticator.class.getDeclaredMethod("md5Encode", String.class, String.class, byte[].class);
+        method.setAccessible(true);
+        return (String) method.invoke(new PostgreSQLMD5PasswordAuthenticator(), username, password, md5Salt);
+    }
+    
+    private void initProxyContext(final ShardingSphereUser user) {
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        MetaDataContexts metaDataContexts = getMetaDataContexts(user);
+        when(contextManager.getMetaDataContexts()).thenReturn(metaDataContexts);
+        ProxyContext.init(contextManager);
+    }
+    
+    private MetaDataContexts getMetaDataContexts(final ShardingSphereUser user) {
+        return new MetaDataContexts(mock(MetaDataPersistService.class),
+                new ShardingSphereMetaData(getDatabases(), buildGlobalRuleMetaData(user), new ConfigurationProperties(new Properties())));
+    }
+    
+    private ByteBuf createByteBuf(final int initialCapacity, final int maxCapacity) {
+        return new UnpooledHeapByteBuf(UnpooledByteBufAllocator.DEFAULT, initialCapacity, maxCapacity);
+    }
+    
+    private Map<String, ShardingSphereDatabase> getDatabases() {
+        Map<String, ShardingSphereDatabase> result = new HashMap<>(10, 1);
+        for (int i = 0; i < 10; i++) {
+            ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+            ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
+            when(database.getResource()).thenReturn(new ShardingSphereResource(Collections.emptyMap()));
+            when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.emptyList()));
+            when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(schema);
+            when(schema.getTables()).thenReturn(Collections.emptyMap());
+            result.put(String.format(SCHEMA_PATTERN, i), database);
+        }
+        return result;
+    }
+    
+    private ShardingSphereRuleMetaData buildGlobalRuleMetaData(final ShardingSphereUser user) {
+        AuthorityRuleConfiguration ruleConfig = new AuthorityRuleConfiguration(Collections.singletonList(user), new AlgorithmConfiguration("ALL_PERMITTED", new Properties()));
+        AuthorityRule rule = new AuthorityRuleBuilder().build(ruleConfig, Collections.emptyMap(), mock(InstanceContext.class));
+        return new ShardingSphereRuleMetaData(Collections.singleton(rule));
+    }
+    
+    private String encodeDigest(final String password, final String random64code, final String token, final int serverIteration) {
+        return new String(OpenGaussAuthenticationAlgorithm.doRFC5802Algorithm(password, random64code, token, serverIteration));
+    }
+}


### PR DESCRIPTION
Fixes #20619.

Changes proposed in this pull request:
- This PR is both  support MD5 and SHA256 authentication  in ss-proxy.
- In default configure, it is same as before SHA256 method.
- To suport MD5 authentication  method, you just need config server.yaml to add ":md5" in Authrity Rule.

example:
rules:
  - !AUTHORITY
  users:
    - root@%:root
    - sharding@:sharding
    - sharding1@%:sharding1:sha256 # use sha256 in default
    - sharding2@%:sharding2:md5 # use md5 in default
    -  sharding2@%:sharding2:aaa   # use sha256 in default
   
notice:
1. this feature effective only in opengauss database on backend.
2. only support ":md5" for md5 method(ignore case), other use default SHA256.

now, you can use postgresql jdbc driver in frontend and backend database type is openGauss!
   
