### PR TITLE
Recover throw SQLException for ScalingRALBackendHandler and RALUpdater execute method

### DIFF
--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/AddMigrationSourceResourceUpdater.java
@@ -26,14 +26,13 @@ import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.datasource.props.DataSourcePropertiesValidator;
-import org.apache.shardingsphere.infra.distsql.exception.resource.InvalidResourcesException;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.exception.external.sql.type.generic.UnsupportedSQLOperationException;
-import org.apache.shardingsphere.infra.util.exception.external.sql.type.wrapper.SQLWrapperException;
 import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
 import org.apache.shardingsphere.sharding.distsql.handler.converter.ResourceSegmentsConverter;
 
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +45,7 @@ public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMi
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final String databaseName, final AddMigrationSourceResourceStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final AddMigrationSourceResourceStatement sqlStatement) throws SQLException {
         List<DataSourceSegment> dataSources = new ArrayList<>(sqlStatement.getDataSources());
         ShardingSpherePreconditions.checkState(dataSources.stream().noneMatch(each -> each instanceof HostnameAndPortBasedDataSourceSegment),
                 () -> new UnsupportedSQLOperationException("Not currently support add hostname and port, please use url"));
@@ -54,11 +53,7 @@ public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMi
         DatabaseType databaseType = DatabaseTypeEngine.getDatabaseType(urlBasedDataSourceSegment.getUrl());
         Map<String, DataSourceProperties> sourcePropertiesMap = ResourceSegmentsConverter.convert(databaseType, dataSources);
         DataSourcePropertiesValidator validator = new DataSourcePropertiesValidator();
-        try {
-            validator.validate(sourcePropertiesMap, databaseType);
-        } catch (final InvalidResourcesException ex) {
-            throw new SQLWrapperException(ex);
-        }
+        validator.validate(sourcePropertiesMap, databaseType);
         JOB_API.addMigrationSourceResources(sourcePropertiesMap);
     }
     

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/CommitMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/CommitMigrationUpdater.java
@@ -32,12 +32,8 @@ public final class CommitMigrationUpdater implements RALUpdater<CommitMigrationS
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final String databaseName, final CommitMigrationStatement sqlStatement) {
-        try {
-            JOB_API.commit(sqlStatement.getJobId());
-        } catch (final SQLException ex) {
-            throw new RuntimeException(ex);
-        }
+    public void executeUpdate(final String databaseName, final CommitMigrationStatement sqlStatement) throws SQLException {
+        JOB_API.commit(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RollbackMigrationUpdater.java
+++ b/shardingsphere-features/shardingsphere-sharding/shardingsphere-sharding-distsql/shardingsphere-sharding-distsql-handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RollbackMigrationUpdater.java
@@ -32,13 +32,8 @@ public final class RollbackMigrationUpdater implements RALUpdater<RollbackMigrat
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final String databaseName, final RollbackMigrationStatement sqlStatement) {
-        // TODO throw SQLException
-        try {
-            JOB_API.rollback(sqlStatement.getJobId());
-        } catch (final SQLException ex) {
-            throw new RuntimeException(ex);
-        }
+    public void executeUpdate(final String databaseName, final RollbackMigrationStatement sqlStatement) throws SQLException {
+        JOB_API.rollback(sqlStatement.getJobId());
     }
     
     @Override

--- a/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/distsql/update/RALUpdater.java
+++ b/shardingsphere-infra/shardingsphere-infra-common/src/main/java/org/apache/shardingsphere/infra/distsql/update/RALUpdater.java
@@ -21,6 +21,8 @@ import org.apache.shardingsphere.infra.util.spi.annotation.SingletonSPI;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPI;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
+import java.sql.SQLException;
+
 /**
  * RAL updater.
  * 
@@ -34,6 +36,7 @@ public interface RALUpdater<T extends SQLStatement> extends TypedSPI {
      *
      * @param databaseName database name
      * @param sqlStatement updatable RAL statement
+     * @throws SQLException SQL exception
      */
-    void executeUpdate(String databaseName, T sqlStatement);
+    void executeUpdate(String databaseName, T sqlStatement) throws SQLException;
 }

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/query/QueryableScalingRALBackendHandler.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.query.QueryResponseHeader;
 
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -43,7 +44,7 @@ public final class QueryableScalingRALBackendHandler implements ProxyBackendHand
     private final DatabaseDistSQLResultSet resultSet;
     
     @Override
-    public ResponseHeader execute() {
+    public ResponseHeader execute() throws SQLException {
         resultSet.init(null, sqlStatement);
         List<QueryHeader> queryHeaders = new ArrayList<>();
         for (String each : resultSet.getColumnNames()) {

--- a/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
@@ -26,6 +26,8 @@ import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
+import java.sql.SQLException;
+
 /**
  * Updatable scaling RAL backend handler factory.
  */
@@ -39,7 +41,7 @@ public final class UpdatableScalingRALBackendHandler implements ProxyBackendHand
     
     @SuppressWarnings("unchecked")
     @Override
-    public ResponseHeader execute() {
+    public ResponseHeader execute() throws SQLException {
         String databaseName = getDatabaseName(connectionSession);
         RALUpdaterFactory.getInstance(sqlStatement.getClass()).executeUpdate(databaseName, sqlStatement);
         return new UpdateResponseHeader(sqlStatement);


### PR DESCRIPTION

Changes proposed in this pull request:
  - Recover throw SQLException for ScalingRALBackendHandler and RALUpdater execute method

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
