### PR TITLE
Optimizing query results for PSQL metadata select.

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/AbstractDatabaseMetadataExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/executor/AbstractDatabaseMetadataExecutor.java
@@ -33,8 +33,8 @@ import org.apache.shardingsphere.infra.metadata.user.Grantee;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.ResourceNotExistedException;
-import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.handler.admin.FunctionWithException;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -45,13 +45,13 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 /**
@@ -82,8 +82,8 @@ public abstract class AbstractDatabaseMetadataExecutor implements DatabaseAdminQ
     
     private void handleResultSet(final String databaseName, final ResultSet resultSet) throws SQLException {
         while (resultSet.next()) {
-            Map<String, Object> rowMap = new LinkedHashMap<>();
-            Map<String, String> aliasMap = new LinkedHashMap<>();
+            Map<String, Object> rowMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            Map<String, String> aliasMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             ResultSetMetaData metaData = resultSet.getMetaData();
             for (int i = 1; i < metaData.getColumnCount() + 1; i++) {
                 aliasMap.put(metaData.getColumnName(i), metaData.getColumnLabel(i));


### PR DESCRIPTION
Fixes #21888.

Because the alias of the query column is case-sensitive, it cannot be found according to the fixed `name`.

Changes proposed in this pull request:
  -  Change type of `row results` and `alias` from `LinkedHashMap` to `TreeMap`

## In Native Postgres
<img width="784" alt="image" src="https://user-images.githubusercontent.com/5668787/199230425-a78ca423-7697-44e5-8353-cd00e8c78fb6.png">

## In Proxy
### Before 
![image](https://user-images.githubusercontent.com/5668787/199230301-fd6e2ad8-8489-493a-a793-d726203e4f59.png)

### After
<img width="716" alt="image" src="https://user-images.githubusercontent.com/5668787/199230282-817ccf8e-87e1-486f-bfc3-714220f6c8e3.png">

---
Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
