### PR TITLE
Update TableExtractor.java

### DIFF
--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
@@ -88,8 +88,9 @@ public final class TableExtractor {
         if (selectStatement.getOrderBy().isPresent()) {
             extractTablesFromOrderByItems(selectStatement.getOrderBy().get().getOrderByItems());
         }
-        if (SelectStatementHandler.getLockSegment(selectStatement).isPresent()) {
-            extractTablesFromLock(SelectStatementHandler.getLockSegment(selectStatement).get());
+        Optional<LockSegment> lockSegment = SelectStatementHandler.getLockSegment(selectStatement);
+        if (lockSegment.isPresent()) {
+            extractTablesFromLock(lockSegment.get());
         }
         if (selectStatement.getCombine().isPresent()) {
             extractTablesFromSelect(selectStatement.getCombine().get().getSelectStatement());

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
@@ -89,9 +89,7 @@ public final class TableExtractor {
             extractTablesFromOrderByItems(selectStatement.getOrderBy().get().getOrderByItems());
         }
         Optional<LockSegment> lockSegment = SelectStatementHandler.getLockSegment(selectStatement);
-        if (lockSegment.isPresent()) {
-            extractTablesFromLock(lockSegment.get());
-        }
+        lockSegment.ifPresent(this::extractTablesFromLock);
         if (selectStatement.getCombine().isPresent()) {
             extractTablesFromSelect(selectStatement.getCombine().get().getSelectStatement());
         }


### PR DESCRIPTION
防止静态方法多次调用和多次判断转换,当SelectStatement不在对应的if语句里面需要多判断4次

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -
  -
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
