### PR TITLE
Fixes #20457, allows to start proxy without configuring authority rule.

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -77,15 +77,14 @@ public final class ProxyConfigurationLoader {
     
     private static YamlProxyServerConfiguration loadServerConfiguration(final File yamlFile) throws IOException {
         YamlProxyServerConfiguration result = YamlEngine.unmarshal(yamlFile, YamlProxyServerConfiguration.class);
-        Preconditions.checkNotNull(result, "Server configuration file `%s` is invalid.", yamlFile.getName());
-        // TODO use SPI with pluggable
-        boolean containsGovernance = null != result.getMode() && "Cluster".equals(result.getMode().getType());
+        if (null == result) {
+            return new YamlProxyServerConfiguration();
+        }
+        // TODO make authority configuration more clear
         if (null != result.getAuthority()) {
             result.getRules().removeIf(each -> each instanceof YamlAuthorityRuleConfiguration);
             result.getRules().add(result.getAuthority().convertToYamlAuthorityRuleConfiguration());
         }
-        YamlRuleConfiguration authorityRuleConfig = result.getRules().stream().filter(each -> each instanceof YamlAuthorityRuleConfiguration).findAny().orElse(null);
-        Preconditions.checkState(containsGovernance || null != authorityRuleConfig, "Authority configuration is invalid.");
         return result;
     }
     

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -18,10 +18,11 @@
 package org.apache.shardingsphere.proxy.backend.config;
 
 import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
-import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDataSourceConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDatabaseConfiguration;
+import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyServerConfiguration;
 import org.apache.shardingsphere.readwritesplitting.yaml.config.YamlReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.yaml.config.rule.YamlReadwriteSplittingDataSourceRuleConfiguration;
 import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
@@ -33,13 +34,25 @@ import java.util.Iterator;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class ProxyConfigurationLoaderTest {
+    
+    @Test
+    public void assertLoadEmptyConfiguration() throws IOException {
+        YamlProxyConfiguration actual = ProxyConfigurationLoader.load("/conf/empty/");
+        YamlProxyServerConfiguration serverConfiguration = actual.getServerConfiguration();
+        assertNull(serverConfiguration.getMode());
+        assertNull(serverConfiguration.getAuthority());
+        assertNull(serverConfiguration.getLabels());
+        assertTrue(serverConfiguration.getProps().isEmpty());
+        assertTrue(serverConfiguration.getRules().isEmpty());
+        assertTrue(actual.getDatabaseConfigurations().isEmpty());
+    }
     
     @Test
     public void assertLoad() throws IOException {

--- a/proxy/backend/src/test/resources/conf/empty/server.yaml
+++ b/proxy/backend/src/test/resources/conf/empty/server.yaml
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+


### PR DESCRIPTION
Fixes #20457.

Changes proposed in this pull request:
  - Allow `server.yaml` configuration to be completely empty
  - Allow the authority configuration to be null, use default root user
  - Add test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
