### PR TITLE
Fix metaspace out of memory error (#22196)

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParser.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParser.java
@@ -65,7 +65,15 @@ public final class InlineExpressionParser {
      * @return result list
      */
     public List<String> splitAndEvaluate() {
-        return Strings.isNullOrEmpty(inlineExpression) ? Collections.emptyList() : flatten(evaluate(split()));
+        if(Strings.isNullOrEmpty(inlineExpression) ){
+            return Collections.emptyList();
+        }
+        if (!isInlineExpression(inlineExpression)) {
+            List<String> res = new ArrayList<>();
+            res.add(inlineExpression);
+            return res;
+        }
+        return flatten(evaluate(split()));
     }
     
     /**

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParser.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParser.java
@@ -68,7 +68,7 @@ public final class InlineExpressionParser {
         if(Strings.isNullOrEmpty(inlineExpression) ){
             return Collections.emptyList();
         }
-        if (!isInlineExpression(inlineExpression)) {
+        if (!isInlineExpressionNeedEvaluate(inlineExpression)) {
             List<String> res = new ArrayList<>();
             res.add(inlineExpression);
             return res;
@@ -83,6 +83,10 @@ public final class InlineExpressionParser {
      */
     public Closure<?> evaluateClosure() {
         return (Closure<?>) evaluate("{it -> \"" + inlineExpression + "\"}");
+    }
+
+    private boolean isInlineExpressionNeedEvaluate() {
+        return inlineExpression.contains("$") || inlineExpression.contains(",");
     }
     
     private List<Object> evaluate(final List<String> inlineExpressions) {


### PR DESCRIPTION
* avoid compiling all input strings.

Fixes #22196.

Changes proposed in this pull request:
  - InlineExpressionParser.splitAndEvaluate method parse every input string, cause metaspace out of memory error, we could avoid compiling all input strings
