### PR TITLE
Fix commmunity documnet build error according to wrong header format in on cloud release guide

### DIFF
--- a/docs/community/content/involved/release/elasticjob-ui.cn.md
+++ b/docs/community/content/involved/release/elasticjob-ui.cn.md
@@ -1,6 +1,6 @@
 +++
-title = "ElasticJob-UI 发布指南"
-weight = 3
+title = "ElasticJob UI 发布指南"
+weight = 4
 chapter = true
 +++
 

--- a/docs/community/content/involved/release/elasticjob-ui.en.md
+++ b/docs/community/content/involved/release/elasticjob-ui.en.md
@@ -1,6 +1,6 @@
 +++
-title = "ElasticJob-UI Release Guide"
-weight = 3
+title = "ElasticJob UI Release Guide"
+weight = 4
 chapter = true
 +++
 

--- a/docs/community/content/involved/release/elasticjob.cn.md
+++ b/docs/community/content/involved/release/elasticjob.cn.md
@@ -1,6 +1,6 @@
 +++
 title = "ElasticJob 发布指南"
-weight = 2
+weight = 3
 chapter = true
 +++
 

--- a/docs/community/content/involved/release/elasticjob.en.md
+++ b/docs/community/content/involved/release/elasticjob.en.md
@@ -1,6 +1,6 @@
 +++
 title = "ElasticJob Release Guide"
-weight = 2
+weight = 3
 chapter = true
 +++
 

--- a/docs/community/content/involved/release/shardingsphere-on-cloud.cn.md
+++ b/docs/community/content/involved/release/shardingsphere-on-cloud.cn.md
@@ -1,4 +1,9 @@
 +++
+title = "ShardingSphere on Cloud 发布指南"
+weight = 2
+chapter = true
++++
+
 ## 准备工作
 
 ### 1. 确认 Release Note

--- a/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
+++ b/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
@@ -1,4 +1,9 @@
 +++
+title = "ShardingSphere on Cloud Release Guide"
+weight = 2
+chapter = true
++++
+
 ## Prepare before release
 
 ### 1. Confirm release notes

--- a/docs/community/content/involved/release/shardingsphere.en.md
+++ b/docs/community/content/involved/release/shardingsphere.en.md
@@ -1,6 +1,6 @@
 +++
 title = "ShardingSphere Release Guide"
-weight = 8
+weight = 1
 chapter = true
 +++
 


### PR DESCRIPTION
Ref #21200.

Changes proposed in this pull request:
  - fix commmunity documnet build error according to wrong header format in on cloud release guide

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
