### PR TITLE
Fix ddl initial SQL execute occasional exception in cluster mode

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -43,6 +43,7 @@ on:
       - '**/pom.xml'
       - '**/src/main/**'
       - 'distribution/proxy/**'
+      - '!test/**'
       - 'test/pom.xml'
       - 'test/integration-test/fixture/**'
       - 'test/integration-test/env/**'
@@ -52,7 +53,6 @@ on:
       - '!distribution/**'
       - '!distribution/proxy/src/main/release-docs/**'
       - '!kernel/data-pipeline/**'
-      - '!test/**'
       - '!*.md'
 
 concurrency:

--- a/test/integration-test/test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/ddl/BaseDDLIT.java
+++ b/test/integration-test/test-suite/src/test/java/org/apache/shardingsphere/test/integration/engine/ddl/BaseDDLIT.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.test.integration.engine.ddl;
 
 import com.google.common.base.Splitter;
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.dialect.exception.syntax.table.NoSuchTableException;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.util.expr.InlineExpressionParser;
@@ -39,6 +40,7 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -69,6 +71,7 @@ public abstract class BaseDDLIT extends SingleITCase {
             try (PreparedStatement preparedStatement = connection.prepareStatement(each)) {
                 preparedStatement.executeUpdate();
             }
+            waitCompleted();
         }
     }
     
@@ -196,5 +199,10 @@ public abstract class BaseDDLIT extends SingleITCase {
                 assertThat(each.isUnique(), is(expected.isUnique()));
             }
         }
+    }
+    
+    @SneakyThrows(InterruptedException.class)
+    private void waitCompleted() {
+        TimeUnit.MILLISECONDS.sleep(100);
     }
 }

--- a/test/integration-test/test-suite/src/test/resources/cases/ddl/ddl-integration-test-cases.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/ddl/ddl-integration-test-cases.xml
@@ -71,11 +71,11 @@
 <!--        </assertion>-->
 <!--    </test-case>-->
 
-<!--    <test-case sql="DROP INDEX t_order_details_index" db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting,sharding_governance">-->
-<!--        <assertion expected-data-file="unchanged_table.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_order_details(id int, description varchar(10));CREATE INDEX t_order_details_index ON t_order_details(description)" affected-table="t_order_details" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="DROP INDEX t_order_details_index" db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting,sharding_governance">
+        <assertion expected-data-file="unchanged_table.xml">
+            <initial-sql sql="CREATE TABLE t_order_details(id int, description varchar(10));CREATE INDEX t_order_details_index ON t_order_details(description)" affected-table="t_order_details" />
+        </assertion>
+    </test-case>
 
     <test-case sql="TRUNCATE TABLE t_order_details" db-types="H2,MySQL,SQLServer,Oracle" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting,sharding_governance">
         <assertion expected-data-file="unchanged_table.xml">
@@ -108,11 +108,11 @@
     </test-case>
 
     <!-- TODO Fix me #20932 -->
-<!--    <test-case sql="ALTER TABLE t_broadcast_table_for_ddl ADD name varchar(10)" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">-->
-<!--        <assertion expected-data-file="alter_broadcast_add.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10))" affected-table="t_broadcast_table_for_ddl" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="ALTER TABLE t_broadcast_table_for_ddl ADD name varchar(10)" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion expected-data-file="alter_broadcast_add.xml">
+            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10))" affected-table="t_broadcast_table_for_ddl" />
+        </assertion>
+    </test-case>
     
     <test-case sql="ALTER TABLE t_broadcast_table_for_ddl DROP COLUMN description" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion expected-data-file="alter_broadcast_drop.xml">
@@ -139,18 +139,17 @@
     </test-case>
 
     <!-- TODO Fix me #20932 -->
-<!--    <test-case sql="DROP INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl" db-types="MySQL,SQLServer,Oracle" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">-->
-<!--        <assertion expected-data-file="unchanged_broadcast_table.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10));CREATE INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl(description)" affected-table="t_broadcast_table_for_ddl" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="DROP INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl" db-types="MySQL,SQLServer,Oracle" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion expected-data-file="unchanged_broadcast_table.xml">
+            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10));CREATE INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl(description)" affected-table="t_broadcast_table_for_ddl" />
+        </assertion>
+    </test-case>
 
-    <!-- TODO Fix me #20932 -->
-<!--    <test-case sql="DROP INDEX t_broadcast_table_for_ddl_index"  db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">-->
-<!--        <assertion expected-data-file="unchanged_broadcast_table.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10));CREATE INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl(description)" affected-table="t_broadcast_table_for_ddl" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="DROP INDEX t_broadcast_table_for_ddl_index"  db-types="PostgreSQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+        <assertion expected-data-file="unchanged_broadcast_table.xml">
+            <initial-sql sql="CREATE TABLE t_broadcast_table_for_ddl(id int, description varchar(10));CREATE INDEX t_broadcast_table_for_ddl_index ON t_broadcast_table_for_ddl(description)" affected-table="t_broadcast_table_for_ddl" />
+        </assertion>
+    </test-case>
 
     <test-case sql="TRUNCATE TABLE t_broadcast_table_for_ddl" db-types="H2,MySQL,SQLServer,Oracle" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion expected-data-file="unchanged_broadcast_table.xml">
@@ -225,18 +224,18 @@
     </test-case>
 
     <!-- TODO Fix me #20932 -->
-<!--    <test-case sql="DROP INDEX t_user_details_index on t_user_details" db-types="MySQL,SQLServer,Oracle" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">-->
-<!--        <assertion expected-data-file="unchanged_table.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_user_details (user_id INT NOT NULL, address_id INT NOT NULL, number_plain VARCHAR(45) NULL, number_cipher VARCHAR(45) NULL, description varchar(10));CREATE INDEX t_user_details_index ON t_user_details(description)" affected-table="t_user_details" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="DROP INDEX t_user_details_index on t_user_details" db-types="MySQL,SQLServer,Oracle" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+        <assertion expected-data-file="unchanged_table.xml">
+            <initial-sql sql="CREATE TABLE t_user_details (user_id INT NOT NULL, address_id INT NOT NULL, number_plain VARCHAR(45) NULL, number_cipher VARCHAR(45) NULL, description varchar(10));CREATE INDEX t_user_details_index ON t_user_details(description)" affected-table="t_user_details" />
+        </assertion>
+    </test-case>
 
     <!-- TODO Fix me #20932 -->
-<!--    <test-case sql="DROP INDEX t_user_details_index" db-types="PostgreSQL" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">-->
-<!--        <assertion expected-data-file="unchanged_table.xml">-->
-<!--            <initial-sql sql="CREATE TABLE t_user_details (user_id INT NOT NULL, address_id INT NOT NULL, number_plain VARCHAR(45) NULL, number_cipher VARCHAR(45) NULL, description varchar(10));CREATE INDEX t_user_details_index ON t_user_details(description)" affected-table="t_user_details" />-->
-<!--        </assertion>-->
-<!--    </test-case>-->
+    <test-case sql="DROP INDEX t_user_details_index" db-types="PostgreSQL" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+        <assertion expected-data-file="unchanged_table.xml">
+            <initial-sql sql="CREATE TABLE t_user_details (user_id INT NOT NULL, address_id INT NOT NULL, number_plain VARCHAR(45) NULL, number_cipher VARCHAR(45) NULL, description varchar(10));CREATE INDEX t_user_details_index ON t_user_details(description)" affected-table="t_user_details" />
+        </assertion>
+    </test-case>
     
     <test-case sql="TRUNCATE TABLE t_user_details" db-types="MySQL,SQLServer,Oracle" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
         <assertion expected-data-file="unchanged_table.xml">


### PR DESCRIPTION
##  Fix ddl initial SQL execute occasional exception in cluster mode

Fixes #20932.

Changes proposed in this pull request:
  - Fix ddl initial SQL execute occasional exception in cluster mode

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
