### PR TITLE
Set proper index for PostgreSQL positional parameters

### DIFF
--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/InsertValue.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/main/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/InsertValue.java
@@ -51,7 +51,7 @@ public class InsertValue {
         ExpressionSegment expressionSegment = values.get(index);
         if (expressionSegment instanceof ParameterMarkerExpressionSegment) {
             ParameterMarkerExpressionSegment segment = (ParameterMarkerExpressionSegment) expressionSegment;
-            return ParameterMarkerType.QUESTION == segment.getParameterMarkerType() ? "?" : "$" + segment.getParameterMarkerIndex();
+            return ParameterMarkerType.QUESTION == segment.getParameterMarkerType() ? "?" : "$" + (segment.getParameterMarkerIndex() + 1);
         } else if (expressionSegment instanceof LiteralExpressionSegment) {
             Object literals = ((LiteralExpressionSegment) expressionSegment).getLiterals();
             return literals instanceof String ? "'" + ((LiteralExpressionSegment) expressionSegment).getLiterals() + "'" : literals.toString();

--- a/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/InsertValueTest.java
+++ b/shardingsphere-infra/shardingsphere-infra-rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/InsertValueTest.java
@@ -34,9 +34,9 @@ public final class InsertValueTest {
     
     @Test
     public void assertToString() {
-        List<ExpressionSegment> expressionSegments = new ArrayList<>(3);
+        List<ExpressionSegment> expressionSegments = new ArrayList<>(4);
         ParameterMarkerExpressionSegment parameterMarkerExpressionSegment = new ParameterMarkerExpressionSegment(1, 1, 1);
-        ParameterMarkerExpressionSegment positionalParameterMarkerExpressionSegment = new ParameterMarkerExpressionSegment(1, 1, 1, ParameterMarkerType.DOLLAR);
+        ParameterMarkerExpressionSegment positionalParameterMarkerExpressionSegment = new ParameterMarkerExpressionSegment(1, 1, 0, ParameterMarkerType.DOLLAR);
         LiteralExpressionSegment literalExpressionSegment = new LiteralExpressionSegment(2, 2, "literals");
         ComplexExpressionSegment complexExpressionSegment = new ComplexExpressionSegment() {
             


### PR DESCRIPTION
Related to #20797.
The parameter index was minus 1 in SQL parser, so we need to plus 1 when rewriting SQL.
