### PR TITLE
Update RQL show default sharding strategy documents

### DIFF
--- a/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.cn.md
+++ b/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.cn.md
@@ -1,6 +1,6 @@
 +++
 title = "SHOW DEFAULT SHARDING STRATEGY"
-weight = 3
+weight = 5
 +++
 
 ### 描述

--- a/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.cn.md
+++ b/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.cn.md
@@ -1,0 +1,78 @@
++++
+title = "SHOW DEFAULT SHARDING STRATEGY"
+weight = 3
++++
+
+### 描述
+
+`SHOW DEFAULT SHARDING STRATEGY` 语法用于查询指定逻辑库的默认分片策略。
+
+### 语法
+
+```
+ShowDefaultShardingStrategy::=
+  'SHOW' 'DEFAULT' 'SHARDING' 'STRATEGY' ('FROM' databaseName)?
+
+databaseName ::=
+  identifier
+```
+
+### 补充说明
+
+- 未指定 `databaseName` 时，默认是当前使用的 `DATABASE`。 如果也未使用 `DATABASE` 则会提示 `No database selected`。
+
+### 返回值说明
+
+| 列                       | 说明          |
+| ------------------------| --------------|
+| name                    | 分片策略范围 |
+| type                    | 分片策略类型    |
+| sharding_column         | 分片键         |
+| sharding_algorithm_name | 分片算法名称    |
+| sharding_algorithm_type | 分片算法类型    |
+| sharding_algorithm_props| 分片算法参数    |
+
+### 示例
+
+- 查询指定逻辑库的默认分片策略
+
+```sql
+SHOW DEFAULT SHARDING STRATEGY FROM test1;
+```
+
+```sql
+mysql> SHOW DEFAULT SHARDING STRATEGY FROM test1;
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| name     | type     | sharding_column | sharding_algorithm_name | sharding_algorithm_type | sharding_algorithm_props                            |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| TABLE    | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
+| DATABASE | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+2 rows in set (0.00 sec)
+```
+
+- 查询当前逻辑库的默认分片策略
+
+```sql
+SHOW DEFAULT SHARDING STRATEGY;
+```
+
+```sql
+mysql> SHOW DEFAULT SHARDING STRATEGY;
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| name     | type     | sharding_column | sharding_algorithm_name | sharding_algorithm_type | sharding_algorithm_props                            |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| TABLE    | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
+| DATABASE | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+2 rows in set (0.00 sec)
+```
+
+### 保留字
+
+`SHOW`、`DEFAULT`、`SHARDING`、`STRATEGY`、`FROM`
+
+### 相关链接
+
+- [保留字](/cn/reference/distsql/syntax/reserved-word/)
+

--- a/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.en.md
+++ b/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.en.md
@@ -1,6 +1,6 @@
 +++
 title = "SHOW DEFAULT SHARDING STRATEGY"
-weight = 3
+weight = 5
 +++
 
 ### Description

--- a/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.en.md
+++ b/docs/document/content/reference/distsql/syntax/rql/rule-query/sharding/show-default-sharding-strategy.en.md
@@ -1,0 +1,77 @@
++++
+title = "SHOW DEFAULT SHARDING STRATEGY"
+weight = 3
++++
+
+### Description
+
+The `SHOW DEFAULT SHARDING STRATEGY` syntax is used to query default sharding strategy in specified database.
+
+### Syntax
+
+```
+ShowDefaultShardingStrategy::=
+  'SHOW' 'DEFAULT' 'SHARDING' 'STRATEGY' ('FROM' databaseName)?
+
+databaseName ::=
+  identifier
+```
+
+### Supplement
+
+- When `databaseName` is not specified, the default is the currently used `DATABASE`. If `DATABASE` is not used, `No database selected` will be prompted.
+
+### Return value description
+
+| Column                   | Description                   |
+| ------------------------ | ----------------------------- |
+| name                     | Sharding strategy scope       |
+| type                     | Sharding strategy type        |
+| sharding_column          | Sharding column               |
+| sharding_algorithm_name  | Sharding algorithm name       |
+| sharding_algorithm_type  | Sharding algorithm type       |
+| sharding_algorithm_props | Sharding algorithm properties |
+
+### Example
+
+- Query default sharding strategy in specified database.
+
+```sql
+SHOW DEFAULT SHARDING STRATEGY FROM test1;
+```
+
+```sql
+mysql> SHOW DEFAULT SHARDING STRATEGY FROM test1;
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| name     | type     | sharding_column | sharding_algorithm_name | sharding_algorithm_type | sharding_algorithm_props                            |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| TABLE    | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
+| DATABASE | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+2 rows in set (0.00 sec)
+```
+
+- Query default sharding strategy in current database.
+
+```sql
+SHOW DEFAULT SHARDING STRATEGY;
+```
+
+```sql
+mysql> SHOW DEFAULT SHARDING STRATEGY;
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| name     | type     | sharding_column | sharding_algorithm_name | sharding_algorithm_type | sharding_algorithm_props                            |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+| TABLE    | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
+| DATABASE | STANDARD | order_id        | table_inline            | inline                  | {algorithm-expression=t_order_item_${order_id % 2}} |
++----------+----------+-----------------+-------------------------+-------------------------+-----------------------------------------------------+
+2 rows in set (0.00 sec)
+```
+
+### Reserved word
+
+`SHOW`、`DEFAULT`、`SHARDING`、`STRATEGY`、`FROM`
+
+### Related links
+
+- [Reserved word](/en/reference/distsql/syntax/reserved-word/)


### PR DESCRIPTION


Changes proposed in this pull request:
  -Update RQL show default sharding strategy documents
 

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
