### PR TITLE
Add Java 19 to ci.yml and Bump Java to 19 in ci-daily

### DIFF
--- a/.github/workflows/ci-daily.yml
+++ b/.github/workflows/ci-daily.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java_version: [ 8, 17, 18 ]
+        java_version: [ 8, 17, 19 ]
     steps:
       - name: Support longpaths in Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java_version: [ 8 ]
+        java_version: [ 8, 19 ]
         os: [ ubuntu-latest ]
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Revise #21188.

#21188 broke the basic boundary testing of JDK compatibility of ShardingSphere.
