### PR TITLE
Fix oracle parse comment without whitespace.

### DIFF
--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Comments.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Comments.g4
@@ -20,4 +20,4 @@ lexer grammar Comments;
 import Symbol;
 
 BLOCK_COMMENT:  '/*' .*? '*/' -> channel(HIDDEN);
-INLINE_COMMENT: (('-- ' | '#') ~[\r\n]* ('\r'? '\n' | EOF) | '--' ('\r'? '\n' | EOF)) -> channel(HIDDEN);
+INLINE_COMMENT: '--' ~[\r\n]* ('\r'? '\n' | EOF) -> channel(HIDDEN);

--- a/test/parser/src/main/resources/case/dml/select.xml
+++ b/test/parser/src/main/resources/case/dml/select.xml
@@ -2722,7 +2722,7 @@
         <comment start-index="44" stop-index="76" text="-- this is another line comment &#x000A;"/>
     </select>
 
-    <select sql-case-id="select_with_single_comment_for_postgresql" >
+    <select sql-case-id="select_with_single_comment_without_whitespace" >
         <from>
             <simple-table name="t_order" start-index="76" stop-index="82" />
         </from>

--- a/test/parser/src/main/resources/sql/supported/dml/select-comment.xml
+++ b/test/parser/src/main/resources/sql/supported/dml/select-comment.xml
@@ -20,5 +20,5 @@
     <sql-case id="select_with_block_comment" value="SELECT * /* this is &#x000D;&#x000A; block comment */ FROM /* this is another &#x000A; block comment */ t_order where status='1'" db-types="MySQL,PostgreSQL,openGauss,Oracle,SQLServer" />
     <sql-case id="select_with_nested_block_comment" value="SELECT * /* this is &#x000D;&#x000A; /* this is another &#x000A; block comment */ block comment */ FROM t_order" db-types="PostgreSQL" />
     <sql-case id="select_with_single_comment" value="SELECT * -- this is an line comment &#x000D;&#x000A; FROM -- this is another line comment &#x000A; t_order where status='1'" db-types="MySQL,PostgreSQL,openGauss" />
-    <sql-case id="select_with_single_comment_for_postgresql" value="SELECT * --this is an line comment &#x000D;&#x000A; FROM --this is another line comment &#x000A; t_order where status='1'" db-types="PostgreSQL,openGauss" />
+    <sql-case id="select_with_single_comment_without_whitespace" value="SELECT * --this is an line comment &#x000D;&#x000A; FROM --this is another line comment &#x000A; t_order where status='1'" db-types="PostgreSQL,openGauss,Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fix oracle comment parse.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
