### PR TITLE
Fix create table sql generator IT using mysql 8

### DIFF
--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.integration.data.pipeline.cases.createtable;
 
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.spi.ddlgenerator.CreateTableSQLGeneratorFactory;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
@@ -58,6 +59,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @RunWith(Parameterized.class)
+@Slf4j
 public final class CreateTableSQLGeneratorIT {
     
     private static final String POSTGRES_CASE_FILE_PATH = "postgresql/create-table-sql-generator.xml";
@@ -127,6 +129,7 @@ public final class CreateTableSQLGeneratorIT {
                 assertIsCorrect(actualDDLs, getVersionOutput(each.getOutputs(), majorVersion));
             }
         }
+        log.info("generate create table sql success");
     }
     
     private void initData() throws SQLException {

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
@@ -117,6 +117,7 @@ public final class CreateTableSQLGeneratorIT {
     
     @Test
     public void assertGenerateCreateTableSQL() throws SQLException {
+        log.info("generate create table sql, parameterized: {}", parameterized);
         initData();
         DataSource dataSource = storageContainer.createAccessDataSource(DEFAULT_DATABASE);
         try (
@@ -129,7 +130,6 @@ public final class CreateTableSQLGeneratorIT {
                 assertIsCorrect(actualDDLs, getVersionOutput(each.getOutputs(), majorVersion));
             }
         }
-        log.info("generate create table sql success");
     }
     
     private void initData() throws SQLException {


### PR DESCRIPTION


Changes proposed in this pull request:
  - Fix create table sql generator IT using mysql 8
  -
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
