### PR TITLE
Consul repository support localhost if no config consul server list

### DIFF
--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepository.java
@@ -24,6 +24,7 @@ import com.ecwid.consul.v1.kv.model.GetValue;
 import com.ecwid.consul.v1.kv.model.PutParams;
 import com.ecwid.consul.v1.session.model.NewSession;
 import com.ecwid.consul.v1.session.model.Session;
+import org.apache.commons.lang.StringUtils;
 import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
 import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepositoryConfiguration;
 import org.apache.shardingsphere.mode.repository.cluster.consul.lock.ConsulInternalLockProvider;
@@ -55,7 +56,14 @@ public class ConsulRepository implements ClusterPersistRepository {
     
     @Override
     public void init(final ClusterPersistRepositoryConfiguration config) {
-        consulClient = new ShardingSphereConsulClient(new ConsulRawClient(config.getServerLists()));
+        ConsulRawClient rawClient;
+        String serverList = config.getServerLists();
+        if (StringUtils.isEmpty(serverList)) {
+            rawClient = new ConsulRawClient();
+        } else {
+            rawClient = new ConsulRawClient(serverList);
+        }
+        consulClient = new ShardingSphereConsulClient(rawClient);
         consulProps = new ConsulProperties(config.getProps());
         consulInternalLockProvider = new ConsulInternalLockProvider(consulClient, consulProps);
         watchKeyMap = new HashMap<>(6, 1);

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulInternalLockProvider.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/main/java/org/apache/shardingsphere/mode/repository/cluster/consul/lock/ConsulInternalLockProvider.java
@@ -119,7 +119,7 @@ public class ConsulInternalLockProvider implements InternalLockProvider {
      * @param sessionId session id
      */
     public void generatorFlushSessionTtlTask(final ConsulClient consulClient, final String sessionId) {
-        SESSION_FLUSH_EXECUTOR.scheduleAtFixedRate(() -> consulClient.renewSession(sessionId, QueryParams.DEFAULT), 5L, 10L, TimeUnit.SECONDS);
+        SESSION_FLUSH_EXECUTOR.scheduleAtFixedRate(() -> consulClient.renewSession(sessionId, QueryParams.DEFAULT), 1L, 10L, TimeUnit.SECONDS);
     }
     
     @RequiredArgsConstructor

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
@@ -26,7 +26,6 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.mode.repository.cluster.consul.lock.ConsulInternalLockProvider;
 import org.apache.shardingsphere.mode.repository.cluster.consul.props.ConsulProperties;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -69,16 +68,16 @@ public final class ConsulRepositoryTest {
     @Mock
     private Response<Boolean> responseBoolean;
     
-    // @Mock
-    // private Response<String> sessionResponse;
+    @Mock
+    private Response<String> sessionResponse;
     
     @Mock
     private GetValue getValue;
     
-    // @Mock
-    // private List<GetValue> getValueList;
-    //
-    // private long index = 123456L;
+    @Mock
+    private List<GetValue> getValueList;
+    
+    private long index = 123456L;
     
     @Before
     public void setUp() {
@@ -90,12 +89,12 @@ public final class ConsulRepositoryTest {
     private void setClient() {
         when(client.getKVValue(any(String.class))).thenReturn(response);
         when(response.getValue()).thenReturn(getValue);
-        // when(client.getKVValues(any(String.class), any(QueryParams.class))).thenReturn(responseGetValueList);
+        when(client.getKVValues(any(String.class), any(QueryParams.class))).thenReturn(responseGetValueList);
         when(client.getKVKeysOnly(any(String.class))).thenReturn(responseList);
-        // when(client.sessionCreate(any(NewSession.class), any(QueryParams.class))).thenReturn(sessionResponse);
-        // when(sessionResponse.getValue()).thenReturn("12323ddsf3sss");
-        // when(responseGetValueList.getConsulIndex()).thenReturn(index++);
-        // when(responseGetValueList.getValue()).thenReturn(getValueList);
+        when(client.sessionCreate(any(NewSession.class), any(QueryParams.class))).thenReturn(sessionResponse);
+        when(sessionResponse.getValue()).thenReturn("12323ddsf3sss");
+        when(responseGetValueList.getConsulIndex()).thenReturn(index++);
+        when(responseGetValueList.getValue()).thenReturn(getValueList);
         when(client.setKVValue(any(String.class), any(String.class))).thenReturn(responseBoolean);
         Plugins.getMemberAccessor().set(repository.getClass().getDeclaredField("consulClient"), repository, client);
         Plugins.getMemberAccessor().set(repository.getClass().getDeclaredField("consulInternalLockProvider"), repository, mock(ConsulInternalLockProvider.class));
@@ -134,17 +133,13 @@ public final class ConsulRepositoryTest {
     }
     
     @Test
-    @Ignore
     public void assertPersistEphemeral() throws InterruptedException {
         repository.persistEphemeral("key1", "value1");
         verify(client).sessionCreate(any(NewSession.class), any(QueryParams.class));
         verify(client).setKVValue(any(String.class), any(String.class), any(PutParams.class));
-        Thread.sleep(6000L);
-        verify(client).renewSession(any(String.class), any(QueryParams.class));
     }
     
     @Test
-    @Ignore
     public void assertWatchUpdate() throws InterruptedException {
         final String key = "sharding/key";
         final String k1 = "sharding/key/key1";
@@ -157,12 +152,11 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.setKVValue(k1, "value1-1");
+        Thread.sleep(1000L);
         verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
-        Thread.sleep(10000L);
     }
     
     @Test
-    @Ignore
     public void assertWatchDelete() throws InterruptedException {
         final String key = "sharding/key";
         final String k1 = "sharding/key/key1";
@@ -178,8 +172,8 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.deleteKVValue(k2);
+        Thread.sleep(1000L);
         verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
-        Thread.sleep(10000L);
     }
     
     @Test

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
@@ -152,7 +152,7 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.setKVValue(k1, "value1-1");
-        Thread.sleep(1000L);
+        Thread.sleep(100L);
         verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
     }
     
@@ -172,7 +172,7 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.deleteKVValue(k2);
-        Thread.sleep(1000L);
+        Thread.sleep(100L);
         verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
     }
     

--- a/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
+++ b/shardingsphere-mode/shardingsphere-mode-type/shardingsphere-cluster-mode/shardingsphere-cluster-mode-repository/shardingsphere-cluster-mode-repository-provider/shardingsphere-cluster-mode-repository-consul/src/test/java/org/apache/shardingsphere/mode/repository/cluster/consul/ConsulRepositoryTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
 import org.mockito.internal.configuration.plugins.Plugins;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.plugins.MemberAccessor;
@@ -152,8 +153,15 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.setKVValue(k1, "value1-1");
-        Thread.sleep(100L);
-        verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
+        while (true) {
+            Thread.sleep(100L);
+            try {
+                verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
+                break;
+            } catch (MockitoException e) {
+                continue;
+            }
+        }
     }
     
     @Test
@@ -172,8 +180,15 @@ public final class ConsulRepositoryTest {
         repository.watch(key, event -> {
         });
         client.deleteKVValue(k2);
-        Thread.sleep(100L);
-        verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
+        while (true) {
+            Thread.sleep(100L);
+            try {
+                verify(client, atLeastOnce()).getKVValues(any(String.class), any(QueryParams.class));
+                break;
+            } catch (MockitoException e) {
+                continue;
+            }
+        }
     }
     
     @Test


### PR DESCRIPTION
Consul repository support use localhost consul agent if not config server list

for example:
 -- one:
`ClusterPersistRepositoryConfiguration clusterPersistRepositoryConfiguration = new ClusterPersistRepositoryConfiguration("Consul", "", "", new Properties())`

consul type repository support serverLists param is empty, if is empty, use the default localhost.

-- two:
modify the unit test, reduce the test cost time


