### PR TITLE
Fix wrong dataNode interpretation in RDL doc.

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/sharding.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/sharding.cn.md
@@ -57,7 +57,7 @@ resource:
     resourceName | inlineExpression
 
 dataNode:
-    resourceName | inlineExpression
+    dataNodeName | inlineExpression
 
 shardingColumn:
     SHARDING_COLUMN=columnName

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/sharding.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/sharding.en.md
@@ -57,7 +57,7 @@ resource:
     resourceName | inlineExpression
 
 dataNode:
-    resourceName | inlineExpression
+    dataNodeName | inlineExpression
 
 shardingColumn:
     SHARDING_COLUMN=columnName


### PR DESCRIPTION
Change resourceName to dataNodeName for `dataNode`.


Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
