### PR TITLE
Fix null exception for #19814

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -155,16 +155,20 @@ public final class ProjectionEngine {
     private Collection<ColumnProjection> getShorthandColumnsFromSimpleTableSegment(final TableSegment table, final String owner) {
         if (!(table instanceof SimpleTableSegment)) {
             return Collections.emptyList();
-        } String tableName = ((SimpleTableSegment) table).getTableName().getIdentifier().getValue();
+        }
+        String tableName = ((SimpleTableSegment) table).getTableName().getIdentifier().getValue();
         String tableAlias = table.getAlias().orElse(tableName);
-        String schemaName = ((SimpleTableSegment) table).getOwner().map(optional -> optional.getIdentifier().getValue()).orElseGet(() -> DatabaseTypeEngine.getDefaultSchemaName(databaseType, databaseName)).toLowerCase();
+        String schemaName = ((SimpleTableSegment) table).getOwner().map(optional -> optional.getIdentifier().getValue())
+                .orElseGet(() -> DatabaseTypeEngine.getDefaultSchemaName(databaseType, databaseName)).toLowerCase();
         ShardingSphereSchema schema = schemas.get(schemaName);
         ShardingSpherePreconditions.checkNotNull(schema, () -> new SchemaNotFoundException(schemaName));
-        Collection<ColumnProjection> result = new LinkedList<>(); if (null == owner) {
+        Collection<ColumnProjection> result = new LinkedList<>();
+        if (null == owner) {
             schema.getVisibleColumnNames(tableName).stream().map(each -> new ColumnProjection(tableAlias, each, null)).forEach(result::add);
         } else if (owner.equalsIgnoreCase(tableAlias)) {
             schema.getVisibleColumnNames(tableName).stream().map(each -> new ColumnProjection(owner, each, null)).forEach(result::add);
-        } return result;
+        }
+        return result;
     }
     
     private Collection<ColumnProjection> getShorthandColumnsFromSubqueryTableSegment(final TableSegment table) {

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
@@ -181,8 +181,10 @@ public final class ProjectionEngineTest {
         table.setRight(customersTableSegment);
         table.setCondition(new CommonExpressionSegment(0, 0, "t_order.customer_id=t_customer.customer_id"));
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10);
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(table, shorthandProjectionSegment);
-        assertTrue(actual.isPresent()); assertThat(actual.get(), instanceOf(ShorthandProjection.class));
+        Optional<Projection> actual = new ProjectionEngine(
+                DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(table, shorthandProjectionSegment);
+        assertTrue(actual.isPresent());
+        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
         Map<String, ColumnProjection> actualColumns = ((ShorthandProjection) actual.get()).getActualColumns();
         assertThat(actualColumns.size(), is(3));
         assertThat(actualColumns.get("t_order.order_id"), is(new ColumnProjection("t_order", "order_id", null)));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/SchemaNotFoundException.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/exception/SchemaNotFoundException.java
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.singletable.exception;
+package org.apache.shardingsphere.infra.exception;
 
-import org.apache.shardingsphere.infra.exception.MetaDataSQLException;
 import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
 
 /**

--- a/kernel/single-table/core/src/main/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidator.java
+++ b/kernel/single-table/core/src/main/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidator.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.singletable.route.validator.ddl;
 
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.singletable.exception.DropNotEmptySchemaException;
-import org.apache.shardingsphere.singletable.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.singletable.route.validator.SingleTableMetadataValidator;
 import org.apache.shardingsphere.singletable.rule.SingleTableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropSchemaStatement;

--- a/kernel/single-table/core/src/test/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidatorTest.java
+++ b/kernel/single-table/core/src/test/java/org/apache/shardingsphere/singletable/route/validator/ddl/SingleTableDropSchemaMetadataValidatorTest.java
@@ -19,11 +19,11 @@ package org.apache.shardingsphere.singletable.route.validator.ddl;
 
 import org.apache.shardingsphere.infra.binder.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
+import org.apache.shardingsphere.infra.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
 import org.apache.shardingsphere.singletable.exception.DropNotEmptySchemaException;
-import org.apache.shardingsphere.singletable.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.singletable.rule.SingleTableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DropSchemaStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;


### PR DESCRIPTION
Fixes #19814.

### Before
```sql
postgres=> select * from t_order;
ERROR:  Cannot invoke "org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema.getVisibleColumnNames(String)" because the return value of "java.util.Map.get(Object)" is null
```

### After
```sql
postgres=> select * from t_order;
ERROR:  Schema `public` does not exist.
```

Changes proposed in this pull request:
  - Check schema exists before use it
  - Add test case
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
