### PR TITLE
Optimize SQLParserErrorListener code style

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
@@ -25,19 +25,19 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DistSQLScriptConstants {
-
+    
     public static final String RESOURCE_DB = "resource_db";
-
+    
     public static final String SHARDING_DB = "sharding_db";
-
+    
     public static final String READWRITE_SPLITTING_DB = "readwrite_splitting_db";
-
+    
     public static final String STANDARD = "standard";
-
+    
     public static final String COMPLEX = "complex";
-
+    
     public static final String HINT = "hint";
-
+    
     public static final String COMMA = ",";
     
     public static final String SEMI = ";";
@@ -134,7 +134,7 @@ public final class DistSQLScriptConstants {
             + "%s"
             + System.lineSeparator()
             + ")";
-
+    
     public static final String TYPE = "TYPE(NAME=\"%s\")";
     
     public static final String TYPE_PROPERTIES = "TYPE(NAME=\"%s\", PROPERTIES(%s))";

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserErrorListener.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserErrorListener.java
@@ -25,27 +25,25 @@ import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.misc.ParseCancellationException;
 
 /**
- * sql parser error listener.
+ * SQL parser error listener.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class ParserErrorListener extends BaseErrorListener {
+public final class SQLParserErrorListener extends BaseErrorListener {
     
-    private static final ParserErrorListener INSTANCE = new ParserErrorListener();
+    private static final SQLParserErrorListener INSTANCE = new SQLParserErrorListener();
     
     /**
-     * get ParserErrorListener instance.
-     * @return ParserErrorListener instance
+     * Get instance.
+     * 
+     * @return instance
      */
-    public static ParserErrorListener getInstance() {
+    public static SQLParserErrorListener getInstance() {
         return INSTANCE;
     }
     
     @Override
     public void syntaxError(final Recognizer<?, ?> recognizer, final Object offendingSymbol, final int line, final int charPositionInLine,
                             final String msg, final RecognitionException e) throws ParseCancellationException {
-        StringBuilder sb = new StringBuilder("syntax error at line ");
-        sb.append(line).append(", position ").append(charPositionInLine).append(", near ").append(offendingSymbol).append(", ").append(msg);
-        throw new ParseCancellationException(sb.toString());
+        throw new ParseCancellationException("syntax error at line " + line + ", position " + charPositionInLine + ", near " + offendingSymbol + ", " + msg);
     }
-    
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserErrorListener.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserErrorListener.java
@@ -43,7 +43,7 @@ public final class SQLParserErrorListener extends BaseErrorListener {
     
     @Override
     public void syntaxError(final Recognizer<?, ?> recognizer, final Object offendingSymbol, final int line, final int charPositionInLine,
-                            final String msg, final RecognitionException e) throws ParseCancellationException {
-        throw new ParseCancellationException("syntax error at line " + line + ", position " + charPositionInLine + ", near " + offendingSymbol + ", " + msg);
+                            final String message, final RecognitionException e) throws ParseCancellationException {
+        throw new ParseCancellationException(message + " at line " + line + ", position " + charPositionInLine + ", near " + offendingSymbol);
     }
 }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserExecutor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserExecutor.java
@@ -60,12 +60,11 @@ public final class SQLParserExecutor {
             ((Parser) sqlParser).reset();
             ((Parser) sqlParser).getInterpreter().setPredictionMode(PredictionMode.LL);
             ((Parser) sqlParser).removeErrorListeners();
-            ((Parser) sqlParser).addErrorListener(ParserErrorListener.getInstance());
+            ((Parser) sqlParser).addErrorListener(SQLParserErrorListener.getInstance());
             try {
                 return (ParseASTNode) sqlParser.parse();
             } catch (final ParseCancellationException e) {
-                StringBuilder sb = new StringBuilder(sql).append(";").append(e.getMessage());
-                throw new SQLParsingException(sb.toString());
+                throw new SQLParsingException(sql + ";" + e.getMessage());
             }
         }
     }

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserExecutor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-engine/src/main/java/org/apache/shardingsphere/sql/parser/core/database/parser/SQLParserExecutor.java
@@ -64,7 +64,7 @@ public final class SQLParserExecutor {
             try {
                 return (ParseASTNode) sqlParser.parse();
             } catch (final ParseCancellationException e) {
-                throw new SQLParsingException(sql + ";" + e.getMessage());
+                throw new SQLParsingException(sql + ", " + e.getMessage());
             }
         }
     }


### PR DESCRIPTION
Ref #20662.

Changes proposed in this pull request:
- Optimize SQLParserErrorListener code style

```
mysql> select * from t_order where order_id = 1 likee 1;
ERROR 11000 (42000): You have an error in your SQL syntax: select * from t_order where order_id = 1 likee 1, no viable alternative at input '=1likee' at line 1, position 41, near [@8,41:45='likee',<780>,1:41]
mysql> java;
ERROR 11000 (42000): You have an error in your SQL syntax: java, no viable alternative at input 'java' at line 1, position 0, near [@0,0:3='java',<780>,1:0]
```