### PR TITLE
Fix Cannot find JDBC type '0' in PostgreSQL column type exception

### DIFF
--- a/shardingsphere-kernel/shardingsphere-sql-federation/shardingsphere-sql-federation-executor/shardingsphere-sql-federation-executor-advanced/src/main/java/org/apache/shardingsphere/sqlfederation/advanced/resultset/FederationResultSetMetaData.java
+++ b/shardingsphere-kernel/shardingsphere-sql-federation/shardingsphere-sql-federation-executor/shardingsphere-sql-federation-executor-advanced/src/main/java/org/apache/shardingsphere/sqlfederation/advanced/resultset/FederationResultSetMetaData.java
@@ -22,13 +22,16 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.Table;
 import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
+import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
 
 import java.sql.ResultSetMetaData;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
@@ -135,12 +138,14 @@ public final class FederationResultSetMetaData extends WrapperAdapter implements
     
     @Override
     public int getColumnType(final int column) {
-        return 0;
+        Optional<ShardingSphereTable> table = findTableName(column).flatMap(optional -> Optional.ofNullable(schema.getTable(optional)));
+        return table.map(optional -> new ArrayList<>(optional.getColumns().values()).get(column - 1).getDataType()).orElse(0);
     }
     
     @Override
     public String getColumnTypeName(final int column) {
-        return "";
+        int columnType = getColumnType(column);
+        return Optional.ofNullable(SqlTypeName.getNameForJdbcType(columnType)).map(SqlTypeName::getName).orElse("");
     }
     
     @Override


### PR DESCRIPTION
Fixes #20987.

Changes proposed in this pull request:
  - fix Cannot find JDBC type '0' in PostgreSQL column type exception

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.

