### PR TITLE
Adjust PostgreSQLAdminExecutorCreator logic for using kernel to support pg_class and pg_namespace.

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/postgresql/PostgreSQLAdminExecutorCreator.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/postgresql/PostgreSQLAdminExecutorCreator.java
@@ -34,6 +34,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.dal.ShowStateme
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -56,6 +57,10 @@ public final class PostgreSQLAdminExecutorCreator implements DatabaseAdminExecut
     
     private static final String PG_PREFIX = "pg_";
     
+    private static final String PG_NAMESPACE = "pg_namespace";
+    
+    private static final Collection<String> KERNEL_SUPPORTED_TABLES = Arrays.asList(PG_NAMESPACE, PG_CLASS);
+    
     @Override
     public Optional<DatabaseAdminExecutor> create(final SQLStatementContext<?> sqlStatementContext) {
         SQLStatement sqlStatement = sqlStatementContext.getSqlStatement();
@@ -70,6 +75,9 @@ public final class PostgreSQLAdminExecutorCreator implements DatabaseAdminExecut
         SQLStatement sqlStatement = sqlStatementContext.getSqlStatement();
         if (sqlStatement instanceof SelectStatement) {
             Collection<String> selectedTableNames = getSelectedTableNames((SelectStatement) sqlStatement);
+            if (KERNEL_SUPPORTED_TABLES.containsAll(selectedTableNames)) {
+                return Optional.empty();
+            }
             if (selectedTableNames.contains(PG_DATABASE)) {
                 return Optional.of(new SelectDatabaseExecutor((SelectStatement) sqlStatement, sql));
             }


### PR DESCRIPTION
For #22052.

Changes proposed in this pull request:
  - Use kernel to support pg_class and pg_namespace.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
