### PR TITLE
Refactor : add new rule for github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -10,6 +10,7 @@ Changes proposed in this pull request:
 Before committing this PR, I'm sure that I have checked the following options:
 - [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
 - [ ] I have self-reviewed the commit code.
-- [ ] I have passed maven check: `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
+- [ ] I have (or in comment I request) added corresponding labels for the pull request.
+- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
 - [ ] I have made corresponding changes to the documentation.
 - [ ] I have added corresponding unit tests for my changes.


### PR DESCRIPTION
Changes proposed in this pull request:
  - add new rule for github pull request template
 
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
