### PR TITLE
Remove unused inner class EmptyTableRuleSegment

### DIFF
--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -81,7 +81,6 @@ import org.apache.shardingsphere.sharding.distsql.parser.segment.strategy.KeyGen
 import org.apache.shardingsphere.sharding.distsql.parser.segment.strategy.ShardingAuditorSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.strategy.ShardingStrategySegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.table.AbstractTableRuleSegment;
-import org.apache.shardingsphere.sharding.distsql.parser.segment.table.AbstractTableRuleSegment.EmptyTableRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.table.AutoTableRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.table.TableReferenceRuleSegment;
 import org.apache.shardingsphere.sharding.distsql.parser.segment.table.TableRuleSegment;
@@ -145,7 +144,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     public ASTNode visitCreateShardingTableRule(final CreateShardingTableRuleContext ctx) {
         Collection<AbstractTableRuleSegment> tableRuleSegments = ctx.shardingTableRuleDefinition().stream()
                 .map(each -> (AbstractTableRuleSegment) visit(each)).filter(Objects::nonNull).collect(Collectors.toList());
-        return tableRuleSegments.isEmpty() ? new EmptyTableRuleSegment() : new CreateShardingTableRuleStatement(tableRuleSegments);
+        return new CreateShardingTableRuleStatement(tableRuleSegments);
     }
     
     @Override
@@ -167,7 +166,7 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     public ASTNode visitAlterShardingTableRule(final AlterShardingTableRuleContext ctx) {
         List<AbstractTableRuleSegment> tableRuleSegments = ctx.shardingTableRuleDefinition().stream()
                 .map(each -> (AbstractTableRuleSegment) visit(each)).filter(Objects::nonNull).collect(Collectors.toList());
-        return tableRuleSegments.isEmpty() ? new EmptyTableRuleSegment() : new AlterShardingTableRuleStatement(tableRuleSegments);
+        return new AlterShardingTableRuleStatement(tableRuleSegments);
     }
     
     @Override

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/segment/table/AbstractTableRuleSegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/segment/table/AbstractTableRuleSegment.java
@@ -43,14 +43,4 @@ public abstract class AbstractTableRuleSegment implements ASTNode {
     private KeyGenerateStrategySegment keyGenerateStrategySegment;
     
     private AuditStrategySegment auditStrategySegment;
-    
-    /**
-     * Empty table rule segment.
-     */
-    public static class EmptyTableRuleSegment extends AbstractTableRuleSegment {
-        
-        public EmptyTableRuleSegment() {
-            super(null, null);
-        }
-    }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
  - Remove unused inner class EmptyTableRuleSegment
  - Revise related visitor

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
