### PR TITLE
Use class collection in OrderedServicesCache#Key to reduce memory usage when user execute distsql frequently

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/spi/type/ordered/cache/OrderedServicesCache.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/spi/type/ordered/cache/OrderedServicesCache.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.infra.util.spi.type.ordered.cache;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.lang.ref.SoftReference;
 import java.util.Collection;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -68,12 +68,17 @@ public final class OrderedServicesCache {
         cache.put(new Key(spiClass, types), services);
     }
     
-    @RequiredArgsConstructor
     @EqualsAndHashCode
     private static final class Key {
         
         private final Class<?> clazz;
         
-        private final Collection<?> types;
+        private final Collection<Class<?>> types;
+        
+        Key(final Class<?> clazz, final Collection<?> types) {
+            this.clazz = clazz;
+            this.types = new LinkedList<>();
+            types.forEach(each -> this.types.add(each.getClass()));
+        }
     }
 }

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/spi/type/ordered/cache/OrderedServicesCacheTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/spi/type/ordered/cache/OrderedServicesCacheTest.java
@@ -35,8 +35,8 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class OrderedServicesCacheTest {
@@ -61,6 +61,21 @@ public final class OrderedServicesCacheTest {
         cachedOrderedServices.put(orderedInterfaceFixture, cacheOrderedSPIFixture);
         OrderedServicesCache.cacheServices(OrderedSPIFixture.class, customInterfaces, cachedOrderedServices);
         Optional<Map<?, ?>> actual = OrderedServicesCache.findCachedServices(OrderedSPIFixture.class, customInterfaces);
+        assertTrue(actual.isPresent());
+        assertThat(actual.get().get(orderedInterfaceFixture), is(cacheOrderedSPIFixture));
+    }
+    
+    @Test
+    public void assertFindCachedServicesWithDifferentTypesObject() {
+        OrderedInterfaceFixture orderedInterfaceFixture = new OrderedInterfaceFixtureImpl();
+        Collection<OrderedInterfaceFixture> customInterfaces = Collections.singleton(orderedInterfaceFixture);
+        OrderedSPIFixture<?> cacheOrderedSPIFixture = new OrderedSPIFixtureImpl();
+        Map<OrderedInterfaceFixture, OrderedSPIFixture<?>> cachedOrderedServices = new LinkedHashMap<>(customInterfaces.size(), 1);
+        cachedOrderedServices.put(orderedInterfaceFixture, cacheOrderedSPIFixture);
+        OrderedServicesCache.cacheServices(OrderedSPIFixture.class, customInterfaces, cachedOrderedServices);
+        OrderedInterfaceFixture newOrderedInterfaceFixture = new OrderedInterfaceFixtureImpl();
+        Collection<OrderedInterfaceFixture> newCustomInterfaces = Collections.singleton(newOrderedInterfaceFixture);
+        Optional<Map<?, ?>> actual = OrderedServicesCache.findCachedServices(OrderedSPIFixture.class, newCustomInterfaces);
         assertTrue(actual.isPresent());
         assertThat(actual.get().get(orderedInterfaceFixture), is(cacheOrderedSPIFixture));
     }


### PR DESCRIPTION
Fixes #22204.

Changes proposed in this pull request:
  - Use class collection in OrderedServicesCache#Key to reduce memory usage when user execute distsql frequently
  - add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
