### PR TITLE
Support heterogeneous databases in single logic database for TransactionRule init

### DIFF
--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/context/EncryptContext.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/context/EncryptContext.java
@@ -26,7 +26,6 @@ import lombok.Setter;
  */
 @RequiredArgsConstructor
 @Getter
-@Setter
 public final class EncryptContext {
     
     private final String databaseName;

--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/context/EncryptContext.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/spi/context/EncryptContext.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.encrypt.spi.context;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 /**
  * Encrypt context.

--- a/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/ShardingSphereTransactionManagerEngine.java
+++ b/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/ShardingSphereTransactionManagerEngine.java
@@ -26,11 +26,10 @@ import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManage
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManagerFactory;
 
 import javax.sql.DataSource;
-import java.util.Collection;
 import java.util.EnumMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 /**
  * ShardingSphere transaction manager engine.
@@ -58,16 +57,20 @@ public final class ShardingSphereTransactionManagerEngine {
     /**
      * Initialize transaction managers.
      *
-     * @param databaseType database type
+     * @param databaseTypes database types
      * @param dataSourceMap data source map
      * @param providerType transaction manager provider type
      */
-    public void init(final DatabaseType databaseType, final Map<String, DataSource> dataSourceMap, final String providerType) {
-        transactionManagers.forEach((key, value) -> value.init(databaseType, getResourceDataSources(dataSourceMap), providerType));
+    public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, DataSource> dataSourceMap, final String providerType) {
+        transactionManagers.forEach((key, value) -> value.init(databaseTypes, getResourceDataSources(dataSourceMap), providerType));
     }
     
-    private Collection<ResourceDataSource> getResourceDataSources(final Map<String, DataSource> dataSourceMap) {
-        return dataSourceMap.entrySet().stream().map(entry -> new ResourceDataSource(entry.getKey(), entry.getValue())).collect(Collectors.toList());
+    private Map<String, ResourceDataSource> getResourceDataSources(final Map<String, DataSource> dataSourceMap) {
+        Map<String, ResourceDataSource> result = new LinkedHashMap<>(dataSourceMap.size(), 1);
+        for (Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
+            result.put(entry.getKey(), new ResourceDataSource(entry.getKey(), entry.getValue()));
+        }
+        return result;
     }
     
     /**

--- a/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/rule/TransactionRule.java
+++ b/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/rule/TransactionRule.java
@@ -17,11 +17,9 @@
 
 package org.apache.shardingsphere.transaction.rule;
 
-import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.rule.identifier.scope.GlobalRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.ResourceHeldRule;
@@ -30,12 +28,10 @@ import org.apache.shardingsphere.transaction.config.TransactionRuleConfiguration
 import org.apache.shardingsphere.transaction.core.TransactionType;
 
 import javax.sql.DataSource;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
-import java.util.Set;
 
 /**
  * Transaction rule.
@@ -56,8 +52,7 @@ public final class TransactionRule implements GlobalRule, ResourceHeldRule<Shard
     
     private volatile ShardingSphereTransactionManagerEngine resource;
     
-    public TransactionRule(final TransactionRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases, final InstanceContext instanceContext) {
-        log.debug("Create transaction rule");
+    public TransactionRule(final TransactionRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases) {
         configuration = ruleConfig;
         defaultType = TransactionType.valueOf(ruleConfig.getDefaultType().toUpperCase());
         providerType = ruleConfig.getProviderType();
@@ -70,21 +65,18 @@ public final class TransactionRule implements GlobalRule, ResourceHeldRule<Shard
         if (databases.isEmpty()) {
             return new ShardingSphereTransactionManagerEngine();
         }
-        Map<String, DataSource> dataSourceMap = new HashMap<>(databases.size());
-        Set<DatabaseType> databaseTypes = new HashSet<>();
+        Map<String, DataSource> dataSourceMap = new LinkedHashMap<>(databases.size(), 1);
+        Map<String, DatabaseType> databaseTypes = new LinkedHashMap<>(databases.size(), 1);
         for (Entry<String, ShardingSphereDatabase> entry : databases.entrySet()) {
             ShardingSphereDatabase database = entry.getValue();
             database.getResourceMetaData().getDataSources().forEach((key, value) -> dataSourceMap.put(database.getName() + "." + key, value));
-            if (null != entry.getValue().getResourceMetaData().getDatabaseType()) {
-                databaseTypes.add(entry.getValue().getResourceMetaData().getDatabaseType());
-            }
+            database.getResourceMetaData().getDatabaseTypes().forEach((key, value) -> databaseTypes.put(database.getName() + "." + key, value));
         }
-        Preconditions.checkState(databaseTypes.size() < 2, "Multiple types of databases are not supported");
         if (dataSourceMap.isEmpty()) {
             return new ShardingSphereTransactionManagerEngine();
         }
         ShardingSphereTransactionManagerEngine result = new ShardingSphereTransactionManagerEngine();
-        result.init(databaseTypes.iterator().next(), dataSourceMap, providerType);
+        result.init(databaseTypes, dataSourceMap, providerType);
         return result;
     }
     

--- a/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/rule/builder/TransactionRuleBuilder.java
+++ b/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/rule/builder/TransactionRuleBuilder.java
@@ -35,7 +35,7 @@ public final class TransactionRuleBuilder implements GlobalRuleBuilder<Transacti
     @Override
     public TransactionRule build(final TransactionRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases, final InstanceContext instanceContext,
                                  final ConfigurationProperties props) {
-        return new TransactionRule(ruleConfig, databases, instanceContext);
+        return new TransactionRule(ruleConfig, databases);
     }
     
     @Override

--- a/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/spi/ShardingSphereTransactionManager.java
+++ b/kernel/transaction/core/src/main/java/org/apache/shardingsphere/transaction/spi/ShardingSphereTransactionManager.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.transaction.core.TransactionType;
 
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
+import java.util.Map;
 
 /**
  * ShardingSphere transaction manager.
@@ -33,11 +33,11 @@ public interface ShardingSphereTransactionManager extends AutoCloseable {
     /**
      * Initialize transaction manager.
      *
-     * @param databaseType database type
+     * @param databaseTypes database types
      * @param resourceDataSources resource data sources
      * @param providerType transaction manager provider type 
      */
-    void init(DatabaseType databaseType, Collection<ResourceDataSource> resourceDataSources, String providerType);
+    void init(Map<String, DatabaseType> databaseTypes, Map<String, ResourceDataSource> resourceDataSources, String providerType);
     
     /**
      * Get transaction type.

--- a/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/ConnectionTransactionTest.java
+++ b/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/ConnectionTransactionTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.transaction;
 
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
-import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.transaction.ConnectionTransaction.DistributedTransactionOperationType;
 import org.apache.shardingsphere.transaction.config.TransactionRuleConfiguration;
 import org.apache.shardingsphere.transaction.rule.TransactionRule;
@@ -28,10 +27,9 @@ import java.util.Collections;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 
 public final class ConnectionTransactionTest {
     
@@ -71,10 +69,10 @@ public final class ConnectionTransactionTest {
     }
     
     private TransactionRule getLocalTransactionRule() {
-        return new TransactionRule(new TransactionRuleConfiguration("LOCAL", null, new Properties()), Collections.emptyMap(), mock(InstanceContext.class));
+        return new TransactionRule(new TransactionRuleConfiguration("LOCAL", null, new Properties()), Collections.emptyMap());
     }
     
     private TransactionRule getXATransactionRule() {
-        return new TransactionRule(new TransactionRuleConfiguration("XA", "Atomikos", new Properties()), Collections.emptyMap(), mock(InstanceContext.class));
+        return new TransactionRule(new TransactionRuleConfiguration("XA", "Atomikos", new Properties()), Collections.emptyMap());
     }
 }

--- a/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/ShardingSphereTransactionManagerEngineTest.java
+++ b/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/ShardingSphereTransactionManagerEngineTest.java
@@ -43,7 +43,7 @@ public final class ShardingSphereTransactionManagerEngineTest {
         Runnable caller = mock(Runnable.class);
         ShardingSphereTransactionManagerFixture transactionManager = (ShardingSphereTransactionManagerFixture) transactionManagerEngine.getTransactionManager(TransactionType.XA);
         transactionManager.setCaller(caller);
-        transactionManagerEngine.init(DatabaseTypeFactory.getInstance("H2"), Collections.emptyMap(), "Atomikos");
+        transactionManagerEngine.init(Collections.singletonMap("sharding_db.ds_0", DatabaseTypeFactory.getInstance("H2")), Collections.emptyMap(), "Atomikos");
         verify(caller).run();
     }
 }

--- a/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/OtherShardingSphereTransactionManagerFixture.java
+++ b/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/OtherShardingSphereTransactionManagerFixture.java
@@ -23,12 +23,12 @@ import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManager;
 
 import java.sql.Connection;
-import java.util.Collection;
+import java.util.Map;
 
 public final class OtherShardingSphereTransactionManagerFixture implements ShardingSphereTransactionManager {
     
     @Override
-    public void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources, final String providerType) {
+    public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, ResourceDataSource> resourceDataSources, final String providerType) {
     }
     
     @Override

--- a/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/ShardingSphereTransactionManagerFixture.java
+++ b/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/core/fixture/ShardingSphereTransactionManagerFixture.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.transaction.core.TransactionType;
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManager;
 
 import java.sql.Connection;
-import java.util.Collection;
+import java.util.Map;
 
 public final class ShardingSphereTransactionManagerFixture implements ShardingSphereTransactionManager {
     
@@ -32,7 +32,7 @@ public final class ShardingSphereTransactionManagerFixture implements ShardingSp
     private Runnable caller;
     
     @Override
-    public void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources, final String providerType) {
+    public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, ResourceDataSource> resourceDataSources, final String providerType) {
         if (null != caller) {
             caller.run();
         }

--- a/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/rule/TransactionRuleTest.java
+++ b/kernel/transaction/core/src/test/java/org/apache/shardingsphere/transaction/rule/TransactionRuleTest.java
@@ -17,37 +17,62 @@
 
 package org.apache.shardingsphere.transaction.rule;
 
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.OpenGaussDatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ShardingSphereResourceMetaData;
+import org.apache.shardingsphere.test.mock.MockedDataSource;
 import org.apache.shardingsphere.transaction.config.TransactionRuleConfiguration;
+import org.apache.shardingsphere.transaction.core.TransactionType;
+import org.apache.shardingsphere.transaction.core.fixture.ShardingSphereTransactionManagerFixture;
 import org.junit.Test;
 
-import java.util.HashMap;
+import javax.sql.DataSource;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public final class TransactionRuleTest {
     
-    @Test(expected = IllegalStateException.class)
-    public void assertMultiDatabaseTypeFail() {
-        TransactionRuleConfiguration transactionRuleConfiguration = mock(TransactionRuleConfiguration.class);
-        when(transactionRuleConfiguration.getDefaultType()).thenReturn("XA");
-        when(transactionRuleConfiguration.getProviderType()).thenReturn("Atomikos");
-        ShardingSphereDatabase db1 = mock(ShardingSphereDatabase.class);
-        ShardingSphereResourceMetaData resourceMetaData1 = mock(ShardingSphereResourceMetaData.class);
-        when(resourceMetaData1.getDatabaseType()).thenReturn(new OpenGaussDatabaseType());
-        when(db1.getResourceMetaData()).thenReturn(resourceMetaData1);
-        ShardingSphereDatabase db2 = mock(ShardingSphereDatabase.class);
-        ShardingSphereResourceMetaData resourceMetaData2 = mock(ShardingSphereResourceMetaData.class);
-        when(resourceMetaData2.getDatabaseType()).thenReturn(new PostgreSQLDatabaseType());
-        when(db2.getResourceMetaData()).thenReturn(resourceMetaData2);
-        Map<String, ShardingSphereDatabase> databaseMap = new HashMap<>();
-        databaseMap.put("db1", db1);
-        databaseMap.put("db2", db2);
-        TransactionRule transactionRule = new TransactionRule(transactionRuleConfiguration, databaseMap, null);
+    @Test
+    public void assertInitTransactionRuleWithMultiDatabaseType() {
+        TransactionRule actual = new TransactionRule(createTransactionRuleConfiguration(), Collections.singletonMap("sharding_db", createDatabase()));
+        assertNotNull(actual.getResource());
+        assertThat(actual.getResource().getTransactionManager(TransactionType.XA), instanceOf(ShardingSphereTransactionManagerFixture.class));
+    }
+    
+    private static ShardingSphereDatabase createDatabase() {
+        ShardingSphereDatabase result = mock(ShardingSphereDatabase.class);
+        ShardingSphereResourceMetaData resourceMetaData = createResourceMetaData();
+        when(result.getResourceMetaData()).thenReturn(resourceMetaData);
+        when(result.getName()).thenReturn("sharding_db");
+        return result;
+    }
+    
+    private static ShardingSphereResourceMetaData createResourceMetaData() {
+        ShardingSphereResourceMetaData result = mock(ShardingSphereResourceMetaData.class);
+        Map<String, DataSource> dataSourceMap = new LinkedHashMap<>(2, 1);
+        dataSourceMap.put("ds_0", new MockedDataSource());
+        dataSourceMap.put("ds_1", new MockedDataSource());
+        when(result.getDataSources()).thenReturn(dataSourceMap);
+        Map<String, DatabaseType> databaseTypes = new LinkedHashMap<>(2, 1);
+        databaseTypes.put("ds_0", new PostgreSQLDatabaseType());
+        databaseTypes.put("ds_1", new OpenGaussDatabaseType());
+        when(result.getDatabaseTypes()).thenReturn(databaseTypes);
+        return result;
+    }
+    
+    private static TransactionRuleConfiguration createTransactionRuleConfiguration() {
+        TransactionRuleConfiguration result = mock(TransactionRuleConfiguration.class);
+        when(result.getDefaultType()).thenReturn("XA");
+        when(result.getProviderType()).thenReturn("Atomikos");
+        return result;
     }
 }

--- a/kernel/transaction/distsql/handler/src/main/java/org/apache/shardingsphere/transaction/distsql/handler/update/AlterTransactionRuleStatementUpdater.java
+++ b/kernel/transaction/distsql/handler/src/main/java/org/apache/shardingsphere/transaction/distsql/handler/update/AlterTransactionRuleStatementUpdater.java
@@ -38,7 +38,7 @@ public final class AlterTransactionRuleStatementUpdater implements GlobalRuleRAL
         globalRules.stream().filter(each -> each instanceof TransactionRule).forEach(each -> ((TransactionRule) each).closeStaleResource());
         globalRules.removeIf(each -> each instanceof TransactionRule);
         TransactionRuleConfiguration toBeAlteredRuleConfig = createToBeAlteredRuleConfiguration(sqlStatement);
-        globalRules.add(new TransactionRule(toBeAlteredRuleConfig, metaData.getDatabases(), null));
+        globalRules.add(new TransactionRule(toBeAlteredRuleConfig, metaData.getDatabases()));
     }
     
     private TransactionRuleConfiguration createToBeAlteredRuleConfiguration(final SQLStatement sqlStatement) {

--- a/kernel/transaction/distsql/handler/src/test/java/org/apache/shardingsphere/transaction/distsql/handler/query/TransactionRuleQueryResultSetTest.java
+++ b/kernel/transaction/distsql/handler/src/test/java/org/apache/shardingsphere/transaction/distsql/handler/query/TransactionRuleQueryResultSetTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.transaction.distsql.handler.query;
 
-import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.transaction.config.TransactionRuleConfiguration;
 import org.apache.shardingsphere.transaction.distsql.parser.statement.queryable.ShowTransactionRuleStatement;
@@ -65,7 +64,7 @@ public final class TransactionRuleQueryResultSetTest {
     }
     
     private ShardingSphereRuleMetaData mockGlobalRuleMetaData(final String defaultType, final String providerType, final Properties props) {
-        TransactionRule rule = new TransactionRule(createAuthorityRuleConfiguration(defaultType, providerType, props), Collections.emptyMap(), mock(InstanceContext.class));
+        TransactionRule rule = new TransactionRule(createAuthorityRuleConfiguration(defaultType, providerType, props), Collections.emptyMap());
         ShardingSphereRuleMetaData result = mock(ShardingSphereRuleMetaData.class);
         when(result.findSingleRule(TransactionRule.class)).thenReturn(Optional.of(rule));
         return result;

--- a/kernel/transaction/distsql/handler/src/test/java/org/apache/shardingsphere/transaction/distsql/handler/update/AlterTransactionRuleStatementUpdaterTest.java
+++ b/kernel/transaction/distsql/handler/src/test/java/org/apache/shardingsphere/transaction/distsql/handler/update/AlterTransactionRuleStatementUpdaterTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.transaction.distsql.handler.update;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -79,7 +78,7 @@ public final class AlterTransactionRuleStatementUpdaterTest {
     }
     
     private TransactionRule createTransactionRule(final Map<String, ShardingSphereDatabase> databases) {
-        return new TransactionRule(new TransactionRuleConfiguration("BASE", null, new Properties()), databases, mock(InstanceContext.class));
+        return new TransactionRule(new TransactionRuleConfiguration("BASE", null, new Properties()), databases);
     }
     
     private ShardingSphereDatabase mockDatabase() {

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
@@ -37,7 +37,6 @@ import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManage
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -65,10 +64,10 @@ public final class SeataATShardingSphereTransactionManager implements ShardingSp
     }
     
     @Override
-    public void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources, final String providerType) {
+    public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, ResourceDataSource> resourceDataSources, final String providerType) {
         if (enableSeataAT) {
             initSeataRPCClient();
-            resourceDataSources.forEach(each -> dataSourceMap.put(each.getOriginalName(), new DataSourceProxy(each.getDataSource())));
+            resourceDataSources.forEach((key, value) -> dataSourceMap.put(value.getOriginalName(), new DataSourceProxy(value.getDataSource())));
         }
     }
     

--- a/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManagerTest.java
+++ b/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManagerTest.java
@@ -86,7 +86,8 @@ public final class SeataATShardingSphereTransactionManagerTest {
     
     @Before
     public void setUp() {
-        seataTransactionManager.init(DatabaseTypeFactory.getInstance("MySQL"), Collections.singletonList(new ResourceDataSource(DATA_SOURCE_UNIQUE_NAME, new MockedDataSource())), "Seata");
+        seataTransactionManager.init(Collections.singletonMap("sharding_db.ds_0", DatabaseTypeFactory.getInstance("MySQL")),
+                Collections.singletonMap("sharding_db.ds_0", new ResourceDataSource(DATA_SOURCE_UNIQUE_NAME, new MockedDataSource())), "Seata");
     }
     
     @After

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
@@ -36,7 +36,6 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,10 +49,10 @@ public final class XAShardingSphereTransactionManager implements ShardingSphereT
     private XATransactionManagerProvider xaTransactionManagerProvider;
     
     @Override
-    public void init(final DatabaseType databaseType, final Collection<ResourceDataSource> resourceDataSources, final String providerType) {
+    public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, ResourceDataSource> resourceDataSources, final String providerType) {
         xaTransactionManagerProvider = XATransactionManagerProviderFactory.getInstance(providerType);
         xaTransactionManagerProvider.init();
-        resourceDataSources.forEach(each -> cachedDataSources.put(each.getOriginalName(), newXATransactionDataSource(databaseType, each)));
+        resourceDataSources.forEach((key, value) -> cachedDataSources.put(value.getOriginalName(), newXATransactionDataSource(databaseTypes.get(key), value)));
     }
     
     private XATransactionDataSource newXATransactionDataSource(final DatabaseType databaseType, final ResourceDataSource resourceDataSource) {


### PR DESCRIPTION
Ref #21481.

Changes proposed in this pull request:
  - support heterogeneous databases in single logic database for TransactionRule init
  - remove useless instanceContent in TransactionRule
  - modify related unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
