### PR TITLE
Improve migration job stopping

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/api/impl/GovernanceRepositoryAPIImpl.java
@@ -51,6 +51,7 @@ public final class GovernanceRepositoryAPIImpl implements GovernanceRepositoryAP
     
     @Override
     public boolean isExisted(final String key) {
+        // TODO delegate to repository isExisted
         return null != repository.getDirectly(key);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DefaultImporter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DefaultImporter.java
@@ -47,6 +47,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -71,6 +72,12 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
     private final PipelineJobProgressListener jobProgressListener;
     
     private final JobRateLimitAlgorithm rateLimitAlgorithm;
+    
+    private volatile Statement batchInsertStatement;
+    
+    private volatile Statement updateStatement;
+    
+    private volatile Statement batchDeleteStatement;
     
     public DefaultImporter(final ImporterConfiguration importerConfig, final PipelineDataSourceManager dataSourceManager, final PipelineChannel channel,
                            final PipelineJobProgressListener jobProgressListener) {
@@ -185,6 +192,7 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
         DataRecord dataRecord = dataRecords.get(0);
         String insertSql = pipelineSqlBuilder.buildInsertSQL(getSchemaName(dataRecord.getTableName()), dataRecord, importerConfig.getShardingColumnsMap());
         try (PreparedStatement ps = connection.prepareStatement(insertSql)) {
+            batchInsertStatement = ps;
             ps.setQueryTimeout(30);
             for (DataRecord each : dataRecords) {
                 for (int i = 0; i < each.getColumnCount(); i++) {
@@ -193,6 +201,8 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
                 ps.addBatch();
             }
             ps.executeBatch();
+        } finally {
+            batchInsertStatement = null;
         }
     }
     
@@ -215,6 +225,7 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
         List<Column> updatedColumns = pipelineSqlBuilder.extractUpdatedColumns(record, importerConfig.getShardingColumnsMap());
         String updateSql = pipelineSqlBuilder.buildUpdateSQL(getSchemaName(record.getTableName()), record, conditionColumns, importerConfig.getShardingColumnsMap());
         try (PreparedStatement ps = connection.prepareStatement(updateSql)) {
+            updateStatement = ps;
             for (int i = 0; i < updatedColumns.size(); i++) {
                 ps.setObject(i + 1, updatedColumns.get(i).getValue());
             }
@@ -226,6 +237,8 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
             if (1 != updateCount) {
                 log.warn("executeUpdate failed, updateCount={}, updateSql={}, updatedColumns={}, conditionColumns={}", updateCount, updateSql, updatedColumns, conditionColumns);
             }
+        } finally {
+            updateStatement = null;
         }
     }
     
@@ -234,6 +247,7 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
         List<Column> conditionColumns = RecordUtil.extractConditionColumns(dataRecord, importerConfig.getShardingColumns(dataRecord.getTableName()));
         String deleteSQL = pipelineSqlBuilder.buildDeleteSQL(getSchemaName(dataRecord.getTableName()), dataRecord, conditionColumns);
         try (PreparedStatement ps = connection.prepareStatement(deleteSQL)) {
+            batchDeleteStatement = ps;
             ps.setQueryTimeout(30);
             for (DataRecord each : dataRecords) {
                 conditionColumns = RecordUtil.extractConditionColumns(each, importerConfig.getShardingColumns(each.getTableName()));
@@ -243,10 +257,17 @@ public final class DefaultImporter extends AbstractLifecycleExecutor implements 
                 ps.addBatch();
             }
             ps.executeBatch();
+        } finally {
+            batchDeleteStatement = null;
         }
     }
     
     @Override
-    protected void doStop() {
+    protected void doStop() throws SQLException {
+        final long startTimeMillis = System.currentTimeMillis();
+        cancelStatement(batchInsertStatement);
+        cancelStatement(updateStatement);
+        cancelStatement(batchDeleteStatement);
+        log.info("doStop cost {} ms", System.currentTimeMillis() - startTimeMillis);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTask.java
@@ -66,6 +66,7 @@ public final class IncrementalTask implements PipelineTask, AutoCloseable {
     @Getter
     private final IncrementalTaskProgress taskProgress;
     
+    // TODO simplify parameters
     public IncrementalTask(final int concurrency, final DumperConfiguration dumperConfig, final ImporterConfiguration importerConfig,
                            final PipelineChannelCreator pipelineChannelCreator, final PipelineDataSourceManager dataSourceManager,
                            final PipelineTableMetaDataLoader sourceMetaDataLoader, final ExecuteEngine incrementalExecuteEngine,
@@ -125,6 +126,7 @@ public final class IncrementalTask implements PipelineTask, AutoCloseable {
             public void onFailure(final Throwable throwable) {
                 log.error("incremental dumper onFailure, taskId={}", taskId);
                 stop();
+                close();
             }
         });
         CompletableFuture<?> importerFuture = incrementalExecuteEngine.submitAll(importers, new ExecuteCallback() {
@@ -138,6 +140,7 @@ public final class IncrementalTask implements PipelineTask, AutoCloseable {
             public void onFailure(final Throwable throwable) {
                 log.error("importer onFailure, taskId={}", taskId, throwable);
                 stop();
+                close();
             }
         });
         return CompletableFuture.allOf(dumperFuture, importerFuture);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
@@ -96,6 +96,7 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
             public void onFailure(final Throwable throwable) {
                 log.error("dumper onFailure, taskId={}", taskId);
                 stop();
+                close();
             }
         });
         CompletableFuture<?> importerFuture = inventoryImporterExecuteEngine.submit(importer, new ExecuteCallback() {
@@ -109,6 +110,7 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
             public void onFailure(final Throwable throwable) {
                 log.error("importer onFailure, taskId={}", taskId, throwable);
                 stop();
+                close();
             }
         });
         return CompletableFuture.allOf(dumperFuture, importerFuture);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckTasksRunner.java
@@ -108,15 +108,11 @@ public final class ConsistencyCheckTasksRunner implements PipelineTasksRunner {
         }
         
         @Override
-        protected void doStop() {
+        protected void doStop() throws SQLException {
             DataConsistencyCalculateAlgorithm algorithm = calculateAlgorithm;
             log.info("doStop, algorithm={}", algorithm);
             if (null != algorithm) {
-                try {
-                    algorithm.cancel();
-                } catch (final SQLException ex) {
-                    throw new RuntimeException(ex);
-                }
+                algorithm.cancel();
             }
         }
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
@@ -26,7 +26,6 @@ import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncreme
 import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DefaultPipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJob;
-import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobCenter;
 import org.apache.shardingsphere.data.pipeline.core.task.InventoryIncrementalTasksRunner;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfigurationSwapper;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
@@ -85,7 +84,7 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
         } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             log.error("job prepare failed, {}-{}", getJobId(), jobItemContext.getShardingItem(), ex);
-            PipelineJobCenter.stop(jobItemContext.getJobId());
+            jobAPI.stop(jobItemContext.getJobId());
             jobItemContext.setStatus(JobStatus.PREPARING_FAILURE);
             jobAPI.persistJobItemProgress(jobItemContext);
             jobAPI.persistJobItemErrorMessage(jobItemContext.getJobId(), jobItemContext.getShardingItem(), ex);


### PR DESCRIPTION

Changes proposed in this pull request:
  - Improve migration job stopping. 1) Dumping data on DB, 2) Importing data on DB, 3) Blocking on queue, 4) Job onFailure on any of task failure, 5) Stop whole job in cluster on failure but not just current instance.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
