### PR TITLE
Support select intersect, except statement in sql federation and refactor combine operator parse

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDecider.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/decider/ShardingSQLFederationDecider.java
@@ -50,7 +50,7 @@ public final class ShardingSQLFederationDecider implements SQLFederationDecider<
         }
         addTableDataNodes(deciderContext, rule, tableNames);
         ShardingConditions shardingConditions = createShardingConditions(queryContext, database, rule);
-        // TODO remove this judge logic when we support issue#21392 
+        // TODO remove this judge logic when we support issue#21392
         if (select.getPaginationContext().isHasPagination() && !(select.getDatabaseType() instanceof PostgreSQLDatabaseType) && !(select.getDatabaseType() instanceof OpenGaussDatabaseType)) {
             return;
         }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -20,6 +20,8 @@ package org.apache.shardingsphere.infra.binder.statement.dml;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.dialect.exception.syntax.database.NoDatabaseSelectedException;
+import org.apache.shardingsphere.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.binder.aware.ParameterAware;
 import org.apache.shardingsphere.infra.binder.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.infra.binder.segment.select.groupby.engine.GroupByContextEngine;
@@ -39,8 +41,6 @@ import org.apache.shardingsphere.infra.binder.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.type.TableAvailable;
 import org.apache.shardingsphere.infra.binder.type.WhereAvailable;
-import org.apache.shardingsphere.dialect.exception.syntax.database.NoDatabaseSelectedException;
-import org.apache.shardingsphere.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
@@ -172,7 +172,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext<Sele
      * @return whether contains combine or not
      */
     public boolean isContainsCombine() {
-        return !getSqlStatement().getCombines().isEmpty();
+        return getSqlStatement().getCombine().isPresent();
     }
     
     /**

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/SQLNodeConverterEngine.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/SQLNodeConverterEngine.java
@@ -47,7 +47,7 @@ public final class SQLNodeConverterEngine {
         if (statement instanceof SelectStatement) {
             SqlNode result = new SelectStatementConverter().convert((SelectStatement) statement);
             if (((SelectStatement) statement).getCombine().isPresent()) {
-                return convert(result, ((SelectStatement) statement));
+                return convert(result, (SelectStatement) statement);
             }
             return result;
         }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/type/CombineOperatorConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/type/CombineOperatorConverter.java
@@ -39,10 +39,12 @@ public final class CombineOperatorConverter {
     private static void registerCombine() {
         REGISTRY.put(CombineType.UNION, SqlStdOperatorTable.UNION);
         REGISTRY.put(CombineType.UNION_ALL, SqlStdOperatorTable.UNION_ALL);
-        REGISTRY.put(CombineType.INTERSECT_ALL, SqlStdOperatorTable.INTERSECT_ALL);
         REGISTRY.put(CombineType.INTERSECT, SqlStdOperatorTable.INTERSECT);
-        REGISTRY.put(CombineType.EXCEPT_ALL, SqlStdOperatorTable.EXCEPT_ALL);
+        REGISTRY.put(CombineType.INTERSECT_ALL, SqlStdOperatorTable.INTERSECT_ALL);
         REGISTRY.put(CombineType.EXCEPT, SqlStdOperatorTable.EXCEPT);
+        REGISTRY.put(CombineType.EXCEPT_ALL, SqlStdOperatorTable.EXCEPT_ALL);
+        REGISTRY.put(CombineType.MINUS, SqlStdOperatorTable.EXCEPT);
+        REGISTRY.put(CombineType.MINUS_ALL, SqlStdOperatorTable.EXCEPT_ALL);
     }
     
     /**

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/util/SQLFederationPlannerUtil.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/util/SQLFederationPlannerUtil.java
@@ -109,18 +109,7 @@ public final class SQLFederationPlannerUtil {
     private static void setUpRules(final RelOptPlanner planner) {
         planner.addRelTraitDef(ConventionTraitDef.INSTANCE);
         planner.addRelTraitDef(RelCollationTraitDef.INSTANCE);
-        planner.addRule(EnumerableRules.ENUMERABLE_CALC_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_SORT_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_LIMIT_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_JOIN_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_AGGREGATE_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_FILTER_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_PROJECT_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_CORRELATE_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_UNION_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_FILTER_TO_CALC_RULE);
-        planner.addRule(EnumerableRules.ENUMERABLE_PROJECT_TO_CALC_RULE);
+        EnumerableRules.rules().forEach(planner::addRule);
     }
     
     private static Collection<RelOptRule> getSubQueryRules() {

--- a/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/type/CombineOperatorConverterTest.java
+++ b/kernel/sql-federation/optimizer/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/type/CombineOperatorConverterTest.java
@@ -34,10 +34,7 @@ public final class CombineOperatorConverterTest {
         assertThat(CombineOperatorConverter.convert(CombineType.INTERSECT), is(SqlStdOperatorTable.INTERSECT));
         assertThat(CombineOperatorConverter.convert(CombineType.EXCEPT_ALL), is(SqlStdOperatorTable.EXCEPT_ALL));
         assertThat(CombineOperatorConverter.convert(CombineType.EXCEPT), is(SqlStdOperatorTable.EXCEPT));
-    }
-    
-    @Test(expected = IllegalStateException.class)
-    public void assertConvertFailure() {
-        CombineOperatorConverter.convert(CombineType.MINUS);
+        assertThat(CombineOperatorConverter.convert(CombineType.MINUS_ALL), is(SqlStdOperatorTable.EXCEPT_ALL));
+        assertThat(CombineOperatorConverter.convert(CombineType.MINUS), is(SqlStdOperatorTable.EXCEPT));
     }
 }

--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -686,11 +686,16 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
         }
         if (null != ctx.queryExpressionBody()) {
             MySQLSelectStatement result = (MySQLSelectStatement) visit(ctx.queryExpressionBody());
-            result.getCombines().add((CombineSegment) visitCombineClause(ctx.combineClause()));
+            CombineSegment combineSegment = (CombineSegment) visitCombineClause(ctx.combineClause());
+            if (result.getCombine().isPresent()) {
+                result.getCombine().get().getSelectStatement().setCombine(combineSegment);
+            } else {
+                result.setCombine(combineSegment);
+            }
             return result;
         }
         MySQLSelectStatement result = (MySQLSelectStatement) visit(ctx.queryExpressionParens());
-        result.getCombines().add((CombineSegment) visitCombineClause(ctx.combineClause()));
+        result.setCombine((CombineSegment) visitCombineClause(ctx.combineClause()));
         return result;
     }
     

--- a/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
+++ b/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
@@ -902,8 +902,13 @@ public abstract class OpenGaussStatementSQLVisitor extends OpenGaussStatementBas
         }
         if (null != ctx.selectClauseN() && !ctx.selectClauseN().isEmpty()) {
             OpenGaussSelectStatement result = (OpenGaussSelectStatement) visit(ctx.selectClauseN(0));
-            result.getCombines().add(new CombineSegment(
-                    ((TerminalNode) ctx.getChild(1)).getSymbol().getStartIndex(), ctx.getStop().getStopIndex(), getCombineType(ctx), (OpenGaussSelectStatement) visit(ctx.selectClauseN(1))));
+            CombineSegment combineSegment = new CombineSegment(((TerminalNode) ctx.getChild(1)).getSymbol().getStartIndex(), ctx.getStop().getStopIndex(), getCombineType(ctx),
+                    (OpenGaussSelectStatement) visit(ctx.selectClauseN(1)));
+            if (result.getCombine().isPresent()) {
+                result.getCombine().get().getSelectStatement().setCombine(combineSegment);
+            } else {
+                result.setCombine(combineSegment);
+            }
             return result;
         }
         return visit(ctx.selectWithParens());

--- a/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -872,8 +872,13 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementP
         }
         if (null != ctx.selectClauseN() && !ctx.selectClauseN().isEmpty()) {
             PostgreSQLSelectStatement result = (PostgreSQLSelectStatement) visit(ctx.selectClauseN(0));
-            result.getCombines().add(new CombineSegment(
-                    ((TerminalNode) ctx.getChild(1)).getSymbol().getStartIndex(), ctx.getStop().getStopIndex(), getCombineType(ctx), (PostgreSQLSelectStatement) visit(ctx.selectClauseN(1))));
+            CombineSegment combineSegment = new CombineSegment(((TerminalNode) ctx.getChild(1)).getSymbol().getStartIndex(), ctx.getStop().getStopIndex(), getCombineType(ctx),
+                    (PostgreSQLSelectStatement) visit(ctx.selectClauseN(1)));
+            if (result.getCombine().isPresent()) {
+                result.getCombine().get().getSelectStatement().setCombine(combineSegment);
+            } else {
+                result.setCombine(combineSegment);
+            }
             return result;
         }
         return visit(ctx.selectWithParens());

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
@@ -91,8 +91,8 @@ public final class TableExtractor {
         if (SelectStatementHandler.getLockSegment(selectStatement).isPresent()) {
             extractTablesFromLock(SelectStatementHandler.getLockSegment(selectStatement).get());
         }
-        if (!selectStatement.getCombines().isEmpty()) {
-            selectStatement.getCombines().forEach(each -> extractTablesFromSelect(each.getSelectStatement()));
+        if (selectStatement.getCombine().isPresent()) {
+            extractTablesFromSelect(selectStatement.getCombine().get().getSelectStatement());
         }
     }
     

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dml/SelectStatement.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dml/SelectStatement.java
@@ -29,8 +29,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.Whe
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.Optional;
 
 /**
@@ -53,7 +51,7 @@ public abstract class SelectStatement extends AbstractSQLStatement implements DM
     
     private OrderBySegment orderBy;
     
-    private final Collection<CombineSegment> combines = new LinkedList<>();
+    private CombineSegment combine;
     
     /**
      * Get where.
@@ -89,5 +87,14 @@ public abstract class SelectStatement extends AbstractSQLStatement implements DM
      */
     public Optional<OrderBySegment> getOrderBy() {
         return Optional.ofNullable(orderBy);
+    }
+    
+    /**
+     * Get combine segment.
+     *
+     * @return order by segment
+     */
+    public Optional<CombineSegment> getCombine() {
+        return Optional.ofNullable(combine);
     }
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dml/SelectStatement.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/dml/SelectStatement.java
@@ -92,7 +92,7 @@ public abstract class SelectStatement extends AbstractSQLStatement implements DM
     /**
      * Get combine segment.
      *
-     * @return order by segment
+     * @return combine segment
      */
     public Optional<CombineSegment> getCombine() {
         return Optional.ofNullable(combine);

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtil.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtil.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.sql.parser.sql.common.util;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.sql.parser.sql.common.constant.SubqueryType;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BetweenExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExistsSubqueryExpression;
@@ -65,13 +64,7 @@ public final class SubqueryExtractUtil {
         if (selectStatement.getWhere().isPresent()) {
             extractSubquerySegmentsFromExpression(result, selectStatement.getWhere().get().getExpr());
         }
-        extractSubquerySegmentsFromCombines(result, selectStatement.getCombines());
-    }
-    
-    private static void extractSubquerySegmentsFromCombines(final List<SubquerySegment> result, final Collection<CombineSegment> combineSegments) {
-        for (CombineSegment each : combineSegments) {
-            extractSubquerySegments(result, each.getSelectStatement());
-        }
+        selectStatement.getCombine().ifPresent(optional -> extractSubquerySegments(result, optional.getSelectStatement()));
     }
     
     private static void extractSubquerySegmentsFromProjections(final List<SubquerySegment> result, final ProjectionsSegment projections) {

--- a/sql-parser/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilTest.java
+++ b/sql-parser/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilTest.java
@@ -170,7 +170,7 @@ public final class SubqueryExtractUtilTest {
     @Test
     public void assertGetSubquerySegmentsWithCombineSegment() {
         SelectStatement selectStatement = new MySQLSelectStatement();
-        selectStatement.getCombines().add(new CombineSegment(0, 0, CombineType.UNION, createSelectStatementForCombineSegment()));
+        selectStatement.setCombine(new CombineSegment(0, 0, CombineType.UNION, createSelectStatementForCombineSegment()));
         Collection<SubquerySegment> actual = SubqueryExtractUtil.getSubquerySegments(selectStatement);
         assertThat(actual.size(), is(1));
     }

--- a/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
+++ b/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
@@ -87,8 +87,6 @@ public final class SQLNodeConverterEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_distinct_with_single_count_group_by");
         SUPPORTED_SQL_CASE_IDS.add("select_bit_xor");
         SUPPORTED_SQL_CASE_IDS.add("select_with_schema");
-        SUPPORTED_SQL_CASE_IDS.add("select_with_union");
-        SUPPORTED_SQL_CASE_IDS.add("select_with_union_all");
         SUPPORTED_SQL_CASE_IDS.add("select_with_same_table_name_and_alias");
         SUPPORTED_SQL_CASE_IDS.add("select_count_like_concat");
         SUPPORTED_SQL_CASE_IDS.add("select_order_by_asc_and_index_desc");
@@ -128,6 +126,12 @@ public final class SQLNodeConverterEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_fetch");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_offset_and_row_count");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_row_count");
+        SUPPORTED_SQL_CASE_IDS.add("select_with_union");
+        SUPPORTED_SQL_CASE_IDS.add("select_with_union_all");
+        SUPPORTED_SQL_CASE_IDS.add("select_union");
+        SUPPORTED_SQL_CASE_IDS.add("select_intersect");
+        SUPPORTED_SQL_CASE_IDS.add("select_except");
+        SUPPORTED_SQL_CASE_IDS.add("select_minus");
     }
     // CHECKSTYLE:ON
     

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/SelectStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/dml/impl/SelectStatementAssert.java
@@ -19,9 +19,9 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.limit.LimitSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.predicate.LockSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.combine.CombineSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.ModelSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WindowSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WithSegment;
@@ -43,13 +43,12 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.w
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.with.WithClauseAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.dml.SelectStatementTestCase;
 
-import java.util.Collection;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -76,7 +75,7 @@ public final class SelectStatementAssert {
         assertTable(assertContext, actual, expected);
         assertLockClause(assertContext, actual, expected);
         assertWithClause(assertContext, actual, expected);
-        assertCombines(assertContext, actual, expected);
+        assertCombineClause(assertContext, actual, expected);
         assertModelClause(assertContext, actual, expected);
     }
     
@@ -181,19 +180,15 @@ public final class SelectStatementAssert {
         }
     }
     
-    private static void assertCombines(final SQLCaseAssertContext assertContext, final SelectStatement actual, final SelectStatementTestCase expected) {
-        if (expected.getCombine().isEmpty()) {
-            return;
-        }
-        Collection<CombineSegment> combineSegments = actual.getCombines();
-        assertFalse(assertContext.getText("Actual combine segment should exist."), combineSegments.isEmpty());
-        assertThat(assertContext.getText("Combine size assertion error: "), combineSegments.size(), is(expected.getCombine().size()));
-        int count = 0;
-        for (CombineSegment each : combineSegments) {
-            assertThat(assertContext.getText("Combine type assertion error: "), each.getCombineType().name(), is(expected.getCombine().get(count).getCombineType()));
-            SQLSegmentAssert.assertIs(assertContext, each, expected.getCombine().get(count));
-            assertIs(assertContext, each.getSelectStatement(), expected.getCombine().get(count).getSelectClause());
-            count++;
+    private static void assertCombineClause(final SQLCaseAssertContext assertContext, final SelectStatement actual, final SelectStatementTestCase expected) {
+        Optional<CombineSegment> combineSegment = actual.getCombine();
+        if (null == expected.getCombineClause()) {
+            assertFalse(assertContext.getText("Actual combine segment should not exist."), combineSegment.isPresent());
+        } else {
+            assertTrue(assertContext.getText("Actual combine segment should exist."), combineSegment.isPresent());
+            assertThat(assertContext.getText("Combine type assertion error: "), combineSegment.get().getCombineType().name(), is(expected.getCombineClause().getCombineType()));
+            SQLSegmentAssert.assertIs(assertContext, combineSegment.get(), expected.getCombineClause());
+            assertIs(assertContext, combineSegment.get().getSelectStatement(), expected.getCombineClause().getSelectClause());
         }
     }
     

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/SelectStatementTestCase.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/dml/SelectStatementTestCase.java
@@ -34,8 +34,6 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Select statement test case.
@@ -78,7 +76,7 @@ public final class SelectStatementTestCase extends SQLParserTestCase {
     private ExpectedWithClause withClause;
     
     @XmlElement(name = "combine")
-    private List<ExpectedCombine> combine = new LinkedList<>();
+    private ExpectedCombine combineClause;
     
     @XmlElement(name = "model")
     private ExpectedModelClause modelClause;

--- a/test/parser/src/main/resources/case/ddl/create-view.xml
+++ b/test/parser/src/main/resources/case/ddl/create-view.xml
@@ -74,30 +74,30 @@
         <select>
             <!-- FIXME support VALUES (1) projection parse -->
             <projections start-index="-1" stop-index="-1" />
+            <combine combine-type="UNION_ALL" start-index="58" stop-index="107">
+                <select>
+                    <projections start-index="75" stop-index="77">
+                        <expression-projection text="n+1" start-index="75" stop-index="77" />
+                    </projections>
+                    <from>
+                        <simple-table name="nums_1_100" start-index="84" stop-index="93" />
+                    </from>
+                    <where start-index="95" stop-index="107">
+                        <expr>
+                            <binary-operation-expression start-index="101" stop-index="107">
+                                <left>
+                                    <column name="n" start-index="101" stop-index="101"/>
+                                </left>
+                                <right>
+                                    <literal-expression value="100" start-index="105" stop-index="107"/>
+                                </right>
+                                <operator>=</operator>
+                            </binary-operation-expression>
+                        </expr>
+                    </where>
+                </select>
+            </combine>
         </select>
-        <combine combine-type="UNION_ALL" start-index="58" stop-index="107">
-            <select>
-                <projections start-index="75" stop-index="77">
-                    <expression-projection text="n+1" alias="a" start-index="75" stop-index="77" />
-                </projections>
-                <from>
-                    <simple-table name="nums_1_100" start-index="84" stop-index="93" />
-                </from>
-                <where start-index="95" stop-index="107">
-                    <expr>
-                        <binary-operation-expression start-index="101" stop-index="107">
-                            <left>
-                                <column name="n" start-index="101" stop-index="101"/>
-                            </left>
-                            <right>
-                                <literal-expression value="100" start-index="105" stop-index="107"/>
-                            </right>
-                            <operator>=</operator>
-                        </binary-operation-expression>
-                    </expr>
-                </where>
-            </select>
-        </combine>
     </create-view>
     
     <create-view sql-case-id="create_view_with_option" view-definition="SELECT * FROM t_order">

--- a/test/parser/src/main/resources/case/dml/select-union.xml
+++ b/test/parser/src/main/resources/case/dml/select-union.xml
@@ -43,7 +43,7 @@
         <from>
             <simple-table name="table1" start-index="14" stop-index="19" />
         </from>
-        <union union-type="UNION_ALL" start-index="21" stop-index="50">
+        <combine combine-type="UNION_ALL" start-index="21" stop-index="50">
             <select>
                 <projections start-index="38" stop-index="38">
                     <shorthand-projection start-index="38" stop-index="38" />
@@ -52,7 +52,7 @@
                     <simple-table name="table2" start-index="45" stop-index="50" />
                 </from>
             </select>
-        </union>
+        </combine>
     </select>
 
     <select sql-case-id="select_union">
@@ -89,16 +89,16 @@
                 <from>
                     <simple-table name="table2" start-index="45" stop-index="50" />
                 </from>
-            </select>
-        </combine>
-        <combine combine-type="INTERSECT" start-index="52" stop-index="81">
-            <select>
-                <projections start-index="69" stop-index="69">
-                    <shorthand-projection start-index="69" stop-index="69" />
-                </projections>
-                <from>
-                    <simple-table name="table3" start-index="76" stop-index="81" />
-                </from>
+                <combine combine-type="INTERSECT" start-index="52" stop-index="81">
+                    <select>
+                        <projections start-index="69" stop-index="69">
+                            <shorthand-projection start-index="69" stop-index="69" />
+                        </projections>
+                        <from>
+                            <simple-table name="table3" start-index="76" stop-index="81" />
+                        </from>
+                    </select>
+                </combine>
             </select>
         </combine>
     </select>
@@ -118,16 +118,16 @@
                 <from>
                     <simple-table name="table2" start-index="46" stop-index="51" />
                 </from>
-            </select>
-        </combine>
-        <combine combine-type="EXCEPT_ALL" start-index="53" stop-index="83">
-            <select>
-                <projections start-index="71" stop-index="71">
-                    <shorthand-projection start-index="71" stop-index="71" />
-                </projections>
-                <from>
-                    <simple-table name="table3" start-index="78" stop-index="83" />
-                </from>
+                <combine combine-type="EXCEPT_ALL" start-index="53" stop-index="83">
+                    <select>
+                        <projections start-index="71" stop-index="71">
+                            <shorthand-projection start-index="71" stop-index="71" />
+                        </projections>
+                        <from>
+                            <simple-table name="table3" start-index="78" stop-index="83" />
+                        </from>
+                    </select>
+                </combine>
             </select>
         </combine>
     </select>


### PR DESCRIPTION
Fixes #21420.

Changes proposed in this pull request:
  - support select intersect, except statement in sql federation
  - refactor combine operator parse
  - add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
