### PR TITLE
Add unit tests to cover CuratorZookeeperRepository.getNumChildren method

### DIFF
--- a/mode/type/cluster/repository/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/CuratorZookeeperRepositoryTest.java
+++ b/mode/type/cluster/repository/provider/zookeeper-curator/src/test/java/org/apache/shardingsphere/mode/repository/cluster/zookeeper/CuratorZookeeperRepositoryTest.java
@@ -304,4 +304,20 @@ public final class CuratorZookeeperRepositoryTest {
         REPOSITORY.delete("/test/children/1");
         verify(backgroundVersionable).forPath("/test/children/1");
     }
+    
+    @Test
+    public void assertGetNumChildrenGtZero() throws Exception {
+        Stat stat = new Stat(1L, 2L, 3L, 4L, 5, 6, 7, 8L, 9, 10, 11L);
+        when(existsBuilder.forPath("/test/children")).thenReturn(stat);
+        int children = REPOSITORY.getNumChildren("/test/children");
+        assertThat(children, is(10));
+    }
+    
+    @Test
+    public void assertGetNumChildrenEqZero() throws Exception {
+        Stat stat = new Stat();
+        when(existsBuilder.forPath("/test/children")).thenReturn(stat);
+        int children = REPOSITORY.getNumChildren("/test/children");
+        assertThat(children, is(0));
+    }
 }


### PR DESCRIPTION
Fixes #21434.

Changes proposed in this pull request:
  - Added test to return num of children set with multiple argument constructor
  - Added test to return zero when using default constructor
---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [X] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
