### PR TITLE
Refactor : refactor some constants and change the default option for PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -8,8 +8,8 @@ Changes proposed in this pull request:
 ---
 
 Before committing this PR, I'm sure that I have checked the following options:
-- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
-- [x] I have self-reviewed the commit code.
-- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
-- [x] I have made corresponding changes to the documentation.
-- [x] I have added corresponding unit tests for my changes.
+- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
+- [ ] I have self-reviewed the commit code.
+- [ ] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
+- [ ] I have made corresponding changes to the documentation.
+- [ ] I have added corresponding unit tests for my changes.

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-showprocesslist/src/test/java/org/apache/shardingsphere/test/integration/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-showprocesslist/src/test/java/org/apache/shardingsphere/test/integration/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.test.integration.env.container.atomic.ITContain
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.AdapterContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.AdapterContainerFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
+import org.apache.shardingsphere.test.integration.env.container.atomic.constants.ProxyContainerConstants;
 import org.apache.shardingsphere.test.integration.env.container.atomic.governance.GovernanceContainer;
 import org.apache.shardingsphere.test.integration.env.container.atomic.governance.GovernanceContainerFactory;
 import org.apache.shardingsphere.test.integration.env.container.atomic.storage.StorageContainer;
@@ -66,9 +67,8 @@ public final class ClusterShowProcessListContainerComposer {
     
     private Map<String, String> getMountedResources(final String scenario, final DatabaseType databaseType) {
         Map<String, String> result = new HashMap<>(2, 1);
-        String pathInContainer = "/opt/shardingsphere-proxy/conf";
-        result.put("/env/common/cluster/proxy/conf/", pathInContainer);
-        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), pathInContainer);
+        result.put("/env/common/cluster/proxy/conf/", ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
+        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
         return result;
     }
     

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/container/config/ProxyClusterContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/container/config/ProxyClusterContainerConfigurationFactory.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
+import org.apache.shardingsphere.test.integration.env.container.atomic.constants.ProxyContainerConstants;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,9 +46,8 @@ public final class ProxyClusterContainerConfigurationFactory {
     
     private static Map<String, String> getMountedResources(final String scenario, final DatabaseType databaseType) {
         Map<String, String> result = new HashMap<>(2, 1);
-        String pathInContainer = "/opt/shardingsphere-proxy/conf";
-        result.put("/env/common/cluster/proxy/conf/", pathInContainer);
-        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), pathInContainer);
+        result.put("/env/common/cluster/proxy/conf/", ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
+        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
         return result;
     }
 }

--- a/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/container/config/ProxyStandaloneContainerConfigurationFactory.java
+++ b/shardingsphere-test/shardingsphere-integration-test/shardingsphere-integration-test-suite/src/test/java/org/apache/shardingsphere/test/integration/container/config/ProxyStandaloneContainerConfigurationFactory.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.test.integration.env.container.atomic.adapter.config.AdaptorContainerConfiguration;
+import org.apache.shardingsphere.test.integration.env.container.atomic.constants.ProxyContainerConstants;
 import org.apache.shardingsphere.test.integration.env.container.atomic.util.AdapterContainerUtil;
 
 import java.util.HashMap;
@@ -45,9 +46,8 @@ public final class ProxyStandaloneContainerConfigurationFactory {
     
     private static Map<String, String> getMountedResources(final String scenario, final DatabaseType databaseType) {
         Map<String, String> result = new HashMap<>(2, 1);
-        String pathInContainer = "/opt/shardingsphere-proxy/conf";
-        result.put("/env/common/standalone/proxy/conf/", pathInContainer);
-        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), pathInContainer);
+        result.put("/env/common/standalone/proxy/conf/", ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
+        result.put("/env/scenario/" + scenario + "/proxy/conf/" + databaseType.getType().toLowerCase(), ProxyContainerConstants.CONFIG_PATH_IN_CONTAINER);
         return result;
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
  - refactor some constants
  - change the default option for pre-check.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have triggered maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
