### PR TITLE
Refactor : revert the windows long name solution

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -36,6 +36,9 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         java-version: [ 8, 17, 19 ]
     steps:
+      - name: Support longpaths in Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.longpaths true
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -36,7 +36,7 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         java-version: [ 8, 17, 19 ]
     steps:
-      - name: Support longpaths in Windows
+      - name: Support long paths in Windows
         if: matrix.os == 'windows-latest'
         run: git config --global core.longpaths true
       - uses: actions/checkout@v3


### PR DESCRIPTION
Changes proposed in this pull request:
  - revert the windows long name solution

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
