### PR TITLE
Improve AbstractMemoryQueryResult.wasNull

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/type/memory/AbstractMemoryQueryResult.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/type/memory/AbstractMemoryQueryResult.java
@@ -47,6 +47,8 @@ public abstract class AbstractMemoryQueryResult implements QueryResult {
     @Getter
     private long rowCount;
     
+    private boolean wasNull;
+    
     protected AbstractMemoryQueryResult(final QueryResultMetaData metaData, final Collection<MemoryQueryResultDataRow> rows) {
         this.metaData = metaData;
         this.rows = rows.iterator();
@@ -66,17 +68,23 @@ public abstract class AbstractMemoryQueryResult implements QueryResult {
     
     @Override
     public final Object getValue(final int columnIndex, final Class<?> type) {
-        return currentRow.getValue().get(columnIndex - 1);
+        Object result = currentRow.getValue().get(columnIndex - 1);
+        wasNull = null == result;
+        return result;
     }
     
     @Override
     public final Object getCalendarValue(final int columnIndex, final Class<?> type, final Calendar calendar) {
-        return currentRow.getValue().get(columnIndex - 1);
+        Object result = currentRow.getValue().get(columnIndex - 1);
+        wasNull = null == result;
+        return result;
     }
     
     @Override
     public final InputStream getInputStream(final int columnIndex, final String type) {
-        return getInputStream(currentRow.getValue().get(columnIndex - 1));
+        Object value = currentRow.getValue().get(columnIndex - 1);
+        wasNull = null == value;
+        return getInputStream(value);
     }
     
     @SneakyThrows(IOException.class)
@@ -91,7 +99,7 @@ public abstract class AbstractMemoryQueryResult implements QueryResult {
     
     @Override
     public final boolean wasNull() {
-        return null == currentRow;
+        return wasNull;
     }
     
     @Override

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/memory/JDBCMemoryQueryResultTest.java
@@ -356,12 +356,27 @@ public final class JDBCMemoryQueryResultTest {
     }
     
     @Test
-    public void assertWasNull() throws SQLException {
-        JDBCMemoryQueryResult queryResult = new JDBCMemoryQueryResult(mockResultSet(), databaseType);
+    public void assertWasNullTrue() throws SQLException {
+        JDBCMemoryQueryResult queryResult = new JDBCMemoryQueryResult(mockResultSetForWasNull(true), databaseType);
         queryResult.next();
-        assertFalse(queryResult.wasNull());
-        queryResult.next();
+        queryResult.getValue(1, int.class);
         assertTrue(queryResult.wasNull());
+    }
+    
+    @Test
+    public void assertWasNullFalse() throws SQLException {
+        JDBCMemoryQueryResult queryResult = new JDBCMemoryQueryResult(mockResultSetForWasNull(false), databaseType);
+        queryResult.next();
+        queryResult.getValue(1, int.class);
+        assertFalse(queryResult.wasNull());
+    }
+    
+    private ResultSet mockResultSetForWasNull(final boolean wasNull) throws SQLException {
+        ResultSet result = getMockedResultSet(Types.INTEGER);
+        when(result.getInt(1)).thenReturn(0);
+        when(result.getMetaData().isSigned(1)).thenReturn(true);
+        when(result.wasNull()).thenReturn(wasNull);
+        return result;
     }
     
     @Test


### PR DESCRIPTION

Changes proposed in this pull request:
  - Improve AbstractMemoryQueryResult.wasNull

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
