### PR TITLE
Support openGauss select offset, count statement parse and remove useless syntax in PostgreSQL grammar

### DIFF
--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
@@ -227,7 +227,7 @@ valuesClause
 
 limitClause
     : LIMIT selectLimitValue
-    | LIMIT selectLimitValue COMMA_ selectOffsetValue
+    | LIMIT selectOffsetValue COMMA_ selectLimitValue 
     | FETCH firstOrNext selectFetchFirstValue rowOrRows ONLY
     | FETCH firstOrNext selectFetchFirstValue rowOrRows WITH TIES
     | FETCH firstOrNext rowOrRows ONLY

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
@@ -229,7 +229,6 @@ valuesClause
 
 limitClause
     : LIMIT selectLimitValue
-    | LIMIT selectLimitValue COMMA_ selectOffsetValue
     | FETCH firstOrNext selectFetchFirstValue rowOrRows ONLY
     | FETCH firstOrNext selectFetchFirstValue rowOrRows WITH TIES
     | FETCH firstOrNext rowOrRows ONLY

--- a/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/shardingsphere-sql-parser/shardingsphere-sql-parser-dialect/shardingsphere-sql-parser-postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -1219,11 +1219,6 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementP
     
     private LimitSegment createLimitSegmentWhenRowCountOrOffsetAbsent(final SelectLimitContext ctx) {
         if (null != ctx.limitClause()) {
-            if (null != ctx.limitClause().selectOffsetValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
-                LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectOffsetValue());
-                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
-            }
             LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
             return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
         }

--- a/shardingsphere-test/shardingsphere-optimize-test/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
+++ b/shardingsphere-test/shardingsphere-optimize-test/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
@@ -58,7 +58,7 @@ import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @RequiredArgsConstructor
-public final class SQLNodeConvertEngineParameterizedTest {
+public final class SQLNodeConverterEngineParameterizedTest {
     
     private static final SQLCasesLoader SQL_CASES_LOADER = CasesRegistry.getInstance().getSqlCasesLoader();
     
@@ -68,6 +68,8 @@ public final class SQLNodeConvertEngineParameterizedTest {
     
     private static final Set<String> SUPPORTED_SQL_CASE_IDS = new HashSet<>();
     
+    // TODO remove SUPPORTED_SQL_CASE_IDS when all sql statement support convert to sql node
+    // CHECKSTYLE:OFF
     static {
         SUPPORTED_SQL_CASE_IDS.add("select_with_join_table_subquery");
         SUPPORTED_SQL_CASE_IDS.add("select_with_projection_subquery");
@@ -76,8 +78,6 @@ public final class SQLNodeConvertEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_with_exist_subquery_condition");
         SUPPORTED_SQL_CASE_IDS.add("select_with_not_exist_subquery_condition");
         SUPPORTED_SQL_CASE_IDS.add("select_with_simple_table");
-        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_offset_and_row_count");
-        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_row_count");
         SUPPORTED_SQL_CASE_IDS.add("select_group_by_with_limit");
         SUPPORTED_SQL_CASE_IDS.add("select_left_outer_join_related_with_alias");
         SUPPORTED_SQL_CASE_IDS.add("select_right_outer_join_related_with_alias");
@@ -108,7 +108,28 @@ public final class SQLNodeConvertEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_cast_function");
         SUPPORTED_SQL_CASE_IDS.add("select_position");
         SUPPORTED_SQL_CASE_IDS.add("select_mod_function");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_row_count");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top_percent_with_ties");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_row_number");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_with_back_quotes");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_and_offset_keyword");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_and_limit");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_and_limit_all");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top_for_greater_than");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top_percent_with_ties_for_greater_than");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top_for_greater_than_and_equal");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_top_percent_with_ties_for_greater_than_and_equal");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_row_number_for_greater_than");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_row_number_for_greater_than_and_equal");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_row_number_not_at_end");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_fetch_first_with_row_number");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_fetch");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_offset_and_row_count");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_row_count");
     }
+    // CHECKSTYLE:ON
     
     private final String sqlCaseId;
     

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-pagination.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/case/dml/select-pagination.xml
@@ -68,7 +68,6 @@
                 <owner name="i" start-index="7" stop-index="7" />
             </shorthand-projection>
         </projections>
-        <!-- TODO parameters-count should be 4, because the last parameter is in offset -->
         <where start-index="99" stop-index="154" literal-stop-index="155">
             <expr>
                 <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">
@@ -750,7 +749,6 @@
                 <owner name="i" start-index="7" stop-index="7" />
             </shorthand-projection>
         </projections>
-        <!-- TODO parameters-count should be 4, because the last parameter is in offset -->
         <where start-index="99" stop-index="154" literal-stop-index="155">
             <expr>
                 <binary-operation-expression start-index="105" stop-index="154" literal-stop-index="155">

--- a/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-pagination.xml
+++ b/shardingsphere-test/shardingsphere-parser-test/src/main/resources/sql/supported/dml/select-pagination.xml
@@ -35,6 +35,6 @@
     <sql-case id="select_pagination_with_row_number_not_at_end" value="SELECT * FROM t_order WHERE ROWNUM &lt;= ? ORDER BY order_id" db-types="Oracle" />
     <sql-case id="select_pagination_with_fetch_first_with_row_number" value="SELECT * FROM t_order ORDER BY order_id FETCH FIRST 5 ROWS ONLY" db-types="Oracle" />
     <sql-case id="select_pagination_with_offset_fetch" value="SELECT * FROM t_order ORDER BY order_id OFFSET 0 ROW FETCH NEXT ? ROWS ONLY" db-types="SQLServer" />
-    <sql-case id="select_pagination_with_limit_offset_and_row_count" value="SELECT order_id, user_id FROM t_order LIMIT 1, 2" db-types="MySQL" />
+    <sql-case id="select_pagination_with_limit_offset_and_row_count" value="SELECT order_id, user_id FROM t_order LIMIT 1, 2" db-types="MySQL,openGauss" />
     <sql-case id="select_pagination_with_limit_row_count" value="SELECT order_id, user_id FROM t_order LIMIT 2" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #21231.
Fixed #11025.

Changes proposed in this pull request:
  - support openGauss select offset, count statement parse
  - remove useless syntax in PostgreSQL grammar
  - add sql parse test case and sql node convert test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
