### PR TITLE
 Fix oracle parsing does not support varchar2 specified type(#21805)

### DIFF
--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -418,7 +418,7 @@ alias
     ;
 
 dataTypeLength
-    : LP_ (INTEGER_ (COMMA_ INTEGER_)?)? RP_
+    : LP_ (INTEGER_ (COMMA_ INTEGER_)? (CHAR | BYTE)?)? RP_
     ;
 
 primaryKey

--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Keyword.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Keyword.g4
@@ -359,6 +359,11 @@ DOUBLE
     : D O U B L E
     ;
 
+BYTE
+    :
+    B Y T E
+    ;
+
 CHAR
     : C H A R
     ;

--- a/test/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/parser/src/main/resources/case/ddl/create-table.xml
@@ -1784,4 +1784,14 @@
             <column name="status" />
         </column-definition>
     </create-table>
+    
+    <create-table sql-case-id="create_table_with_varchar2_char_and_byte_type">
+        <table name="t_order" start-index="13" stop-index="19" />
+        <column-definition type="VARCHAR2" start-index="22" stop-index="62">
+            <column name="SYS_ID" />
+        </column-definition>
+        <column-definition type="VARCHAR2" start-index="65" stop-index="118">
+            <column name="ATTACHMENT_NAME" />
+        </column-definition>
+    </create-table>
 </sql-parser-test-cases>

--- a/test/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -127,4 +127,5 @@
     <sql-case id="create_table_national" value="CREATE TABLE t_order (national int);" db-types="PostgreSQL,openGauss" />
     <sql-case id="create_table_with_visible" value="CREATE TABLE t_order (order_id INT, user_id INT, status VARCHAR(10) VISIBLE) ENGINE=INNODB" db-types="MySQL" />
     <sql-case id="create_table_with_invisible" value="CREATE TABLE t_order (order_id INT, user_id INT, status VARCHAR(10) INVISIBLE) ENGINE=INNODB" db-types="MySQL" />
+    <sql-case id="create_table_with_varchar2_char_and_byte_type" value="CREATE TABLE t_order (SYS_ID VARCHAR2(32 CHAR) VISIBLE NOT NULL, ATTACHMENT_NAME VARCHAR2(1024 BYTE) VISIBLE DEFAULT '')" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
 Fix oracle parsing does not support varchar2 specified type

Fixes #21805.

Changes proposed in this pull request:
  -  Fix oracle parsing does not support varchar2 specified type

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
