### PR TITLE
Update CODE_OF_CONDUCT about assertThat

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,7 +61,7 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
  - Without particular reasons, test cases should be fully covered.
  - Every test case need precised assertion.
  - Environment preparation codes should be separate from test codes.
- - Only those that relate to junit `Assert`, hamcrest `CoreMatchers` and `Mockito` can use static import.
+ - Only those that relate to `Mockito`, junit `Assert`, hamcrest `CoreMatchers` and `MatcherAssert` can use static import.
  - For single parameter asserts, `assertTrue`, `assertFalse`, `assertNull` and `assertNotNull` should be used.
  - For multiple parameter asserts, `assertThat` should be used.
  - For accurate asserts, try not to use `not`, `containsString` to make assertions.

--- a/docs/community/content/involved/conduct/code.cn.md
+++ b/docs/community/content/involved/conduct/code.cn.md
@@ -74,7 +74,7 @@ chapter = true
  - 除去简单的 `getter /setter` 方法，以及声明 SPI 的静态代码，如：`getType / getOrder`，单元测试需全覆盖。
  - 每个测试用例需精确断言。
  - 准备环境的代码和测试代码分离。
- - 只有 junit `Assert`，hamcrest `CoreMatchers`，Mockito 相关可以使用 static import。
+ - 只有 Mockito，junit `Assert`，hamcrest `CoreMatchers` 和 `MatcherAssert` 相关可以使用 static import。
  - 单数据断言，应使用 `assertTrue`，`assertFalse`，`assertNull` 和 `assertNotNull`。
  - 多数据断言，应使用 `assertThat`。
  - 精确断言，尽量不使用 `not`，`containsString` 断言。

--- a/docs/community/content/involved/conduct/code.en.md
+++ b/docs/community/content/involved/conduct/code.en.md
@@ -72,7 +72,7 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
  - Test cases should be fully covered expect simply `getter /setter` methods, and declared static codes of SPI, such as: `getType / getOrder`.
  - Every test case need precised assertion.
  - Environment preparation codes should be separate from test codes.
- - Only those that relate to junit `Assert`, hamcrest `CoreMatchers` and `Mockito` can use static import.
+ - Only those that relate to `Mockito`, junit `Assert`, hamcrest `CoreMatchers` and `MatcherAssert` can use static import.
  - For single parameter asserts, `assertTrue`, `assertFalse`, `assertNull` and `assertNotNull` should be used.
  - For multiple parameter asserts, `assertThat` should be used.
  - For accurate asserts, try not to use `not`, `containsString` to make assertions.


### PR DESCRIPTION
Fixes #19845.

Changes proposed in this pull request:
  - Update CODE_OF_CONDUCT about `assertThat`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
