### PR TITLE
Change link of repojacking vulnerable link

### DIFF
--- a/docs/blog/content/material/committer.en.md
+++ b/docs/blog/content/material/committer.en.md
@@ -44,11 +44,11 @@ How about starting with a task and training hands? The tasks currently announced
 
 - Implement rule configuration of Sharding-SpringBoot using Inline expression
 
-  https://github.com/sharding-sphere/sharding-sphere/issues/1686
+  https://github.com/apache/shardingsphere/issues/1686
 
 - Implement the rule configuration of Sharding-SpringBoot using SpringBoot placeholder
 
-  https://github.com/sharding-sphere/sharding-sphere/issues/1687
+  https://github.com/apache/shardingsphere/issues/1687
 
 
 We will also regularly publish some development function tasks in the form of issue on GitHub in the future. Welcome to follow us by subscribing to our mailing list. For details, please refer to the official website:

--- a/docs/blog/content/material/proxy.en.md
+++ b/docs/blog/content/material/proxy.en.md
@@ -247,7 +247,7 @@ If you feel confused, please keep it in mind CONNECTION_STRICTLY is a scenario t
 ### 03 Summary
 Sharding-Sphere has been continuous improvement and development since 2016. A growing number of companies and individuals uses it, and they provide many successful cases for us.  We will move forward to improve current features, achieve soft transaction, data governance and so on in succession. If someone has good ideas or wants to do proposals, welcome to join Sharding-Sphere open source project.
 
-*   https://github.com/sharding-sphere/sharding-sphere/
+*   https://github.com/apache/shardingsphere
     
 *   https://gitee.com/sharding-sphere/sharding-sphere/
     


### PR DESCRIPTION
Hello from Hacktoberfest :)
The link to github.com/sharding-sphere/sharding-sphere/ is vulnerable to repojacking (it redirects to the orignial project that changed name), you should change the link to the current name of the project. if you won't change the link, an attacker can open the linked repository and attacks users that trust your links