### PR TITLE
Add a missing keyword in PostgreSQL Declare Statement

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DDLStatement.g4
@@ -1777,6 +1777,7 @@ cursorOption
     : NO SCROLL
     | SCROLL
     | BINARY
+    | ASENSITIVE
     | INSENSITIVE
     ;
 

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/PostgreSQLKeyword.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/PostgreSQLKeyword.g4
@@ -1456,3 +1456,7 @@ BYPASSRLS
 NOBYPASSRLS
     : N O B Y P A S S R L S
     ;
+
+ASENSITIVE
+    : A S E N S I T I V E
+    ;


### PR DESCRIPTION
For #17844 

Changes proposed in this pull request:
- Add a missing keyword for `cursorOption` in [PostgreSQL Declare Statement](https://www.postgresql.org/docs/current/sql-declare.html).