### PR TITLE
test(issue-21464): ShowShardingHintStatusStatement

### DIFF
--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
@@ -25,18 +25,21 @@ import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.AddShard
 import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.SetShardingHintDatabaseValueStatement;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.SetReadwriteSplittingHintStatement;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.ShowReadwriteSplittingHintStatusStatement;
+import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.ShowShardingHintStatusStatement;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.AddShardingHintDatabaseValueStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.AddShardingHintTableValueStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.SetShardingHintDatabaseValueStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.SetReadwriteSplittingHintStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.ShowReadwriteSplittingHintStatusStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.ShowShardingHintStatusStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.AddShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.SetShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.SetReadwriteSplittingHintStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowReadwriteSplittingHintStatusStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowShardingHintStatusStatementTestCase;
 
 /**
  * Hint RAL statement assert.
@@ -62,6 +65,8 @@ public class HintRALStatementAssert {
             SetReadwriteSplittingHintStatementAssert.assertIs(assertContext, (SetReadwriteSplittingHintStatement) actual, (SetReadwriteSplittingHintStatementTestCase) expected);
         } else if (actual instanceof ShowReadwriteSplittingHintStatusStatement) {
             ShowReadwriteSplittingHintStatusStatementAssert.assertIs(assertContext, (ShowReadwriteSplittingHintStatusStatement) actual, (ShowReadwriteSplittingHintStatusStatementTestCase) expected);
+        } else if (actual instanceof ShowShardingHintStatusStatement) {
+            ShowShardingHintStatusStatementAssert.assertIs(assertContext, (ShowShardingHintStatusStatement) actual, (ShowShardingHintStatusStatementTestCase) expected);
         }
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/hint/ShowShardingHintStatusStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/hint/ShowShardingHintStatusStatementAssert.java
@@ -19,27 +19,27 @@ package org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.dis
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.ShowReadwriteSplittingHintStatusStatement;
+import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.ShowShardingHintStatusStatement;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.SQLCaseAssertContext;
-import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowReadwriteSplittingHintStatusStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowShardingHintStatusStatementTestCase;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
- * Add readwrite-splitting hint status statement assert.
+ * Show sharding hint status statement assert.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ShowReadwriteSplittingHintStatusStatementAssert {
+public class ShowShardingHintStatusStatementAssert {
     
     /**
-     * Assert show readwrite-splitting hint status statement is correct with expected parser result.
+     * Assert show sharding hint status statement is correct with expected parser result.
      *
      * @param assertContext assert context
-     * @param actual actual show readwrite-splitting hint status statement
-     * @param expected expected show readwrite-splitting hint status statement test case
+     * @param actual actual show sharding hint status statement
+     * @param expected expected show sharding hint status statement test case
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowReadwriteSplittingHintStatusStatement actual, final ShowReadwriteSplittingHintStatusStatementTestCase expected) {
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowShardingHintStatusStatement actual, final ShowShardingHintStatusStatementTestCase expected) {
         if (null == expected) {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {


### PR DESCRIPTION
For #21464.

Changes proposed in this pull request:
  - Add test unit for ShowShardingHintStatusStatement.
  - Rename readwrite-splitting hint status

Particularly Notes:  SQL statement `<show-sharding-hint-status sql-case-id="show-sharding-hint-status" />`  has already been in the XML file `hint.xml`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
