### PR TITLE
Disable fail-fast for Daily Continuous Integration

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         java_version: [ 8, 17, 18 ]


### PR DESCRIPTION
Purpose:
- Windows CI is always failed since path length too long, it's not resolved for now. Make sure CI on other OS could be done but not cancelled. CI result could be checked on https://github.com/apache/shardingsphere/actions/workflows/ci-daily.yml

Changes proposed in this pull request:
  - Add `fail-fast: false` in `ci-daily.yml`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
