### PR TITLE
Added SQL parser test case for AddShardingHintTableValueStatement

### DIFF
--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/RALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/RALStatementAssert.java
@@ -19,12 +19,14 @@ package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statemen
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.HintRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.RALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.QueryableScalingRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.HintRALStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.QueryableRALStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.migration.QueryableScalingRALStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.UpdatableRALStatementAssert;
@@ -53,6 +55,8 @@ public final class RALStatementAssert {
             QueryableRALStatementAssert.assertIs(assertContext, (QueryableRALStatement) actual, expected);
         } else if (actual instanceof UpdatableRALStatement) {
             UpdatableRALStatementAssert.assertIs(assertContext, (UpdatableRALStatement) actual, expected);
+        } else if (actual instanceof HintRALStatement) {
+            HintRALStatementAssert.assertIs(assertContext, (HintRALStatement) actual, expected);
         }
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.HintRALStatement;
+import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.AddShardingHintTableValueStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.hint.AddShardingHintTableValueStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
+
+/**
+ * Hint RAL statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class HintRALStatementAssert {
+    
+    /**
+     * Assert Hint RAL statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual hint RAL statement
+     * @param expected expected hint RAL statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final HintRALStatement actual, final SQLParserTestCase expected) {
+        if (actual instanceof AddShardingHintTableValueStatement) {
+            AddShardingHintTableValueStatementAssert.assertIs(assertContext, (AddShardingHintTableValueStatement) actual, (AddShardingHintTableValueStatementTestCase) expected);
+        }
+    }
+}

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/hint/AddShardingHintTableValueStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/asserts/statement/distsql/ral/impl/hint/AddShardingHintTableValueStatementAssert.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.parameterized.asserts.statement.distsql.ral.impl.hint;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.AddShardingHintTableValueStatement;
+import org.apache.shardingsphere.test.sql.parser.parameterized.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Add sharding hint statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AddShardingHintTableValueStatementAssert {
+    
+    /**
+     * Assert add sharding hint statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual add sharding hint statement
+     * @param expected expected add sharding hint statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final AddShardingHintTableValueStatement actual, final AddShardingHintTableValueStatementTestCase expected) {
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual statement should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual statement should exist."), actual);
+            assertThat(actual.getLogicTableName(), is(expected.getLogicTableName()));
+            assertThat(actual.getShardingValue(), is(expected.getShardingValue()));
+        }
+    }
+}

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/AddShardingHintTableValueStatementTestCase.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/parameterized/jaxb/cases/domain/statement/distsql/ral/AddShardingHintTableValueStatementTestCase.java
@@ -17,10 +17,22 @@
 
 package org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.distsql.ral;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.parameterized.jaxb.cases.domain.statement.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
  * Add sharding hint table value statement test case.
  */
+@Getter
+@Setter
 public final class AddShardingHintTableValueStatementTestCase extends SQLParserTestCase {
+    
+    @XmlAttribute(name = "logic-table-name")
+    private String logicTableName;
+    
+    @XmlAttribute(name = "sharding-value")
+    private String shardingValue;
 }

--- a/test/parser/src/main/resources/case/ral/hint.xml
+++ b/test/parser/src/main/resources/case/ral/hint.xml
@@ -19,7 +19,7 @@
 <sql-parser-test-cases>
     <show-sharding-hint-status sql-case-id="show-sharding-hint-status" />
     <add-sharding-hint-database-value sql-case-id="add-sharding-hint-database-value" />
-    <add-sharding-hint-table-value sql-case-id="add-sharding-hint-table-value" />
+    <add-sharding-hint-table-value sql-case-id="add-sharding-hint-table-value" logic-table-name="T_ORDER" sharding-value="1"/>
     <set-sharding-hint-database-value sql-case-id="set-sharding-hint-database-value" />
     <clear-sharding-hint sql-case-id="clear-sharding-hint" />
     


### PR DESCRIPTION
Fixes #[21468](https://github.com/apache/shardingsphere/issues/21468).

Changes proposed in this pull request:
  -
  -  HintRALStatementAssert created for all Hint SQL parsing test cases, RAL statement are extended by Update, 
     Query and Hint.
 -  comparing logic table name and sharding value for query
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
