### PR TITLE
[ISSUE #21573] Update datatype specifier in the input parameter to ma…

### DIFF
--- a/agent/api/src/main/java/org/apache/shardingsphere/agent/config/PluginConfiguration.java
+++ b/agent/api/src/main/java/org/apache/shardingsphere/agent/config/PluginConfiguration.java
@@ -46,6 +46,6 @@ public final class PluginConfiguration {
      */
     public void validate(final String type) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(host), "Hostname of %s is required", type);
-        Preconditions.checkArgument(port > 0, "Port `%d` of %s must be a positive number", port, type);
+        Preconditions.checkArgument(port > 0, "Port `%s` of %s must be a positive number", port, type);
     }
 }


### PR DESCRIPTION
Fixes #21573.

Changes proposed in this pull request.
  - The google.guava library (**Refer**: https://github.com/google/guava/blob/989e3b261eb3c67b42c97f612b5d726f03e1e300/guava/src/com/google/common/base/Strings.java#L285) which formats the string has implementation only to replace %s in the supplied string template.
  - This would lead to wrong data being returned.
  -  The below code will not return the desired data 
      `Preconditions.checkArgument(false, "Port %d of %s must be a positive number", 8080, "Data");`

        Ideally the code should return
        **Port 8080 of Data must be a positive number**
         Whereas the code will return
        **Port %d of 8080 must be a positive number [Data]**

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
