### PR TITLE
Rename and move PipelineJobExecutor

### DIFF
--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/PipelineJobWorker.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/PipelineJobWorker.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.execute;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.shardingsphere.data.pipeline.core.metadata.node.PipelineMetaDataNodeWatcher;
 
 /**
  * Pipeline job worker.
@@ -41,7 +42,7 @@ public final class PipelineJobWorker {
                 return;
             }
             log.info("start worker initialization");
-            PipelineJobExecutor.getInstance();
+            PipelineMetaDataNodeWatcher.getInstance();
             WORKER_INITIALIZED.set(true);
             log.info("worker initialization done");
         }

--- a/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeWatcher.java
+++ b/shardingsphere-kernel/shardingsphere-data-pipeline/shardingsphere-data-pipeline-core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/PipelineMetaDataNodeWatcher.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.core.execute;
+package org.apache.shardingsphere.data.pipeline.core.metadata.node;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
@@ -31,16 +31,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 /**
- * Pipeline job executor.
+ * Pipeline metaData nodeWatcher.
  */
 @Slf4j
-public final class PipelineJobExecutor {
+public final class PipelineMetaDataNodeWatcher {
     
-    private static final PipelineJobExecutor INSTANCE = new PipelineJobExecutor();
+    private static final PipelineMetaDataNodeWatcher INSTANCE = new PipelineMetaDataNodeWatcher();
     
     private final Map<Pattern, PipelineMetaDataChangedHandler> listenerMap = new ConcurrentHashMap<>();
     
-    private PipelineJobExecutor() {
+    private PipelineMetaDataNodeWatcher() {
         Collection<PipelineMetaDataChangedHandler> instances = PipelineMetaDataChangedHandlerFactory.findAllInstances();
         for (PipelineMetaDataChangedHandler each : instances) {
             listenerMap.put(each.getKeyPattern(), each);
@@ -58,11 +58,11 @@ public final class PipelineJobExecutor {
     }
     
     /**
-     * Get pipeline job executor instance.
+     * Get pipeline metaData nodeWatcher instance.
      *
-     * @return pipeline job executor
+     * @return pipeline metaData nodeWatcher
      */
-    public static PipelineJobExecutor getInstance() {
+    public static PipelineMetaDataNodeWatcher getInstance() {
         return INSTANCE;
     }
 }


### PR DESCRIPTION
Fixes #20885.

Changes proposed in this pull request:
  - Rename PipelineJobExecutor to PipelineMetaDataNodeWatcher
  - Move PipelineMetaDataNodeWatcher to package `org.apache.shardingsphere.data.pipeline.core.metadata.node`


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.

