### PR TITLE
Fixes #21698, change keywords for `migration source resource`.

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/migration/usage.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/migration/usage.cn.md
@@ -135,7 +135,7 @@ KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
 2. 在 proxy 配置源端资源。
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_0 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
     URL="jdbc:mysql://127.0.0.1:3306/migration_ds_0?serverTimezone=UTC&useSSL=false",
     USER="root",
     PASSWORD="root",
@@ -329,7 +329,7 @@ KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
 2. 在 proxy 配置源端资源。
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_0 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
     URL="jdbc:postgresql://127.0.0.1:5432/migration_ds_0",
     USER="postgres",
     PASSWORD="root",
@@ -512,7 +512,7 @@ KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
 2. 在 proxy 配置源端资源。
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_2 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_2 (
     URL="jdbc:opengauss://127.0.0.1:5432/migration_ds_0",
     USER="gaussdb",
     PASSWORD="Root@123",

--- a/docs/document/content/user-manual/shardingsphere-proxy/migration/usage.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/migration/usage.en.md
@@ -131,7 +131,7 @@ If you are migrating to a heterogeneous database, you need to execute the table-
 2. Configure the source resources in proxy.
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_0 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
     URL="jdbc:mysql://127.0.0.1:3306/migration_ds_0?serverTimezone=UTC&useSSL=false",
     USER="root",
     PASSWORD="root",
@@ -326,7 +326,7 @@ If you are migrating to a heterogeneous database, you need to execute the table-
 2. Configure the source resources in proxy.
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_0 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
     URL="jdbc:postgresql://127.0.0.1:5432/migration_ds_0",
     USER="postgres",
     PASSWORD="root",
@@ -509,7 +509,7 @@ If you are migrating to a heterogeneous database, you need to execute the table-
 2. Configure the source resources in proxy.
 
 ```sql
-ADD MIGRATION SOURCE RESOURCE ds_2 (
+REGISTER MIGRATION SOURCE STORAGE UNIT ds_2 (
     URL="jdbc:opengauss://127.0.0.1:5432/migration_ds_0",
     USER="gaussdb",
     PASSWORD="Root@123",

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsQueryResultSet.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsQueryResultSet.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.data.pipeline.api.MigrationJobPublicAPI;
 import org.apache.shardingsphere.data.pipeline.api.PipelineJobPublicAPIFactory;
 import org.apache.shardingsphere.infra.distsql.query.DatabaseDistSQLResultSet;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceResourcesStatement;
+import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceStorageUnitsStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
@@ -29,9 +29,9 @@ import java.util.Collection;
 import java.util.Iterator;
 
 /**
- * Show migration source resources query result set.
+ * Show migration source storage units query result set.
  */
-public final class ShowMigrationSourceResourceQueryResultSet implements DatabaseDistSQLResultSet {
+public final class ShowMigrationSourceStorageUnitsQueryResultSet implements DatabaseDistSQLResultSet {
     
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
@@ -60,6 +60,6 @@ public final class ShowMigrationSourceResourceQueryResultSet implements Database
     
     @Override
     public String getType() {
-        return ShowMigrationSourceResourcesStatement.class.getName();
+        return ShowMigrationSourceStorageUnitsStatement.class.getName();
     }
 }

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RegisterMigrationSourceStorageUnitUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/RegisterMigrationSourceStorageUnitUpdater.java
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.infra.datasource.props.DataSourcePropertiesVali
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.exception.external.sql.type.generic.UnsupportedSQLOperationException;
-import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
+import org.apache.shardingsphere.migration.distsql.statement.RegisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.sharding.distsql.handler.converter.ResourceSegmentsConverter;
 
 import java.util.ArrayList;
@@ -37,14 +37,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Add migration source resource updater.
+ * Register migration source storage unit updater.
  */
-public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMigrationSourceResourceStatement> {
+public final class RegisterMigrationSourceStorageUnitUpdater implements RALUpdater<RegisterMigrationSourceStorageUnitStatement> {
     
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final String databaseName, final AddMigrationSourceResourceStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final RegisterMigrationSourceStorageUnitStatement sqlStatement) {
         List<DataSourceSegment> dataSources = new ArrayList<>(sqlStatement.getDataSources());
         ShardingSpherePreconditions.checkState(dataSources.stream().noneMatch(each -> each instanceof HostnameAndPortBasedDataSourceSegment),
                 () -> new UnsupportedSQLOperationException("Not currently support add hostname and port, please use url"));
@@ -58,6 +58,6 @@ public final class AddMigrationSourceResourceUpdater implements RALUpdater<AddMi
     
     @Override
     public String getType() {
-        return AddMigrationSourceResourceStatement.class.getName();
+        return RegisterMigrationSourceStorageUnitStatement.class.getName();
     }
 }

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/UnregisterMigrationSourceStorageUnitUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/update/UnregisterMigrationSourceStorageUnitUpdater.java
@@ -20,22 +20,22 @@ package org.apache.shardingsphere.migration.distsql.handler.update;
 import org.apache.shardingsphere.data.pipeline.api.MigrationJobPublicAPI;
 import org.apache.shardingsphere.data.pipeline.api.PipelineJobPublicAPIFactory;
 import org.apache.shardingsphere.infra.distsql.update.RALUpdater;
-import org.apache.shardingsphere.migration.distsql.statement.DropMigrationSourceResourceStatement;
+import org.apache.shardingsphere.migration.distsql.statement.UnregisterMigrationSourceStorageUnitStatement;
 
 /**
- * Drop migration source resource updater.
+ * Unregister migration source storage unit updater.
  */
-public final class DropMigrationSourceResourceUpdater implements RALUpdater<DropMigrationSourceResourceStatement> {
+public final class UnregisterMigrationSourceStorageUnitUpdater implements RALUpdater<UnregisterMigrationSourceStorageUnitStatement> {
     
     private static final MigrationJobPublicAPI JOB_API = PipelineJobPublicAPIFactory.getMigrationJobPublicAPI();
     
     @Override
-    public void executeUpdate(final String databaseName, final DropMigrationSourceResourceStatement sqlStatement) {
+    public void executeUpdate(final String databaseName, final UnregisterMigrationSourceStorageUnitStatement sqlStatement) {
         JOB_API.dropMigrationSourceResources(sqlStatement.getNames());
     }
     
     @Override
     public String getType() {
-        return DropMigrationSourceResourceStatement.class.getName();
+        return UnregisterMigrationSourceStorageUnitStatement.class.getName();
     }
 }

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.query.DistSQLResultSet
@@ -27,7 +27,7 @@ org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStat
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationListQueryResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusQueryResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckAlgorithmsQueryResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceResourceQueryResultSet
+org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsQueryResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsQueryResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorsQueryResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAuditorsQueryResultSet

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.distsql.update.RALUpdater
@@ -20,8 +20,8 @@ org.apache.shardingsphere.migration.distsql.handler.update.StartMigrationUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.StopMigrationUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.CommitMigrationUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.RollbackMigrationUpdater
-org.apache.shardingsphere.migration.distsql.handler.update.AddMigrationSourceResourceUpdater
-org.apache.shardingsphere.migration.distsql.handler.update.DropMigrationSourceResourceUpdater
+org.apache.shardingsphere.migration.distsql.handler.update.RegisterMigrationSourceStorageUnitUpdater
+org.apache.shardingsphere.migration.distsql.handler.update.UnregisterMigrationSourceStorageUnitUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.CheckMigrationJobUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.StartMigrationCheckUpdater
 org.apache.shardingsphere.migration.distsql.handler.update.StopMigrationCheckUpdater

--- a/features/sharding/distsql/parser/src/main/antlr4/imports/migration/Keyword.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/imports/migration/Keyword.g4
@@ -174,3 +174,23 @@ RESOURCE
 RESOURCES
     : R E S O U R C E S
     ;
+
+REGISTER
+    : R E G I S T E R
+    ;
+
+UNREGISTER
+    : U N R E G I S T E R
+    ;
+
+STORAGE
+    : S T O R A G E
+    ;
+
+UNIT
+    : U N I T
+    ;
+
+UNITS
+    : U N I T S
+    ;

--- a/features/sharding/distsql/parser/src/main/antlr4/imports/migration/RALStatement.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/imports/migration/RALStatement.g4
@@ -95,11 +95,11 @@ identifier
     : IDENTIFIER
     ;
 
-resourceDefinition
-    : resourceName LP (simpleSource | urlSource) COMMA USER EQ user (COMMA PASSWORD EQ password)? (COMMA propertiesDefinition)? RP
+storageUnitDefinition
+    : storageUnitName LP (simpleSource | urlSource) COMMA USER EQ user (COMMA PASSWORD EQ password)? (COMMA propertiesDefinition)? RP
     ;
 
-resourceName
+storageUnitName
     : IDENTIFIER
     ;
 
@@ -135,10 +135,10 @@ password
     : STRING
     ;
 
-addMigrationSourceResource
-    : ADD MIGRATION SOURCE RESOURCE resourceDefinition (COMMA resourceDefinition)*
+registerMigrationSourceStorageUnit
+    : REGISTER MIGRATION SOURCE STORAGE UNIT storageUnitDefinition (COMMA storageUnitDefinition)*
     ;
     
-dropMigrationSourceResource
-    : DROP MIGRATION SOURCE RESOURCE resourceName (COMMA resourceName)*
+unregisterMigrationSourceStorageUnit
+    : UNREGISTER MIGRATION SOURCE STORAGE UNIT storageUnitName (COMMA storageUnitName)*
     ;

--- a/features/sharding/distsql/parser/src/main/antlr4/imports/migration/RQLStatement.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/imports/migration/RQLStatement.g4
@@ -19,6 +19,6 @@ grammar RQLStatement;
 
 import BaseRule;
 
-showMigrationSourceResources
-    : SHOW MIGRATION SOURCE RESOURCES
+showMigrationSourceStorageUnits
+    : SHOW MIGRATION SOURCE STORAGE UNITS
     ;

--- a/features/sharding/distsql/parser/src/main/antlr4/migration/org/apache/shardingsphere/distsql/parser/autogen/MigrationDistSQLStatement.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/migration/org/apache/shardingsphere/distsql/parser/autogen/MigrationDistSQLStatement.g4
@@ -29,9 +29,9 @@ execute
     | commitMigration
     | checkMigration
     | showMigrationCheckAlgorithms
-    | addMigrationSourceResource
-    | dropMigrationSourceResource
-    | showMigrationSourceResources
+    | registerMigrationSourceStorageUnit
+    | unregisterMigrationSourceStorageUnit
+    | showMigrationSourceStorageUnits
     | showMigrationCheckStatus
     | startMigrationCheck
     | stopMigrationCheck

--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/migration/distsql/parser/core/MigrationDistSQLStatementVisitor.java
@@ -21,45 +21,45 @@ import com.google.common.base.Splitter;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementBaseVisitor;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser;
-import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.AddMigrationSourceResourceContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.AlgorithmDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.CheckMigrationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.CommitMigrationContext;
-import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.DropMigrationSourceResourceContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.MigrateTableContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.PasswordContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.PropertiesDefinitionContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.PropertyContext;
-import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ResourceDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.RegisterMigrationSourceStorageUnitContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.RollbackMigrationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationCheckAlgorithmsContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationCheckStatusContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationListContext;
-import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationSourceResourcesContext;
+import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationSourceStorageUnitsContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.ShowMigrationStatusContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.StartMigrationCheckContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.StartMigrationContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.StopMigrationCheckContext;
 import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.StopMigrationContext;
+import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.StorageUnitDefinitionContext;
+import org.apache.shardingsphere.distsql.parser.autogen.MigrationDistSQLStatementParser.UnregisterMigrationSourceStorageUnitContext;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.distsql.parser.segment.DataSourceSegment;
 import org.apache.shardingsphere.distsql.parser.segment.HostnameAndPortBasedDataSourceSegment;
 import org.apache.shardingsphere.distsql.parser.segment.URLBasedDataSourceSegment;
-import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
 import org.apache.shardingsphere.migration.distsql.statement.CheckMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.CommitMigrationStatement;
-import org.apache.shardingsphere.migration.distsql.statement.DropMigrationSourceResourceStatement;
 import org.apache.shardingsphere.migration.distsql.statement.MigrateTableStatement;
+import org.apache.shardingsphere.migration.distsql.statement.RegisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.migration.distsql.statement.RollbackMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationCheckAlgorithmsStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationCheckStatusStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationListStatement;
-import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceResourcesStatement;
+import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceStorageUnitsStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationStatusStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StartMigrationCheckStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StartMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StopMigrationCheckStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StopMigrationStatement;
+import org.apache.shardingsphere.migration.distsql.statement.UnregisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.sql.parser.api.visitor.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.SQLVisitor;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
@@ -148,16 +148,16 @@ public final class MigrationDistSQLStatementVisitor extends MigrationDistSQLStat
     }
     
     @Override
-    public ASTNode visitResourceDefinition(final MigrationDistSQLStatementParser.ResourceDefinitionContext ctx) {
+    public ASTNode visitStorageUnitDefinition(final MigrationDistSQLStatementParser.StorageUnitDefinitionContext ctx) {
         String user = getIdentifierValue(ctx.user());
         String password = null == ctx.password() ? "" : getPassword(ctx.password());
         Properties props = getProperties(ctx.propertiesDefinition());
         DataSourceSegment result = null;
         if (null != ctx.urlSource()) {
-            result = new URLBasedDataSourceSegment(getIdentifierValue(ctx.resourceName()), getIdentifierValue(ctx.urlSource().url()), user, password, props);
+            result = new URLBasedDataSourceSegment(getIdentifierValue(ctx.storageUnitName()), getIdentifierValue(ctx.urlSource().url()), user, password, props);
         }
         if (null != ctx.simpleSource()) {
-            result = new HostnameAndPortBasedDataSourceSegment(getIdentifierValue(ctx.resourceName()), getIdentifierValue(ctx.simpleSource().hostname()), ctx.simpleSource().port().getText(),
+            result = new HostnameAndPortBasedDataSourceSegment(getIdentifierValue(ctx.storageUnitName()), getIdentifierValue(ctx.simpleSource().hostname()), ctx.simpleSource().port().getText(),
                     getIdentifierValue(ctx.simpleSource().dbName()), user, password, props);
         }
         return result;
@@ -179,22 +179,22 @@ public final class MigrationDistSQLStatementVisitor extends MigrationDistSQLStat
     }
     
     @Override
-    public ASTNode visitAddMigrationSourceResource(final AddMigrationSourceResourceContext ctx) {
+    public ASTNode visitRegisterMigrationSourceStorageUnit(final RegisterMigrationSourceStorageUnitContext ctx) {
         Collection<DataSourceSegment> dataSources = new ArrayList<>();
-        for (ResourceDefinitionContext each : ctx.resourceDefinition()) {
+        for (StorageUnitDefinitionContext each : ctx.storageUnitDefinition()) {
             dataSources.add((DataSourceSegment) visit(each));
         }
-        return new AddMigrationSourceResourceStatement(dataSources);
+        return new RegisterMigrationSourceStorageUnitStatement(dataSources);
     }
     
     @Override
-    public ASTNode visitDropMigrationSourceResource(final DropMigrationSourceResourceContext ctx) {
-        return new DropMigrationSourceResourceStatement(ctx.resourceName().stream().map(ParseTree::getText).map(each -> new IdentifierValue(each).getValue()).collect(Collectors.toList()));
+    public ASTNode visitUnregisterMigrationSourceStorageUnit(final UnregisterMigrationSourceStorageUnitContext ctx) {
+        return new UnregisterMigrationSourceStorageUnitStatement(ctx.storageUnitName().stream().map(ParseTree::getText).map(each -> new IdentifierValue(each).getValue()).collect(Collectors.toList()));
     }
     
     @Override
-    public ASTNode visitShowMigrationSourceResources(final ShowMigrationSourceResourcesContext ctx) {
-        return new ShowMigrationSourceResourcesStatement();
+    public ASTNode visitShowMigrationSourceStorageUnits(final ShowMigrationSourceStorageUnitsContext ctx) {
+        return new ShowMigrationSourceStorageUnitsStatement();
     }
     
     @Override

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/RegisterMigrationSourceStorageUnitStatement.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/RegisterMigrationSourceStorageUnitStatement.java
@@ -15,17 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
+package org.apache.shardingsphere.migration.distsql.statement;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.segment.DataSourceSegment;
+import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
+
+import java.util.Collection;
 
 /**
- * Show migration source resources statement test case.
+ * Register migration source storage unit statement.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ShowMigrationSourceResourcesStatementTestCase extends SQLParserTestCase {
+public final class RegisterMigrationSourceStorageUnitStatement extends UpdatableScalingRALStatement {
     
+    private final Collection<DataSourceSegment> dataSources;
 }

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/ShowMigrationSourceStorageUnitsStatement.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/ShowMigrationSourceStorageUnitsStatement.java
@@ -17,19 +17,10 @@
 
 package org.apache.shardingsphere.migration.distsql.statement;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.distsql.parser.segment.DataSourceSegment;
-import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
-
-import java.util.Collection;
+import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.QueryableScalingRALStatement;
 
 /**
- * Add resource statement.
+ * Show migration source storage units statement.
  */
-@RequiredArgsConstructor
-@Getter
-public final class AddMigrationSourceResourceStatement extends UpdatableScalingRALStatement {
-    
-    private final Collection<DataSourceSegment> dataSources;
+public final class ShowMigrationSourceStorageUnitsStatement extends QueryableScalingRALStatement {
 }

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/UnregisterMigrationSourceStorageUnitStatement.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/migration/distsql/statement/UnregisterMigrationSourceStorageUnitStatement.java
@@ -15,21 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
+package org.apache.shardingsphere.migration.distsql.statement;
 
 import lombok.Getter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
 
-import javax.xml.bind.annotation.XmlElement;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.Collection;
 
 /**
- * Drop migration source resource statement test case.
+ * Unregister migration source storage unit statement.
  */
 @Getter
-public final class DropMigrationSourceResourceStatementTestCase extends SQLParserTestCase {
+public final class UnregisterMigrationSourceStorageUnitStatement extends UpdatableScalingRALStatement {
     
-    @XmlElement(name = "data-source")
-    private final List<String> dataSources = new LinkedList<>();
+    private final Collection<String> names;
+    
+    public UnregisterMigrationSourceStorageUnitStatement(final Collection<String> names) {
+        this.names = names;
+    }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/connection/RegisterMigrationSourceStorageUnitException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/connection/RegisterMigrationSourceStorageUnitException.java
@@ -15,12 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.migration.distsql.statement;
+package org.apache.shardingsphere.data.pipeline.core.exception.connection;
 
-import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.QueryableScalingRALStatement;
+import org.apache.shardingsphere.data.pipeline.core.exception.PipelineSQLException;
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+
+import java.util.Collection;
 
 /**
- * Show migration source resources statement.
+ * Register migration source storage unit exception.
  */
-public final class ShowMigrationSourceResourcesStatement extends QueryableScalingRALStatement {
+public final class RegisterMigrationSourceStorageUnitException extends PipelineSQLException {
+    
+    private static final long serialVersionUID = -3952313247315105684L;
+    
+    public RegisterMigrationSourceStorageUnitException(final Collection<String> duplicateDataSourceNames) {
+        super(XOpenSQLState.DUPLICATE, 30, "Duplicate storage unit names `%s`.", duplicateDataSourceNames);
+    }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/connection/UnregisterMigrationSourceStorageUnitException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/connection/UnregisterMigrationSourceStorageUnitException.java
@@ -23,13 +23,13 @@ import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpe
 import java.util.Collection;
 
 /**
- * Drop migration source resource exception.
+ * Unregister migration source storage unit exception.
  */
-public final class DropMigrationSourceResourceException extends PipelineSQLException {
+public final class UnregisterMigrationSourceStorageUnitException extends PipelineSQLException {
     
     private static final long serialVersionUID = -7133815271017274299L;
     
-    public DropMigrationSourceResourceException(final Collection<String> resourceNames) {
-        super(XOpenSQLState.NOT_FOUND, 31, "Resource names `%s` do not exist.", resourceNames);
+    public UnregisterMigrationSourceStorageUnitException(final Collection<String> resourceNames) {
+        super(XOpenSQLState.NOT_FOUND, 31, "Storage units `%s` do not exist.", resourceNames);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
@@ -56,8 +56,8 @@ import org.apache.shardingsphere.data.pipeline.core.api.impl.PipelineDataSourceP
 import org.apache.shardingsphere.data.pipeline.core.context.InventoryIncrementalProcessContext;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceFactory;
-import org.apache.shardingsphere.data.pipeline.core.exception.connection.AddMigrationSourceResourceException;
-import org.apache.shardingsphere.data.pipeline.core.exception.connection.DropMigrationSourceResourceException;
+import org.apache.shardingsphere.data.pipeline.core.exception.connection.RegisterMigrationSourceStorageUnitException;
+import org.apache.shardingsphere.data.pipeline.core.exception.connection.UnregisterMigrationSourceStorageUnitException;
 import org.apache.shardingsphere.data.pipeline.core.metadata.loader.PipelineSchemaUtil;
 import org.apache.shardingsphere.data.pipeline.core.metadata.loader.PipelineTableMetaDataUtil;
 import org.apache.shardingsphere.data.pipeline.core.metadata.loader.StandardPipelineTableMetaDataLoader;
@@ -342,7 +342,7 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
                 duplicateDataSourceNames.add(entry.getKey());
             }
         }
-        ShardingSpherePreconditions.checkState(duplicateDataSourceNames.isEmpty(), () -> new AddMigrationSourceResourceException(duplicateDataSourceNames));
+        ShardingSpherePreconditions.checkState(duplicateDataSourceNames.isEmpty(), () -> new RegisterMigrationSourceStorageUnitException(duplicateDataSourceNames));
         Map<String, DataSourceProperties> result = new LinkedHashMap<>(existDataSources);
         result.putAll(dataSourcePropsMap);
         dataSourcePersistService.persist(getJobType(), result);
@@ -352,7 +352,7 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
     public void dropMigrationSourceResources(final Collection<String> resourceNames) {
         Map<String, DataSourceProperties> metaDataDataSource = dataSourcePersistService.load(getJobType());
         List<String> noExistResources = resourceNames.stream().filter(each -> !metaDataDataSource.containsKey(each)).collect(Collectors.toList());
-        ShardingSpherePreconditions.checkState(noExistResources.isEmpty(), () -> new DropMigrationSourceResourceException(resourceNames));
+        ShardingSpherePreconditions.checkState(noExistResources.isEmpty(), () -> new UnregisterMigrationSourceStorageUnitException(resourceNames));
         for (String each : resourceNames) {
             metaDataDataSource.remove(each);
         }

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
@@ -74,14 +74,14 @@ public abstract class AbstractMigrationITCase extends BaseITCase {
                 log.warn("Drop sharding_db failed, maybe it's not exist. error msg={}", ex.getMessage());
             }
         }
-        String addSourceResource = migrationDistSQLCommand.getAddMigrationSourceResourceTemplate().replace("${user}", getUsername())
+        String addSourceResource = migrationDistSQLCommand.getRegisterMigrationSourceStorageUnitTemplate().replace("${user}", getUsername())
                 .replace("${password}", getPassword())
                 .replace("${ds0}", appendBatchInsertParam(getActualJdbcUrlTemplate(DS_0, true)));
         addResource(addSourceResource);
     }
     
     protected void addMigrationTargetResource() throws SQLException {
-        String addTargetResource = migrationDistSQLCommand.getAddMigrationTargetResourceTemplate().replace("${user}", getUsername())
+        String addTargetResource = migrationDistSQLCommand.getRegisterMigrationTargetStorageUnitTemplate().replace("${user}", getUsername())
                 .replace("${password}", getPassword())
                 .replace("${ds2}", appendBatchInsertParam(getActualJdbcUrlTemplate(DS_2, true)))
                 .replace("${ds3}", appendBatchInsertParam(getActualJdbcUrlTemplate(DS_3, true)))

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/command/MigrationDistSQLCommand.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/command/MigrationDistSQLCommand.java
@@ -46,13 +46,13 @@ public final class MigrationDistSQLCommand {
     @Getter
     private String createTargetOrderItemTableRule;
     
-    @XmlElement(name = "add-migration-source-resource-template")
+    @XmlElement(name = "register-migration-source-storage-unit-template")
     @Getter
-    private String addMigrationSourceResourceTemplate;
+    private String registerMigrationSourceStorageUnitTemplate;
     
-    @XmlElement(name = "add-migration-target-resource-template")
+    @XmlElement(name = "register-migration-target-storage-unit-template")
     @Getter
-    private String addMigrationTargetResourceTemplate;
+    private String registerMigrationTargetStorageUnitTemplate;
     
     @XmlElement(name = "migration-single-table")
     private String migrationSingleTable;

--- a/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
+++ b/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
@@ -33,15 +33,15 @@
         );
     </alter-migration-rule>
     
-    <add-migration-source-resource-template>
-        ADD MIGRATION SOURCE RESOURCE ds_0 (
+    <register-migration-source-storage-unit-template>
+        REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (
         URL="${ds0}",
         USER="${user}",
         PASSWORD="${password}"
         );
-    </add-migration-source-resource-template>
+    </register-migration-source-storage-unit-template>
     
-    <add-migration-target-resource-template>
+    <register-migration-target-storage-unit-template>
         REGISTER STORAGE UNIT ds_2 (
         URL="${ds2}",
         USER="${user}",
@@ -55,7 +55,7 @@
         USER="${user}",
         PASSWORD="${password}"
         )
-    </add-migration-target-resource-template>
+    </register-migration-target-storage-unit-template>
     
     <create-target-order-table-encrypt-rule>
         CREATE ENCRYPT RULE t_order (

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/QueryableScalingRALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/QueryableScalingRALStatementAssert.java
@@ -20,22 +20,22 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.QueryableScalingRALStatement;
-import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationCheckStatusStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationCheckAlgorithmsStatement;
+import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationCheckStatusStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationListStatement;
-import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceResourcesStatement;
+import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceStorageUnitsStatement;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationStatusStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationCheckStatusStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationCheckAlgorithmsStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationCheckStatusStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationListStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationSourceResourceStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationSourceStorageUnitsStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query.ShowMigrationStatusStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowMigrationListStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationCheckStatusStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationCheckAlgorithmsStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceResourcesStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationCheckStatusStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceStorageUnitsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationStatusStatementTestCase;
 
 /**
@@ -61,8 +61,8 @@ public final class QueryableScalingRALStatementAssert {
             ShowMigrationCheckStatusStatementAssert.assertIs(assertContext, (ShowMigrationCheckStatusStatement) actual, (ShowMigrationCheckStatusStatementTestCase) expected);
         } else if (actual instanceof ShowMigrationStatusStatement) {
             ShowMigrationStatusStatementAssert.assertIs(assertContext, (ShowMigrationStatusStatement) actual, (ShowMigrationStatusStatementTestCase) expected);
-        } else if (actual instanceof ShowMigrationSourceResourcesStatement) {
-            ShowMigrationSourceResourceStatementAssert.assertIs(assertContext, (ShowMigrationSourceResourcesStatement) actual, (ShowMigrationSourceResourcesStatementTestCase) expected);
+        } else if (actual instanceof ShowMigrationSourceStorageUnitsStatement) {
+            ShowMigrationSourceStorageUnitsStatementAssert.assertIs(assertContext, (ShowMigrationSourceStorageUnitsStatement) actual, (ShowMigrationSourceStorageUnitsStatementTestCase) expected);
         }
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/UpdatableScalingRALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/UpdatableScalingRALStatementAssert.java
@@ -20,32 +20,32 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
-import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
 import org.apache.shardingsphere.migration.distsql.statement.CheckMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.CommitMigrationStatement;
-import org.apache.shardingsphere.migration.distsql.statement.DropMigrationSourceResourceStatement;
 import org.apache.shardingsphere.migration.distsql.statement.MigrateTableStatement;
+import org.apache.shardingsphere.migration.distsql.statement.RegisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.migration.distsql.statement.RollbackMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StartMigrationStatement;
 import org.apache.shardingsphere.migration.distsql.statement.StopMigrationStatement;
+import org.apache.shardingsphere.migration.distsql.statement.UnregisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.AddMigrationSourceResourceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.CheckMigrationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.CommitMigrationStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.DropMigrationSourceResourceStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.MigrateTableStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.RegisterMigrationSourceStorageUnitStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.RollbackMigrationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.StartMigrationStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.StopMigrationStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.update.UnregisterMigrationSourceStorageUnitStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.AddMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CheckMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CommitMigrationStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.MigrateTableStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.RegisterMigrationSourceStorageUnitStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.RollbackMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.StartMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.StopMigrationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.UnregisterMigrationSourceStorageUnitStatementTestCase;
 
 /**
  * Updatable Scaling RAL statement assert.
@@ -72,10 +72,12 @@ public final class UpdatableScalingRALStatementAssert {
             RollbackMigrationStatementAssert.assertIs(assertContext, (RollbackMigrationStatement) actual, (RollbackMigrationStatementTestCase) expected);
         } else if (actual instanceof StartMigrationStatement) {
             StartMigrationStatementAssert.assertIs(assertContext, (StartMigrationStatement) actual, (StartMigrationStatementTestCase) expected);
-        } else if (actual instanceof AddMigrationSourceResourceStatement) {
-            AddMigrationSourceResourceStatementAssert.assertIs(assertContext, (AddMigrationSourceResourceStatement) actual, (AddMigrationSourceResourceStatementTestCase) expected);
-        } else if (actual instanceof DropMigrationSourceResourceStatement) {
-            DropMigrationSourceResourceStatementAssert.assertIs(assertContext, (DropMigrationSourceResourceStatement) actual, (DropMigrationSourceResourceStatementTestCase) expected);
+        } else if (actual instanceof RegisterMigrationSourceStorageUnitStatement) {
+            RegisterMigrationSourceStorageUnitStatementAssert.assertIs(assertContext, (RegisterMigrationSourceStorageUnitStatement) actual,
+                    (RegisterMigrationSourceStorageUnitStatementTestCase) expected);
+        } else if (actual instanceof UnregisterMigrationSourceStorageUnitStatement) {
+            UnregisterMigrationSourceStorageUnitStatementAssert.assertIs(assertContext, (UnregisterMigrationSourceStorageUnitStatement) actual,
+                    (UnregisterMigrationSourceStorageUnitStatementTestCase) expected);
         } else if (actual instanceof CheckMigrationStatement) {
             CheckMigrationStatementAssert.assertIs(assertContext, (CheckMigrationStatement) actual, (CheckMigrationStatementTestCase) expected);
         }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/query/ShowMigrationSourceStorageUnitsStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/query/ShowMigrationSourceStorageUnitsStatementAssert.java
@@ -17,26 +17,26 @@
 
 package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.query;
 
-import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceResourcesStatement;
+import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceStorageUnitsStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceResourcesStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceStorageUnitsStatementTestCase;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * Show migration source resources statement assert.
+ * Show migration source storage units statement assert.
  */
-public final class ShowMigrationSourceResourceStatementAssert {
+public final class ShowMigrationSourceStorageUnitsStatementAssert {
     
     /**
      * Assert show migration status is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual check migration statement
-     * @param expected expected check migration statement test case
+     * @param actual actual show migration storage units statement
+     * @param expected expected show migration storage units statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowMigrationSourceResourcesStatement actual, final ShowMigrationSourceResourcesStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowMigrationSourceStorageUnitsStatement actual, final ShowMigrationSourceStorageUnitsStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/RegisterMigrationSourceStorageUnitStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/RegisterMigrationSourceStorageUnitStatementAssert.java
@@ -20,34 +20,35 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.segment.DataSourceSegment;
-import org.apache.shardingsphere.migration.distsql.statement.AddMigrationSourceResourceStatement;
+import org.apache.shardingsphere.migration.distsql.statement.RegisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.segment.distsql.DataSourceAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.distsql.ExpectedDataSource;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.AddMigrationSourceResourceStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.RegisterMigrationSourceStorageUnitStatementTestCase;
 
 import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
- * Add migration source resource statement assert.
+ * Register migration source storage unit statement assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class AddMigrationSourceResourceStatementAssert {
+public final class RegisterMigrationSourceStorageUnitStatementAssert {
     
     /**
-     * Assert add migration source resource statement is correct with expected parser result.
+     * Assert register migration source storage unit statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual add migration source resource statement
-     * @param expected expected add migration source resource statement test case
+     * @param actual actual register migration source storage unit statement
+     * @param expected expected register migration source storage unit statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final AddMigrationSourceResourceStatement actual, final AddMigrationSourceResourceStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final RegisterMigrationSourceStorageUnitStatement actual,
+                                final RegisterMigrationSourceStorageUnitStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/UnregisterMigrationSourceStorageUnitStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/migration/update/UnregisterMigrationSourceStorageUnitStatementAssert.java
@@ -19,28 +19,29 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.migration.distsql.statement.DropMigrationSourceResourceStatement;
+import org.apache.shardingsphere.migration.distsql.statement.UnregisterMigrationSourceStorageUnitStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationSourceResourceStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.UnregisterMigrationSourceStorageUnitStatementTestCase;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 
 /**
- * Drop migration source resource statement assert.
+ * Unregister migration source storage unit statement assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class DropMigrationSourceResourceStatementAssert {
+public final class UnregisterMigrationSourceStorageUnitStatementAssert {
     
     /**
-     * Assert drop migration source resource statement is correct with expected parser result.
+     * Assert unregister migration source storage unit statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual drop migration source resource statement
-     * @param expected expected drop migration source resource statement test case
+     * @param actual actual unregister migration source storage unit statement
+     * @param expected expected unregister migration source storage unit statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final DropMigrationSourceResourceStatement actual, final DropMigrationSourceResourceStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final UnregisterMigrationSourceStorageUnitStatement actual,
+                                final UnregisterMigrationSourceStorageUnitStatementTestCase expected) {
         if (null == expected.getDataSources()) {
             assertNull(assertContext.getText("Actual resource should not exist."), actual);
         } else {

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/SQLParserTestCases.java
@@ -314,18 +314,18 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowTrafficRulesStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.ShowTransactionRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.UnlabelInstanceStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.AddMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CheckMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.CommitMigrationStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.DropMigrationSourceResourceStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.MigrateTableStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.RegisterMigrationSourceStorageUnitStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.RollbackMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationCheckAlgorithmsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationCheckStatusStatementTestCase;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceResourcesStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationSourceStorageUnitsStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.ShowMigrationStatusStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.StartMigrationStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.StopMigrationStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration.UnregisterMigrationSourceStorageUnitStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.rdl.alter.AlterDatabaseDiscoveryConstructionRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.rdl.alter.AlterDatabaseDiscoveryDefinitionRuleStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.rdl.alter.AlterDatabaseDiscoveryHeartbeatStatementTestCase;
@@ -881,8 +881,8 @@ public final class SQLParserTestCases {
     @XmlElement(name = "add-resource")
     private final List<AddResourceStatementTestCase> addResourceTestCases = new LinkedList<>();
     
-    @XmlElement(name = "add-migration-source-resource")
-    private final List<AddMigrationSourceResourceStatementTestCase> addMigrationSourceResourceTestCases = new LinkedList<>();
+    @XmlElement(name = "register-migration-source-storage-unit")
+    private final List<RegisterMigrationSourceStorageUnitStatementTestCase> registerMigrationSourceStorageUnitStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "alter-resource")
     private final List<AlterResourceStatementTestCase> alterResourceTestCases = new LinkedList<>();
@@ -1001,8 +1001,8 @@ public final class SQLParserTestCases {
     @XmlElement(name = "show-sharding-table-rule")
     private final List<ShowShardingTableRulesStatementTestCase> showShardingTableRuleTestCases = new LinkedList<>();
     
-    @XmlElement(name = "show-migration-source-resources")
-    private final List<ShowMigrationSourceResourcesStatementTestCase> showMigrationResourcesStatementTestCases = new LinkedList<>();
+    @XmlElement(name = "show-migration-source-storage-units")
+    private final List<ShowMigrationSourceStorageUnitsStatementTestCase> showMigrationSourceStorageUnitsStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "show-migration-list")
     private final List<ShowMigrationListStatementTestCase> showMigrationListTestCases = new LinkedList<>();
@@ -1661,8 +1661,8 @@ public final class SQLParserTestCases {
     @XmlElement(name = "create-operator")
     private final List<CreateOperatorStatementTestCase> createOperatorStatementTestCases = new LinkedList<>();
     
-    @XmlElement(name = "drop-migration-source-resource")
-    private final List<DropMigrationSourceResourceStatementTestCase> dropMigrationSourceResourceTestCases = new LinkedList<>();
+    @XmlElement(name = "unregister-migration-source-storage-unit")
+    private final List<UnregisterMigrationSourceStorageUnitStatementTestCase> unregisterMigrationSourceStorageUnitStatementTestCases = new LinkedList<>();
     
     @XmlElement(name = "create-policy")
     private final List<CreatePolicyStatementTestCase> createPolicyStatementTestCases = new LinkedList<>();

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/RegisterMigrationSourceStorageUnitStatementTestCase.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/RegisterMigrationSourceStorageUnitStatementTestCase.java
@@ -15,22 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.migration.distsql.statement;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
 
 import lombok.Getter;
-import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.distsql.ExpectedDataSource;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
-import java.util.Collection;
+import javax.xml.bind.annotation.XmlElement;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
- * Drop resource statement.
+ * Register migration source storage unit statement test case.
  */
 @Getter
-public final class DropMigrationSourceResourceStatement extends UpdatableScalingRALStatement {
+public final class RegisterMigrationSourceStorageUnitStatementTestCase extends SQLParserTestCase {
     
-    private final Collection<String> names;
-    
-    public DropMigrationSourceResourceStatement(final Collection<String> names) {
-        this.names = names;
-    }
+    @XmlElement(name = "data-source")
+    private final List<ExpectedDataSource> dataSources = new LinkedList<>();
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/ShowMigrationSourceStorageUnitsStatementTestCase.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/ShowMigrationSourceStorageUnitsStatementTestCase.java
@@ -15,21 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.core.exception.connection;
+package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
 
-import org.apache.shardingsphere.data.pipeline.core.exception.PipelineSQLException;
-import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
-
-import java.util.Collection;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 /**
- * Add migration source resource exception.
+ * Show migration source storage units statement test case.
  */
-public final class AddMigrationSourceResourceException extends PipelineSQLException {
+@Getter
+@Setter
+public final class ShowMigrationSourceStorageUnitsStatementTestCase extends SQLParserTestCase {
     
-    private static final long serialVersionUID = -3952313247315105684L;
-    
-    public AddMigrationSourceResourceException(final Collection<String> duplicateDataSourceNames) {
-        super(XOpenSQLState.DUPLICATE, 30, "Duplicate resource names `%s`.", duplicateDataSourceNames);
-    }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/UnregisterMigrationSourceStorageUnitStatementTestCase.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/migration/UnregisterMigrationSourceStorageUnitStatementTestCase.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.migration;
 
 import lombok.Getter;
-import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.segment.impl.distsql.ExpectedDataSource;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -26,11 +25,11 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * Add migration source resource statement test case.
+ * Unregister migration source storage unit statement test case.
  */
 @Getter
-public final class AddMigrationSourceResourceStatementTestCase extends SQLParserTestCase {
+public final class UnregisterMigrationSourceStorageUnitStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "data-source")
-    private final List<ExpectedDataSource> dataSources = new LinkedList<>();
+    private final List<String> dataSources = new LinkedList<>();
 }

--- a/test/parser/src/main/resources/case/ral/migration.xml
+++ b/test/parser/src/main/resources/case/ral/migration.xml
@@ -17,7 +17,7 @@
   -->
 
 <sql-parser-test-cases>
-    <show-migration-source-resources sql-case-id="show-migration-source-resources" />
+    <show-migration-source-storage-units sql-case-id="show-migration-source-storage-units" />
     <show-migration-list sql-case-id="show-migration-list" />
     <show-migration-check-algorithms sql-case-id="show-migration-check-algorithms" />
     
@@ -86,8 +86,8 @@
         <job-id>123</job-id>
     </start-migration>
     
-    <drop-migration-source-resource sql-case-id="drop-migration-source-resource">
+    <unregister-migration-source-storage-unit sql-case-id="unregister-migration-source-storage-unit">
         <data-source>ds_0</data-source>
         <data-source>ds_1</data-source>
-    </drop-migration-source-resource>
+    </unregister-migration-source-storage-unit>
 </sql-parser-test-cases>

--- a/test/parser/src/main/resources/case/rdl/create.xml
+++ b/test/parser/src/main/resources/case/rdl/create.xml
@@ -30,9 +30,9 @@
         <data-source name="ds_1" hostname="127.0.0.1" port="3306" db="test1" user="ROOT" password="123456" />
     </add-resource>
     
-    <add-migration-source-resource sql-case-id="single-add-migration-source-resource">
+    <register-migration-source-storage-unit sql-case-id="single-register-migration-source-storage-unit">
         <data-source name="ds_0" hostname="127.0.0.1" port="3306" db="test0" user="ROOT" password="123456" url="jdbc:mysql://127.0.0.1:3306/test0"/>
-    </add-migration-source-resource>
+    </register-migration-source-storage-unit>
 
     <add-resource sql-case-id="add-resource-with-quota">
         <data-source name="ds_0" hostname="127.0.0.1" port="3306" db="test0" user="ROOT" password="" />

--- a/test/parser/src/main/resources/sql/supported/ral/migration.xml
+++ b/test/parser/src/main/resources/sql/supported/ral/migration.xml
@@ -18,7 +18,7 @@
 
 <sql-cases>
     <distsql-case id="show-migration-list" value="SHOW MIGRATION LIST;" />
-    <distsql-case id="show-migration-source-resources" value="SHOW MIGRATION SOURCE RESOURCES;" />
+    <distsql-case id="show-migration-source-storage-units" value="SHOW MIGRATION SOURCE STORAGE UNITS;" />
     <distsql-case id="show-migration-check-algorithms" value="SHOW MIGRATION CHECK ALGORITHMS;" />
     <distsql-case id="check-migration" value="CHECK MIGRATION 123;" />
     <distsql-case id="show-migration-status" value="SHOW MIGRATION STATUS 123;" />
@@ -33,5 +33,5 @@
     <distsql-case id="commit-migration" value="COMMIT MIGRATION 123;" />
     <distsql-case id="stop-migration" value="STOP MIGRATION 123;" />
     <distsql-case id="start-migration" value="START MIGRATION 123;" />
-    <distsql-case id="drop-migration-source-resource" value="DROP MIGRATION SOURCE RESOURCE ds_0,ds_1" />
+    <distsql-case id="unregister-migration-source-storage-unit" value="UNREGISTER MIGRATION SOURCE STORAGE UNIT ds_0,ds_1" />
 </sql-cases>

--- a/test/parser/src/main/resources/sql/supported/rdl/create.xml
+++ b/test/parser/src/main/resources/sql/supported/rdl/create.xml
@@ -62,5 +62,5 @@
     <distsql-case id="create-shadow-rule-with-quota" value="CREATE SHADOW RULE `shadow_rule`(SOURCE=demo_ds,SHADOW=demo_ds_shadow,t_order((TYPE(NAME='REGEX_MATCH',PROPERTIES('operation'='insert','column'='user_id','regex'='[1]'))),(simple_hint_algorithm,TYPE(NAME='SIMPLE_HINT',PROPERTIES('shadow'='true','foo'='bar')))))" />
     <distsql-case id="create-sharding-key-generator" value="CREATE SHARDING KEY GENERATOR uuid_key_generator(TYPE(NAME='uuid'))" />
     <distsql-case id="create-sharding-auditor" value="CREATE SHARDING AUDITOR sharding_key_required_auditor(TYPE(NAME='DML_SHARDING_CONDITIONS'))" />
-    <distsql-case id="single-add-migration-source-resource" value="ADD MIGRATION SOURCE RESOURCE ds_0 (URL='jdbc:mysql://127.0.0.1:3306/test0',USER='ROOT',PASSWORD='123456');" />
+    <distsql-case id="single-register-migration-source-storage-unit" value="REGISTER MIGRATION SOURCE STORAGE UNIT ds_0 (URL='jdbc:mysql://127.0.0.1:3306/test0',USER='ROOT',PASSWORD='123456');" />
 </sql-cases>


### PR DESCRIPTION
Fixes #21698.

Changes proposed in this pull request:
  - Update syntax `ADD MIGRATION SOURCE RESOURCE` to `REGISTER MIGRATION SOURCE STORAGE UNIT`
  - Update syntax `DROP MIGRATION SOURCE RESOURCE` to `UNREGISTER MIGRATION SOURCE STORAGE UNIT`
  - Update syntax `SHOW MIGRATION SOURCE RESOURCES` to `SHOW MIGRATION SOURCE STORAGE UNITS`
  - Update documents
  - Update test cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
