### PR TITLE
Revert cache key changes in #21466

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -53,9 +53,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-${{ hashFiles('**/pom.xml') }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Run checkstyle
         run: ./mvnw checkstyle:check -T1C
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-${{ hashFiles('**/pom.xml') }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build prod with Maven
@@ -88,9 +88,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven- 
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -41,9 +41,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-${{ hashFiles('**/pom.xml') }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/it-scaling.yml
+++ b/.github/workflows/it-scaling.yml
@@ -84,10 +84,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
           restore-keys: |
-            shardingsphere-maven-third-party-it-cache-
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:
@@ -117,10 +116,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
-          restore-keys: |
-            shardingsphere-maven-third-party-it-cache-
-            shardingsphere-maven-third-party-
+          key: shardingsphere-it-cache-${{ github.sha }}
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/it-transaction.yml
+++ b/.github/workflows/it-transaction.yml
@@ -73,10 +73,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
           restore-keys: |
-            shardingsphere-maven-third-party-it-cache
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Set up JDK 8
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -76,10 +76,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
           restore-keys: |
-            shardingsphere-maven-third-party-it-cache-
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build IT image
@@ -109,7 +108,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -146,7 +145,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -183,7 +182,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-it-cache-${{ github.sha }}
+          key: shardingsphere-it-cache-${{ github.sha }}
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -212,9 +211,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-${{ hashFiles('**/pom.xml') }}
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build Project

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -33,10 +33,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-cache-${{ github.sha }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-cache-
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -47,10 +47,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-cache-${{ github.sha }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-cache-
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Build prod with Maven
         run: ./mvnw -T1C -B -ntp clean install
       - name: Build examples with Maven

--- a/.github/workflows/nightly-it-example-generator.yml
+++ b/.github/workflows/nightly-it-example-generator.yml
@@ -59,10 +59,9 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
-          key: shardingsphere-maven-third-party-cache-${{ github.sha }}
+          key: shardingsphere-${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
-            shardingsphere-maven-third-party-cache-
-            shardingsphere-maven-third-party-
+            ${{ runner.os }}-maven-
       - name: Maven resolve ranges
         run: ./mvnw versions:resolve-ranges -ntp -Dincludes='org.springframework:*,org.springframework.boot:*'
       - name: Build with Maven


### PR DESCRIPTION
Revise #21466.

`.m2` repository contains ShardingSphere Snapshot artifacts, so:
- Naming it 'third party' is inaccurate.
- Cache should not be restored from previous commit.


Impacting:
https://github.com/apache/shardingsphere/actions/runs/3246744387/jobs/5325855937#step:4:18 of https://github.com/apache/shardingsphere/pull/21552