### PR TITLE
Fix wrong column label when execute aggregation function with PostgreSQL/openGauss database

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -72,6 +72,6 @@ public class AggregationProjection implements Projection {
     @Override
     public String getColumnLabel() {
         boolean isPostgreSQLOpenGaussStatement = databaseType instanceof PostgreSQLDatabaseType || databaseType instanceof OpenGaussDatabaseType;
-        return getAlias().orElseGet(() -> isPostgreSQLOpenGaussStatement ? type.name() : getExpression());
+        return getAlias().orElseGet(() -> isPostgreSQLOpenGaussStatement ? type.name().toLowerCase() : getExpression());
     }
 }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
@@ -17,7 +17,10 @@
 
 package org.apache.shardingsphere.infra.binder.segment.select.projection.impl;
 
+import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.OpenGaussDatabaseType;
+import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.AggregationType;
 import org.junit.Test;
 
@@ -30,35 +33,41 @@ import static org.mockito.Mockito.mock;
 
 public final class AggregationProjectionTest {
     
-    private final AggregationType aggregationType = AggregationType.COUNT;
-    
-    private final String innerExpression = "( A.\"DIRECTION\" )";
-    
-    private final String alias = "AVG_DERIVED_COUNT_0";
-    
-    private final AggregationProjection aggregationProjection1 = new AggregationProjection(aggregationType, innerExpression, alias, mock(DatabaseType.class));
-    
-    private final AggregationProjection aggregationProjection2 = new AggregationProjection(aggregationType, innerExpression, null, mock(DatabaseType.class));
-    
     @Test
     public void assertGetExpression() {
-        assertThat(aggregationProjection1.getExpression(), is(aggregationType + innerExpression));
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, mock(DatabaseType.class));
+        assertThat(projection.getExpression(), is("COUNT( A.\"DIRECTION\" )"));
     }
     
     @Test
     public void assertGetAlias() {
-        Optional<String> actual = aggregationProjection1.getAlias();
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", "AVG_DERIVED_COUNT_0", mock(DatabaseType.class));
+        Optional<String> actual = projection.getAlias();
         assertTrue(actual.isPresent());
-        assertThat(actual.get(), is(alias));
+        assertThat(actual.get(), is("AVG_DERIVED_COUNT_0"));
     }
     
     @Test
-    public void assertGetColumnLabel() {
-        assertThat(aggregationProjection1.getColumnLabel(), is(alias));
+    public void assertGetColumnLabelWithAlias() {
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", "AVG_DERIVED_COUNT_0", mock(DatabaseType.class));
+        assertThat(projection.getColumnLabel(), is("AVG_DERIVED_COUNT_0"));
     }
     
     @Test
     public void assertGetColumnLabelWithoutAlias() {
-        assertThat(aggregationProjection2.getColumnLabel(), is(aggregationType + innerExpression));
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, mock(DatabaseType.class));
+        assertThat(projection.getColumnLabel(), is("COUNT( A.\"DIRECTION\" )"));
+    }
+    
+    @Test
+    public void assertGetColumnLabelWithoutAliasForPostgreSQL() {
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, mock(PostgreSQLDatabaseType.class));
+        assertThat(projection.getColumnLabel(), is("count"));
+    }
+    
+    @Test
+    public void assertGetColumnLabelWithoutAliasForOpenGauss() {
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, mock(OpenGaussDatabaseType.class));
+        assertThat(projection.getColumnLabel(), is("count"));
     }
 }

--- a/kernel/sql-federation/executor/advanced/src/main/java/org/apache/shardingsphere/sqlfederation/advanced/resultset/SQLFederationResultSet.java
+++ b/kernel/sql-federation/executor/advanced/src/main/java/org/apache/shardingsphere/sqlfederation/advanced/resultset/SQLFederationResultSet.java
@@ -97,7 +97,7 @@ public final class SQLFederationResultSet extends AbstractUnsupportedOperationRe
     private String getColumnLabel(final Projection projection, final DatabaseType databaseType) {
         if (projection instanceof AggregationDistinctProjection) {
             boolean isPostgreSQLOpenGaussStatement = databaseType instanceof PostgreSQLDatabaseType || databaseType instanceof OpenGaussDatabaseType;
-            return isPostgreSQLOpenGaussStatement ? ((AggregationDistinctProjection) projection).getType().name() : projection.getExpression();
+            return isPostgreSQLOpenGaussStatement ? ((AggregationDistinctProjection) projection).getType().name().toLowerCase() : projection.getExpression();
         }
         return projection.getColumnLabel();
     }

--- a/kernel/sql-federation/executor/advanced/src/test/java/org/apache/shardingsphere/sqlfederation/advanced/result/SQLFederationResultSetTest.java
+++ b/kernel/sql-federation/executor/advanced/src/test/java/org/apache/shardingsphere/sqlfederation/advanced/result/SQLFederationResultSetTest.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementConte
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.sqlfederation.advanced.resultset.SQLFederationResultSet;
 import org.apache.shardingsphere.sqlfederation.optimizer.metadata.filter.FilterableSchema;
-import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +51,7 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -124,280 +124,280 @@ public final class SQLFederationResultSetTest {
     public void assertGetByteWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{(byte) 1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getByte(1), is((byte) 1));
+        assertThat(federationResultSet.getByte(1), is((byte) 1));
     }
     
     @Test
     public void assertGetByteWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{(byte) 1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getByte("order_id"), is((byte) 1));
+        assertThat(federationResultSet.getByte("order_id"), is((byte) 1));
     }
     
     @Test
     public void assertGetShortWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{(short) 1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getShort(1), is((short) 1));
+        assertThat(federationResultSet.getShort(1), is((short) 1));
     }
     
     @Test
     public void assertGetShortWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{(short) 1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getShort("order_id"), is((short) 1));
+        assertThat(federationResultSet.getShort("order_id"), is((short) 1));
     }
     
     @Test
     public void assertGetIntWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getInt(1), is(1));
+        assertThat(federationResultSet.getInt(1), is(1));
     }
     
     @Test
     public void assertGetIntWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getInt("order_id"), is(1));
+        assertThat(federationResultSet.getInt("order_id"), is(1));
     }
     
     @Test
     public void assertGetLongWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1L, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getLong(1), is(1L));
+        assertThat(federationResultSet.getLong(1), is(1L));
     }
     
     @Test
     public void assertGetLongWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1L, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getLong("order_id"), is(1L));
+        assertThat(federationResultSet.getLong("order_id"), is(1L));
     }
     
     @Test
     public void assertGetFloatWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1.0F, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getFloat(1), is(1.0F));
+        assertThat(federationResultSet.getFloat(1), is(1.0F));
     }
     
     @Test
     public void assertGetFloatWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1.0F, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getFloat("order_id"), is(1.0F));
+        assertThat(federationResultSet.getFloat("order_id"), is(1.0F));
     }
     
     @Test
     public void assertGetDoubleWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1.0D, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDouble(1), is(1.0D));
+        assertThat(federationResultSet.getDouble(1), is(1.0D));
     }
     
     @Test
     public void assertGetDoubleWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1.0D, 1, true, 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDouble("order_id"), is(1.0D));
+        assertThat(federationResultSet.getDouble("order_id"), is(1.0D));
     }
     
     @Test
     public void assertGetStringWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getString(3), is("OK"));
+        assertThat(federationResultSet.getString(3), is("OK"));
     }
     
     @Test
     public void assertGetStringWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getString("status"), is("OK"));
+        assertThat(federationResultSet.getString("status"), is("OK"));
     }
     
     @Test
     public void assertGetNStringWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getNString(3), is("OK"));
+        assertThat(federationResultSet.getNString(3), is("OK"));
     }
     
     @Test
     public void assertGetNStringWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{1, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getNString("status"), is("OK"));
+        assertThat(federationResultSet.getNString("status"), is("OK"));
     }
     
     @Test
     public void assertGetBigDecimalWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new BigDecimal("1"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBigDecimal(1), is(new BigDecimal("1")));
+        assertThat(federationResultSet.getBigDecimal(1), is(new BigDecimal("1")));
     }
     
     @Test
     public void assertGetBigDecimalWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new BigDecimal("1"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBigDecimal("order_id"), is(new BigDecimal("1")));
+        assertThat(federationResultSet.getBigDecimal("order_id"), is(new BigDecimal("1")));
     }
     
     @Test
     public void assertGetBigDecimalAndScaleWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new BigDecimal("1"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBigDecimal(1, 10), is(new BigDecimal("1")));
+        assertThat(federationResultSet.getBigDecimal(1, 10), is(new BigDecimal("1")));
     }
     
     @Test
     public void assertGetBigDecimalAndScaleWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new BigDecimal("1"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBigDecimal("order_id", 10), is(new BigDecimal("1")));
+        assertThat(federationResultSet.getBigDecimal("order_id", 10), is(new BigDecimal("1")));
     }
     
     @Test
     public void assertGetBytesWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new byte[]{(byte) 1}, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBytes(1), is(new byte[]{(byte) 1}));
+        assertThat(federationResultSet.getBytes(1), is(new byte[]{(byte) 1}));
     }
     
     @Test
     public void assertGetBytesWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new byte[]{(byte) 1}, 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBytes("order_id"), is(new byte[]{(byte) 1}));
+        assertThat(federationResultSet.getBytes("order_id"), is(new byte[]{(byte) 1}));
     }
     
     @Test
     public void assertGetDateWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Date(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDate(1), is(new Date(0L)));
+        assertThat(federationResultSet.getDate(1), is(new Date(0L)));
     }
     
     @Test
     public void assertGetDateWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Date(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDate("order_id"), is(new Date(0L)));
+        assertThat(federationResultSet.getDate("order_id"), is(new Date(0L)));
     }
     
     @Test
     public void assertGetDateAndCalendarWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Date(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDate(1, Calendar.getInstance()), is(new Date(0L)));
+        assertThat(federationResultSet.getDate(1, Calendar.getInstance()), is(new Date(0L)));
     }
     
     @Test
     public void assertGetDateAndCalendarWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Date(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getDate("order_id", Calendar.getInstance()), is(new Date(0L)));
+        assertThat(federationResultSet.getDate("order_id", Calendar.getInstance()), is(new Date(0L)));
     }
     
     @Test
     public void assertGetTimeWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Time(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTime(1), is(new Time(0L)));
+        assertThat(federationResultSet.getTime(1), is(new Time(0L)));
     }
     
     @Test
     public void assertGetTimeWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Time(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTime("order_id"), is(new Time(0L)));
+        assertThat(federationResultSet.getTime("order_id"), is(new Time(0L)));
     }
     
     @Test
     public void assertGetTimeAndCalendarWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Time(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTime(1, Calendar.getInstance()), is(new Time(0L)));
+        assertThat(federationResultSet.getTime(1, Calendar.getInstance()), is(new Time(0L)));
     }
     
     @Test
     public void assertGetTimeAndCalendarWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Time(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTime("order_id", Calendar.getInstance()), is(new Time(0L)));
+        assertThat(federationResultSet.getTime("order_id", Calendar.getInstance()), is(new Time(0L)));
     }
     
     @Test
     public void assertGetTimestampWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Timestamp(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTimestamp(1), is(new Timestamp(0L)));
+        assertThat(federationResultSet.getTimestamp(1), is(new Timestamp(0L)));
     }
     
     @Test
     public void assertGetTimestampWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Timestamp(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTimestamp("order_id"), is(new Timestamp(0L)));
+        assertThat(federationResultSet.getTimestamp("order_id"), is(new Timestamp(0L)));
     }
     
     @Test
     public void assertGetTimestampAndCalendarWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Timestamp(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTimestamp(1, Calendar.getInstance()), is(new Timestamp(0L)));
+        assertThat(federationResultSet.getTimestamp(1, Calendar.getInstance()), is(new Timestamp(0L)));
     }
     
     @Test
     public void assertGetTimestampAndCalendarWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{new Timestamp(0L), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getTimestamp("order_id", Calendar.getInstance()), is(new Timestamp(0L)));
+        assertThat(federationResultSet.getTimestamp("order_id", Calendar.getInstance()), is(new Timestamp(0L)));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetAsciiStreamWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getAsciiStream(1), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getAsciiStream(1), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetAsciiStreamWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getAsciiStream("order_id"), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getAsciiStream("order_id"), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetUnicodeStreamWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getUnicodeStream(1), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getUnicodeStream(1), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetUnicodeStreamWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getUnicodeStream("order_id"), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getUnicodeStream("order_id"), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetBinaryStreamWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBinaryStream(1), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getBinaryStream(1), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
     public void assertGetBinaryStreamWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(InputStream.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getBinaryStream("order_id"), instanceOf(InputStream.class));
+        assertThat(federationResultSet.getBinaryStream("order_id"), instanceOf(InputStream.class));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)
@@ -446,28 +446,28 @@ public final class SQLFederationResultSetTest {
     public void assertGetArrayWithColumnIndex() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(Array.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getArray(1), instanceOf(Array.class));
+        assertThat(federationResultSet.getArray(1), instanceOf(Array.class));
     }
     
     @Test
     public void assertGetArrayWithColumnLabel() throws SQLException {
         when(enumerator.current()).thenReturn(new Object[]{mock(Array.class), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getArray("order_id"), instanceOf(Array.class));
+        assertThat(federationResultSet.getArray("order_id"), instanceOf(Array.class));
     }
     
     @Test
     public void assertGetURLWithColumnIndex() throws SQLException, MalformedURLException {
         when(enumerator.current()).thenReturn(new Object[]{new URL("http://xxx.xxx"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getURL(1), is(new URL("http://xxx.xxx")));
+        assertThat(federationResultSet.getURL(1), is(new URL("http://xxx.xxx")));
     }
     
     @Test
     public void assertGetURLWithColumnLabel() throws SQLException, MalformedURLException {
         when(enumerator.current()).thenReturn(new Object[]{new URL("http://xxx.xxx"), 1, "OK", 1});
         federationResultSet.next();
-        MatcherAssert.assertThat(federationResultSet.getURL("order_id"), is(new URL("http://xxx.xxx")));
+        assertThat(federationResultSet.getURL("order_id"), is(new URL("http://xxx.xxx")));
     }
     
     @Test(expected = SQLFeatureNotSupportedException.class)

--- a/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLOptimizeEngineTest.java
+++ b/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLOptimizeEngineTest.java
@@ -37,7 +37,6 @@ import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigu
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sqlfederation.optimizer.metadata.translatable.TranslatableSchema;
 import org.apache.shardingsphere.sqlfederation.optimizer.util.SQLFederationPlannerUtil;
-import org.hamcrest.MatcherAssert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,6 +48,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 
 public final class SQLOptimizeEngineTest {
@@ -143,7 +143,7 @@ public final class SQLOptimizeEngineTest {
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], proj#0..1=[{exprs}])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($0):INTEGER, 13), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -152,7 +152,7 @@ public final class SQLOptimizeEngineTest {
         SQLStatement sqlStatement = sqlParserEngine.parse(SELECT_WHERE_ALL_FIELDS, false);
         String actual = optimizeEngine.optimize(sqlStatement).getBestPlan().explain();
         String expected = "TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0, 1]], filters=[[=(CAST($0):INTEGER, 12), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -161,7 +161,7 @@ public final class SQLOptimizeEngineTest {
         SQLStatement sqlStatement = sqlParserEngine.parse(SELECT_WHERE_SINGLE_FIELD, false);
         String actual = optimizeEngine.optimize(sqlStatement).getBestPlan().explain();
         String expected = "TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($0):INTEGER, 12)]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -175,7 +175,7 @@ public final class SQLOptimizeEngineTest {
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], proj#0..1=[{exprs}])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -189,7 +189,7 @@ public final class SQLOptimizeEngineTest {
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], proj#0..1=[{exprs}])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -203,7 +203,7 @@ public final class SQLOptimizeEngineTest {
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "    EnumerableCalc(expr#0=[{inputs}], expr#1=[CAST($t0):VARCHAR], proj#0..1=[{exprs}])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($0):INTEGER, 13), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -212,7 +212,7 @@ public final class SQLOptimizeEngineTest {
         SQLStatement sqlStatement = sqlParserEngine.parse(SELECT_SUBQUERY_FROM, false);
         String actual = optimizeEngine.optimize(sqlStatement).getBestPlan().explain();
         String expected = "TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0, 1]], filters=[[>(CAST($0):INTEGER, 1), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -226,7 +226,7 @@ public final class SQLOptimizeEngineTest {
                 + "    EnumerableAggregate(group=[{}], agg#0=[MIN($0)])" + LINE_SEPARATOR
                 + "      EnumerableCalc(expr#0..1=[{inputs}], expr#2=[true], $f0=[$t2])" + LINE_SEPARATOR
                 + "        TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0, 1]], filters=[[=(CAST($cor0.user_id):VARCHAR, CAST($0):VARCHAR), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -239,7 +239,7 @@ public final class SQLOptimizeEngineTest {
                 + "    TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "    EnumerableAggregate(group=[{0}])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -256,7 +256,7 @@ public final class SQLOptimizeEngineTest {
                 + "          TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($0):INTEGER, 1)]])" + LINE_SEPARATOR
                 + "    EnumerableAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])" + LINE_SEPARATOR
                 + "      TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($0):INTEGER, 3)]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -268,7 +268,7 @@ public final class SQLOptimizeEngineTest {
                 + "  TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR
                 + "  EnumerableCalc(expr#0=[{inputs}], expr#1=['1':VARCHAR], EXPR$0=[$t1], user_id=[$t0])" + LINE_SEPARATOR
                 + "    TranslatableTableScan(table=[[federate_jdbc, t_user_info]], fields=[[0]], filters=[[=(CAST($1):VARCHAR, 'before'), null]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
     
     @Test
@@ -278,6 +278,6 @@ public final class SQLOptimizeEngineTest {
         String actual = optimizeEngine.optimize(sqlStatement).getBestPlan().explain();
         String expected = "EnumerableLimit(fetch=[1])" + LINE_SEPARATOR
                 + "  TranslatableTableScan(table=[[federate_jdbc, t_order_federate]], fields=[[0, 1]])" + LINE_SEPARATOR;
-        MatcherAssert.assertThat(actual, is(expected));
+        assertThat(actual, is(expected));
     }
 }

--- a/src/resources/checkstyle.xml
+++ b/src/resources/checkstyle.xml
@@ -117,7 +117,7 @@
         <!-- Imports -->
         <module name="AvoidStarImport" />
         <module name="AvoidStaticImport">
-            <property name="excludes" value="org.junit.Assert.*,org.hamcrest.Matchers.*,org.hamcrest.CoreMatchers.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*" />
+            <property name="excludes" value="org.junit.Assert.*,org.hamcrest.Matchers.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*" />
         </module>
         <module name="IllegalImport">
             <property name="illegalClasses" value="org.mockito.junit.MockitoJUnitRunner.Silent" />

--- a/test/integration-test/test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -644,6 +644,10 @@
         <assertion parameters="0:int" expected-data-source-name="shadow_dataset" />
     </test-case>
 
+    <test-case sql="SELECT MIN(o.order_id), MIN(o.merchant_id), i.product_id FROM t_order o INNER JOIN t_order_item i ON o.order_id = i.order_id WHERE o.user_id = ? GROUP BY i.product_id" db-types="PostgreSQL,openGauss" scenario-types="db">
+        <assertion parameters="10:int" expected-data-source-name="read_dataset" />
+    </test-case>
+
 <!--    TODO FIX ME Expected: is "true" but was "1"-->
 <!--    <test-case sql="SELECT order_id, user_id, order_name, type_char, type_boolean, type_smallint, type_enum, type_decimal, type_date, type_time, type_timestamp FROM t_shadow WHERE user_id = ?" db-types="MySQL" scenario-types="sharding_and_shadow">-->
 <!--        <assertion parameters="1:int" expected-data-source-name="prod_dataset" />-->


### PR DESCRIPTION
Fixes #21379.

Changes proposed in this pull request:
  - fix wrong column label when execute aggregation function with PostgreSQL/openGauss database
  - add unit test and integration test
  - modify checkstyle static import

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
