### PR TITLE
Add MySQL 8 auth plugin case at migration IT

### DIFF
--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
@@ -26,8 +26,6 @@ import org.apache.shardingsphere.test.integration.env.container.atomic.storage.c
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.opengauss.OpenGaussContainerConfigurationFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.postgresql.PostgreSQLContainerConfigurationFactory;
 
-import java.util.Map;
-
 /**
  * Storage container configuration factory.
  */
@@ -44,31 +42,6 @@ public final class StorageContainerConfigurationFactory {
         switch (databaseType.getType()) {
             case "MySQL":
                 return MySQLContainerConfigurationFactory.newInstance();
-            case "PostgreSQL":
-                return PostgreSQLContainerConfigurationFactory.newInstance();
-            case "openGauss":
-                return OpenGaussContainerConfigurationFactory.newInstance();
-            case "H2":
-                return H2ContainerConfigurationFactory.newInstance();
-            default:
-                throw new RuntimeException(String.format("Database `%s` is unknown.", databaseType.getType()));
-        }
-    }
-    
-    /**
-     * Create new instance of storage container configuration.
-     *
-     * @param databaseType database type
-     * @param command command
-     * @param containerEnvironments container environments
-     * @param mountedResources mounted resources
-     * @return created instance
-     */
-    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType, final String command, final Map<String, String> containerEnvironments,
-                                                            final Map<String, String> mountedResources) {
-        switch (databaseType.getType()) {
-            case "MySQL":
-                return MySQLContainerConfigurationFactory.newInstance(command, containerEnvironments, mountedResources);
             case "PostgreSQL":
                 return PostgreSQLContainerConfigurationFactory.newInstance();
             case "openGauss":

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
@@ -26,6 +26,8 @@ import org.apache.shardingsphere.test.integration.env.container.atomic.storage.c
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.opengauss.OpenGaussContainerConfigurationFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.postgresql.PostgreSQLContainerConfigurationFactory;
 
+import java.util.Map;
+
 /**
  * Storage container configuration factory.
  */
@@ -34,7 +36,7 @@ public final class StorageContainerConfigurationFactory {
     
     /**
      * Create new instance of storage container configuration.
-     * 
+     *
      * @param databaseType database type
      * @return created instance
      */
@@ -42,6 +44,31 @@ public final class StorageContainerConfigurationFactory {
         switch (databaseType.getType()) {
             case "MySQL":
                 return MySQLContainerConfigurationFactory.newInstance();
+            case "PostgreSQL":
+                return PostgreSQLContainerConfigurationFactory.newInstance();
+            case "openGauss":
+                return OpenGaussContainerConfigurationFactory.newInstance();
+            case "H2":
+                return H2ContainerConfigurationFactory.newInstance();
+            default:
+                throw new RuntimeException(String.format("Database `%s` is unknown.", databaseType.getType()));
+        }
+    }
+    
+    /**
+     * Create new instance of storage container configuration.
+     *
+     * @param databaseType database type
+     * @param command command
+     * @param containerEnvironments container environments
+     * @param mountedResources mounted resources
+     * @return created instance
+     */
+    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType, final String command, final Map<String, String> containerEnvironments,
+                                                            final Map<String, String> mountedResources) {
+        switch (databaseType.getType()) {
+            case "MySQL":
+                return MySQLContainerConfigurationFactory.newInstance(command, containerEnvironments, mountedResources);
             case "PostgreSQL":
                 return PostgreSQLContainerConfigurationFactory.newInstance();
             case "openGauss":

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
@@ -36,11 +36,11 @@ public final class MySQLContainerConfigurationFactory {
     
     /**
      * Create new instance of MySQL container configuration.
-     *
+     * 
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getDefaultCommand(), getDefaultContainerEnvironments(), getDefaultMountedResources());
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
     }
     
     /**
@@ -52,37 +52,22 @@ public final class MySQLContainerConfigurationFactory {
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance(final String command, final Map<String, String> containerEnvironments, final Map<String, String> mountedResources) {
-        return new StorageContainerConfiguration(ObjectUtils.defaultIfNull(command, getDefaultCommand()), ObjectUtils.defaultIfNull(containerEnvironments, getDefaultContainerEnvironments()),
-                ObjectUtils.defaultIfNull(mountedResources, getDefaultMountedResources()));
+        return new StorageContainerConfiguration(ObjectUtils.defaultIfNull(command, getCommand()), ObjectUtils.defaultIfNull(containerEnvironments, getContainerEnvironments()),
+                ObjectUtils.defaultIfNull(mountedResources, getMountedResources()));
     }
     
-    /**
-     * Get default command.
-     *
-     * @return command
-     */
-    public static String getDefaultCommand() {
+    private static String getCommand() {
         return "--server-id=" + ContainerUtil.generateMySQLServerId();
     }
     
-    /**
-     * Get default container environments.
-     *
-     * @return container environments
-     */
-    public static Map<String, String> getDefaultContainerEnvironments() {
+    private static Map<String, String> getContainerEnvironments() {
         Map<String, String> result = new HashMap<>(2, 1);
         result.put("LANG", "C.UTF-8");
         result.put("MYSQL_RANDOM_ROOT_PASSWORD", "yes");
         return result;
     }
     
-    /**
-     * Get default mounted resources.
-     *
-     * @return container environments
-     */
-    public static Map<String, String> getDefaultMountedResources() {
+    private static Map<String, String> getMountedResources() {
         return Collections.singletonMap("/env/mysql/my.cnf", StorageContainerConstants.MYSQL_CONF_IN_CONTAINER);
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-env/src/test/java/org/apache/shardingsphere/test/integration/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.integration.env.container.atomic.storage.
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.shardingsphere.test.integration.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.integration.env.container.atomic.util.ContainerUtil;
@@ -35,25 +36,53 @@ public final class MySQLContainerConfigurationFactory {
     
     /**
      * Create new instance of MySQL container configuration.
-     * 
+     *
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+        return new StorageContainerConfiguration(getDefaultCommand(), getDefaultContainerEnvironments(), getDefaultMountedResources());
     }
     
-    private static String getCommand() {
+    /**
+     * Create new instance of MySQL container configuration with parameter.
+     *
+     * @param command command
+     * @param containerEnvironments container environments
+     * @param mountedResources mounted resources
+     * @return created instance
+     */
+    public static StorageContainerConfiguration newInstance(final String command, final Map<String, String> containerEnvironments, final Map<String, String> mountedResources) {
+        return new StorageContainerConfiguration(ObjectUtils.defaultIfNull(command, getDefaultCommand()), ObjectUtils.defaultIfNull(containerEnvironments, getDefaultContainerEnvironments()),
+                ObjectUtils.defaultIfNull(mountedResources, getDefaultMountedResources()));
+    }
+    
+    /**
+     * Get default command.
+     *
+     * @return command
+     */
+    public static String getDefaultCommand() {
         return "--server-id=" + ContainerUtil.generateMySQLServerId();
     }
     
-    private static Map<String, String> getContainerEnvironments() {
+    /**
+     * Get default container environments.
+     *
+     * @return container environments
+     */
+    public static Map<String, String> getDefaultContainerEnvironments() {
         Map<String, String> result = new HashMap<>(2, 1);
         result.put("LANG", "C.UTF-8");
         result.put("MYSQL_RANDOM_ROOT_PASSWORD", "yes");
         return result;
     }
     
-    private static Map<String, String> getMountedResources() {
+    /**
+     * Get default mounted resources.
+     *
+     * @return container environments
+     */
+    public static Map<String, String> getDefaultMountedResources() {
         return Collections.singletonMap("/env/mysql/my.cnf", StorageContainerConstants.MYSQL_CONF_IN_CONTAINER);
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/container/compose/DockerContainerComposer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/container/compose/DockerContainerComposer.java
@@ -33,11 +33,11 @@ import org.apache.shardingsphere.test.integration.env.container.atomic.storage.D
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.StorageContainerFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
+import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.mysql.MySQLContainerConfigurationFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.util.DatabaseTypeUtil;
 import org.apache.shardingsphere.test.integration.env.runtime.DataSourceEnvironment;
 
 import java.util.Collections;
-import java.util.Map;
 
 /**
  * Composed container, include governance container and database container.
@@ -57,11 +57,13 @@ public final class DockerContainerComposer extends BaseContainerComposer {
     public DockerContainerComposer(final DatabaseType databaseType, final String storageContainerImage) {
         this.databaseType = databaseType;
         governanceContainer = getContainers().registerContainer(new ZookeeperContainer());
-        Map<String, String> mountedResources = null;
+        StorageContainerConfiguration storageContainerConfig;
         if (DatabaseTypeUtil.isMySQL(databaseType) && new DockerImageVersion(storageContainerImage).getMajorVersion() > 5) {
-            mountedResources = Collections.singletonMap("/env/mysql/mysql8/my.cnf", StorageContainerConstants.MYSQL_CONF_IN_CONTAINER);
+            storageContainerConfig = MySQLContainerConfigurationFactory.newInstance(null, null,
+                    Collections.singletonMap("/env/mysql/mysql8/my.cnf", StorageContainerConstants.MYSQL_CONF_IN_CONTAINER));
+        } else {
+            storageContainerConfig = StorageContainerConfigurationFactory.newInstance(databaseType);
         }
-        StorageContainerConfiguration storageContainerConfig = StorageContainerConfigurationFactory.newInstance(databaseType, null, null, mountedResources);
         storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage,
                 "", storageContainerConfig));
         AdaptorContainerConfiguration containerConfig = ScalingProxyClusterContainerConfigurationFactory.newInstance(databaseType, storageContainerImage);

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/container/compose/DockerContainerComposer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/container/compose/DockerContainerComposer.java
@@ -20,17 +20,24 @@ package org.apache.shardingsphere.integration.data.pipeline.framework.container.
 import lombok.Getter;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.integration.data.pipeline.framework.container.config.proxy.ScalingProxyClusterContainerConfigurationFactory;
+import org.apache.shardingsphere.integration.data.pipeline.util.DockerImageVersion;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.AdapterContainerFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.impl.ShardingSphereProxyClusterContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.constants.AdapterContainerConstants;
 import org.apache.shardingsphere.test.integration.env.container.atomic.constants.EnvironmentConstants;
+import org.apache.shardingsphere.test.integration.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.integration.env.container.atomic.governance.GovernanceContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.governance.impl.ZookeeperContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.DockerStorageContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.StorageContainerFactory;
+import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
+import org.apache.shardingsphere.test.integration.env.container.atomic.util.DatabaseTypeUtil;
 import org.apache.shardingsphere.test.integration.env.runtime.DataSourceEnvironment;
+
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * Composed container, include governance container and database container.
@@ -50,8 +57,13 @@ public final class DockerContainerComposer extends BaseContainerComposer {
     public DockerContainerComposer(final DatabaseType databaseType, final String storageContainerImage) {
         this.databaseType = databaseType;
         governanceContainer = getContainers().registerContainer(new ZookeeperContainer());
+        Map<String, String> mountedResources = null;
+        if (DatabaseTypeUtil.isMySQL(databaseType) && new DockerImageVersion(storageContainerImage).getMajorVersion() > 5) {
+            mountedResources = Collections.singletonMap("/env/mysql/mysql8/my.cnf", StorageContainerConstants.MYSQL_CONF_IN_CONTAINER);
+        }
+        StorageContainerConfiguration storageContainerConfig = StorageContainerConfigurationFactory.newInstance(databaseType, null, null, mountedResources);
         storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage,
-                "", StorageContainerConfigurationFactory.newInstance(databaseType)));
+                "", storageContainerConfig));
         AdaptorContainerConfiguration containerConfig = ScalingProxyClusterContainerConfigurationFactory.newInstance(databaseType, storageContainerImage);
         ShardingSphereProxyClusterContainer proxyClusterContainer = (ShardingSphereProxyClusterContainer) AdapterContainerFactory.newInstance(EnvironmentConstants.CLUSTER_MODE,
                 AdapterContainerConstants.PROXY, databaseType, storageContainer, "", containerConfig);

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/util/DockerImageVersion.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/util/DockerImageVersion.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.integration.data.pipeline.util;
+
+/**
+ * Docker image version util.
+ */
+public final class DockerImageVersion {
+    
+    private static final String SEPARATOR = ":";
+    
+    private final String version;
+    
+    public DockerImageVersion(final String dockerImageName) {
+        if (!dockerImageName.contains(SEPARATOR)) {
+            version = dockerImageName;
+        } else {
+            String[] split = dockerImageName.split(SEPARATOR);
+            version = split[1];
+        }
+    }
+    
+    /**
+     * Get major version.
+     *
+     * @return major version
+     */
+    public int getMajorVersion() {
+        String[] split = version.split("\\.");
+        return Integer.parseInt(split[0]);
+    }
+}

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/resources/env/mysql/mysql8/my.cnf
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-scaling/src/test/resources/env/mysql/mysql8/my.cnf
@@ -22,7 +22,7 @@ log-bin=mysql-bin
 binlog-format=row
 binlog-row-image=full
 max_connections=600
-default-authentication-plugin=mysql_native_password
+default-authentication-plugin=caching_sha2_password
 sql_mode=
 lower_case_table_names=1
-
+secure_file_priv=/var/lib/mysql


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add MySQL auth plugin case at migration IT

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
