### PR TITLE
test(issue-21463): ClearReadwriteSplittingHintStatement

### DIFF
--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/HintRALStatementAssert.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.SetShard
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.SetReadwriteSplittingHintStatement;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.ShowReadwriteSplittingHintStatusStatement;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.hint.ShowShardingHintStatusStatement;
+import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.ClearReadwriteSplittingHintStatement;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.AddShardingHintDatabaseValueStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.AddShardingHintTableValueStatementAssert;
@@ -33,6 +34,7 @@ import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.dist
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.SetReadwriteSplittingHintStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.ShowReadwriteSplittingHintStatusStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.ShowShardingHintStatusStatementAssert;
+import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint.ClearReadwriteSplittingHintStatementAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.SQLParserTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.AddShardingHintDatabaseValueStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.AddShardingHintTableValueStatementTestCase;
@@ -40,6 +42,7 @@ import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.stat
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.SetReadwriteSplittingHintStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowReadwriteSplittingHintStatusStatementTestCase;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ShowShardingHintStatusStatementTestCase;
+import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ClearReadwriteSplittingHintStatementTestCase;
 
 /**
  * Hint RAL statement assert.
@@ -67,6 +70,8 @@ public class HintRALStatementAssert {
             ShowReadwriteSplittingHintStatusStatementAssert.assertIs(assertContext, (ShowReadwriteSplittingHintStatusStatement) actual, (ShowReadwriteSplittingHintStatusStatementTestCase) expected);
         } else if (actual instanceof ShowShardingHintStatusStatement) {
             ShowShardingHintStatusStatementAssert.assertIs(assertContext, (ShowShardingHintStatusStatement) actual, (ShowShardingHintStatusStatementTestCase) expected);
+        } else if (actual instanceof ClearReadwriteSplittingHintStatement) {
+            ClearReadwriteSplittingHintStatementAssert.assertIs(assertContext, (ClearReadwriteSplittingHintStatement) actual, (ClearReadwriteSplittingHintStatementTestCase) expected);
         }
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/hint/ClearReadwriteSplittingHintStatementAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/statement/distsql/ral/impl/hint/ClearReadwriteSplittingHintStatementAssert.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.distsql.ral.impl.hint;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.hint.ClearReadwriteSplittingHintStatement;
+import org.apache.shardingsphere.test.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.sql.parser.internal.jaxb.cases.domain.statement.distsql.ral.ClearReadwriteSplittingHintStatementTestCase;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Clear readwrite-splitting hint statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ClearReadwriteSplittingHintStatementAssert {
+    
+    /**
+     * Assert clear readwrite-splitting hint statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual clear readwrite-splitting hint statement
+     * @param expected expected clear readwrite-splitting hint statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ClearReadwriteSplittingHintStatement actual, final ClearReadwriteSplittingHintStatementTestCase expected) {
+        if (null == expected) {
+            assertNull(assertContext.getText("Actual statement should not exist."), actual);
+        } else {
+            assertNotNull(assertContext.getText("Actual statement should exist."), actual);
+        }
+    }
+}


### PR DESCRIPTION
For #21463.

Changes proposed in this pull request:
  - Add test unit for ClearReadwriteSplittingHintStatement.

Particularly Notes: SQL statement `<distsql-case id="clear-readwrite-splitting-hint-source" value="CLEAR READWRITE_SPLITTING HINT" />`has already been in the XML file `hint.xml`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
