### PR TITLE
Cluster mode repository support consul register center

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/pom.xml
@@ -31,5 +31,6 @@
     <modules>
         <module>shardingsphere-standalone-mode</module>
         <module>shardingsphere-cluster-mode</module>
+        <!--        <module>shardingsphere-cluster-mode-repository-consul</module>-->
     </modules>
 </project>

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/pom.xml
@@ -32,5 +32,6 @@
         <module>shardingsphere-cluster-mode-repository-zookeeper-curator</module>
         <module>shardingsphere-cluster-mode-repository-etcd</module>
         <module>shardingsphere-cluster-mode-repository-nacos</module>
+        <module>shardingsphere-cluster-mode-repository-consul</module>
     </modules>
 </project>

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
@@ -35,5 +35,12 @@
             <version>1.4.1</version>
         </dependency>
         
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
+            <scope>compile</scope>
+        </dependency>
+        
     </dependencies>
 </project>

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-cluster-mode-repository-provider</artifactId>
+        <version>5.1.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>shardingsphere-cluster-mode-repository-consul</artifactId>
+    <name>${project.artifactId}</name>
+    
+    <properties>
+        <maven.compiler.source>16</maven.compiler.source>
+        <maven.compiler.target>16</maven.compiler.target>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-cluster-mode-repository-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        
+        <!--        <dependency>-->
+        <!--            <groupId>com.orbitz.consul</groupId>-->
+        <!--            <artifactId>consul-client</artifactId>-->
+        <!--            <version>1.5.3</version>-->
+        <!--        </dependency>-->
+        
+        <dependency>
+            <groupId>com.ecwid.consul</groupId>
+            <artifactId>consul-api</artifactId>
+            <version>1.4.1</version>
+        </dependency>
+        
+    </dependencies>
+</project>

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
         <artifactId>shardingsphere-cluster-mode-repository-provider</artifactId>
-        <version>5.1.3-SNAPSHOT</version>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>shardingsphere-cluster-mode-repository-consul</artifactId>
     <name>${project.artifactId}</name>
@@ -14,6 +14,7 @@
     <properties>
         <maven.compiler.source>16</maven.compiler.source>
         <maven.compiler.target>16</maven.compiler.target>
+        <consul.api.version>1.4.1</consul.api.version>
     </properties>
     
     <dependencies>
@@ -23,16 +24,10 @@
             <version>${project.version}</version>
         </dependency>
         
-        <!--        <dependency>-->
-        <!--            <groupId>com.orbitz.consul</groupId>-->
-        <!--            <artifactId>consul-client</artifactId>-->
-        <!--            <version>1.5.3</version>-->
-        <!--        </dependency>-->
-        
         <dependency>
             <groupId>com.ecwid.consul</groupId>
             <artifactId>consul-api</artifactId>
-            <version>1.4.1</version>
+            <version>${consul.api.version}</version>
         </dependency>
         
         <dependency>

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/pom.xml
@@ -12,8 +12,6 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <maven.compiler.source>16</maven.compiler.source>
-        <maven.compiler.target>16</maven.compiler.target>
         <consul.api.version>1.4.1</consul.api.version>
     </properties>
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
@@ -44,8 +44,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Registry repository of Consul.
- * @Author: Gavin.peng
- * @Date: 2022/9/3 20:04
  */
 public class ConsulRepository implements ClusterPersistRepository {
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+import com.ecwid.consul.v1.kv.model.PutParams;
+import com.ecwid.consul.v1.session.model.NewSession;
+import com.ecwid.consul.v1.session.model.Session;
+import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
+import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepositoryConfiguration;
+import org.apache.shardingsphere.mode.repository.cluster.consul.lock.ConsulInternalLockHolder;
+import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulProperties;
+import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulPropertyKey;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEventListener;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Registry repository of Consul.
+ * @Author: Gavin.peng
+ * @Date: 2022/9/3 20:04
+ */
+public class ConsulRepository implements ClusterPersistRepository {
+    
+    private ScheduledThreadPoolExecutor scheduledThreadPoolExecutor;
+    
+    private ConsulClient consulClient;
+    
+    private ConsulInternalLockHolder consulInternalLockHolder;
+    
+    private ConsulProperties consulProperties;
+    
+    private Map<String, Set<String>> watchKeyMap;
+    
+    @Override
+    public void init(final ClusterPersistRepositoryConfiguration config) {
+        this.consulClient = new ConsulClient(config.getServerLists());
+        this.consulProperties = new ConsulProperties(config.getProps());
+        this.consulInternalLockHolder = new ConsulInternalLockHolder(this.consulClient, this.consulProperties);
+        this.scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(2);
+        this.watchKeyMap = new HashMap<String, Set<String>>(4);
+    }
+    
+    @Override
+    public String get(final String key) {
+        Response<GetValue> response = this.consulClient.getKVValue(key);
+        return response != null ? response.getValue().getValue() : null;
+    }
+    
+    @Override
+    public List<String> getChildrenKeys(final String key) {
+        Response<List<String>> response = this.consulClient.getKVKeysOnly(key);
+        return response != null ? response.getValue() : Collections.EMPTY_LIST;
+    }
+    
+    @Override
+    public void persist(final String key, final String value) {
+        this.consulClient.setKVValue(key, value);
+    }
+    
+    @Override
+    public void delete(final String key) {
+        this.consulClient.deleteKVValue(key);
+    }
+    
+    @Override
+    public void close() {
+        // this.consulClien
+        // this.consulClient.
+    }
+    
+    @Override
+    public void persistEphemeral(final String key, final String value) {
+        NewSession session = new NewSession();
+        session.setName(key);
+        session.setBehavior(Session.Behavior.DELETE);
+        session.setTtl(this.consulProperties.getValue(ConsulPropertyKey.TIME_TO_LIVE_SECONDS));
+        Response<String> response = this.consulClient.sessionCreate(session, QueryParams.DEFAULT);
+        final String sessionId = response.getValue();
+        PutParams putParams = new PutParams();
+        putParams.setAcquireSession(sessionId);
+        this.consulClient.setKVValue(key, value, putParams);
+        this.scheduledThreadPoolExecutor.scheduleAtFixedRate(new Runnable() {
+            
+            @Override
+            public void run() {
+                ConsulRepository.this.consulClient.renewSession(sessionId, QueryParams.DEFAULT);
+            }
+        }, 5, 10, TimeUnit.SECONDS);
+    }
+    
+    @Override
+    public String getSequentialId(final String key, final String value) {
+        return null;
+    }
+    
+    @Override
+    public void watch(final String key, final DataChangedEventListener listener) {
+        Thread watchThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                watchChildKeyChangeEvent(key, listener);
+            }
+        });
+        watchThread.setDaemon(true);
+        watchThread.start();
+    }
+    
+    private void watchChildKeyChangeEvent(final String key, final DataChangedEventListener listener) {
+        AtomicBoolean running = new AtomicBoolean(true);
+        long currentIndex = 0;
+        while (running.get()) {
+            Response<List<GetValue>> response = consulClient.getKVValues(key,
+                    new QueryParams(consulProperties.getValue(ConsulPropertyKey.BLOCK_QUERY_TIME_TO_SECONDS), currentIndex));
+            Long index = response.getConsulIndex();
+            if (index != null && currentIndex == 0) {
+                currentIndex = index;
+                Set<String> watchKeySet = watchKeyMap.get(key);
+                if (watchKeySet == null) {
+                    watchKeySet = new HashSet<>();
+                }
+                for (GetValue getValue : response.getValue()) {
+                    if (!watchKeySet.contains(getValue.getKey())) {
+                        watchKeySet.add(getValue.getKey());
+                    }
+                }
+                continue;
+            }
+            if (index != null && index > currentIndex) {
+                currentIndex = index;
+                Set<String> newKeySet = new HashSet<>(response.getValue().size());
+                Set<String> watchKeySet = watchKeyMap.get(key);
+                for (GetValue getValue : response.getValue()) {
+                    newKeySet.add(getValue.getKey());
+                    if (!watchKeySet.contains(getValue.getKey())) {
+                        watchKeySet.add(getValue.getKey());
+                        fireDataChangeEvent(getValue, listener, DataChangedEvent.Type.ADDED);
+                    } else if (watchKeySet.contains(getValue.getKey()) && getValue.getModifyIndex() >= currentIndex) {
+                        fireDataChangeEvent(getValue, listener, DataChangedEvent.Type.UPDATED);
+                    }
+                }
+                for (String existKey : watchKeySet) {
+                    if (!newKeySet.contains(existKey)) {
+                        GetValue getValue = new GetValue();
+                        getValue.setKey(existKey);
+                        fireDataChangeEvent(getValue, listener, DataChangedEvent.Type.DELETED);
+                    }
+                }
+                this.watchKeyMap.put(key, newKeySet);
+            } else if (index != null && index < currentIndex) {
+                currentIndex = 0;
+            }
+        }
+    }
+    
+    private void fireDataChangeEvent(final GetValue getValue, final DataChangedEventListener listener, final DataChangedEvent.Type type) {
+        DataChangedEvent event = new DataChangedEvent(getValue.getKey(), getValue.getValue(), type);
+        listener.onChange(event);
+    }
+    
+    @Override
+    public void watchSessionConnection(final InstanceContext instanceContext) {
+        // TODO
+    }
+    
+    @Override
+    public Lock getInternalMutexLock(final String lockName) {
+        return this.consulInternalLockHolder.getInternalMutexLock(lockName);
+    }
+    
+    @Override
+    public Lock getInternalReentrantMutexLock(final String lockName) {
+        return this.consulInternalLockHolder.getInternalReentrantMutexLock(lockName);
+    }
+    
+    @Override
+    public String getType() {
+        return "Consul";
+    }
+    
+    @Override
+    public Collection<String> getTypeAliases() {
+        return ClusterPersistRepository.super.getTypeAliases();
+    }
+    
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereConsulClient.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereConsulClient.java
@@ -22,8 +22,6 @@ import com.ecwid.consul.v1.ConsulRawClient;
 
 /**
  * ShardingSphere consul client support use raw client.
- * @Author: Gavin.peng
- * @Date: 2022/9/25 15:41
  */
 public class ShardingSphereConsulClient extends ConsulClient {
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereConsulClient.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereConsulClient.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.ConsulRawClient;
+
+/**
+ * ShardingSphere consul client support use raw client.
+ * @Author: Gavin.peng
+ * @Date: 2022/9/25 15:41
+ */
+public class ShardingSphereConsulClient extends ConsulClient {
+    
+    private ConsulRawClient rawClient;
+    
+    public ShardingSphereConsulClient(final ConsulRawClient rawClient) {
+        super(rawClient);
+        this.rawClient = rawClient;
+    }
+    
+    /**
+     * Get consul raw client.
+     * @return raw consul client
+     */
+    public ConsulRawClient getRawClient() {
+        return rawClient;
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * ShardingConsul Query Params support wait time MILLISECONDS level.
- * @author Gavin.peng
  */
 public final class ShardingSphereQueryParams implements UrlParameters {
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ShardingSphereQueryParams.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul;
+
+import com.ecwid.consul.UrlParameters;
+import com.ecwid.consul.Utils;
+import com.ecwid.consul.v1.ConsistencyMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * ShardingConsul Query Params support wait time MILLISECONDS level.
+ * @author Gavin.peng
+ */
+public final class ShardingSphereQueryParams implements UrlParameters {
+    
+    public static final ShardingSphereQueryParams DEFAULT = new ShardingSphereQueryParams(ConsistencyMode.DEFAULT);
+    
+    private final String datacenter;
+    
+    private final ConsistencyMode consistencyMode;
+    
+    private final long waitTime;
+    
+    private TimeUnit timeUnit;
+    
+    private final long index;
+    
+    private final String near;
+    
+    private ShardingSphereQueryParams(final String datacenter, final ConsistencyMode consistencyMode, final long waitTime, final TimeUnit timeUnit, final long index, final String near) {
+        this.datacenter = datacenter;
+        this.consistencyMode = consistencyMode;
+        this.waitTime = waitTime;
+        this.timeUnit = timeUnit;
+        this.index = index;
+        this.near = near;
+    }
+    
+    private ShardingSphereQueryParams(final String datacenter, final ConsistencyMode consistencyMode, final long waitTime, final long index) {
+        this(datacenter, consistencyMode, waitTime, TimeUnit.MILLISECONDS, index, null);
+    }
+    
+    public ShardingSphereQueryParams(final ConsistencyMode consistencyMode) {
+        this(null, consistencyMode, -1, -1);
+    }
+    
+    public ShardingSphereQueryParams(final long waitTime, final long index) {
+        this(null, ConsistencyMode.DEFAULT, waitTime, index);
+    }
+    
+    @Override
+    public List<String> toUrlParameters() {
+        List<String> params = new ArrayList<String>();
+        if (datacenter != null) {
+            params.add("dc=" + Utils.encodeValue(datacenter));
+        }
+        if (consistencyMode != ConsistencyMode.DEFAULT) {
+            params.add(consistencyMode.name().toLowerCase());
+        }
+        if (waitTime != -1) {
+            String waitStr = String.valueOf(timeUnit.toMillis(waitTime)) + "ms";
+            params.add("wait=" + waitStr);
+        }
+        if (index != -1) {
+            params.add("index=" + Utils.toUnsignedString(index));
+        }
+        if (near != null) {
+            params.add("near=" + Utils.encodeValue(near));
+        }
+        return params;
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulInternalLockHolder.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulInternalLockHolder.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul.lock;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+import com.ecwid.consul.v1.kv.model.PutParams;
+import com.ecwid.consul.v1.session.model.NewSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+
+/**
+ * Consul internal lock holder.
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class ConsulInternalLockHolder {
+    
+    private static Logger log = LoggerFactory
+            .getLogger(ConsulInternalLockHolder.class);
+    
+    private static final String CONSUL_ROOT_PATH = "sharding/lock";
+    
+    private static final long DEFAULT_LOCK_WAIT_TIME = 10L;
+    
+    private final Map<String, ConsulInternalLock> locks = new ConcurrentHashMap<String, ConsulInternalLock>();
+    
+    private final ConsulClient consulClient;
+    
+    private final ConsulProperties consulProps;
+    
+    /**
+     * Get internal mutex lock.
+     *
+     * @param lockName lock name
+     * @return internal mutex lock
+     */
+    public Lock getInternalMutexLock(final String lockName) {
+        return getInternalReentrantMutexLock(lockName);
+    }
+    
+    /**
+     * Get internal reentrant mutex lock.
+     *
+     * @param lockName lock name
+     * @return internal reentrant mutex lock
+     */
+    public Lock getInternalReentrantMutexLock(final String lockName) {
+        ConsulInternalLock result = locks.get(lockName);
+        if (result == null) {
+            result = createLock(lockName);
+            locks.put(lockName, result);
+        }
+        return result;
+    }
+    
+    private ConsulInternalLock createLock(final String lockName) {
+        try {
+            NewSession session = new NewSession();
+            session.setName(lockName);
+            return new ConsulInternalLock(consulClient, lockName);
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            log.error("ConsulRepository tryLock error, lockName:{}", lockName, ex);
+        }
+        return null;
+    }
+    
+    /**
+     * Consul internal lock.
+     */
+    private static class ConsulInternalLock implements Lock {
+        
+        private final ConsulClient consulClient;
+        
+        private final ThreadLocal<String> lockSessionMap;
+        
+        private final String lockName;
+        
+        ConsulInternalLock(final ConsulClient consulClient, final String lockName) {
+            this.consulClient = consulClient;
+            this.lockName = lockName;
+            this.lockSessionMap = new ThreadLocal<String>();
+        }
+        
+        @Override
+        public void lock() {
+            try {
+                PutParams putParams = new PutParams();
+                NewSession session = new NewSession();
+                session.setName(lockName);
+                String sessionId = this.consulClient.sessionCreate(session, null).getValue();
+                lockSessionMap.set(sessionId);
+                String lockPath = CONSUL_ROOT_PATH + "/" + lockName;
+                while (true) {
+                    if (log.isDebugEnabled()) {
+                        log.debug("Start acquire lock {} with session id {}", lockName, sessionId);
+                    }
+                    putParams.setAcquireSession(sessionId);
+                    Response<Boolean> response = consulClient.setKVValue(lockPath, "lock:" + System.nanoTime(), putParams);
+                    if (response.getValue()) {
+                        // lock success
+                        if (log.isDebugEnabled()) {
+                            log.debug("Session id {} get lock {} is success", sessionId, lockName);
+                        }
+                        return;
+                    } else {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Acquire lock {} failed with session id {},start wait lock by release", lockName, sessionId);
+                        }
+                        // lock failed,exist race so retry
+                        // block query if value is change so return
+                        Long lockIndex = response.getConsulIndex();
+                        if (lockIndex == null) {
+                            lockIndex = 0L;
+                        }
+                        long waitTime = doWaitRelease(lockPath, lockIndex, DEFAULT_LOCK_WAIT_TIME);
+                        if (log.isDebugEnabled()) {
+                            log.debug("Wait lock {} time {}ms found lock is by release so to retry lock", lockName, TimeUnit.NANOSECONDS.toMillis(waitTime));
+                        }
+                    }
+                }
+                // CHECKSTYLE:OFF
+            } catch (final Exception ex) {
+                // CHECKSTYLE:ON
+                log.error("ConsulRepository tryLock error, lockName:{}", lockName, ex);
+                throw new IllegalStateException("Acquire consul lock failed", ex);
+            }
+        }
+        
+        @Override
+        public boolean tryLock() {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public boolean tryLock(final long time, final TimeUnit timeUnit) {
+            try {
+                long lockTime = timeUnit.toSeconds(time);
+                PutParams putParams = new PutParams();
+                NewSession session = new NewSession();
+                session.setName(lockName);
+                String sessionId = this.consulClient.sessionCreate(session, null).getValue();
+                lockSessionMap.set(sessionId);
+                String lockPath = CONSUL_ROOT_PATH + "/" + lockName;
+                while (true) {
+                    putParams.setAcquireSession(sessionId);
+                    Response<Boolean> response = consulClient.setKVValue(lockPath, "lock:" + System.nanoTime(), putParams);
+                    if (response.getValue()) {
+                        // lock success
+                        return true;
+                    } else {
+                        // lock failed,exist race so retry
+                        // block query if value is change so return
+                        long waitTime = doWaitRelease(lockPath, response.getConsulIndex(), lockTime);
+                        if (waitTime < lockTime) {
+                            lockTime = lockTime - waitTime;
+                            continue;
+                        } else {
+                            consulClient.sessionDestroy(sessionId, null);
+                            return false;
+                        }
+                    }
+                }
+                // CHECKSTYLE:OFF
+            } catch (final Exception ex) {
+                // CHECKSTYLE:ON
+                log.error("EtcdRepository tryLock error, lockName:{}", lockName, ex);
+                return false;
+            }
+        }
+        
+        @Override
+        public void unlock() {
+            try {
+                PutParams putParams = new PutParams();
+                String sessionId = lockSessionMap.get();
+                putParams.setReleaseSession(sessionId);
+                String lockPath = CONSUL_ROOT_PATH + "/" + lockName;
+                this.consulClient.setKVValue(lockPath, "unlock:" + System.nanoTime(), putParams).getValue();
+                this.consulClient.sessionDestroy(sessionId, null);
+                if (log.isDebugEnabled()) {
+                    log.debug("Release lock {} with session id {} success", lockName, sessionId);
+                }
+                // CHECKSTYLE:OFF
+            } catch (final Exception ex) {
+                // CHECKSTYLE:ON
+                log.error("EtcdRepository unlock error, lockName:{}", lockName, ex);
+            } finally {
+                lockSessionMap.remove();
+            }
+        }
+        
+        @Override
+        public void lockInterruptibly() {
+            throw new UnsupportedOperationException();
+        }
+        
+        @Override
+        public Condition newCondition() {
+            throw new UnsupportedOperationException();
+        }
+        
+        private long doWaitRelease(final String key, final long valueIndex, final long waitTime) {
+            long currentIndex = valueIndex;
+            if (currentIndex < 0) {
+                currentIndex = 0;
+            }
+            AtomicBoolean running = new AtomicBoolean(true);
+            while (running.get()) {
+                long startWaitTime = System.nanoTime();
+                Response<GetValue> response = consulClient.getKVValue(key,
+                        new QueryParams(waitTime, currentIndex));
+                Long index = response.getConsulIndex();
+                if (index != null && index > currentIndex) {
+                    if (currentIndex == 0) {
+                        currentIndex = index;
+                        continue;
+                    }
+                    currentIndex = index;
+                    GetValue getValue = response.getValue();
+                    if (getValue == null || getValue.getValue() == null) {
+                        continue;
+                    }
+                    if (!key.equals(getValue.getKey())) {
+                        continue;
+                    }
+                    return System.nanoTime() - startWaitTime;
+                } else if (index != null && index < currentIndex) {
+                    currentIndex = 0;
+                }
+            }
+            return -1;
+        }
+    }
+    
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulProperties.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulProperties.java
@@ -17,8 +17,7 @@
 
 package org.apache.shardingsphere.mode.repository.cluster.consul.props;
 
-import org.apache.shardingsphere.infra.properties.TypedProperties;
-
+import org.apache.shardingsphere.infra.util.props.TypedProperties;
 import java.util.Properties;
 
 /**

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulProperties.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulProperties.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul.props;
+
+import org.apache.shardingsphere.infra.properties.TypedProperties;
+
+import java.util.Properties;
+
+/**
+ * Typed properties of Consul.
+ */
+public final class ConsulProperties extends TypedProperties<ConsulPropertyKey> {
+    
+    public ConsulProperties(final Properties props) {
+        super(ConsulPropertyKey.class, props);
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
@@ -23,8 +23,6 @@ import org.apache.shardingsphere.infra.util.props.TypedPropertyKey;
 
 /**
  * Typed property key of Consul.
- * @Author: Gavin.peng
- * @Date: 2022/9/3 20:04
  */
 @RequiredArgsConstructor
 @Getter

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.mode.repository.cluster.consul.props;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.properties.TypedPropertyKey;
+import org.apache.shardingsphere.infra.util.props.TypedPropertyKey;
 
 /**
  * Typed property key of Consul.

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertyKey.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul.props;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.properties.TypedPropertyKey;
+
+/**
+ * Typed property key of Consul.
+ * @Author: Gavin.peng
+ * @Date: 2022/9/3 20:04
+ */
+@RequiredArgsConstructor
+@Getter
+public enum ConsulPropertyKey implements TypedPropertyKey {
+    
+    /**
+     * Time to live seconds.
+     */
+    TIME_TO_LIVE_SECONDS("timeToLiveSeconds", "30s", String.class),
+    
+    /**
+     *Time to live seconds.
+     */
+    LOCK_DELAY_TO_MICORSENDS("lockDelayToMicorsends", "2", String.class),
+    
+    /**
+     *Block query time seconds.
+     */
+    BLOCK_QUERY_TIME_TO_SECONDS("blockQueryTimeToSeconds", "60", long.class);
+    
+    private final String key;
+    
+    private final String defaultValue;
+    
+    private final Class<?> type;
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/resources/META-INF.services/org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/resources/META-INF.services/org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.mode.repository.cluster.etcd.ConsulRepository

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.QueryParams;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.kv.model.GetValue;
+import com.ecwid.consul.v1.kv.model.PutParams;
+import com.ecwid.consul.v1.session.model.NewSession;
+import com.google.protobuf.ByteString;
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulProperties;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
+import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEventListener;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.internal.configuration.plugins.Plugins;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.plugins.MemberAccessor;
+
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class ConsulRepositoryTest {
+    
+    private final ConsulRepository repository = new ConsulRepository();
+    
+    @Mock
+    private ConsulClient client;
+
+    @Mock
+    private Response<GetValue> response;
+    
+    @Mock
+    private Response<List<String>> responseList;
+
+    @Mock
+    private Response<List<GetValue>> responseGetValueList;
+
+    @Mock
+    private Response<Boolean> responseBoolean;
+    
+    @Mock
+    private Response<String> sessionResponse;
+
+    @Mock
+    private GetValue getValue;
+
+    @Mock
+    private List<GetValue> getValueList;
+
+    private long index = 123456L;
+    
+    @Before
+    public void setUp() {
+        setClient();
+        setProperties();
+    }
+    
+    @SneakyThrows(ReflectiveOperationException.class)
+    private void setClient() {
+        mockClient();
+        MemberAccessor accessor = Plugins.getMemberAccessor();
+        accessor.set(repository.getClass().getDeclaredField("consulClient"), repository, client);
+    }
+    
+    @SneakyThrows(ReflectiveOperationException.class)
+    private void setProperties() {
+        MemberAccessor accessor = Plugins.getMemberAccessor();
+        accessor.set(repository.getClass().getDeclaredField("consulProperties"), repository, new ConsulProperties(new Properties()));
+        accessor.set(repository.getClass().getDeclaredField("scheduledThreadPoolExecutor"), repository, new ScheduledThreadPoolExecutor(3));
+        accessor.set(repository.getClass().getDeclaredField("watchKeyMap"), repository, new HashMap<>(4));
+    }
+    
+    @SuppressWarnings("unchecked")
+//    @SneakyThrows({InterruptedException.class, ExecutionException.class})
+    private ConsulClient mockClient() {
+        when(client.getKVValue(any(String.class))).thenReturn(response);
+        when(response.getValue()).thenReturn(getValue);
+        when(client.getKVValues(any(String.class), any(QueryParams.class))).thenReturn(responseGetValueList);
+        when(client.getKVKeysOnly(any(String.class))).thenReturn(responseList);
+        when(client.sessionCreate(any(NewSession.class), any(QueryParams.class))).thenReturn(sessionResponse);
+        when(sessionResponse.getValue()).thenReturn("12323ddsf3sss");
+        when(responseGetValueList.getConsulIndex()).thenReturn(index++);
+        when(responseGetValueList.getValue()).thenReturn(getValueList);
+        when(client.setKVValue(any(String.class), any(String.class))).thenReturn(responseBoolean);
+        return client;
+    }
+    
+    @Test
+    public void assertGetKey() {
+        repository.get("key");
+        verify(client).getKVValue("key");
+        verify(response).getValue();
+    }
+    
+    @Test
+    public void assertGetChildrenKeys() {
+        final String key = "/key";
+        String k1 = "/key/key1/key1-1";
+        String v1 = "value1";
+        client.setKVValue(k1, v1);
+        String k2 = "/key/key2";
+        String v2 = "value2";
+        client.setKVValue(k2, v2);
+        List<String> getValues = Arrays.asList(k1, k2);
+        when(responseList.getValue()).thenReturn(getValues);
+        List<String> actual = repository.getChildrenKeys(key);
+        assertThat(actual.size(), is(2));
+        Iterator<String> iterator = actual.iterator();
+        assertThat(iterator.next(), is("/key/key1/key1-1"));
+        assertThat(iterator.next(), is("/key/key2"));
+    }
+    
+    @Test
+    @SuppressWarnings("unchecked")
+    public void assertPersistEphemeral() {
+        repository.persistEphemeral("key1", "value1");
+        verify(client).sessionCreate(any(NewSession.class), any(QueryParams.class));
+        verify(client).setKVValue(any(String.class), any(String.class), any(PutParams.class));
+        //verify(client).renewSession(any(String.class), any(QueryParams.class));
+    }
+    
+    @Test
+    public void assertWatchUpdate() {
+        String key = "sharding/key";
+        String k1 = "sharding/key/key1";
+        String v1 = "value1";
+        client.setKVValue(k1,v1);
+        GetValue getValue1 = new GetValue();
+        getValue1.setKey(k1);
+        getValue1.setValue(v1);
+        List<GetValue> getValues = Arrays.asList(getValue1);
+        when(responseGetValueList.getValue()).thenReturn(getValues);
+        repository.watch(key, event -> {
+        });
+        verify(client.getKVValues(any(String.class), any(QueryParams.class)));
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+    }
+    
+    @Test
+    public void assertWatchDelete() {
+
+    }
+    
+    @Test
+    public void assertWatchIgnored() {
+        // doAnswer(invocationOnMock -> {
+        // Watch.Listener listener = (Watch.Listener) invocationOnMock.getArguments()[2];
+        // listener.onNext(buildWatchResponse(WatchEvent.EventType.UNRECOGNIZED));
+        // return mock(Watch.Watcher.class);
+        // }).when(watch).watch(any(ByteSequence.class), any(WatchOption.class), any(Watch.Listener.class));
+        // repository.watch("key1", event -> {
+        // });
+        // verify(watch).watch(any(ByteSequence.class), any(WatchOption.class), any(Watch.Listener.class));
+    }
+
+//    @SneakyThrows({NoSuchFieldException.class, SecurityException.class, IllegalAccessException.class})
+//    private WatchResponse buildWatchResponse(final WatchEvent.EventType eventType) {
+//        WatchResponse result = new WatchResponse(mock(io.etcd.jetcd.api.WatchResponse.class), ByteSequence.EMPTY);
+//        List<WatchEvent> events = new LinkedList<>();
+//        io.etcd.jetcd.api.KeyValue keyValue1 = io.etcd.jetcd.api.KeyValue.newBuilder()
+//                .setKey(ByteString.copyFromUtf8("key1"))
+//                .setValue(ByteString.copyFromUtf8("value1")).build();
+//        KeyValue keyValue = new KeyValue(keyValue1, ByteSequence.EMPTY);
+//        events.add(new WatchEvent(keyValue, mock(KeyValue.class), eventType));
+//        MemberAccessor accessor = Plugins.getMemberAccessor();
+//        accessor.set(result.getClass().getDeclaredField("events"), result, events);
+//        return result;
+//    }
+    
+    @Test
+    public void assertDelete() {
+        repository.delete("key");
+        verify(client).deleteKVValue(any(String.class));
+    }
+    
+    @Test
+    public void assertPersist() {
+        repository.persist("key1", "value1");
+        verify(client).setKVValue(any(String.class), any(String.class));
+    }
+    
+    @Test
+    public void assertClose() {
+        repository.close();
+        // verify(client).close();
+    }
+}

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
@@ -23,11 +23,8 @@ import com.ecwid.consul.v1.Response;
 import com.ecwid.consul.v1.kv.model.GetValue;
 import com.ecwid.consul.v1.kv.model.PutParams;
 import com.ecwid.consul.v1.session.model.NewSession;
-import com.google.protobuf.ByteString;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulProperties;
-import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
-import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEventListener;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,17 +33,17 @@ import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.plugins.MemberAccessor;
 
-import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.atLeastOnce;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class ConsulRepositoryTest {
@@ -54,29 +51,29 @@ public final class ConsulRepositoryTest {
     private final ConsulRepository repository = new ConsulRepository();
     
     @Mock
-    private ConsulClient client;
-
+    private ShardingSphereConsulClient client;
+    
     @Mock
     private Response<GetValue> response;
     
     @Mock
     private Response<List<String>> responseList;
-
+    
     @Mock
     private Response<List<GetValue>> responseGetValueList;
-
+    
     @Mock
     private Response<Boolean> responseBoolean;
     
     @Mock
     private Response<String> sessionResponse;
-
+    
     @Mock
     private GetValue getValue;
-
+    
     @Mock
     private List<GetValue> getValueList;
-
+    
     private long index = 123456L;
     
     @Before
@@ -96,12 +93,11 @@ public final class ConsulRepositoryTest {
     private void setProperties() {
         MemberAccessor accessor = Plugins.getMemberAccessor();
         accessor.set(repository.getClass().getDeclaredField("consulProperties"), repository, new ConsulProperties(new Properties()));
-        accessor.set(repository.getClass().getDeclaredField("scheduledThreadPoolExecutor"), repository, new ScheduledThreadPoolExecutor(3));
         accessor.set(repository.getClass().getDeclaredField("watchKeyMap"), repository, new HashMap<>(4));
     }
     
     @SuppressWarnings("unchecked")
-//    @SneakyThrows({InterruptedException.class, ExecutionException.class})
+    // @SneakyThrows({InterruptedException.class, ExecutionException.class})
     private ConsulClient mockClient() {
         when(client.getKVValue(any(String.class))).thenReturn(response);
         when(response.getValue()).thenReturn(getValue);
@@ -146,15 +142,20 @@ public final class ConsulRepositoryTest {
         repository.persistEphemeral("key1", "value1");
         verify(client).sessionCreate(any(NewSession.class), any(QueryParams.class));
         verify(client).setKVValue(any(String.class), any(String.class), any(PutParams.class));
-        //verify(client).renewSession(any(String.class), any(QueryParams.class));
+        try {
+            Thread.sleep(6000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        verify(client).renewSession(any(String.class), any(QueryParams.class));
     }
     
     @Test
     public void assertWatchUpdate() {
-        String key = "sharding/key";
-        String k1 = "sharding/key/key1";
-        String v1 = "value1";
-        client.setKVValue(k1,v1);
+        final String key = "sharding/key";
+        final String k1 = "sharding/key/key1";
+        final String v1 = "value1";
+        client.setKVValue(k1, v1);
         GetValue getValue1 = new GetValue();
         getValue1.setKey(k1);
         getValue1.setValue(v1);
@@ -162,45 +163,45 @@ public final class ConsulRepositoryTest {
         when(responseGetValueList.getValue()).thenReturn(getValues);
         repository.watch(key, event -> {
         });
-        verify(client.getKVValues(any(String.class), any(QueryParams.class)));
+        client.setKVValue(k1, "value1-1");
+        verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
         try {
             Thread.sleep(10000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }
-
+        
     }
     
     @Test
     public void assertWatchDelete() {
-
+        final String key = "sharding/key";
+        final String k1 = "sharding/key/key1";
+        final String v1 = "value1";
+        final String k2 = "sharding/key/key2";
+        final String v2 = "value1";
+        client.setKVValue(k1, v1);
+        client.setKVValue(k2, v2);
+        GetValue getValue1 = new GetValue();
+        getValue1.setKey(k1);
+        getValue1.setValue(v1);
+        List<GetValue> getValues = Arrays.asList(getValue1);
+        when(responseGetValueList.getValue()).thenReturn(getValues);
+        repository.watch(key, event -> {
+        });
+        client.deleteKVValue(k2);
+        verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
+        try {
+            Thread.sleep(10000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
     
     @Test
     public void assertWatchIgnored() {
-        // doAnswer(invocationOnMock -> {
-        // Watch.Listener listener = (Watch.Listener) invocationOnMock.getArguments()[2];
-        // listener.onNext(buildWatchResponse(WatchEvent.EventType.UNRECOGNIZED));
-        // return mock(Watch.Watcher.class);
-        // }).when(watch).watch(any(ByteSequence.class), any(WatchOption.class), any(Watch.Listener.class));
-        // repository.watch("key1", event -> {
-        // });
-        // verify(watch).watch(any(ByteSequence.class), any(WatchOption.class), any(Watch.Listener.class));
+        // TODO
     }
-
-//    @SneakyThrows({NoSuchFieldException.class, SecurityException.class, IllegalAccessException.class})
-//    private WatchResponse buildWatchResponse(final WatchEvent.EventType eventType) {
-//        WatchResponse result = new WatchResponse(mock(io.etcd.jetcd.api.WatchResponse.class), ByteSequence.EMPTY);
-//        List<WatchEvent> events = new LinkedList<>();
-//        io.etcd.jetcd.api.KeyValue keyValue1 = io.etcd.jetcd.api.KeyValue.newBuilder()
-//                .setKey(ByteString.copyFromUtf8("key1"))
-//                .setValue(ByteString.copyFromUtf8("value1")).build();
-//        KeyValue keyValue = new KeyValue(keyValue1, ByteSequence.EMPTY);
-//        events.add(new WatchEvent(keyValue, mock(KeyValue.class), eventType));
-//        MemberAccessor accessor = Plugins.getMemberAccessor();
-//        accessor.set(result.getClass().getDeclaredField("events"), result, events);
-//        return result;
-//    }
     
     @Test
     public void assertDelete() {

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertiesTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/props/ConsulPropertiesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mode.repository.cluster.consul.props;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public final class ConsulPropertiesTest {
+    
+    @Test
+    public void assertGetValue() {
+        assertThat(new ConsulProperties(createProperties()).getValue(ConsulPropertyKey.BLOCK_QUERY_TIME_TO_SECONDS), is(60L));
+    }
+    
+    private Properties createProperties() {
+        Properties result = new Properties();
+        result.setProperty(ConsulPropertyKey.TIME_TO_LIVE_SECONDS.getKey(), "50");
+        return result;
+    }
+    
+    @Test
+    public void assertGetDefaultValue() {
+        assertThat(new ConsulProperties(new Properties()).getValue(ConsulPropertyKey.TIME_TO_LIVE_SECONDS), is(30L));
+    }
+}


### PR DESCRIPTION
New feature for support consul register center， so far 5.2.1 shardingsphere cluster mode repository support zk,etcd,nacos,but not support consul, but consul is very welcome used config center,so support consul is more perfect

Changes proposed in this pull request:
  - config support persist to consul
  - lock implements by consul and support reentrant
  - support watch key update,add,delete event
  - support persist ephemeral node

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
