### PR TITLE
Migration job stop cascade latest consistency check job

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusQueryResultSet.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusQueryResultSet.java
@@ -48,7 +48,7 @@ public final class ShowMigrationCheckStatusQueryResultSet implements DatabaseDis
         List<Collection<Object>> result = new LinkedList<>();
         String checkResult = null == progressInfo.getCheckSuccess() ? "" : progressInfo.getCheckSuccess().toString();
         result.add(Arrays.asList(Optional.ofNullable(progressInfo.getTableNames()).orElse(""), checkResult, String.valueOf(progressInfo.getFinishedPercentage()),
-                progressInfo.getDurationSeconds(),
+                progressInfo.getRemainingSeconds(),
                 Optional.ofNullable(progressInfo.getCheckBeginTime()).orElse(""),
                 Optional.ofNullable(progressInfo.getCheckEndTime()).orElse(""),
                 progressInfo.getDurationSeconds(), Optional.ofNullable(progressInfo.getErrorMessage()).orElse("")));

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobHasAlreadyFinishedException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/job/PipelineJobHasAlreadyFinishedException.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpe
 /**
  * Pipeline job has already finished exception.
  */
+// TODO keep it for now, it might be used later
 public final class PipelineJobHasAlreadyFinishedException extends PipelineSQLException {
     
     private static final long serialVersionUID = 6881217592831423520L;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJobAPIImpl.java
@@ -39,7 +39,6 @@ import org.apache.shardingsphere.data.pipeline.core.api.GovernanceRepositoryAPI;
 import org.apache.shardingsphere.data.pipeline.core.api.InventoryIncrementalJobAPI;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.api.impl.AbstractPipelineJobAPIImpl;
-import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobHasAlreadyFinishedException;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PipelineJobNotFoundException;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.UncompletedConsistencyCheckJobExistsException;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
@@ -146,7 +145,10 @@ public final class ConsistencyCheckJobAPIImpl extends AbstractPipelineJobAPIImpl
     public void startDisabledJob(final String jobId) {
         log.info("Start disable check job {}", jobId);
         PipelineJobItemProgress jobProgress = getJobItemProgress(jobId, 0);
-        ShardingSpherePreconditions.checkState(null == jobProgress || JobStatus.FINISHED != jobProgress.getStatus(), () -> new PipelineJobHasAlreadyFinishedException(jobId));
+        if (null != jobProgress && JobStatus.FINISHED == jobProgress.getStatus()) {
+            log.info("job status is FINISHED, ignore, jobId={}", jobId);
+            return;
+        }
         super.startDisabledJob(jobId);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
@@ -250,12 +250,28 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
     @Override
     public void startDisabledJob(final String jobId) {
         super.startDisabledJob(jobId);
-        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> ConsistencyCheckJobAPIFactory.getInstance().startDisabledJob(optional));
+        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> {
+            try {
+                ConsistencyCheckJobAPIFactory.getInstance().startDisabledJob(optional);
+                // CHECKSTYLE:OFF
+            } catch (final RuntimeException ex) {
+                // CHECKSTYLE:ON
+                log.warn("start related check job failed, check job id: {}, error: {}", optional, ex.getMessage());
+            }
+        });
     }
     
     @Override
     public void stop(final String jobId) {
-        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> ConsistencyCheckJobAPIFactory.getInstance().stop(optional));
+        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> {
+            try {
+                ConsistencyCheckJobAPIFactory.getInstance().stop(optional);
+                // CHECKSTYLE:OFF
+            } catch (final RuntimeException ex) {
+                // CHECKSTYLE:ON
+                log.warn("stop related check job failed, check job id: {}, error: {}", optional, ex.getMessage());
+            }
+        });
         super.stop(jobId);
     }
     
@@ -278,7 +294,13 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
         log.info("dropCheckJobs start...");
         long startTimeMillis = System.currentTimeMillis();
         for (String each : checkJobIds) {
-            dropJob(each);
+            try {
+                dropJob(each);
+                // CHECKSTYLE:OFF
+            } catch (final RuntimeException ex) {
+                // CHECKSTYLE:ON
+                log.info("drop check job failed, check job id: {}, error: {}", each, ex.getMessage());
+            }
         }
         log.info("dropCheckJobs cost {} ms", System.currentTimeMillis() - startTimeMillis);
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
@@ -248,6 +248,18 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
     }
     
     @Override
+    public void startDisabledJob(final String jobId) {
+        super.startDisabledJob(jobId);
+        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> ConsistencyCheckJobAPIFactory.getInstance().startDisabledJob(optional));
+    }
+    
+    @Override
+    public void stop(final String jobId) {
+        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> ConsistencyCheckJobAPIFactory.getInstance().stop(optional));
+        super.stop(jobId);
+    }
+    
+    @Override
     public void rollback(final String jobId) throws SQLException {
         log.info("Rollback job {}", jobId);
         final long startTimeMillis = System.currentTimeMillis();
@@ -421,12 +433,6 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
         result.setType(type);
         result.setParameter(parameter);
         return result;
-    }
-    
-    @Override
-    public void startDisabledJob(final String jobId) {
-        super.startDisabledJob(jobId);
-        PipelineAPIFactory.getGovernanceRepositoryAPI().getCheckLatestJobId(jobId).ifPresent(optional -> ConsistencyCheckJobAPIFactory.getInstance().startDisabledJob(optional));
     }
     
     @Override


### PR DESCRIPTION

Changes proposed in this pull request:
  - Migration job stop cascade latest check job
  - Start consistency check job do not throw exception when check job is finished
  - Fix wrong column of remaining_seconds
  - Ignore related consistency check job error on start/stop/commit/rollback

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
