### PR TITLE
Refactor : refactor the CSV generator to avoid the multi-thread issue

### DIFF
--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/env/IntegrationTestEnvironment.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/env/IntegrationTestEnvironment.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.env;
 
 import lombok.Getter;
 import lombok.SneakyThrows;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -32,10 +33,13 @@ public final class IntegrationTestEnvironment {
     
     private final boolean sqlParserITEnabled;
     
+    private final String resultPath;
+    
     private IntegrationTestEnvironment() {
         props = loadProperties();
         String sqlParserITEnabledStr = null == System.getProperty("sql.parser.it.enabled") ? props.get("sql.parser.it.enabled").toString() : System.getProperty("sql.parser.it.enabled");
         sqlParserITEnabled = null == sqlParserITEnabledStr ? false : Boolean.parseBoolean(sqlParserITEnabledStr);
+        resultPath = props.get("sql.parser.it.report.path").toString();
     }
     
     /**

--- a/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/result/CSVResultGenerator.java
+++ b/test/integration-test/sql-parser/src/test/java/org/apache/shardingsphere/sql/parser/result/CSVResultGenerator.java
@@ -42,7 +42,7 @@ public final class CSVResultGenerator {
         }
     }
     
-    private synchronized void createHeader(File csvFile) {
+    private synchronized void createHeader(final File csvFile) {
         if (!csvFile.exists()) {
             try (CSVPrinter printer = new CSVPrinter(new FileWriter(csvFile), CSVFormat.DEFAULT.builder().setSkipHeaderRecord(false).build())) {
                 printer.printRecord("SQLCaseId", "DatabaseType", "Result", "SQL");

--- a/test/integration-test/sql-parser/src/test/resources/env/it-env.properties
+++ b/test/integration-test/sql-parser/src/test/resources/env/it-env.properties
@@ -16,3 +16,4 @@
 #
 
 sql.parser.it.enabled=false
+sql.parser.it.report.path=/tmp/


### PR DESCRIPTION
for #21999

Changes proposed in this pull request:
  - refactor the CSV generator to avoid the multi-thread issue
  -  add customized report path
  
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
