### PR TITLE
Refactor PipelineTask.start futures handling

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.api.executor.LifecycleExecutor;
 import org.apache.shardingsphere.infra.executor.kernel.thread.ExecutorThreadFactoryBuilder;
 
-import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -71,29 +70,6 @@ public final class ExecuteEngine {
      */
     public CompletableFuture<?> submit(final LifecycleExecutor lifecycleExecutor, final ExecuteCallback executeCallback) {
         return CompletableFuture.runAsync(lifecycleExecutor, executorService).whenCompleteAsync((unused, throwable) -> {
-            if (null == throwable) {
-                executeCallback.onSuccess();
-            } else {
-                Throwable cause = throwable.getCause();
-                executeCallback.onFailure(null != cause ? cause : throwable);
-            }
-        }, executorService);
-    }
-    
-    /**
-     * Submit a collection of {@code LifecycleExecutor} with callback {@code ExecuteCallback} to execute.
-     *
-     * @param lifecycleExecutors lifecycle executor
-     * @param executeCallback execute callback
-     * @return execute future of all
-     */
-    public CompletableFuture<?> submitAll(final Collection<? extends LifecycleExecutor> lifecycleExecutors, final ExecuteCallback executeCallback) {
-        CompletableFuture<?>[] futures = new CompletableFuture[lifecycleExecutors.size()];
-        int i = 0;
-        for (LifecycleExecutor each : lifecycleExecutors) {
-            futures[i++] = CompletableFuture.runAsync(each, executorService);
-        }
-        return CompletableFuture.allOf(futures).whenCompleteAsync((unused, throwable) -> {
             if (null == throwable) {
                 executeCallback.onSuccess();
             } else {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
@@ -149,9 +149,9 @@ public final class InventoryIncrementalTasksRunner implements PipelineTasksRunne
             if (null != throwable) {
                 log.error("onFailure, incremental task execute failed.", throwable);
                 updateLocalAndRemoteJobItemStatus(JobStatus.EXECUTE_INCREMENTAL_TASK_FAILURE);
-                PipelineAPIFactory.getPipelineJobAPI(PipelineJobIdUtils.parseJobType(jobItemContext.getJobId()))
-                        .persistJobItemErrorMessage(jobItemContext.getJobId(), jobItemContext.getShardingItem(), throwable);
-                stop();
+                String jobId = jobItemContext.getJobId();
+                jobAPI.persistJobItemErrorMessage(jobId, jobItemContext.getShardingItem(), throwable);
+                jobAPI.stop(jobId);
             }
         });
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
@@ -98,7 +98,7 @@ public final class InventoryIncrementalTasksRunner implements PipelineTasksRunne
             if (each.getTaskProgress().getPosition() instanceof FinishedPosition) {
                 continue;
             }
-            futures.add(each.start());
+            futures.addAll(each.start());
         }
         CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
             if (null != throwable) {
@@ -143,7 +143,7 @@ public final class InventoryIncrementalTasksRunner implements PipelineTasksRunne
             if (each.getTaskProgress().getPosition() instanceof FinishedPosition) {
                 continue;
             }
-            futures.add(each.start());
+            futures.addAll(each.start());
         }
         CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
             if (null != throwable) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
@@ -39,6 +39,8 @@ import org.apache.shardingsphere.data.pipeline.spi.importer.ImporterCreatorFacto
 import org.apache.shardingsphere.data.pipeline.spi.ingest.channel.PipelineChannelCreator;
 
 import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
@@ -84,8 +86,9 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
     }
     
     @Override
-    public CompletableFuture<?> start() {
-        CompletableFuture<?> dumperFuture = inventoryDumperExecuteEngine.submit(dumper, new ExecuteCallback() {
+    public Collection<CompletableFuture<?>> start() {
+        Collection<CompletableFuture<?>> result = new LinkedList<>();
+        result.add(inventoryDumperExecuteEngine.submit(dumper, new ExecuteCallback() {
             
             @Override
             public void onSuccess() {
@@ -98,8 +101,8 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
                 stop();
                 close();
             }
-        });
-        CompletableFuture<?> importerFuture = inventoryImporterExecuteEngine.submit(importer, new ExecuteCallback() {
+        }));
+        result.add(inventoryImporterExecuteEngine.submit(importer, new ExecuteCallback() {
             
             @Override
             public void onSuccess() {
@@ -112,8 +115,8 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
                 stop();
                 close();
             }
-        });
-        return CompletableFuture.allOf(dumperFuture, importerFuture);
+        }));
+        return result;
     }
     
     private PipelineChannel createChannel(final PipelineChannelCreator pipelineChannelCreator) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/PipelineTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/PipelineTask.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.task;
 
 import org.apache.shardingsphere.data.pipeline.api.task.progress.TaskProgress;
 
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -31,7 +32,7 @@ public interface PipelineTask {
      *
      * @return future
      */
-    CompletableFuture<?> start();
+    Collection<CompletableFuture<?>> start();
     
     /**
      * Stop task.

--- a/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTaskTest.java
+++ b/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTaskTest.java
@@ -31,6 +31,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -61,7 +62,7 @@ public final class IncrementalTaskTest {
     
     @Test
     public void assertStart() throws ExecutionException, InterruptedException, TimeoutException {
-        incrementalTask.start().get(10, TimeUnit.SECONDS);
+        CompletableFuture.allOf(incrementalTask.start().toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
         assertThat(incrementalTask.getTaskId(), is("standard_0"));
         assertThat(incrementalTask.getTaskProgress().getPosition(), instanceOf(PlaceholderPosition.class));
     }

--- a/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTaskTest.java
+++ b/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTaskTest.java
@@ -38,6 +38,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -75,7 +76,7 @@ public final class InventoryTaskTest {
                 InventoryTask inventoryTask = new InventoryTask(inventoryDumperConfig, taskConfig.getImporterConfig(),
                         PipelineContextUtil.getPipelineChannelCreator(), DATA_SOURCE_MANAGER, dataSource,
                         metaDataLoader, PipelineContextUtil.getExecuteEngine(), PipelineContextUtil.getExecuteEngine(), new FixtureInventoryIncrementalJobItemContext())) {
-            inventoryTask.start().get(10, TimeUnit.SECONDS);
+            CompletableFuture.allOf(inventoryTask.start().toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
         }
     }
     
@@ -90,7 +91,7 @@ public final class InventoryTaskTest {
                 InventoryTask inventoryTask = new InventoryTask(inventoryDumperConfig, taskConfig.getImporterConfig(),
                         PipelineContextUtil.getPipelineChannelCreator(), new DefaultPipelineDataSourceManager(), dataSource,
                         metaDataLoader, PipelineContextUtil.getExecuteEngine(), PipelineContextUtil.getExecuteEngine(), new FixtureInventoryIncrementalJobItemContext())) {
-            inventoryTask.start().get(10, TimeUnit.SECONDS);
+            CompletableFuture.allOf(inventoryTask.start().toArray(new CompletableFuture[0])).get(10, TimeUnit.SECONDS);
             assertThat(inventoryTask.getTaskProgress().getPosition(), instanceOf(IntegerPrimaryKeyPosition.class));
         }
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor PipelineTask.start return Collection<CompletableFuture<?>>. Make sure any task thread failure will break job.
  - Remove unused ExecuteEngine.submitAll

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
