### PR TITLE
Fix binding table check exception when sharding table ends with number

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/TableRule.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/main/java/org/apache/shardingsphere/sharding/rule/TableRule.java
@@ -145,7 +145,9 @@ public final class TableRule {
     }
     
     private DataNodeInfo createTableDataNode(final Collection<DataNode> actualDataNodes) {
-        String prefix = DATA_NODE_SUFFIX_PATTERN.matcher(actualDataNodes.iterator().next().getTableName()).replaceAll("");
+        String tableName = actualDataNodes.iterator().next().getTableName();
+        String prefix = tableName.startsWith(logicTable) ? logicTable + DATA_NODE_SUFFIX_PATTERN.matcher(tableName.substring(logicTable.length())).replaceAll("")
+                : DATA_NODE_SUFFIX_PATTERN.matcher(tableName).replaceAll("");
         int suffixMinLength = actualDataNodes.stream().map(each -> each.getTableName().length() - prefix.length()).min(Comparator.comparing(Integer::intValue)).orElse(1);
         return new DataNodeInfo(prefix, suffixMinLength, DEFAULT_PADDING_CHAR);
     }

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/TableRuleTest.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-core/src/test/java/org/apache/shardingsphere/sharding/rule/TableRuleTest.java
@@ -191,6 +191,16 @@ public final class TableRuleTest {
     }
     
     @Test
+    public void assertGetTableDataNodeWhenLogicTableEndWithNumber() {
+        ShardingTableRuleConfiguration shardingTableRuleConfig = new ShardingTableRuleConfiguration("t_order0", "ds_0.t_order0_0,ds_0.t_order0_1");
+        TableRule tableRule = new TableRule(shardingTableRuleConfig, Arrays.asList("ds_0", "ds_1"), "order_id");
+        DataNodeInfo actual = tableRule.getTableDataNode();
+        assertThat(actual.getPrefix(), is("t_order0_"));
+        assertThat(actual.getPaddingChar(), is('0'));
+        assertThat(actual.getSuffixMinLength(), is(1));
+    }
+    
+    @Test
     public void assertGetDataSourceDataNode() {
         ShardingTableRuleConfiguration shardingTableRuleConfig = new ShardingTableRuleConfiguration("t_order", "ds_0.t_order,ds_1.t_order");
         TableRule tableRule = new TableRule(shardingTableRuleConfig, Arrays.asList("ds_0", "ds_1"), "order_id");


### PR DESCRIPTION
Fixes #20746.

Changes proposed in this pull request:
- fix binding table check exception when sharding table ends with number
- add unit test
