### PR TITLE
fix issue: startup application with springboot failed when no rules config.

### DIFF
--- a/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/ShardingSphereAutoConfiguration.java
+++ b/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/ShardingSphereAutoConfiguration.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.mode.YamlModeConfigurationSwapper;
 import org.apache.shardingsphere.spring.boot.datasource.DataSourceMapSetter;
 import org.apache.shardingsphere.spring.boot.prop.SpringBootPropertiesConfiguration;
-import org.apache.shardingsphere.spring.boot.rule.LocalRulesCondition;
+import org.apache.shardingsphere.spring.boot.rule.ShardingSphereSpringBootCondition;
 import org.apache.shardingsphere.spring.boot.schema.DatabaseNameSetter;
 import org.apache.shardingsphere.spring.transaction.TransactionTypeScanner;
 import org.springframework.beans.factory.ObjectProvider;
@@ -84,7 +84,7 @@ public class ShardingSphereAutoConfiguration implements EnvironmentAware {
      * @throws SQLException SQL exception
      */
     @Bean
-    @Conditional(LocalRulesCondition.class)
+    @Conditional(ShardingSphereSpringBootCondition.class)
     @Autowired(required = false)
     public DataSource shardingSphereDataSource(final ObjectProvider<List<RuleConfiguration>> rules, final ObjectProvider<ModeConfiguration> modeConfig) throws SQLException {
         Collection<RuleConfiguration> ruleConfigs = Optional.ofNullable(rules.getIfAvailable()).orElseGet(Collections::emptyList);

--- a/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/rule/LocalRulesCondition.java
+++ b/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/rule/LocalRulesCondition.java
@@ -24,16 +24,16 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
 /**
- * Local rules condition.
+ * Local configuration condition.
  */
 public final class LocalRulesCondition extends SpringBootCondition {
     
-    private static final String SHARDING_PREFIX = "spring.shardingsphere.rules";
+    private static final String SHARDING_PREFIX = "spring.shardingsphere";
     
     @Override
     public ConditionOutcome getMatchOutcome(final ConditionContext conditionContext, final AnnotatedTypeMetadata annotatedTypeMetadata) {
         return PropertyUtil.containPropertyPrefix(conditionContext.getEnvironment(), SHARDING_PREFIX)
                 ? ConditionOutcome.match()
-                : ConditionOutcome.noMatch("Can't find ShardingSphere rule configuration in local file.");
+                : ConditionOutcome.noMatch("Can't find ShardingSphere configuration in local file.");
     }
 }

--- a/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/rule/ShardingSphereSpringBootCondition.java
+++ b/jdbc/spring/core/spring-boot-starter/src/main/java/org/apache/shardingsphere/spring/boot/rule/ShardingSphereSpringBootCondition.java
@@ -26,7 +26,7 @@ import org.springframework.core.type.AnnotatedTypeMetadata;
 /**
  * Local configuration condition.
  */
-public final class LocalRulesCondition extends SpringBootCondition {
+public final class ShardingSphereSpringBootCondition extends SpringBootCondition {
     
     private static final String SHARDING_PREFIX = "spring.shardingsphere";
     

--- a/jdbc/spring/core/spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/SpringBootStarterWithoutRulesTest.java
+++ b/jdbc/spring/core/spring-boot-starter/src/test/java/org/apache/shardingsphere/spring/boot/SpringBootStarterWithoutRulesTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.spring.boot;
+
+import org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SpringBootStarterWithoutRulesTest.class)
+@SpringBootApplication
+@ActiveProfiles("no-rules")
+public class SpringBootStarterWithoutRulesTest {
+    
+    @Autowired
+    private ShardingSphereDataSource dataSource;
+    
+    @Test
+    public void assertSpringBootStartup() {
+        assertNotNull(dataSource);
+    }
+}

--- a/jdbc/spring/core/spring-boot-starter/src/test/resources/application-no-rules.properties
+++ b/jdbc/spring/core/spring-boot-starter/src/test/resources/application-no-rules.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+spring.shardingsphere.database.name=foo_db
+
+spring.shardingsphere.datasource.names=read_ds_${0..1},write_ds
+
+spring.shardingsphere.datasource.read_ds_0.type=org.apache.shardingsphere.test.mock.MockedDataSource
+spring.shardingsphere.datasource.read_ds_1.type=org.apache.shardingsphere.test.mock.MockedDataSource
+spring.shardingsphere.datasource.write_ds.type=org.apache.shardingsphere.test.mock.MockedDataSource
+
+spring.shardingsphere.props.sql-show=true
+spring.shardingsphere.props.kernel-executor-size=10
+
+spring.main.banner-mode=off


### PR DESCRIPTION
Fixes #21775.

Changes proposed in this pull request:
  - Modify `SHARDING_PREFIX` in `LocalRulesCondition` to make springboot application startup successfully with no rules.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
