### PR TITLE
Refactor : move some jobs take time from ci to nightly ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
+  MAVEN_OPTS: -T1C -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
 
 jobs:
   ci:
@@ -76,9 +76,9 @@ jobs:
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build prod with Maven
-        run: ./mvnw -B -T1C -ntp clean install
+        run: ./mvnw -B -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -T1C -f examples/pom.xml clean package -DskipTests
+        run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
 
   test-coverage:
     if: github.repository == 'apache/shardingsphere'
@@ -98,6 +98,6 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -B -T1C -ntp clean install cobertura:cobertura -Djacoco.skip=false
+        run: ./mvnw -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build prod with Maven
-        run: ./mvnw -B -ntp clean install
+        run: ./mvnw -B -T1C -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
+        run: ./mvnw -B -T1C -f examples/pom.xml clean package -DskipTests
 
   test-coverage:
     if: github.repository == 'apache/shardingsphere'
@@ -98,6 +98,6 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
+        run: ./mvnw -B -T1C -ntp clean install cobertura:cobertura -Djacoco.skip=false
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
 
 jobs:
   ci:
@@ -76,7 +76,7 @@ jobs:
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build prod with Maven
-        run: ./mvnw -B -ntp clean install -Dmaven.javadoc.skip=true -Djacoco.skip=true 
+        run: ./mvnw -B -ntp clean install
       - name: Build examples with Maven
         run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
 
@@ -98,6 +98,6 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -B -ntp clean install cobertura:cobertura -Dmaven.javadoc.skip=true
+        run: ./mvnw -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -T1C -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dmaven.javadoc.skip=true -Djacoco.skip=true
 
 jobs:
   ci:
@@ -76,9 +76,9 @@ jobs:
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build prod with Maven
-        run: ./mvnw -B -ntp clean install
+        run: ./mvnw -T1C -B -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -f examples/pom.xml clean package -DskipTests
+        run: ./mvnw -T1C -B -f examples/pom.xml clean package -DskipTests
 
   test-coverage:
     if: github.repository == 'apache/shardingsphere'
@@ -98,6 +98,6 @@ jobs:
           distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
+        run: ./mvnw -T1C -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -22,7 +22,7 @@ on:
     - cron: '0 18 */1 * *'  # once a day. UTC time
 
 env:
-  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true
+  MAVEN_OPTS: -T1C -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true
 
 jobs:
   ci:
@@ -51,6 +51,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build prod with Maven
-        run: ./mvnw -B -T1C -ntp clean install
+        run: ./mvnw -B -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -T1C -f examples/pom.xml clean package
+        run: ./mvnw -B -f examples/pom.xml clean package

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -51,6 +51,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build prod with Maven
-        run: ./mvnw -B -ntp clean install
+        run: ./mvnw -B -T1C -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -f examples/pom.xml clean package
+        run: ./mvnw -B -T1C -f examples/pom.xml clean package

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -22,7 +22,7 @@ on:
     - cron: '0 18 */1 * *'  # once a day. UTC time
 
 env:
-  MAVEN_OPTS: -T1C -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dcheckstyle.skip=true
 
 jobs:
   ci:
@@ -51,6 +51,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Build prod with Maven
-        run: ./mvnw -B -ntp clean install
+        run: ./mvnw -T1C -B -ntp clean install
       - name: Build examples with Maven
-        run: ./mvnw -B -f examples/pom.xml clean package
+        run: ./mvnw -T1C -B -f examples/pom.xml clean package


### PR DESCRIPTION
Fixes #21404 .

Changes proposed in this pull request:
  - move javadoc test from ci to nightly ci
  - refactor the ci install to concurrent
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
