### PR TITLE
Change Exception to SQLException and RuntimeException when validate storage unit.

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesValidator.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesValidator.java
@@ -59,8 +59,7 @@ public final class DataSourcePropertiesValidator {
             dataSource = DataSourcePoolCreator.create(dataSourceProps);
             checkFailFast(dataSource);
             // CHECKSTYLE:OFF
-            // TODO check why catch exception here, can it simplify to catch SQLException and ShardingSphereInternalException?
-        } catch (final Exception ex) {
+        } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             throw new InvalidDataSourcePropertiesException(dataSourceName, ex.getMessage());
         } finally {


### PR DESCRIPTION
Hi @terrymanu 
I noticed your comment on "DataSourceProperties Validator".

> // TODO check why catch exception here, can it simplify to catch SQLException and ShardingSphereInternalException?

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/5668787/202212486-dc9d13fb-51e4-4ae8-81f7-02e344608c77.png">

After some research, I found that there are two kinds of exceptions that can occur when executing the `checkFailFast` method:
1. **SQLException**, such as wrong password
2. **RuntimeException**, such as missing connector driver

Among them, `RuntimeException` is thrown by `com.zaxxer.hikari.util.DriverDataSource` when the driver fails to load, the code is as shown in the figure:
<img width="1118" alt="image" src="https://user-images.githubusercontent.com/5668787/202215045-de383ba6-308f-4779-be7c-42deb5871af3.png">


So, I change `Exception` to `SQLException` and `RuntimeException` now.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
