### PR TITLE
Update library to serve building GraalVM Native Image

### DIFF
--- a/agent/plugins/tracing/test/pom.xml
+++ b/agent/plugins/tracing/test/pom.xml
@@ -56,6 +56,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>compile</scope>

--- a/dialect-exception/postgresql/src/test/java/org/apache/shardingsphere/dialect/postgresql/message/ServerErrorMessageBuilderTest.java
+++ b/dialect-exception/postgresql/src/test/java/org/apache/shardingsphere/dialect/postgresql/message/ServerErrorMessageBuilderTest.java
@@ -18,19 +18,19 @@
 package org.apache.shardingsphere.dialect.postgresql.message;
 
 import org.apache.shardingsphere.dialect.postgresql.vendor.PostgreSQLVendorError;
-import org.junit.Assert;
 import org.junit.Test;
 import org.postgresql.util.ServerErrorMessage;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class ServerErrorMessageBuilderTest {
     
     @Test
     public void assertToServerErrorMessage() {
         ServerErrorMessage actual = ServerErrorMessageBuilder.build("FATAL", PostgreSQLVendorError.PRIVILEGE_NOT_GRANTED, "foo_user", "foo_db");
-        Assert.assertThat(actual.getSeverity(), is("FATAL"));
-        Assert.assertThat(actual.getSQLState(), is(PostgreSQLVendorError.PRIVILEGE_NOT_GRANTED.getSqlState().getValue()));
-        Assert.assertThat(actual.getMessage(), is("Access denied for user 'foo_user' to database 'foo_db'"));
+        assertThat(actual.getSeverity(), is("FATAL"));
+        assertThat(actual.getSQLState(), is(PostgreSQLVendorError.PRIVILEGE_NOT_GRANTED.getSqlState().getValue()));
+        assertThat(actual.getMessage(), is("Access denied for user 'foo_user' to database 'foo_db'"));
     }
 }

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -222,7 +222,7 @@ The text of each license is the standard Apache 2.0 license.
     avatica-core 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     avatica-metrics 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     auto-service-annotations 1.0: https://github.com/google/auto/tree/master/service, Apache 2.0
-    caffeine 2.9.2: https://github.com/ben-manes/caffeine, Apache 2.0
+    caffeine 2.9.3: https://github.com/ben-manes/caffeine, Apache 2.0
     calcite-core 1.32.0: https://calcite.apache.org, Apache 2.0
     calcite-linq4j 1.32.0: https://calcite.apache.org, Apache 2.0
     commons-codec 1.15: https://github.com/apache/commons-codec, Apache 2.0
@@ -230,25 +230,25 @@ The text of each license is the standard Apache 2.0 license.
     commons-exec 1.3: https://github.com/apache/commons-exec, Apache 2.0
     commons-io 2.11.0: https://github.com/apache/commons-io, Apache 2.0
     commons-lang 2.6: https://github.com/apache/commons-lang, Apache 2.0
-    commons-lang3 3.8: https://github.com/apache/commons-lang, Apache 2.0
+    commons-lang3 3.12.0: https://github.com/apache/commons-lang, Apache 2.0
     commons-logging 1.1.3: https://github.com/apache/commons-logging, Apache 2.0
-    curator-client 5.1.0:  https://github.com/apache/curator, Apache 2.0
-    curator-framework 5.1.0:  https://github.com/apache/curator, Apache 2.0
-    curator-recipes 5.1.0:  https://github.com/apache/curator, Apache 2.0
+    curator-client 5.3.0:  https://github.com/apache/curator, Apache 2.0
+    curator-framework 5.3.0:  https://github.com/apache/curator, Apache 2.0
+    curator-recipes 5.3.0:  https://github.com/apache/curator, Apache 2.0
     cosid-core 1.14.4: https://github.com/Ahoo-Wang/CosId, Apache 2.0
     error_prone_annotations 2.3.4: https://github.com/google/error-prone, Apache 2.0
     failsafe 2.4.1: https://github.com/jhalterman/failsafe, Apache 2.0
     failureaccess 1.0.1: https://github.com/google/guava, Apache 2.0 
     freemarker 2.3.31: https://freemarker.apache.org/, Apache 2.0
-    groovy 4.0.3: https://groovy.apache.org/, Apache 2.0
-    grpc-api 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-context 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-core 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-grpclb 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-netty 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-protobuf 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-protobuf-lite 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
-    grpc-stub 1.39.0: https://github.com/grpc/grpc-java, Apache 2.0
+    groovy 4.0.5: https://groovy.apache.org/, Apache 2.0
+    grpc-api 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-context 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-core 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-grpclb 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-netty 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-protobuf 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-protobuf-lite 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
+    grpc-stub 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
     gson 2.9.1: https://github.com/google/gson, Apache 2.0
     guava 30.0-jre: https://github.com/google/guava, Apache 2.0
     HikariCP 3.4.2: https://github.com/brettwooldridge/HikariCP, Apache 2.0
@@ -260,30 +260,30 @@ The text of each license is the standard Apache 2.0 license.
     jackson-databind 2.10.0: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-dataformat-yaml 2.13.2: http://github.com/FasterXML/jackson, Apache 2.0
     jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
-    jetcd-common 0.5.10: https://github.com/etcd-io/jetcd, Apache 2.0
-    jetcd-core 0.5.10: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-common 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-core 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
     json-path 2.7.0: https://github.com/jayway/JsonPath, Apache 2.0
     json-smart 2.4.7: https://www.minidev.net/, Apache 2.0
     json-simple 1.1.1: https://code.google.com/archive/p/json-simple/, Apache 2.0 
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-codec-dns 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-resolver-dns 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.80.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.80.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.80.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.80.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-codec-dns 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-resolver-dns 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.84.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.84.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.84.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.84.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.23.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.0.1: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0
@@ -293,8 +293,8 @@ The text of each license is the standard Apache 2.0 license.
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
     vertx-mysql-client 4.3.3: https://github.com/eclipse-vertx/vertx-sql-client, Apache 2.0
     vertx-sql-client 4.3.3: https://github.com/eclipse-vertx/vertx-sql-client, Apache 2.0
-    zookeeper 3.6.0: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.6.0: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
 
 ========================================================================
 Apache 2.0 licenses
@@ -303,11 +303,11 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    atomikos-util 5.0.8: https://www.atomikos.com, Apache 2.0
-    transactions 5.0.8: https://www.atomikos.com, Apache 2.0
-    transactions-api 5.0.8: https://www.atomikos.com, Apache 2.0
-    transactions-jdbc 5.0.8: https://www.atomikos.com, Apache 2.0
-    transactions-jta 5.0.8: https://www.atomikos.com, Apache 2.0
+    atomikos-util 5.0.9: https://www.atomikos.com, Apache 2.0
+    transactions 5.0.9: https://www.atomikos.com, Apache 2.0
+    transactions-api 5.0.9: https://www.atomikos.com, Apache 2.0
+    transactions-jdbc 5.0.9: https://www.atomikos.com, Apache 2.0
+    transactions-jta 5.0.9: https://www.atomikos.com, Apache 2.0
     vertx-core 4.3.3: https://github.com/eclipse-vertx/vert.x, Apache 2.0
     
 ========================================================================
@@ -344,8 +344,8 @@ EPL licenses
 The following components are provided under the EPL License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    logback-classic 1.2.10: https://github.com/qos-ch/logback, EPL 1.0
-    logback-core 1.2.10: https://github.com/qos-ch/logback, EPL 1.0
+    logback-classic 1.2.11: https://github.com/qos-ch/logback, EPL 1.0
+    logback-core 1.2.11: https://github.com/qos-ch/logback, EPL 1.0
     mchange-commons-java 0.2.15: https://github.com/swaldman/mchange-commons-java, EPL 1.0
     h2 2.1.214: https://github.com/h2database/h2database, EPL 1.0
 

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -240,7 +240,7 @@ The text of each license is the standard Apache 2.0 license.
     failsafe 2.4.1: https://github.com/jhalterman/failsafe, Apache 2.0
     failureaccess 1.0.1: https://github.com/google/guava, Apache 2.0 
     freemarker 2.3.31: https://freemarker.apache.org/, Apache 2.0
-    groovy 4.0.5: https://groovy.apache.org/, Apache 2.0
+    groovy 4.0.6: https://groovy.apache.org/, Apache 2.0
     grpc-api 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-context 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
     grpc-core 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
@@ -40,7 +40,7 @@ ShardingSphere-Proxy 支持配置多个逻辑数据源，每个以 `config-` 前
 
 ShardingSphere-Proxy 默认集成 ZooKeeper Curator 客户端，集群模式使用 ZooKeeper 无须引入其他依赖。
 
-如果集群模式使用 Etcd，需要将 Etcd 的客户端驱动程序 [jetcd-core 0.5.0](https://repo1.maven.org/maven2/io/etcd/jetcd-core/0.5.0/jetcd-core-0.5.0.jar) 复制至目录 `ext-lib`。
+如果集群模式使用 Etcd，需要将 Etcd 的客户端驱动程序 [jetcd-core 0.7.3](https://repo1.maven.org/maven2/io/etcd/jetcd-core/0.7.3/jetcd-core-0.7.3.jar) 复制至目录 `ext-lib`。
 
 6. （可选）引入分布式事务所需依赖
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
@@ -41,7 +41,7 @@ If the backend is connected to a MySQL database, please download [mysql-connecto
 
 ShardingSphere-Proxy integrates the ZooKeeper Curator client by default. ZooKeeper is used in cluster mode without introducing other dependencies.
 
-If the cluster mode uses Etcd, the client drivers of Etcd [jetcd-core 0.5.0](https://repo1.maven.org/maven2/io/etcd/jetcd-core/0.5.0/jetcd-core-0.5.0.jar) need to be copied into the `ext-lib` directory.
+If the cluster mode uses Etcd, the client drivers of Etcd [jetcd-core 0.7.3](https://repo1.maven.org/maven2/io/etcd/jetcd-core/0.7.3/jetcd-core-0.7.3.jar) need to be copied into the `ext-lib` directory.
 
 6. Introduce dependencies required by distributed transactions (Optional)
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -64,7 +64,7 @@
         
         <seata.version>1.4.2</seata.version>
         
-        <junit.version>4.13.2</junit.version>
+        <junit4.version>4.13.2</junit4.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.7.21</mockito.version>
         
@@ -373,7 +373,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
+            <version>${junit4.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesTest.java
@@ -18,9 +18,7 @@
 package org.apache.shardingsphere.infra.datasource.props;
 
 import org.apache.shardingsphere.test.mock.MockedDataSource;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -32,15 +30,12 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class DataSourcePropertiesTest {
-    
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
     
     @SuppressWarnings("unchecked")
     @Test

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/AbstractPipelineJobAPIImpl.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.api.impl;
 
 import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.shardingsphere.data.pipeline.api.config.job.PipelineJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.config.job.yaml.YamlPipelineJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.job.PipelineJobId;

--- a/kernel/transaction/type/xa/provider/atomikos/pom.xml
+++ b/kernel/transaction/type/xa/provider/atomikos/pom.xml
@@ -28,7 +28,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <atomikos.version>5.0.8</atomikos.version>
+        <atomikos.version>5.0.9</atomikos.version>
     </properties>
     
     <dependencies>

--- a/mode/type/cluster/repository/provider/etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/EtcdRepository.java
+++ b/mode/type/cluster/repository/provider/etcd/src/main/java/org/apache/shardingsphere/mode/repository/cluster/etcd/EtcdRepository.java
@@ -17,17 +17,19 @@
 
 package org.apache.shardingsphere.mode.repository.cluster.etcd;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import io.etcd.jetcd.ByteSequence;
 import io.etcd.jetcd.Client;
 import io.etcd.jetcd.KeyValue;
-import io.etcd.jetcd.Util;
 import io.etcd.jetcd.Watch;
 import io.etcd.jetcd.options.DeleteOption;
 import io.etcd.jetcd.options.GetOption;
+import io.etcd.jetcd.options.OptionsUtil;
 import io.etcd.jetcd.options.PutOption;
 import io.etcd.jetcd.options.WatchOption;
 import io.etcd.jetcd.support.Observers;
+import io.etcd.jetcd.support.Util;
 import io.etcd.jetcd.watch.WatchEvent;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -200,8 +202,10 @@ public final class EtcdRepository implements ClusterPersistRepository {
                 }
             }
         });
-        client.getWatchClient().watch(ByteSequence.from(key, StandardCharsets.UTF_8),
-                WatchOption.newBuilder().withPrefix(ByteSequence.from(key, StandardCharsets.UTF_8)).build(), listener);
+        ByteSequence prefix = ByteSequence.from(key, StandardCharsets.UTF_8);
+        Preconditions.checkNotNull(prefix, "prefix should not be null");
+        client.getWatchClient().watch(prefix,
+                WatchOption.newBuilder().withRange(OptionsUtil.prefixEndOf(prefix)).build(), listener);
     }
     
     private Type getEventChangedType(final WatchEvent event) {

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <antlr4.version>4.9.2</antlr4.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <gson.version>2.9.1</gson.version>
-        <groovy.version>4.0.5</groovy.version>
+        <groovy.version>4.0.6</groovy.version>
         
         <jaxb.version>2.3.0</jaxb.version>
         <annotation-api.version>1.3.2</annotation-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,14 @@
         <shade.package>org.apache.shardingsphere.dependencies</shade.package>
         
         <guava.version>30.0-jre</guava.version>
-        <commons-lang3.version>3.8</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-collections4.version>4.4</commons-collections4.version>
         <commons-codec.version>1.15</commons-codec.version>
         
         <antlr4.version>4.9.2</antlr4.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <gson.version>2.9.1</gson.version>
-        <groovy.version>4.0.3</groovy.version>
+        <groovy.version>4.0.5</groovy.version>
         
         <jaxb.version>2.3.0</jaxb.version>
         <annotation-api.version>1.3.2</annotation-api.version>
@@ -75,20 +75,20 @@
         
         <calcite.version>1.32.0</calcite.version>
         <vertx.version>4.3.3</vertx.version>
-        <netty.version>4.1.80.Final</netty.version>
+        <netty.version>4.1.84.Final</netty.version>
         
         <javax.transaction.version>1.1</javax.transaction.version>
         
-        <zookeeper.version>3.6.0</zookeeper.version>
-        <curator.version>5.1.0</curator.version>
-        <jetcd.version>0.5.10</jetcd.version>
+        <zookeeper.version>3.8.0</zookeeper.version>
+        <curator.version>5.3.0</curator.version>
+        <jetcd.version>0.7.3</jetcd.version>
         
         <elasticjob.version>3.0.1</elasticjob.version>
         
         <springframework.version>[4.3.6.RELEASE,5.0.0.M1)</springframework.version>
         <spring-boot.version>[1.5.20.RELEASE,2.0.0.M1)</spring-boot.version>
         
-        <bytebuddy.version>1.12.10</bytebuddy.version>
+        <bytebuddy.version>1.12.12</bytebuddy.version>
         <prometheus.version>0.11.0</prometheus.version>
         <prometheus.jmx.version>0.16.1</prometheus.jmx.version>
         <opentracing.version>0.31.0</opentracing.version>
@@ -99,7 +99,7 @@
         <opentelemetry-autoconfigure.version>1.3.0-alpha</opentelemetry-autoconfigure.version>
         
         <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.10</logback.version>
+        <logback.version>1.2.11</logback.version>
         
         <lombok.version>1.18.20</lombok.version>
         
@@ -112,10 +112,11 @@
         
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <commons-dbcp2.version>2.2.0</commons-dbcp2.version>
-        
-        <junit.version>4.13.2</junit.version>
+
+        <junit5.version>5.9.1</junit5.version>
+        <junit4.version>4.13.2</junit4.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <mockito.version>4.5.1</mockito.version>
+        <mockito.version>4.8.0</mockito.version>
         
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -123,7 +124,7 @@
         <maven-javadoc-plugin.version>3.3.0</maven-javadoc-plugin.version>
         <maven-resources-plugin.version>3.3.0</maven-resources-plugin.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
-        <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-release-plugin.version>3.0.0-M6</maven-release-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
@@ -151,7 +152,7 @@
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <freemarker.version>2.3.31</freemarker.version>
         <spotless-maven-plugin.version>2.22.1</spotless-maven-plugin.version>
-        <caffeine.version>2.9.2</caffeine.version>
+        <caffeine.version>2.9.3</caffeine.version>
     </properties>
     
     <dependencyManagement>
@@ -372,6 +373,14 @@
                     <exclusion>
                         <groupId>com.google.android</groupId>
                         <artifactId>annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.vertx</groupId>
+                        <artifactId>vertx-grpc</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-transport-native-unix-common</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -611,7 +620,13 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>${junit.version}</version>
+                <version>${junit4.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+                <version>${junit5.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -709,6 +724,10 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
         </dependency>
@@ -773,6 +792,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <trimStackTrace>false</trimStackTrace>
                         <excludes>

--- a/proxy/frontend/reactive-core/src/test/java/org/apache/shardingsphere/proxy/frontend/reactive/protocol/ReactiveDatabaseProtocolFrontendEngineFactoryTest.java
+++ b/proxy/frontend/reactive-core/src/test/java/org/apache/shardingsphere/proxy/frontend/reactive/protocol/ReactiveDatabaseProtocolFrontendEngineFactoryTest.java
@@ -17,18 +17,18 @@
 
 package org.apache.shardingsphere.proxy.frontend.reactive.protocol;
 
-import org.apache.shardingsphere.proxy.frontend.reactive.protocol.fixture.DummyReactiveDatabaseProtocolFrontendEngine;
 import org.apache.shardingsphere.infra.util.spi.exception.ServiceProviderNotFoundServerException;
-import org.junit.Assert;
+import org.apache.shardingsphere.proxy.frontend.reactive.protocol.fixture.DummyReactiveDatabaseProtocolFrontendEngine;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class ReactiveDatabaseProtocolFrontendEngineFactoryTest {
     
     @Test
     public void assertNewInstance() {
-        Assert.assertThat(ReactiveDatabaseProtocolFrontendEngineFactory.newInstance("Dummy"), instanceOf(DummyReactiveDatabaseProtocolFrontendEngine.class));
+        assertThat(ReactiveDatabaseProtocolFrontendEngineFactory.newInstance("Dummy"), instanceOf(DummyReactiveDatabaseProtocolFrontendEngine.class));
     }
     
     @Test(expected = ServiceProviderNotFoundServerException.class)

--- a/test/common/pom.xml
+++ b/test/common/pom.xml
@@ -42,5 +42,10 @@
             <artifactId>junit</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/test/integration-test/transaction/pom.xml
+++ b/test/integration-test/transaction/pom.xml
@@ -29,7 +29,7 @@
     
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <atomikos.version>5.0.8</atomikos.version>
+        <atomikos.version>5.0.9</atomikos.version>
         <narayana.version>5.12.4.Final</narayana.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <jboss-logging.version>3.2.1.Final</jboss-logging.version>

--- a/test/parser/pom.xml
+++ b/test/parser/pom.xml
@@ -108,6 +108,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test-common</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Introduce `junit-vintage-engine` to support unit testing inside GraalVM Native Image. Reference https://github.com/graalvm/native-build-tools/issues/53 .
  - Update netty to `4.1.84` to get the new automatically generate native-image `conditional` metadata for `ChannelHandler` implementations. See https://github.com/netty/netty/pull/12794 .
  - Update `logback` to match graalvm reachability metadata at https://github.com/oracle/graalvm-reachability-metadata/tree/master/metadata/ch.qos.logback/logback-classic/1.2.11 .
  - Update `maven-surefire-plugin` to milestone version to automatically handle use of `org.junit.platform:junit-platform-launcher`. Reference https://graalvm.github.io/native-build-tools/latest/maven-plugin.html#testing-support-version-compatibility .
  - Update `mockito` and `byte-buddy` to be in sync with the latest `Junit Platform` requirements as much as possible.
  - Update most of the dependencies to get https://github.com/oracle/graalvm-reachability-metadata support faster in the future. The exception is `hikaricp`, it has some breaking changes from `3.4.2` to `4.0.3`. I'll continue to see how it should be handled at https://github.com/apache/shardingsphere/issues/21347 .
  - Handle most deprecated methods.
  - Update LICENSE.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
