### PR TITLE
Fix nightly builds of GraalVM Native Image

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: 'releases'
+          version: 'dev'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Fix nightly builds of GraalVM Native Image .
  - The Log at https://github.com/apache/shardingsphere/actions/runs/3298856474/jobs/5441511861 shows that the CI of GraalVM Native Image is broken.  This question first came from https://github.com/apache/shardingsphere/pull/21677. 
  - Refer to https://github.com/apache/shardingsphere/issues/21347#issuecomment-1287302217 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
