### PR TITLE
Optimize DatabaseDiscoveryDataSourceRule getDataSourceMapper logic and DynamicReadwriteSplittingStrategy getAllDataSources logic

### DIFF
--- a/features/db-discovery/core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryDataSourceRule.java
+++ b/features/db-discovery/core/src/main/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryDataSourceRule.java
@@ -25,9 +25,9 @@ import org.apache.shardingsphere.dbdiscovery.spi.DatabaseDiscoveryProviderAlgori
 
 import javax.sql.DataSource;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -124,10 +124,9 @@ public final class DatabaseDiscoveryDataSourceRule {
      * @return data source mapper
      */
     public Map<String, Collection<String>> getDataSourceMapper() {
-        Map<String, Collection<String>> result = new HashMap<>(dataSourceNames.size(), 1);
-        for (String each : dataSourceNames) {
-            result.put(groupName, Collections.singletonList(each));
-        }
+        Map<String, Collection<String>> result = new HashMap<>(1, 1);
+        Collection<String> actualDataSourceNames = new LinkedList<>(dataSourceNames);
+        result.put(groupName, actualDataSourceNames);
         return result;
     }
 }

--- a/features/db-discovery/core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryDataSourceRuleTest.java
+++ b/features/db-discovery/core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryDataSourceRuleTest.java
@@ -67,7 +67,7 @@ public final class DatabaseDiscoveryDataSourceRuleTest {
     
     private Map<String, Collection<String>> getExpectedDataSourceMapper() {
         Map<String, Collection<String>> result = new LinkedHashMap<>(2, 1);
-        result.put("test_pr", Collections.singletonList("ds_1"));
+        result.put("test_pr", Arrays.asList("ds_0", "ds_1"));
         return result;
     }
 }

--- a/features/db-discovery/core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
+++ b/features/db-discovery/core/src/test/java/org/apache/shardingsphere/dbdiscovery/rule/DatabaseDiscoveryRuleTest.java
@@ -82,7 +82,7 @@ public final class DatabaseDiscoveryRuleTest {
     
     private Map<String, Collection<String>> getDataSourceMapper() {
         Map<String, Collection<String>> result = new HashMap<>(1, 1);
-        result.put("replica_ds", Collections.singletonList("replica_ds_1"));
+        result.put("replica_ds", Arrays.asList("primary_ds", "replica_ds_0", "replica_ds_1"));
         return result;
     }
     

--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/strategy/type/DynamicReadwriteSplittingStrategy.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/strategy/type/DynamicReadwriteSplittingStrategy.java
@@ -24,7 +24,7 @@ import org.apache.shardingsphere.readwritesplitting.strategy.ReadwriteSplittingS
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -52,9 +52,6 @@ public final class DynamicReadwriteSplittingStrategy implements ReadwriteSplitti
     
     @Override
     public Collection<String> getAllDataSources() {
-        Collection<String> result = new LinkedList<>();
-        result.add(dynamicDataSource.getPrimaryDataSourceName(autoAwareDataSourceName));
-        result.addAll(dynamicDataSource.getReplicaDataSourceNames(autoAwareDataSourceName));
-        return result;
+        return Collections.singletonList(autoAwareDataSourceName);
     }
 }

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/strategy/type/DynamicReadwriteSplittingStrategyTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/strategy/type/DynamicReadwriteSplittingStrategyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.readwritesplitting.strategy.type;
+
+import org.apache.shardingsphere.infra.rule.identifier.type.DynamicDataSourceContainedRule;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public final class DynamicReadwriteSplittingStrategyTest {
+    
+    @Test
+    public void assertGetDataSourceMapper() {
+        DynamicReadwriteSplittingStrategy dynamicReadwriteSplittingStrategy = new DynamicReadwriteSplittingStrategy("database_discovery_ds", true, mock(DynamicDataSourceContainedRule.class));
+        assertThat(dynamicReadwriteSplittingStrategy.getAllDataSources(), is(Collections.singletonList("database_discovery_ds")));
+    }
+}


### PR DESCRIPTION
Fixes #22197

Changes proposed in this pull request:
  - optimize DatabaseDiscoveryDataSourceRule getDataSourceMapper logic
  - optimize DynamicReadwriteSplittingStrategy getAllDataSources logic
  - add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
