### PR TITLE
Fix finish connection if not exist executionId.

### DIFF
--- a/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandler.java
+++ b/shardingsphere-proxy/shardingsphere-proxy-frontend/shardingsphere-proxy-frontend-core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/FrontendChannelInboundHandler.java
@@ -37,6 +37,8 @@ import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngi
 import org.apache.shardingsphere.proxy.frontend.state.ProxyStateContext;
 import org.apache.shardingsphere.transaction.rule.TransactionRule;
 
+import java.util.Optional;
+
 /**
  * Frontend channel inbound handler.
  */
@@ -100,7 +102,7 @@ public final class FrontendChannelInboundHandler extends ChannelInboundHandlerAd
     private void closeAllResources() {
         ConnectionThreadExecutorGroup.getInstance().unregisterAndAwaitTermination(connectionSession.getConnectionId());
         connectionSession.getBackendConnection().closeAllResources();
-        ExecuteProcessEngine.finishConnection(connectionSession.getExecutionId());
+        Optional.ofNullable(connectionSession.getExecutionId()).ifPresent(ExecuteProcessEngine::finishConnection);
         databaseProtocolFrontendEngine.release(connectionSession);
     }
     


### PR DESCRIPTION
cause of  this pr https://github.com/apache/shardingsphere/pull/21193/files#diff-6dd45a9e3110b1a7b9e342150b79eab828efd267e1f6479c255741ea6ca04d27
the code is been restored.

For #20896.

Changes proposed in this pull request:
  - Fix finish connection if not exist executionId.
  - Fix run `FrontendChannelInboundHandlerTest` occur error log.
  
 ```
Exception in thread "ShardingSphere-Command-0" java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1111)
	at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1102)
	at org.apache.shardingsphere.mode.process.ShowProcessListManager.removeProcessStatement(ShowProcessListManager.java:116)
	at org.apache.shardingsphere.mode.process.GovernanceExecuteProcessReporter.reportRemove(GovernanceExecuteProcessReporter.java:78)
	at org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine.lambda$finishConnection$1(ExecuteProcessEngine.java:73)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine.finishConnection(ExecuteProcessEngine.java:73)
	at org.apache.shardingsphere.proxy.frontend.netty.FrontendChannelInboundHandler.closeAllResources(FrontendChannelInboundHandler.java:108)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Exception in thread "ShardingSphere-Command-1" java.lang.NullPointerException: Cannot invoke "Object.hashCode()" because "key" is null
	at java.base/java.util.concurrent.ConcurrentHashMap.replaceNode(ConcurrentHashMap.java:1111)
	at java.base/java.util.concurrent.ConcurrentHashMap.remove(ConcurrentHashMap.java:1102)
	at org.apache.shardingsphere.mode.process.ShowProcessListManager.removeProcessStatement(ShowProcessListManager.java:116)
	at org.apache.shardingsphere.mode.process.GovernanceExecuteProcessReporter.reportRemove(GovernanceExecuteProcessReporter.java:78)
	at org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine.lambda$finishConnection$1(ExecuteProcessEngine.java:73)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine.finishConnection(ExecuteProcessEngine.java:73)
	at org.apache.shardingsphere.proxy.frontend.netty.FrontendChannelInboundHandler.closeAllResources(FrontendChannelInboundHandler.java:108)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```