### PR TITLE
Fix wrong number of arguments on IT of dynamic loading SQL case

### DIFF
--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.JsonPath;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.infra.util.spi.exception.ServiceProviderNotFoundServerException;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.api.SQLParserEngine;
 import org.apache.shardingsphere.sql.parser.api.SQLVisitorEngine;
@@ -67,7 +68,7 @@ public abstract class DynamicLoadingSQLParserParameterizedTest {
             }
         }
         if (result.isEmpty()) {
-            result.add(new Object[]{null, null});
+            result.add(new Object[]{null, null, null});
         }
         return result;
     }
@@ -133,7 +134,8 @@ public abstract class DynamicLoadingSQLParserParameterizedTest {
         try {
             ParseASTNode parseASTNode = new SQLParserEngine(databaseType, new CacheOption(128, 1024L)).parse(sql, false);
             new SQLVisitorEngine(databaseType, "STATEMENT", true, new Properties()).visit(parseASTNode);
-        } catch (final SQLParsingException | ClassCastException | NullPointerException | SQLASTVisitorException | NumberFormatException | StringIndexOutOfBoundsException ignore) {
+        } catch (final SQLParsingException | ClassCastException | NullPointerException | SQLASTVisitorException
+                | NumberFormatException | StringIndexOutOfBoundsException | ServiceProviderNotFoundServerException ignore) {
             result = "failed";
             log.warn("ParserError: " + sqlCaseId + " value: " + sql + " db-type: " + databaseType);
         }

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
@@ -134,8 +134,7 @@ public abstract class DynamicLoadingSQLParserParameterizedTest {
         try {
             ParseASTNode parseASTNode = new SQLParserEngine(databaseType, new CacheOption(128, 1024L)).parse(sql, false);
             new SQLVisitorEngine(databaseType, "STATEMENT", true, new Properties()).visit(parseASTNode);
-        } catch (final SQLParsingException | ClassCastException | NullPointerException | SQLASTVisitorException
-                | NumberFormatException | StringIndexOutOfBoundsException | ServiceProviderNotFoundServerException ignore) {
+        } catch (final Exception ignore) {
             result = "failed";
             log.warn("ParserError: " + sqlCaseId + " value: " + sql + " db-type: " + databaseType);
         }

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
@@ -21,13 +21,12 @@ import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.JsonPath;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.infra.util.exception.external.sql.type.kernel.KernelSQLException;
 import org.apache.shardingsphere.infra.util.spi.exception.ServiceProviderNotFoundServerException;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.api.SQLParserEngine;
 import org.apache.shardingsphere.sql.parser.api.SQLVisitorEngine;
 import org.apache.shardingsphere.sql.parser.core.ParseASTNode;
-import org.apache.shardingsphere.sql.parser.exception.SQLASTVisitorException;
-import org.apache.shardingsphere.sql.parser.exception.SQLParsingException;
 import org.apache.shardingsphere.sql.parser.result.CSVResultGenerator;
 import org.junit.Test;
 
@@ -134,7 +133,7 @@ public abstract class DynamicLoadingSQLParserParameterizedTest {
         try {
             ParseASTNode parseASTNode = new SQLParserEngine(databaseType, new CacheOption(128, 1024L)).parse(sql, false);
             new SQLVisitorEngine(databaseType, "STATEMENT", true, new Properties()).visit(parseASTNode);
-        } catch (final Exception ignore) {
+        } catch (final KernelSQLException | ClassCastException | NullPointerException | NumberFormatException | StringIndexOutOfBoundsException | ServiceProviderNotFoundServerException ignore) {
             result = "failed";
             log.warn("ParserError: " + sqlCaseId + " value: " + sql + " db-type: " + databaseType);
         }

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/base/DynamicLoadingSQLParserParameterizedTest.java
@@ -21,8 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.jayway.jsonpath.JsonPath;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.shardingsphere.infra.util.exception.external.sql.type.kernel.KernelSQLException;
-import org.apache.shardingsphere.infra.util.spi.exception.ServiceProviderNotFoundServerException;
+import org.apache.shardingsphere.infra.util.exception.external.ShardingSphereExternalException;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.api.SQLParserEngine;
 import org.apache.shardingsphere.sql.parser.api.SQLVisitorEngine;
@@ -133,7 +132,7 @@ public abstract class DynamicLoadingSQLParserParameterizedTest {
         try {
             ParseASTNode parseASTNode = new SQLParserEngine(databaseType, new CacheOption(128, 1024L)).parse(sql, false);
             new SQLVisitorEngine(databaseType, "STATEMENT", true, new Properties()).visit(parseASTNode);
-        } catch (final KernelSQLException | ClassCastException | NullPointerException | NumberFormatException | StringIndexOutOfBoundsException | ServiceProviderNotFoundServerException ignore) {
+        } catch (final ShardingSphereExternalException | ClassCastException | NullPointerException | IllegalArgumentException | IndexOutOfBoundsException ignore) {
             result = "failed";
             log.warn("ParserError: " + sqlCaseId + " value: " + sql + " db-type: " + databaseType);
         }

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/mysql/DynamicLoadingMySQLParserParameterizedIT.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/mysql/DynamicLoadingMySQLParserParameterizedIT.java
@@ -31,8 +31,8 @@ import java.util.Collections;
 @RunWith(ShardingSphereParallelTestParameterized.class)
 public final class DynamicLoadingMySQLParserParameterizedIT extends DynamicLoadingSQLParserParameterizedTest {
     
-    public DynamicLoadingMySQLParserParameterizedIT(final String sqlCaseId, final String sqlCaseValue) {
-        super(sqlCaseId, sqlCaseValue, "MySQL", new CSVResultGenerator("MySQL"));
+    public DynamicLoadingMySQLParserParameterizedIT(final String sqlCaseId, final String sqlCaseValue, final String databaseType) {
+        super(sqlCaseId, sqlCaseValue, databaseType, new CSVResultGenerator(databaseType));
     }
     
     /**

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/DynamicLoadingPostgreSQLParserParameterizedIT.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/DynamicLoadingPostgreSQLParserParameterizedIT.java
@@ -31,8 +31,8 @@ import java.util.Collections;
 @RunWith(ShardingSphereParallelTestParameterized.class)
 public final class DynamicLoadingPostgreSQLParserParameterizedIT extends DynamicLoadingSQLParserParameterizedTest {
     
-    public DynamicLoadingPostgreSQLParserParameterizedIT(final String sqlCaseId, final String sqlCaseValue) {
-        super(sqlCaseId, sqlCaseValue, "PostgreSQL", new CSVResultGenerator("PostgreSQL"));
+    public DynamicLoadingPostgreSQLParserParameterizedIT(final String sqlCaseId, final String sqlCaseValue, final String databaseType) {
+        super(sqlCaseId, sqlCaseValue, databaseType, new CSVResultGenerator(databaseType));
     }
     
     /**


### PR DESCRIPTION
Changes proposed in this pull request:
  - add ServiceProviderNotFoundServerException
  - resize empty result to 3
  - add databaseType as 3rd param

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
