### PR TITLE
Update Snakeyaml to 1.33 and open YAML 3MB limit

### DIFF
--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -289,7 +289,7 @@ The text of each license is the standard Apache 2.0 license.
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0
     quartz 2.3.2: https://github.com/quartz-scheduler/quartz, Apache 2.0
     sketches-core 0.9.0, Apache 2.0
-    snakeyaml 1.32: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
+    snakeyaml 1.33: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
     vertx-mysql-client 4.3.3: https://github.com/eclipse-vertx/vertx-sql-client, Apache 2.0
     vertx-sql-client 4.3.3: https://github.com/eclipse-vertx/vertx-sql-client, Apache 2.0

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/YamlEngine.java
@@ -93,7 +93,7 @@ public final class YamlEngine {
      * @return object from YAML
      */
     public static <T> T unmarshal(final String yamlContent, final Class<T> classType, final boolean skipMissingProps) {
-        Representer representer = new Representer();
+        Representer representer = new Representer(new DumperOptions());
         representer.getPropertyUtils().setSkipMissingProperties(skipMissingProps);
         return new Yaml(new ShardingSphereYamlConstructor(classType), representer).loadAs(yamlContent, classType);
     }
@@ -108,8 +108,8 @@ public final class YamlEngine {
         DumperOptions dumperOptions = new DumperOptions();
         dumperOptions.setLineBreak(DumperOptions.LineBreak.getPlatformLineBreak());
         if (value instanceof Collection) {
-            return new Yaml(new ShardingSphereYamlRepresenter(), dumperOptions).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
+            return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAs(value, null, DumperOptions.FlowStyle.BLOCK);
         }
-        return new Yaml(new ShardingSphereYamlRepresenter(), dumperOptions).dumpAsMap(value);
+        return new Yaml(new ShardingSphereYamlRepresenter(dumperOptions)).dumpAsMap(value);
     }
 }

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/constructor/ShardingSphereYamlConstructor.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.util.yaml.constructor;
 
 import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.infra.util.yaml.shortcuts.ShardingSphereYamlShortcutsFactory;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.constructor.Construct;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -37,7 +38,12 @@ public class ShardingSphereYamlConstructor extends Constructor {
     private final Class<?> rootClass;
     
     public ShardingSphereYamlConstructor(final Class<?> rootClass) {
-        super(rootClass);
+        super(rootClass, new LoaderOptions() {
+            
+            {
+                setCodePointLimit(Integer.MAX_VALUE);
+            }
+        });
         ShardingSphereYamlConstructFactory.getInstances().forEach(each -> typeConstructs.put(each.getType(), each));
         ShardingSphereYamlShortcutsFactory.getAllYamlShortcuts().forEach((key, value) -> addTypeDescription(new TypeDescription(value, key)));
         this.rootClass = rootClass;

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
@@ -38,7 +38,8 @@ import java.util.Map.Entry;
  */
 public final class ShardingSphereYamlRepresenter extends Representer {
     
-    public ShardingSphereYamlRepresenter() {
+    public ShardingSphereYamlRepresenter(DumperOptions dumperOptions) {
+        super(dumperOptions);
         ShardingSphereYamlShortcutsFactory.getAllYamlShortcuts().forEach((key, value) -> addClassTag(value, new Tag(key)));
     }
     

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenter.java
@@ -38,7 +38,7 @@ import java.util.Map.Entry;
  */
 public final class ShardingSphereYamlRepresenter extends Representer {
     
-    public ShardingSphereYamlRepresenter(DumperOptions dumperOptions) {
+    public ShardingSphereYamlRepresenter(final DumperOptions dumperOptions) {
         super(dumperOptions);
         ShardingSphereYamlShortcutsFactory.getAllYamlShortcuts().forEach((key, value) -> addClassTag(value, new Tag(key)));
     }

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenterTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/yaml/representer/ShardingSphereYamlRepresenterTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.util.yaml.representer;
 
 import org.apache.shardingsphere.infra.util.yaml.fixture.pojo.YamlConfigurationFixture;
 import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import java.util.Arrays;
@@ -36,7 +37,7 @@ public final class ShardingSphereYamlRepresenterTest {
     @Test
     public void assertToYamlWithoutContent() {
         YamlConfigurationFixture actual = new YamlConfigurationFixture();
-        assertThat(new Yaml(new ShardingSphereYamlRepresenter()).dumpAsMap(actual), is("{}\n"));
+        assertThat(new Yaml(new ShardingSphereYamlRepresenter(new DumperOptions())).dumpAsMap(actual), is("{}\n"));
     }
     
     @Test
@@ -52,7 +53,7 @@ public final class ShardingSphereYamlRepresenterTest {
         actual.getEmbeddedMap().put("embedded_map_1", new LinkedHashMap<>());
         actual.getEmbeddedMap().put("embedded_map_2", Collections.singletonMap("embedded_map_foo", "embedded_map_foo_value"));
         actual.setCustomizedTag("customized_tag");
-        String expected = new Yaml(new ShardingSphereYamlRepresenter()).dumpAsMap(actual);
+        String expected = new Yaml(new ShardingSphereYamlRepresenter(new DumperOptions())).dumpAsMap(actual);
         assertThat(expected, containsString("collection:\n- value1\n- value2\n"));
         assertThat(expected, containsString("map:\n  key1: value1\n  key2: value2\n"));
         assertThat(expected, not(containsString("embedded_map_1")));

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         
         <antlr4.version>4.9.2</antlr4.version>
-        <snakeyaml.version>1.32</snakeyaml.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
         <gson.version>2.9.1</gson.version>
         <groovy.version>4.0.3</groovy.version>
         


### PR DESCRIPTION
Fixes #21048.

Changes proposed in this pull request:
  - Update Snakeyaml to 1.33 to open 3MB limit . Refer to https://bitbucket.org/snakeyaml/snakeyaml/issues/553/loaderoptionssetcodepointlimit-not-honored .
  - Maybe related to https://github.com/apache/shardingsphere/issues/21211, https://github.com/apache/shardingsphere/issues/21083 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
