### PR TITLE
Refactor : change the scope for longpath solution since system scope doesn't work

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Support longpaths in Windows
         if: matrix.os == 'windows-latest'
-        run: git config --system core.longpaths true
+        run: git config --global core.longpaths true
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v2


### PR DESCRIPTION
Changes proposed in this pull request:
  - change the scope for Windows long path solution

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
