### PR TITLE
Add sharding columns in SQL condition for migration incremental task

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/data/pipeline/ShardingColumnsExtractorImpl.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/data/pipeline/ShardingColumnsExtractorImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.data.pipeline;
+
+import org.apache.shardingsphere.data.pipeline.api.metadata.LogicTableName;
+import org.apache.shardingsphere.data.pipeline.spi.sharding.ShardingColumnsExtractor;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ComplexShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Sharding columns extractor implementation.
+ */
+public final class ShardingColumnsExtractorImpl implements ShardingColumnsExtractor {
+    
+    @Override
+    public Map<LogicTableName, Set<String>> getShardingColumnsMap(final Collection<YamlRuleConfiguration> yamlRuleConfigs, final Set<LogicTableName> logicTableNames) {
+        ShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(yamlRuleConfigs);
+        Set<String> defaultDatabaseShardingColumns = extractShardingColumns(shardingRuleConfig.getDefaultDatabaseShardingStrategy());
+        Set<String> defaultTableShardingColumns = extractShardingColumns(shardingRuleConfig.getDefaultTableShardingStrategy());
+        Map<LogicTableName, Set<String>> result = new ConcurrentHashMap<>();
+        for (ShardingTableRuleConfiguration each : shardingRuleConfig.getTables()) {
+            LogicTableName logicTableName = new LogicTableName(each.getLogicTable());
+            if (!logicTableNames.contains(logicTableName)) {
+                continue;
+            }
+            Set<String> shardingColumns = new HashSet<>();
+            shardingColumns.addAll(null == each.getDatabaseShardingStrategy() ? defaultDatabaseShardingColumns : extractShardingColumns(each.getDatabaseShardingStrategy()));
+            shardingColumns.addAll(null == each.getTableShardingStrategy() ? defaultTableShardingColumns : extractShardingColumns(each.getTableShardingStrategy()));
+            result.put(logicTableName, shardingColumns);
+        }
+        for (ShardingAutoTableRuleConfiguration each : shardingRuleConfig.getAutoTables()) {
+            LogicTableName logicTableName = new LogicTableName(each.getLogicTable());
+            if (!logicTableNames.contains(logicTableName)) {
+                continue;
+            }
+            ShardingStrategyConfiguration shardingStrategy = each.getShardingStrategy();
+            Set<String> shardingColumns = new HashSet<>(extractShardingColumns(shardingStrategy));
+            result.put(logicTableName, shardingColumns);
+        }
+        return result;
+    }
+    
+    private Set<String> extractShardingColumns(final ShardingStrategyConfiguration shardingStrategy) {
+        if (shardingStrategy instanceof StandardShardingStrategyConfiguration) {
+            return new HashSet<>(Collections.singleton(((StandardShardingStrategyConfiguration) shardingStrategy).getShardingColumn()));
+        }
+        if (shardingStrategy instanceof ComplexShardingStrategyConfiguration) {
+            return new HashSet<>(Arrays.asList(((ComplexShardingStrategyConfiguration) shardingStrategy).getShardingColumns().split(",")));
+        }
+        return Collections.emptySet();
+    }
+}

--- a/features/sharding/core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.sharding.ShardingColumnsExtractor
+++ b/features/sharding/core/src/main/resources/META-INF/services/org.apache.shardingsphere.data.pipeline.spi.sharding.ShardingColumnsExtractor
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+org.apache.shardingsphere.sharding.data.pipeline.ShardingColumnsExtractorImpl

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/exception/external/sql/ShardingSphereSQLException.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/exception/external/sql/ShardingSphereSQLException.java
@@ -40,9 +40,14 @@ public abstract class ShardingSphereSQLException extends ShardingSphereExternalE
     }
     
     public ShardingSphereSQLException(final String sqlState, final int typeOffset, final int errorCode, final String reason, final Object... messageArguments) {
+        this(sqlState, typeOffset, errorCode, null == reason ? null : String.format(reason, messageArguments));
+    }
+    
+    private ShardingSphereSQLException(final String sqlState, final int typeOffset, final int errorCode, final String reason) {
+        super(reason);
         this.sqlState = sqlState;
         vendorCode = typeOffset * 10000 + errorCode;
-        this.reason = null == reason ? null : String.format(reason, messageArguments);
+        this.reason = reason;
     }
     
     /**

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -59,7 +59,7 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
     
     private void enableRangeQueryForInline(final YamlShardingRuleConfiguration shardingRuleConfig) {
         for (YamlAlgorithmConfiguration each : shardingRuleConfig.getShardingAlgorithms().values()) {
-            if ("INLINE".equals(each.getType())) {
+            if ("INLINE".equalsIgnoreCase(each.getType())) {
                 each.getProps().put("allow-range-query-with-inline-sharding", Boolean.TRUE.toString());
             }
         }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractor.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.spi.sharding;
+
+import org.apache.shardingsphere.data.pipeline.api.metadata.LogicTableName;
+import org.apache.shardingsphere.infra.util.spi.type.required.RequiredSPI;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Sharding columns extractor.
+ */
+public interface ShardingColumnsExtractor extends RequiredSPI {
+    
+    /**
+     * Get sharding columns map.
+     *
+     * @param yamlRuleConfigs YAML rule configurations
+     * @param logicTableNames logic table names
+     * @return sharding columns map
+     */
+    Map<LogicTableName, Set<String>> getShardingColumnsMap(Collection<YamlRuleConfiguration> yamlRuleConfigs, Set<LogicTableName> logicTableNames);
+}

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractorFactory.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractorFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.spi.sharding;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.util.spi.ShardingSphereServiceLoader;
+import org.apache.shardingsphere.infra.util.spi.type.required.RequiredSPIRegistry;
+
+/**
+ * Sharding columns extractor factory.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ShardingColumnsExtractorFactory {
+    
+    static {
+        ShardingSphereServiceLoader.register(ShardingColumnsExtractor.class);
+    }
+    
+    /**
+     * Get sharding columns extractor instance.
+     *
+     * @return sharding columns extractor
+     */
+    public static ShardingColumnsExtractor getInstance() {
+        return RequiredSPIRegistry.getRegisteredService(ShardingColumnsExtractor.class);
+    }
+}

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/CRC32MatchDataConsistencyCalculateAlgorithm.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/CRC32MatchDataConsistencyCalculateAlgorithm.java
@@ -82,6 +82,7 @@ public final class CRC32MatchDataConsistencyCalculateAlgorithm extends AbstractD
             int recordsCount = resultSet.getInt(2);
             return new CalculatedItem(crc32, recordsCount);
         } catch (final SQLException ex) {
+            log.error("calculateCRC32 failed, tableName={}", logicTableName, ex);
             throw new PipelineTableDataConsistencyCheckLoadingFailedException(logicTableName);
         }
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/DataMatchDataConsistencyCalculateAlgorithm.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/DataMatchDataConsistencyCalculateAlgorithm.java
@@ -122,6 +122,7 @@ public final class DataMatchDataConsistencyCalculateAlgorithm extends AbstractSt
             }
             return records.isEmpty() ? Optional.empty() : Optional.of(new CalculatedResult(maxUniqueKeyValue, records.size(), records));
         } catch (final SQLException ex) {
+            log.error("calculateChunk failed, schemaName={}, tableName={}", parameter.getSchemaName(), parameter.getLogicTableName(), ex);
             throw new PipelineTableDataConsistencyCheckLoadingFailedException(parameter.getLogicTableName());
         }
     }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/MigrationJobAPIImpl.java
@@ -64,6 +64,7 @@ import org.apache.shardingsphere.data.pipeline.core.metadata.loader.StandardPipe
 import org.apache.shardingsphere.data.pipeline.core.sqlbuilder.PipelineSQLBuilderFactory;
 import org.apache.shardingsphere.data.pipeline.scenario.consistencycheck.ConsistencyCheckJobAPIFactory;
 import org.apache.shardingsphere.data.pipeline.scenario.consistencycheck.ConsistencyCheckJobItemContext;
+import org.apache.shardingsphere.data.pipeline.spi.sharding.ShardingColumnsExtractorFactory;
 import org.apache.shardingsphere.data.pipeline.spi.sqlbuilder.PipelineSQLBuilder;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfigurationSwapper;
@@ -188,8 +189,9 @@ public final class MigrationJobAPIImpl extends AbstractInventoryIncrementalJobAP
         TableNameSchemaNameMapping tableNameSchemaNameMapping = new TableNameSchemaNameMapping(tableNameSchemaMap);
         CreateTableConfiguration createTableConfig = buildCreateTableConfiguration(jobConfig);
         DumperConfiguration dumperConfig = buildDumperConfiguration(jobConfig.getJobId(), jobConfig.getSourceResourceName(), jobConfig.getSource(), tableNameMap, tableNameSchemaNameMapping);
-        // TODO now shardingColumnsMap always empty,
-        ImporterConfiguration importerConfig = buildImporterConfiguration(jobConfig, pipelineProcessConfig, Collections.emptyMap(), tableNameSchemaNameMapping);
+        Map<LogicTableName, Set<String>> shardingColumnsMap = ShardingColumnsExtractorFactory.getInstance().getShardingColumnsMap(
+                ((ShardingSpherePipelineDataSourceConfiguration) jobConfig.getTarget()).getRootConfig().getRules(), Collections.singleton(new LogicTableName(jobConfig.getTargetTableName())));
+        ImporterConfiguration importerConfig = buildImporterConfiguration(jobConfig, pipelineProcessConfig, shardingColumnsMap, tableNameSchemaNameMapping);
         MigrationTaskConfiguration result = new MigrationTaskConfiguration(jobConfig.getSourceResourceName(), createTableConfig, dumperConfig, importerConfig);
         log.info("buildTaskConfiguration, sourceResourceName={}, result={}", jobConfig.getSourceResourceName(), result);
         return result;

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.integration.data.pipeline.cases.migration;
 
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -111,7 +112,10 @@ public abstract class AbstractMigrationITCase extends BaseITCase {
     }
     
     protected void createTargetOrderTableRule() throws SQLException {
-        proxyExecuteWithLog(migrationDistSQLCommand.getCreateTargetOrderTableRule(), 2);
+        for (String each : Splitter.on(";").trimResults().splitToList(migrationDistSQLCommand.getCreateTargetOrderTableRule()).stream()
+                .filter(each -> !Strings.isNullOrEmpty(each)).collect(Collectors.toList())) {
+            proxyExecuteWithLog(each, 2);
+        }
     }
     
     protected void createTargetOrderTableEncryptRule() throws SQLException {

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/AbstractMigrationITCase.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.integration.data.pipeline.cases.migration;
 
-import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -112,10 +111,7 @@ public abstract class AbstractMigrationITCase extends BaseITCase {
     }
     
     protected void createTargetOrderTableRule() throws SQLException {
-        for (String each : Splitter.on(";").trimResults().splitToList(migrationDistSQLCommand.getCreateTargetOrderTableRule()).stream()
-                .filter(each -> !Strings.isNullOrEmpty(each)).collect(Collectors.toList())) {
-            proxyExecuteWithLog(each, 2);
-        }
+        proxyExecuteWithLog(migrationDistSQLCommand.getCreateTargetOrderTableRule(), 2);
     }
     
     protected void createTargetOrderTableEncryptRule() throws SQLException {

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/general/PostgreSQLMigrationGeneralIT.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/cases/migration/general/PostgreSQLMigrationGeneralIT.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.integration.data.pipeline.env.enums.ITEnvTypeEn
 import org.apache.shardingsphere.integration.data.pipeline.framework.helper.ScalingCaseHelper;
 import org.apache.shardingsphere.integration.data.pipeline.framework.param.ScalingParameterized;
 import org.apache.shardingsphere.integration.data.pipeline.util.AutoIncrementKeyGenerateAlgorithm;
-import org.apache.shardingsphere.sharding.spi.KeyGenerateAlgorithm;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -50,7 +49,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 @Slf4j
 public final class PostgreSQLMigrationGeneralIT extends AbstractMigrationITCase {
     
-    private static final KeyGenerateAlgorithm KEY_GENERATE_ALGORITHM = new AutoIncrementKeyGenerateAlgorithm();
+    private static final AutoIncrementKeyGenerateAlgorithm KEY_GENERATE_ALGORITHM = new AutoIncrementKeyGenerateAlgorithm();
     
     private final ScalingParameterized parameterized;
     
@@ -100,13 +99,11 @@ public final class PostgreSQLMigrationGeneralIT extends AbstractMigrationITCase 
         log.info("init data end: {}", LocalDateTime.now());
         checkOrderMigration(jdbcTemplate);
         checkOrderItemMigration();
-        if (ENV.getItEnvType() == ITEnvTypeEnum.DOCKER) {
-            for (String each : listJobId()) {
-                commitMigrationByJobId(each);
-            }
-            List<String> lastJobIds = listJobId();
-            assertThat(lastJobIds.size(), is(0));
+        for (String each : listJobId()) {
+            commitMigrationByJobId(each);
         }
+        List<String> lastJobIds = listJobId();
+        assertThat(lastJobIds.size(), is(0));
         assertGreaterThanOrderTableInitRows(TABLE_INIT_ROW_COUNT, SCHEMA_NAME);
     }
     

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/helper/ScalingCaseHelper.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/framework/helper/ScalingCaseHelper.java
@@ -21,8 +21,8 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.integration.data.pipeline.util.AutoIncrementKeyGenerateAlgorithm;
 import org.apache.shardingsphere.sharding.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
-import org.apache.shardingsphere.sharding.spi.KeyGenerateAlgorithm;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -57,7 +57,7 @@ public final class ScalingCaseHelper {
      * @param insertRows insert rows
      * @return insert data list
      */
-    public static Pair<List<Object[]>, List<Object[]>> generateFullInsertData(final KeyGenerateAlgorithm orderIdGenerate, final DatabaseType databaseType, final int insertRows) {
+    public static Pair<List<Object[]>, List<Object[]>> generateFullInsertData(final AutoIncrementKeyGenerateAlgorithm orderIdGenerate, final DatabaseType databaseType, final int insertRows) {
         if (insertRows < 0) {
             return Pair.of(null, null);
         }
@@ -65,7 +65,7 @@ public final class ScalingCaseHelper {
         List<Object[]> orderItemData = new ArrayList<>(insertRows);
         for (int i = 0; i < insertRows; i++) {
             Comparable<?> orderId = orderIdGenerate.generateKey();
-            int userId = generateInt(0, 6);
+            int userId = orderIdGenerate.generateKey();
             LocalDateTime now = LocalDateTime.now();
             int randomInt = generateInt(-100, 100);
             int randomUnsignedInt = generateInt(0, 100);

--- a/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/util/AutoIncrementKeyGenerateAlgorithm.java
+++ b/test/integration-test/scaling/src/test/java/org/apache/shardingsphere/integration/data/pipeline/util/AutoIncrementKeyGenerateAlgorithm.java
@@ -20,14 +20,14 @@ package org.apache.shardingsphere.integration.data.pipeline.util;
 import org.apache.shardingsphere.sharding.spi.KeyGenerateAlgorithm;
 
 import java.util.Properties;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class AutoIncrementKeyGenerateAlgorithm implements KeyGenerateAlgorithm {
     
-    private final AtomicLong idGen = new AtomicLong(1);
+    private final AtomicInteger idGen = new AtomicInteger(1);
     
     @Override
-    public Comparable<?> generateKey() {
+    public Integer generateKey() {
         return idGen.getAndIncrement();
     }
     

--- a/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
+++ b/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
@@ -64,15 +64,11 @@
     </create-target-order-table-encrypt-rule>
     
     <create-target-order-table-rule>
-        CREATE SHARDING ALGORITHM database_inline (
-        TYPE(NAME="inline", PROPERTIES("algorithm-expression"="ds_${user_id % 3 + 2}"))
-        ), table_inline (
-        TYPE(NAME="inline", PROPERTIES("algorithm-expression"="t_order_${order_id % 2}"))
-        );
         CREATE SHARDING TABLE RULE t_order (
         DATANODES("ds_${2..4}.t_order_${0..1}"),
-        DATABASE_STRATEGY(TYPE="standard", SHARDING_COLUMN=user_id, SHARDING_ALGORITHM=database_inline),
-        TABLE_STRATEGY(TYPE="standard", SHARDING_COLUMN=order_id, SHARDING_ALGORITHM=table_inline)
+        DATABASE_STRATEGY(TYPE="standard",SHARDING_COLUMN=user_id,SHARDING_ALGORITHM(TYPE(NAME="inline",PROPERTIES("algorithm-expression"="ds_${user_id % 3 + 2}")))),
+        TABLE_STRATEGY(TYPE="standard",SHARDING_COLUMN=order_id,SHARDING_ALGORITHM(TYPE(NAME="inline",PROPERTIES("algorithm-expression"="t_order_${order_id % 2}")))),
+        KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
         );
     </create-target-order-table-rule>
     

--- a/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
+++ b/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
@@ -64,10 +64,10 @@
     </create-target-order-table-encrypt-rule>
     
     <create-target-order-table-rule>
-        CREATE SHARDING TABLE RULE t_order (
-        DATANODES("ds_${2..4}.t_order_${0..1}"),
-        DATABASE_STRATEGY(TYPE="standard",SHARDING_COLUMN=user_id,SHARDING_ALGORITHM(TYPE(NAME="inline",PROPERTIES("algorithm-expression"="ds_${user_id % 3 + 2}")))),
-        TABLE_STRATEGY(TYPE="standard",SHARDING_COLUMN=order_id,SHARDING_ALGORITHM(TYPE(NAME="inline",PROPERTIES("algorithm-expression"="t_order_${order_id % 2}")))),
+        CREATE SHARDING TABLE RULE t_order(
+        STORAGE_UNITS(ds_2,ds_3,ds_4),
+        SHARDING_COLUMN=user_id,
+        TYPE(NAME="hash_mod",PROPERTIES("sharding-count"="6")),
         KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
         );
     </create-target-order-table-rule>

--- a/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
+++ b/test/integration-test/scaling/src/test/resources/env/common/migration-command.xml
@@ -64,12 +64,16 @@
     </create-target-order-table-encrypt-rule>
     
     <create-target-order-table-rule>
-        CREATE SHARDING TABLE RULE t_order(
-        STORAGE_UNITS(ds_2,ds_3,ds_4),
-        SHARDING_COLUMN=order_id,
-        TYPE(NAME="hash_mod",PROPERTIES("sharding-count"="6")),
-        KEY_GENERATE_STRATEGY(COLUMN=order_id,TYPE(NAME="snowflake"))
-        )
+        CREATE SHARDING ALGORITHM database_inline (
+        TYPE(NAME="inline", PROPERTIES("algorithm-expression"="ds_${user_id % 3 + 2}"))
+        ), table_inline (
+        TYPE(NAME="inline", PROPERTIES("algorithm-expression"="t_order_${order_id % 2}"))
+        );
+        CREATE SHARDING TABLE RULE t_order (
+        DATANODES("ds_${2..4}.t_order_${0..1}"),
+        DATABASE_STRATEGY(TYPE="standard", SHARDING_COLUMN=user_id, SHARDING_ALGORITHM=database_inline),
+        TABLE_STRATEGY(TYPE="standard", SHARDING_COLUMN=order_id, SHARDING_ALGORITHM=table_inline)
+        );
     </create-target-order-table-rule>
     
     <create-target-order-item-table-rule>

--- a/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractorFactoryTest.java
+++ b/test/pipeline/src/test/java/org/apache/shardingsphere/data/pipeline/spi/sharding/ShardingColumnsExtractorFactoryTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.spi.sharding;
+
+import org.apache.shardingsphere.sharding.data.pipeline.ShardingColumnsExtractorImpl;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class ShardingColumnsExtractorFactoryTest {
+    
+    @Test
+    public void assertGetInstance() {
+        assertThat(ShardingColumnsExtractorFactory.getInstance(), instanceOf(ShardingColumnsExtractorImpl.class));
+    }
+}


### PR DESCRIPTION
Currently, shardingColumnsMap is always empty for migration job, UPDATE/DELETE SQL in incremental task doesn't include sharding columns in condition, so the logic SQL will be routed broadcastly, it might hurt performance.

shardingColumnsMap was set before, it should be set up again.

Changes proposed in this pull request:
  - Add ShardingColumnsExtractor and implementation
  - Use shardingColumnsMap for migration job
  - Update related migration IT: t_order use user_id as sharding column; Some improvement of IT
  - Fix bugs found in real test: 1) sharding strategy type should be case-insensitive, 2) error message in ShardingSphereSQLException is missed

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
