### PR TITLE
Extract more methods to AbstractPipelineJob and AbstractSimplePipelineJob for common usage

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
@@ -41,22 +41,21 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Abstract pipeline job.
  */
-@Getter
 @Slf4j
 public abstract class AbstractPipelineJob implements PipelineJob {
     
+    @Getter
     private volatile String jobId;
     
     @Getter(value = AccessLevel.PROTECTED)
     private volatile PipelineJobAPI jobAPI;
     
-    @Setter
+    @Getter
     private volatile boolean stopping;
     
     @Setter
     private volatile JobBootstrap jobBootstrap;
     
-    @Getter(value = AccessLevel.PRIVATE)
     private final Map<Integer, PipelineTasksRunner> tasksRunnerMap = new ConcurrentHashMap<>();
     
     private final PipelineDistributedBarrier distributedBarrier = PipelineDistributedBarrier.getInstance();
@@ -120,7 +119,7 @@ public abstract class AbstractPipelineJob implements PipelineJob {
     }
     
     private void innerStop() {
-        setStopping(true);
+        stopping = true;
         if (null != jobBootstrap) {
             jobBootstrap.shutdown();
         }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.job;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.api.context.PipelineJobItemContext;
+import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
+import org.apache.shardingsphere.elasticjob.api.ShardingContext;
+import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
+
+/**
+ * Abstract simple pipeline job.
+ */
+@Slf4j
+public abstract class AbstractSimplePipelineJob extends AbstractPipelineJob implements SimpleJob {
+    
+    protected abstract PipelineJobItemContext buildPipelineJobItemContext(ShardingContext shardingContext);
+    
+    protected abstract PipelineTasksRunner buildPipelineTasksRunner(PipelineJobItemContext pipelineJobItemContext);
+    
+    @Override
+    public void execute(final ShardingContext shardingContext) {
+        int shardingItem = shardingContext.getShardingItem();
+        log.info("Execute job {}-{}", shardingContext.getJobName(), shardingItem);
+        if (isStopping()) {
+            log.info("stopping true, ignore");
+            return;
+        }
+        setJobId(shardingContext.getJobName());
+        PipelineJobItemContext jobItemContext = buildPipelineJobItemContext(shardingContext);
+        if (containsTasksRunner(shardingItem)) {
+            log.warn("tasksRunnerMap contains shardingItem {}, ignore", shardingItem);
+            return;
+        }
+        PipelineTasksRunner tasksRunner = buildPipelineTasksRunner(jobItemContext);
+        getJobAPI().cleanJobItemErrorMessage(jobItemContext.getJobId(), jobItemContext.getShardingItem());
+        runInBackground(() -> {
+            prepare(jobItemContext);
+            tasksRunner.start();
+            log.info("start tasks runner, jobId={}, shardingItem={}", getJobId(), shardingItem);
+        });
+        addTasksRunner(shardingItem, tasksRunner);
+    }
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/OraclePipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/OraclePipelineSQLBuilder.java
@@ -69,7 +69,7 @@ public final class OraclePipelineSQLBuilder extends AbstractPipelineSQLBuilder {
     public String buildSplitByPrimaryKeyRangeSQL(final String schemaName, final String tableName, final String primaryKey) {
         String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
         String quotedUniqueKey = quote(primaryKey);
-        return String.format("SELECT MAX(%s) FROM (SELECT * FROM (SELECT %s FROM %s WHERE %s>=? ORDER BY %s) WHERE ROWNUM<=?) t",
+        return String.format("SELECT MAX(%s), COUNT(1) FROM (SELECT * FROM (SELECT %s FROM %s WHERE %s>=? ORDER BY %s) WHERE ROWNUM<=?) t",
                 quotedUniqueKey, quotedUniqueKey, qualifiedTableName, quotedUniqueKey, quotedUniqueKey);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJob.java
@@ -20,8 +20,6 @@ package org.apache.shardingsphere.data.pipeline.scenario.consistencycheck;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.job.ConsistencyCheckJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
-import org.apache.shardingsphere.data.pipeline.api.job.PipelineJob;
-import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
 import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJob;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlConsistencyCheckJobConfigurationSwapper;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
@@ -31,7 +29,7 @@ import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
  * Consistency check job.
  */
 @Slf4j
-public final class ConsistencyCheckJob extends AbstractPipelineJob implements SimpleJob, PipelineJob {
+public final class ConsistencyCheckJob extends AbstractPipelineJob implements SimpleJob {
     
     private final ConsistencyCheckJobAPI jobAPI = ConsistencyCheckJobAPIFactory.getInstance();
     
@@ -59,18 +57,6 @@ public final class ConsistencyCheckJob extends AbstractPipelineJob implements Si
     }
     
     @Override
-    public void stop() {
-        setStopping(true);
-        if (null != getJobBootstrap()) {
-            getJobBootstrap().shutdown();
-        }
-        if (null == getJobId()) {
-            log.info("stop consistency check job, jobId is null, ignore");
-            return;
-        }
-        for (PipelineTasksRunner each : getTasksRunners()) {
-            each.stop();
-        }
-        clearTasksRunner();
+    protected void doClean() {
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/ConsistencyCheckJob.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.scenario.consistencycheck;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.job.ConsistencyCheckJobConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJob;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlConsistencyCheckJobConfigurationSwapper;
@@ -54,6 +55,10 @@ public final class ConsistencyCheckJob extends AbstractPipelineJob implements Si
         ConsistencyCheckTasksRunner tasksRunner = new ConsistencyCheckTasksRunner(jobItemContext);
         tasksRunner.start();
         addTasksRunner(shardingItem, tasksRunner);
+    }
+    
+    @Override
+    protected void doPrepare(final PipelineJobItemContext jobItemContext) {
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
@@ -22,14 +22,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.job.MigrationJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.api.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceManager;
-import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncrementalJobItemProgress;
+import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
+import org.apache.shardingsphere.data.pipeline.core.context.InventoryIncrementalJobItemContext;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DefaultPipelineDataSourceManager;
-import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJob;
+import org.apache.shardingsphere.data.pipeline.core.job.AbstractSimplePipelineJob;
 import org.apache.shardingsphere.data.pipeline.core.task.InventoryIncrementalTasksRunner;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfigurationSwapper;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
-import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
 
 import java.sql.SQLException;
 
@@ -38,7 +38,7 @@ import java.sql.SQLException;
  */
 @RequiredArgsConstructor
 @Slf4j
-public final class MigrationJob extends AbstractPipelineJob implements SimpleJob {
+public final class MigrationJob extends AbstractSimplePipelineJob {
     
     private final MigrationJobAPI jobAPI = MigrationJobAPIFactory.getInstance();
     
@@ -48,31 +48,19 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
     private final MigrationJobPreparer jobPreparer = new MigrationJobPreparer();
     
     @Override
-    public void execute(final ShardingContext shardingContext) {
+    protected InventoryIncrementalJobItemContext buildPipelineJobItemContext(final ShardingContext shardingContext) {
         int shardingItem = shardingContext.getShardingItem();
-        log.info("Execute job {}-{}", shardingContext.getJobName(), shardingItem);
-        if (isStopping()) {
-            log.info("stopping true, ignore");
-            return;
-        }
-        setJobId(shardingContext.getJobName());
         MigrationJobConfiguration jobConfig = new YamlMigrationJobConfigurationSwapper().swapToObject(shardingContext.getJobParameter());
         InventoryIncrementalJobItemProgress initProgress = jobAPI.getJobItemProgress(shardingContext.getJobName(), shardingItem);
         MigrationProcessContext jobProcessContext = jobAPI.buildPipelineProcessContext(jobConfig);
         MigrationTaskConfiguration taskConfig = jobAPI.buildTaskConfiguration(jobConfig, shardingItem, jobProcessContext.getPipelineProcessConfig());
-        MigrationJobItemContext jobItemContext = new MigrationJobItemContext(jobConfig, shardingItem, initProgress, jobProcessContext, taskConfig, dataSourceManager);
-        if (containsTasksRunner(shardingItem)) {
-            log.warn("tasksRunnerMap contains shardingItem {}, ignore", shardingItem);
-            return;
-        }
-        log.info("start tasks runner, jobId={}, shardingItem={}", getJobId(), shardingItem);
-        jobAPI.cleanJobItemErrorMessage(jobItemContext.getJobId(), jobItemContext.getShardingItem());
-        InventoryIncrementalTasksRunner tasksRunner = new InventoryIncrementalTasksRunner(jobItemContext, jobItemContext.getInventoryTasks(), jobItemContext.getIncrementalTasks());
-        runInBackground(() -> {
-            prepare(jobItemContext);
-            tasksRunner.start();
-        });
-        addTasksRunner(shardingItem, tasksRunner);
+        return new MigrationJobItemContext(jobConfig, shardingItem, initProgress, jobProcessContext, taskConfig, dataSourceManager);
+    }
+    
+    @Override
+    protected PipelineTasksRunner buildPipelineTasksRunner(final PipelineJobItemContext pipelineJobItemContext) {
+        InventoryIncrementalJobItemContext jobItemContext = (InventoryIncrementalJobItemContext) pipelineJobItemContext;
+        return new InventoryIncrementalTasksRunner(jobItemContext, jobItemContext.getInventoryTasks(), jobItemContext.getIncrementalTasks());
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.scenario.migration;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.job.MigrationJobConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncrementalJobItemProgress;
@@ -74,24 +75,9 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
         addTasksRunner(shardingItem, tasksRunner);
     }
     
-    private void prepare(final MigrationJobItemContext jobItemContext) {
-        try {
-            long startTimeMillis = System.currentTimeMillis();
-            jobPreparer.prepare(jobItemContext);
-            log.info("prepare cost {} ms", System.currentTimeMillis() - startTimeMillis);
-            // CHECKSTYLE:OFF
-        } catch (final SQLException | RuntimeException ex) {
-            // CHECKSTYLE:ON
-            log.error("job prepare failed, {}-{}", getJobId(), jobItemContext.getShardingItem(), ex);
-            jobAPI.stop(jobItemContext.getJobId());
-            jobItemContext.setStatus(JobStatus.PREPARING_FAILURE);
-            jobAPI.persistJobItemProgress(jobItemContext);
-            jobAPI.persistJobItemErrorMessage(jobItemContext.getJobId(), jobItemContext.getShardingItem(), ex);
-            if (ex instanceof RuntimeException) {
-                throw (RuntimeException) ex;
-            }
-            throw new RuntimeException(ex);
-        }
+    @Override
+    protected void doPrepare(final PipelineJobItemContext jobItemContext) throws SQLException {
+        jobPreparer.prepare((MigrationJobItemContext) jobItemContext);
     }
     
     @Override

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJob.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.data.pipeline.api.config.job.MigrationJobConfig
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncrementalJobItemProgress;
-import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
 import org.apache.shardingsphere.data.pipeline.core.datasource.DefaultPipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJob;
 import org.apache.shardingsphere.data.pipeline.core.task.InventoryIncrementalTasksRunner;
@@ -95,24 +94,8 @@ public final class MigrationJob extends AbstractPipelineJob implements SimpleJob
         }
     }
     
-    /**
-     * Stop job.
-     */
-    public void stop() {
-        setStopping(true);
+    @Override
+    public void doClean() {
         dataSourceManager.close();
-        if (null != getJobBootstrap()) {
-            getJobBootstrap().shutdown();
-        }
-        String jobId = getJobId();
-        if (null == jobId) {
-            log.info("stop, jobId is null, ignore");
-            return;
-        }
-        log.info("stop tasks runner, jobId={}", jobId);
-        for (PipelineTasksRunner each : getTasksRunners()) {
-            each.stop();
-        }
-        clearTasksRunner();
     }
 }


### PR DESCRIPTION
Part of #19421.

Changes proposed in this pull request:
  - Extract stop() / prepare() to AbstractPipelineJob
  - Add AbstractSimplePipelineJob

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
