### PR TITLE
Rename SQL parser IT test engine names

### DIFF
--- a/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/external/ExternalMySQLParserParameterizedIT.java
+++ b/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/external/ExternalMySQLParserParameterizedIT.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.mysql.external;
 
-import org.apache.shardingsphere.test.sql.parser.external.engine.SQLParserParameterizedIT;
+import org.apache.shardingsphere.test.sql.parser.external.engine.ExternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.external.loader.SQLCaseLoader;
 import org.apache.shardingsphere.test.sql.parser.external.loader.strategy.impl.GitHubSQLCaseLoadStrategy;
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
@@ -28,9 +28,9 @@ import java.net.URI;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class MySQLParserParameterizedIT extends SQLParserParameterizedIT {
+public final class ExternalMySQLParserParameterizedIT extends ExternalSQLParserParameterizedIT {
     
-    public MySQLParserParameterizedIT(final String sqlCaseId, final String sql) {
+    public ExternalMySQLParserParameterizedIT(final String sqlCaseId, final String sql) {
         super(sqlCaseId, sql, "MySQL", "CSV");
     }
     

--- a/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/internal/InternalMySQLParserParameterizedIT.java
+++ b/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/internal/InternalMySQLParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal;
+package org.apache.shardingsphere.sql.parser.mysql.internal;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class DistSQLParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalMySQLParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public DistSQLParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalMySQLParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("ShardingSphere");
+        return InternalSQLParserParameterizedIT.getTestParameters("MySQL", "H2");
     }
 }

--- a/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/internal/InternalUnsupportedMySQLParserParameterizedIT.java
+++ b/sql-parser/dialect/mysql/src/test/java/org/apache/shardingsphere/sql/parser/mysql/internal/InternalUnsupportedMySQLParserParameterizedIT.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sql.parser.mysql.internal;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedMySQLParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalUnsupportedMySQLParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public UnsupportedMySQLParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedMySQLParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("MySQL");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("MySQL");
     }
 }

--- a/sql-parser/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/opengauss/InternalOpenGaussParserParameterizedIT.java
+++ b/sql-parser/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/opengauss/InternalOpenGaussParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.postgresql.internal;
+package org.apache.shardingsphere.sql.parser.opengauss;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class PostgreSQLParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalOpenGaussParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public PostgreSQLParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalOpenGaussParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("PostgreSQL");
+        return InternalSQLParserParameterizedIT.getTestParameters("openGauss");
     }
 }

--- a/sql-parser/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/opengauss/InternalUnsupportedOpenGaussParserParameterizedIT.java
+++ b/sql-parser/dialect/opengauss/src/test/java/org/apache/shardingsphere/sql/parser/opengauss/InternalUnsupportedOpenGaussParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql92;
+package org.apache.shardingsphere.sql.parser.opengauss;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedSQL92ParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalUnsupportedOpenGaussParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public UnsupportedSQL92ParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedOpenGaussParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("SQL92");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("openGauss");
     }
 }

--- a/sql-parser/dialect/oracle/src/test/java/org/apache/shardingsphere/sql/parser/oracle/InternalOracleParserParameterizedIT.java
+++ b/sql-parser/dialect/oracle/src/test/java/org/apache/shardingsphere/sql/parser/oracle/InternalOracleParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.opengauss;
+package org.apache.shardingsphere.sql.parser.oracle;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedOpenGaussParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalOracleParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public UnsupportedOpenGaussParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalOracleParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("openGauss");
+        return InternalSQLParserParameterizedIT.getTestParameters("Oracle");
     }
 }

--- a/sql-parser/dialect/oracle/src/test/java/org/apache/shardingsphere/sql/parser/oracle/InternalUnsupportedOracleParserParameterizedIT.java
+++ b/sql-parser/dialect/oracle/src/test/java/org/apache/shardingsphere/sql/parser/oracle/InternalUnsupportedOracleParserParameterizedIT.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sql.parser.oracle;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedOracleParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalUnsupportedOracleParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public UnsupportedOracleParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedOracleParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("Oracle");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("Oracle");
     }
 }

--- a/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/external/ExternalPostgreSQLParserParameterizedIT.java
+++ b/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/external/ExternalPostgreSQLParserParameterizedIT.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.sql.parser.postgresql.external;
 
-import org.apache.shardingsphere.test.sql.parser.external.engine.SQLParserParameterizedIT;
+import org.apache.shardingsphere.test.sql.parser.external.engine.ExternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.external.loader.SQLCaseLoader;
 import org.apache.shardingsphere.test.sql.parser.external.loader.strategy.impl.GitHubSQLCaseLoadStrategy;
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
@@ -28,9 +28,9 @@ import java.net.URI;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class PostgreSQLParserParameterizedIT extends SQLParserParameterizedIT {
+public final class ExternalPostgreSQLParserParameterizedIT extends ExternalSQLParserParameterizedIT {
     
-    public PostgreSQLParserParameterizedIT(final String sqlCaseId, final String sql) {
+    public ExternalPostgreSQLParserParameterizedIT(final String sqlCaseId, final String sql) {
         super(sqlCaseId, sql, "PostgreSQL", "CSV");
     }
     

--- a/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/internal/InternalPostgreSQLParserParameterizedIT.java
+++ b/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/internal/InternalPostgreSQLParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sql92;
+package org.apache.shardingsphere.sql.parser.postgresql.internal;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class SQL92ParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalPostgreSQLParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public SQL92ParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalPostgreSQLParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("SQL92");
+        return InternalSQLParserParameterizedIT.getTestParameters("PostgreSQL");
     }
 }

--- a/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/internal/InternalUnsupportedPostgreSQLParserParameterizedIT.java
+++ b/sql-parser/dialect/postgresql/src/test/java/org/apache/shardingsphere/sql/parser/postgresql/internal/InternalUnsupportedPostgreSQLParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.opengauss;
+package org.apache.shardingsphere.sql.parser.postgresql.internal;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class OpenGaussParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalUnsupportedPostgreSQLParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public OpenGaussParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedPostgreSQLParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("openGauss");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("PostgreSQL");
     }
 }

--- a/sql-parser/dialect/sql92/src/test/java/org/apache/shardingsphere/sql/parser/sql92/InternalSQL92ParserParameterizedIT.java
+++ b/sql-parser/dialect/sql92/src/test/java/org/apache/shardingsphere/sql/parser/sql92/InternalSQL92ParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.postgresql.internal;
+package org.apache.shardingsphere.sql.parser.sql92;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedPostgreSQLParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalSQL92ParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public UnsupportedPostgreSQLParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalSQL92ParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("PostgreSQL");
+        return InternalSQLParserParameterizedIT.getTestParameters("SQL92");
     }
 }

--- a/sql-parser/dialect/sql92/src/test/java/org/apache/shardingsphere/sql/parser/sql92/InternalUnsupportedSQL92ParserParameterizedIT.java
+++ b/sql-parser/dialect/sql92/src/test/java/org/apache/shardingsphere/sql/parser/sql92/InternalUnsupportedSQL92ParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.sqlserver;
+package org.apache.shardingsphere.sql.parser.sql92;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class SQLServerParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalUnsupportedSQL92ParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public SQLServerParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedSQL92ParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("SQLServer");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("SQL92");
     }
 }

--- a/sql-parser/dialect/sqlserver/src/test/java/org/apache/shardingsphere/sql/parser/sqlserver/InternalSQLServerParserParameterizedIT.java
+++ b/sql-parser/dialect/sqlserver/src/test/java/org/apache/shardingsphere/sql/parser/sqlserver/InternalSQLServerParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.oracle;
+package org.apache.shardingsphere.sql.parser.sqlserver;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class OracleParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalSQLServerParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public OracleParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalSQLServerParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("Oracle");
+        return InternalSQLParserParameterizedIT.getTestParameters("SQLServer");
     }
 }

--- a/sql-parser/dialect/sqlserver/src/test/java/org/apache/shardingsphere/sql/parser/sqlserver/InternalUnsupportedSQLServerParserParameterizedIT.java
+++ b/sql-parser/dialect/sqlserver/src/test/java/org/apache/shardingsphere/sql/parser/sqlserver/InternalUnsupportedSQLServerParserParameterizedIT.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.sql.parser.sqlserver;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.UnsupportedSQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalUnsupportedSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class UnsupportedSQLServerParserParameterizedTest extends UnsupportedSQLParserParameterizedTest {
+public final class InternalUnsupportedSQLServerParserParameterizedIT extends InternalUnsupportedSQLParserParameterizedIT {
     
-    public UnsupportedSQLServerParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalUnsupportedSQLServerParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return UnsupportedSQLParserParameterizedTest.getTestParameters("SQLServer");
+        return InternalUnsupportedSQLParserParameterizedIT.getTestParameters("SQLServer");
     }
 }

--- a/test/common/src/main/java/org/apache/shardingsphere/test/runner/parallel/impl/DefaultParallelRunnerExecutor.java
+++ b/test/common/src/main/java/org/apache/shardingsphere/test/runner/parallel/impl/DefaultParallelRunnerExecutor.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 
 /**
  * Default parallel runner executor.
+ * 
  * @param <T> key type bind to parallel executor
  */
 public class DefaultParallelRunnerExecutor<T> implements ParallelRunnerExecutor<T> {

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/external/engine/ExternalSQLParserParameterizedIT.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/external/engine/ExternalSQLParserParameterizedIT.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import java.util.Properties;
 
 @Slf4j
-public abstract class SQLParserParameterizedIT {
+public abstract class ExternalSQLParserParameterizedIT {
     
     private final String sqlCaseId;
     
@@ -40,7 +40,7 @@ public abstract class SQLParserParameterizedIT {
     
     private final SQLParseResultReporter resultReporter;
     
-    protected SQLParserParameterizedIT(final String sqlCaseId, final String sql, final String databaseType, final String reportType) {
+    protected ExternalSQLParserParameterizedIT(final String sqlCaseId, final String sql, final String databaseType, final String reportType) {
         this.sqlCaseId = sqlCaseId;
         this.sql = sql;
         this.databaseType = databaseType;

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/external/engine/ExternalSQLParserParameterizedIT.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/external/engine/ExternalSQLParserParameterizedIT.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.test.sql.parser.external.engine;
 
-import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.util.exception.external.ShardingSphereExternalException;
 import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sql.parser.api.SQLParserEngine;
@@ -29,7 +28,6 @@ import org.junit.Test;
 
 import java.util.Properties;
 
-@Slf4j
 public abstract class ExternalSQLParserParameterizedIT {
     
     private final String sqlCaseId;

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/engine/InternalSQLParserParameterizedIT.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/engine/InternalSQLParserParameterizedIT.java
@@ -39,7 +39,7 @@ import java.util.LinkedList;
 import java.util.Properties;
 
 @RequiredArgsConstructor
-public abstract class SQLParserParameterizedTest {
+public abstract class InternalSQLParserParameterizedIT {
     
     private static final SQLCasesLoader SQL_CASES_LOADER = SQLCasesRegistry.getInstance().getSqlCasesLoader();
     

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/engine/InternalUnsupportedSQLParserParameterizedIT.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/engine/InternalUnsupportedSQLParserParameterizedIT.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.Properties;
 
 @RequiredArgsConstructor
-public abstract class UnsupportedSQLParserParameterizedTest {
+public abstract class InternalUnsupportedSQLParserParameterizedIT {
     
     private static final SQLCasesLoader SQL_CASES_LOADER = UnsupportedSQLCasesRegistry.getInstance().getSqlCasesLoader();
     

--- a/test/parser/src/test/java/org/apache/shardingsphere/test/sql/parser/internal/InternalDistSQLParserParameterizedIT.java
+++ b/test/parser/src/test/java/org/apache/shardingsphere/test/sql/parser/internal/InternalDistSQLParserParameterizedIT.java
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sql.parser.mysql.internal;
+package org.apache.shardingsphere.test.sql.parser.internal;
 
 import org.apache.shardingsphere.test.runner.ShardingSphereParallelTestParameterized;
-import org.apache.shardingsphere.test.sql.parser.internal.engine.SQLParserParameterizedTest;
+import org.apache.shardingsphere.test.sql.parser.internal.engine.InternalSQLParserParameterizedIT;
 import org.apache.shardingsphere.test.sql.parser.internal.jaxb.domain.SQLCaseType;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -26,14 +26,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Collection;
 
 @RunWith(ShardingSphereParallelTestParameterized.class)
-public final class MySQLParserParameterizedTest extends SQLParserParameterizedTest {
+public final class InternalDistSQLParserParameterizedIT extends InternalSQLParserParameterizedIT {
     
-    public MySQLParserParameterizedTest(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
+    public InternalDistSQLParserParameterizedIT(final String sqlCaseId, final String databaseType, final SQLCaseType sqlCaseType) {
         super(sqlCaseId, databaseType, sqlCaseType);
     }
     
     @Parameters(name = "{0} ({2}) -> {1}")
     public static Collection<Object[]> getTestParameters() {
-        return SQLParserParameterizedTest.getTestParameters("MySQL", "H2");
+        return InternalSQLParserParameterizedIT.getTestParameters("ShardingSphere");
     }
 }


### PR DESCRIPTION
- Rename SQLParserParameterizedIT to ExternalSQLParserParameterizedIT
- Rename SQLParserParameterizedTest to InternalSQLParserParameterizedIT