### PR TITLE
Remove sharding-core dependency for database-datetime infra module

### DIFF
--- a/infra/datetime/type/database/pom.xml
+++ b/infra/datetime/type/database/pom.xml
@@ -32,12 +32,6 @@
             <artifactId>shardingsphere-infra-datetime-spi</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- TODO seems it's not necessary -->
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-sharding-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove sharding-core dependency for database-datetime infra module (infra module should not depend on sharding-core module which is part of features module)

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
