### PR TITLE
Fix parsing not like operator missing whitespace.

### DIFF
--- a/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
+++ b/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
@@ -336,7 +336,7 @@ public abstract class OpenGaussStatementSQLVisitor extends OpenGaussStatementBas
     }
     
     private BinaryOperationExpression createPatternMatchingOperationSegment(final AExprContext ctx) {
-        String operator = ctx.patternMatchingOperator().getText();
+        String operator = getOriginalText(ctx.patternMatchingOperator());
         ExpressionSegment left = (ExpressionSegment) visit(ctx.aExpr(0));
         ListExpression right = new ListExpression(ctx.aExpr(1).start.getStartIndex(), ctx.aExpr().get(ctx.aExpr().size() - 1).stop.getStopIndex());
         for (int i = 1; i < ctx.aExpr().size(); i++) {

--- a/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -336,7 +336,7 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementP
     }
     
     private BinaryOperationExpression createPatternMatchingOperationSegment(final AExprContext ctx) {
-        String operator = ctx.patternMatchingOperator().getText();
+        String operator = getOriginalText(ctx.patternMatchingOperator());
         ExpressionSegment left = (ExpressionSegment) visit(ctx.aExpr(0));
         ListExpression right = new ListExpression(ctx.aExpr(1).start.getStartIndex(), ctx.aExpr().get(ctx.aExpr().size() - 1).stop.getStopIndex());
         for (int i = 1; i < ctx.aExpr().size(); i++) {

--- a/test/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/parser/src/main/resources/case/dml/select-expression.xml
@@ -906,6 +906,34 @@
         </where>
     </select>
 
+    <select sql-case-id="select_where_with_predicate_with_not_like">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7"/>
+        </projections>
+        <where start-index="22" stop-index="55">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="55">
+                    <left>
+                        <column name="status" start-index="28" stop-index="41">
+                            <owner name="t_order" start-index="28" stop-index="34"/>
+                        </column>
+                    </left>
+                    <operator>NOT LIKE</operator>
+                    <right>
+                        <list-expression start-index="52" stop-index="55">
+                            <items>
+                                <literal-expression value="1%" start-index="52" stop-index="55"/>
+                            </items>
+                        </list-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
     <select sql-case-id="select_where_with_predicate_with_regexp">
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20"/>

--- a/test/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -43,6 +43,7 @@
     <sql-case id="select_where_with_predicate_with_between" value="SELECT * FROM t_order WHERE t_order.order_id BETWEEN ? AND ?" db-types="MySQL" />
     <sql-case id="select_where_with_predicate_with_sounds_like" value="SELECT * FROM t_order WHERE t_order.order_id SOUNDS LIKE '1%'" db-types="MySQL" />
     <sql-case id="select_where_with_predicate_with_like" value="SELECT * FROM t_order WHERE t_order.order_id NOT LIKE '1%' ESCAPE '$'" db-types="MySQL" />
+    <sql-case id="select_where_with_predicate_with_not_like" value="SELECT * FROM t_order WHERE t_order.status NOT LIKE '1%'" db-types="MySQL,PostgreSQL,openGauss" />
     <sql-case id="select_where_with_predicate_with_regexp" value="SELECT * FROM t_order WHERE t_order.order_id NOT REGEXP '[123]'" db-types="MySQL" />
     <sql-case id="select_where_with_bit_expr_with_vertical_bar" value="SELECT * FROM t_order WHERE t_order.order_id | ?" db-types="MySQL" />
     <sql-case id="select_where_with_bit_expr_with_ampersand" value="SELECT * FROM t_order WHERE t_order.order_id &amp; ?" db-types="MySQL" />


### PR DESCRIPTION
For #22052.

Changes proposed in this pull request:
  - Fix parsing not like operator missing whitespace.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
