### PR TITLE
Restructure DynamicLoadingSQLParserParameterizedTest with URI

### DIFF
--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/mysql/DynamicLoadingMySQLParserParameterizedIT.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/mysql/DynamicLoadingMySQLParserParameterizedIT.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.engine.DynamicLoa
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -41,7 +42,7 @@ public final class DynamicLoadingMySQLParserParameterizedIT extends DynamicLoadi
     @Parameters(name = "{0} (MySQL) -> {1}")
     public static Collection<Object[]> getTestParameters() {
         if (IntegrationTestEnvironment.getInstance().isSqlParserITEnabled()) {
-            return DynamicLoadingSQLParserParameterizedTest.getTestParameters("https://github.com/mysql/mysql-server/tree/8.0/mysql-test/t");
+            return DynamicLoadingSQLParserParameterizedTest.getTestParameters("https://api.github.com/repos/", URI.create("https://github.com/mysql/mysql-server/tree/8.0/mysql-test/t"));
         }
         return Collections.emptyList();
     }

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/DynamicLoadingPostgreSQLParserParameterizedIT.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/DynamicLoadingPostgreSQLParserParameterizedIT.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.test.sql.parser.parameterized.engine.DynamicLoa
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
 
-import java.io.IOException;
+import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -40,9 +40,9 @@ public final class DynamicLoadingPostgreSQLParserParameterizedIT extends Dynamic
      * @return Test cases from GitHub.
      **/
     @Parameters(name = "{0} (PostgreSQL) -> {1}")
-    public static Collection<Object[]> getTestParameters() throws IOException {
+    public static Collection<Object[]> getTestParameters() {
         if (IntegrationTestEnvironment.getInstance().isSqlParserITEnabled()) {
-            return DynamicLoadingSQLParserParameterizedTest.getTestParameters("https://github.com/postgres/postgres/tree/master/src/test/regress/sql");
+            return DynamicLoadingSQLParserParameterizedTest.getTestParameters("https://api.github.com/repos/", URI.create("https://github.com/postgres/postgres/tree/master/src/test/regress/sql"));
         }
         return Collections.emptyList();
     }


### PR DESCRIPTION
Follows #22006.

Changes proposed in this pull request:
  - restructure DynamicLoadingSQLParserParameterizedTest with URI
  - modify DynamicLoadingMySQLParserParameterizedTestIT, DynamicLoadingPostgreSQLParserParameterizedTestIT

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
