### PR TITLE
Update Oracle SQL XMLTABLE function parse

### DIFF
--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -1624,6 +1624,7 @@ xmlFunction
     | xmlQueryFunction
     | xmlRootFunction
     | xmlSerializeFunction
+    | xmlTableFunction
     ;
 
 xmlAggFunction
@@ -1664,4 +1665,20 @@ xmlRootFunction
 
 xmlSerializeFunction
     : XMLSERIALIZE LP_ (DOCUMENT | CONTENT) expr (AS dataType)? (ENCODING STRING_)? (VERSION stringLiterals)? (NO IDENT | IDENT (SIZE EQ_ INTEGER_)?)? ((HIDE | SHOW) DEFAULT)? RP_
+    ;
+
+xmlTableFunction
+    : XMLTABLE LP_ (xmlNameSpacesClause COMMA_)? STRING_ xmlTableOptions RP_
+    ;
+
+xmlNameSpacesClause
+    : XMLNAMESPACES LP_ (STRING_ AS identifier | DEFAULT STRING_) (COMMA_ (STRING_ AS identifier | DEFAULT STRING_))* RP_
+    ;
+
+xmlTableOptions
+    : xmlPassingClause? (RETURNING SEQUENCE BY REF)? (COLUMNS xmlTableColumn (COMMA_ xmlTableColumn)*)?
+    ;
+
+xmlTableColumn
+    : columnName (FOR ORDINALITY | (dataType | XMLTYPE (LP_ SEQUENCE RP_ BY REF)?) (PATH STRING_)? (DEFAULT expr)?)
     ;

--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -1672,7 +1672,15 @@ xmlTableFunction
     ;
 
 xmlNameSpacesClause
-    : XMLNAMESPACES LP_ (STRING_ AS identifier | DEFAULT STRING_) (COMMA_ (STRING_ AS identifier | DEFAULT STRING_))* RP_
+    : XMLNAMESPACES LP_ (defaultString COMMA_)? (xmlNameSpaceStringAsIdentifier | defaultString) (COMMA_ (xmlNameSpaceStringAsIdentifier | defaultString))* RP_
+    ;
+
+xmlNameSpaceStringAsIdentifier
+    : STRING_ AS identifier
+    ;
+
+defaultString
+    : DEFAULT STRING_
     ;
 
 xmlTableOptions

--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -436,7 +436,11 @@ fromClauseOption
     ;
 
 xmlTable
-    : tableName alias? COMMA_ xmlTableFunction alias
+    : tableName alias? COMMA_ xmlTableFunction xmlTableFunctionAlias
+    ;
+
+xmlTableFunctionAlias
+    : alias
     ;
 
 selectTableReference

--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -432,6 +432,11 @@ fromClauseOption
     | LP_ joinClause RP_
     | selectTableReference
     | inlineAnalyticView
+    | xmlTable
+    ;
+
+xmlTable
+    : tableName alias? COMMA_ xmlTableFunction alias
     ;
 
 selectTableReference

--- a/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Keyword.g4
+++ b/sql-parser/dialect/oracle/src/main/antlr4/imports/oracle/Keyword.g4
@@ -751,3 +751,19 @@ HIDE
 SHOW
     : S H O W
     ;
+
+XMLTABLE
+    : X M L T A B L E
+    ;
+
+XMLNAMESPACES
+    : X M L N A M E S P A C E S
+    ;
+
+ORDINALITY
+    : O R D I N A L I T Y
+    ;
+
+PATH
+    : P A T H
+    ;

--- a/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
+++ b/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
@@ -813,19 +813,9 @@ public final class OracleDMLStatementSQLVisitor extends OracleStatementSQLVisito
     
     @Override
     public ASTNode visitXmlTable(final XmlTableContext ctx) {
-        String tableAlias;
-        String xmlTableAlias;
-        if (null == ctx.alias()) {
-            tableAlias = null;
-            xmlTableAlias = null;
-        } else if (null == ctx.alias(1) && null != ctx.alias(0)) {
-            tableAlias = null;
-            xmlTableAlias = ctx.alias(0).getText();
-        } else {
-            tableAlias = ctx.alias(0).getText();
-            xmlTableAlias = ctx.alias(1).getText();
-        }
-        return new XmlTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), ctx.tableName().getText(), tableAlias, (XmlTableFunctionSegment) visit(ctx.xmlTableFunction()), xmlTableAlias);
+        String tableAlias = null == ctx.alias() ? null : ctx.alias().getText();
+        return new XmlTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), ctx.tableName().getText(),
+                tableAlias, (XmlTableFunctionSegment) visit(ctx.xmlTableFunction()), ctx.xmlTableFunctionAlias().alias().getText());
     }
     
     @Override

--- a/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
+++ b/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleDMLStatementSQLVisitor.java
@@ -103,6 +103,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.Update
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.UsingClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.WhereClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.WithClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableContext;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.OrderDirection;
@@ -116,9 +117,10 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOp
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.DatetimeExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.FunctionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlQueryAndExistsFunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlPiFunctionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlQueryAndExistsFunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlSerializeFunctionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTableFunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonTableExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
@@ -126,12 +128,12 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.DatetimeProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ExpressionProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.SubqueryProjectionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.DatetimeProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.GroupBySegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.OrderBySegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.item.ColumnOrderByItemSegment;
@@ -150,6 +152,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.Joi
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.XmlTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
 import org.apache.shardingsphere.sql.parser.sql.common.value.collection.CollectionValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
@@ -799,10 +802,30 @@ public final class OracleDMLStatementSQLVisitor extends OracleStatementSQLVisito
     
     @Override
     public ASTNode visitFromClauseOption(final FromClauseOptionContext ctx) {
+        if (null != ctx.xmlTable()) {
+            return visit(ctx.xmlTable());
+        }
         if (null != ctx.joinClause()) {
             return visit(ctx.joinClause());
         }
         return visit(ctx.selectTableReference());
+    }
+    
+    @Override
+    public ASTNode visitXmlTable(final XmlTableContext ctx) {
+        String tableAlias;
+        String xmlTableAlias;
+        if (null == ctx.alias()) {
+            tableAlias = null;
+            xmlTableAlias = null;
+        } else if (null == ctx.alias(1) && null != ctx.alias(0)) {
+            tableAlias = null;
+            xmlTableAlias = ctx.alias(0).getText();
+        } else {
+            tableAlias = ctx.alias(0).getText();
+            xmlTableAlias = ctx.alias(1).getText();
+        }
+        return new XmlTableSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), ctx.tableName().getText(), tableAlias, (XmlTableFunctionSegment) visit(ctx.xmlTableFunction()), xmlTableAlias);
     }
     
     @Override

--- a/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleStatementSQLVisitor.java
+++ b/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleStatementSQLVisitor.java
@@ -680,17 +680,17 @@ public abstract class OracleStatementSQLVisitor extends OracleStatementBaseVisit
         // TODO : throw exception if more than one defaultString exists in a xml name space clause
         String defaultString = null == ctx.defaultString() ? null : ctx.defaultString(0).STRING_().getText();
         Collection<XmlNameSpaceStringAsIdentifierSegment> xmlNameSpaceStringAsIdentifierSegments = null == ctx.xmlNameSpaceStringAsIdentifier() ? Collections.emptyList()
-                : ctx.xmlNameSpaceStringAsIdentifier().stream().map(each ->(XmlNameSpaceStringAsIdentifierSegment) visit(each)).collect(Collectors.toList());
+                : ctx.xmlNameSpaceStringAsIdentifier().stream().map(each -> (XmlNameSpaceStringAsIdentifierSegment) visit(each)).collect(Collectors.toList());
         XmlNameSpacesClauseSegment result = new XmlNameSpacesClauseSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), defaultString, getOriginalText(ctx));
         result.getStringAsIdentifier().addAll(xmlNameSpaceStringAsIdentifierSegments);
         return result;
     }
-
+    
     @Override
     public ASTNode visitXmlNameSpaceStringAsIdentifier(final XmlNameSpaceStringAsIdentifierContext ctx) {
         return new XmlNameSpaceStringAsIdentifierSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), ctx.STRING_().getText(), ctx.identifier().getText(), getOriginalText(ctx));
     }
-
+    
     @Override
     public ASTNode visitXmlTableOptions(final XmlTableOptionsContext ctx) {
         XmlTableOptionsSegment result = new XmlTableOptionsSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), getOriginalText(ctx));

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpaceStringAsIdentifierSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpaceStringAsIdentifierSegment.java
@@ -22,24 +22,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
  * Xml name spaces segment.
  */
 @RequiredArgsConstructor
 @Getter
 @ToString
-public final class XmlNameSpacesClauseSegment implements ComplexExpressionSegment {
+public final class XmlNameSpaceStringAsIdentifierSegment implements ComplexExpressionSegment {
     
     private final int startIndex;
     
     private final int stopIndex;
     
-    private final String defaultString;
+    private final String xmlNameSpaceString;
     
-    private final Collection<XmlNameSpaceStringAsIdentifierSegment> StringAsIdentifier = new LinkedList<>();
+    private final String xmlNameSpaceIdentifier;
     
     private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpaceStringAsIdentifierSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpaceStringAsIdentifierSegment.java
@@ -23,7 +23,7 @@ import lombok.ToString;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
 
 /**
- * Xml name spaces segment.
+ * Xml name spaces string as identifier segment.
  */
 @RequiredArgsConstructor
 @Getter

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpacesClauseSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpacesClauseSegment.java
@@ -39,7 +39,7 @@ public final class XmlNameSpacesClauseSegment implements ComplexExpressionSegmen
     
     private final String defaultString;
     
-    private final Collection<XmlNameSpaceStringAsIdentifierSegment> StringAsIdentifier = new LinkedList<>();
+    private final Collection<XmlNameSpaceStringAsIdentifierSegment> stringAsIdentifier = new LinkedList<>();
     
     private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpacesClauseSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlNameSpacesClauseSegment.java
@@ -15,30 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
 
-import javax.xml.bind.annotation.XmlElement;
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
- * Expected tables.
+ * Xml name spaces segment.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+@ToString
+public final class XmlNameSpacesClauseSegment implements ComplexExpressionSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    private final int startIndex;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    private final int stopIndex;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    private final Collection<String> nameSpacesString = new LinkedList<>();
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    private final Collection<String> nameSpacesIdentifier = new LinkedList<>();
+    
+    private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableColumnSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableColumnSegment.java
@@ -15,30 +15,32 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
-
-import javax.xml.bind.annotation.XmlElement;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
 
 /**
- * Expected tables.
+ * Xml table column segment.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+@ToString
+public final class XmlTableColumnSegment implements ComplexExpressionSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    private final int startIndex;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    private final int stopIndex;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    private final String columnName;
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    private final String dataType;
+    
+    private final String path;
+    
+    private final ExpressionSegment defaultExpr;
+    
+    private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableFunctionSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableFunctionSegment.java
@@ -15,30 +15,33 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
-
-import javax.xml.bind.annotation.XmlElement;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 
 /**
- * Expected tables.
+ * Xml table function segment.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+@ToString
+public final class XmlTableFunctionSegment implements ComplexExpressionSegment, ProjectionSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    private final int startIndex;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    private final int stopIndex;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    private final String functionName;
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    private final XmlNameSpacesClauseSegment xmlNameSpacesClause;
+    
+    private final String xQueryString;
+    
+    private final XmlTableOptionsSegment xmlTableOption;
+    
+    private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableOptionsSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/XmlTableOptionsSegment.java
@@ -15,30 +15,31 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr;
 
 import lombok.Getter;
-import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
 
-import javax.xml.bind.annotation.XmlElement;
+import java.util.Collection;
+import java.util.LinkedList;
 
 /**
- * Expected tables.
+ * Xml table options segment.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+@ToString
+public final class XmlTableOptionsSegment implements ComplexExpressionSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    private final int startIndex;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    private final int stopIndex;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    private final Collection<ExpressionSegment> parameters = new LinkedList<>();
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    private final Collection<XmlTableColumnSegment> xmlTableColumnSegments = new LinkedList<>();
+    
+    private final String text;
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
@@ -26,6 +26,9 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegm
 
 import java.util.Optional;
 
+/**
+ * XML table segment.
+ */
 @RequiredArgsConstructor
 @Getter
 @Setter

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
@@ -15,30 +15,41 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
+import lombok.ToString;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTableFunctionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 
-import javax.xml.bind.annotation.XmlElement;
+import java.util.Optional;
 
-/**
- * Expected tables.
- */
+@RequiredArgsConstructor
 @Getter
 @Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+@ToString
+public final class XmlTableSegment implements TableSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    private final int startIndex;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    private final int stopIndex;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    private final String tableName;
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    private final String tableNameAlias;
+    
+    private final XmlTableFunctionSegment xmlTableFunction;
+    
+    private final String xmlTableFunctionAlias;
+    
+    @Override
+    public Optional<String> getAlias() {
+        return Optional.empty();
+    }
+    
+    @Override
+    public void setAlias(AliasSegment alias) {
+    }
 }

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
@@ -50,6 +50,6 @@ public final class XmlTableSegment implements TableSegment {
     }
     
     @Override
-    public void setAlias(AliasSegment alias) {
+    public void setAlias(final AliasSegment alias) {
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -20,22 +20,26 @@ package org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.table
 import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTableFunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.XmlTableSegment;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.column.ColumnAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.expression.ExpressionAssert;
+import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.owner.OwnerAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.asserts.statement.dml.impl.SelectStatementAssert;
-import org.apache.shardingsphere.test.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.column.ExpectedColumn;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.expr.ExpectedXmlTableFunction;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table.ExpectedJoinTable;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table.ExpectedSimpleTable;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table.ExpectedSubqueryTable;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table.ExpectedTable;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table.ExpectedXmlTable;
 
 import java.util.Collection;
 import java.util.List;
@@ -65,10 +69,38 @@ public final class TableAssert {
             assertIs(assertContext, (SimpleTableSegment) actual, expected.getSimpleTable());
         } else if (actual instanceof SubqueryTableSegment) {
             assertIs(assertContext, (SubqueryTableSegment) actual, expected.getSubqueryTable());
+        } else if (actual instanceof XmlTableSegment) {
+            assertIs(assertContext, (XmlTableSegment) actual, expected.getXmlTable());
         } else {
             throw new UnsupportedOperationException(
                     String.format("Unsupported table segment type `%s`.", actual.getClass()));
         }
+    }
+
+    /**
+     * Assert actual xml table segment is correct with expected xml table.
+     *
+     * @param assertContext assert context
+     * @param actual actual xml table
+     * @param expected expected xml table
+     */
+    private static void assertIs(final SQLCaseAssertContext assertContext, final XmlTableSegment actual, final ExpectedXmlTable expected) {
+        assertThat(assertContext.getText("Table name assertion error"), actual.getTableName(), is(expected.getTableName()));
+        assertThat(assertContext.getText("Table name alias assertion error"), actual.getTableNameAlias(), is(expected.getTableAlias()));
+        assertXmlTableFunction(assertContext, actual.getXmlTableFunction(), expected.getXmlTableFunction());
+        assertThat(assertContext.getText("Xml table function alias assertion error"), actual.getXmlTableFunctionAlias(), is(expected.getXmlTableFunctionAlias()));
+    }
+
+    /**
+     * Assert actual xml table function segment is correct with expected xml table function.
+     *
+     * @param assertContext assert context
+     * @param actual actual xml table function
+     * @param expected expected xml table function
+     */
+    private static void assertXmlTableFunction(final SQLCaseAssertContext assertContext, final XmlTableFunctionSegment actual, final ExpectedXmlTableFunction expected) {
+        assertThat(assertContext.getText("Function name assertion error"), actual.getFunctionName(), is(expected.getFunctionName()));
+        assertThat(assertContext.getText("Function text assert error"), actual.getText(), is(expected.getText()));
     }
     
     /**

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -90,7 +90,7 @@ public final class TableAssert {
         assertXmlTableFunction(assertContext, actual.getXmlTableFunction(), expected.getXmlTableFunction());
         assertThat(assertContext.getText("Xml table function alias assertion error"), actual.getXmlTableFunctionAlias(), is(expected.getXmlTableFunctionAlias()));
     }
-
+    
     /**
      * Assert actual table segment is correct with expected table.
      *
@@ -180,7 +180,7 @@ public final class TableAssert {
             assertThat(assertContext.getText("Actual join-type should exist."), actual, is(expected));
         }
     }
-
+    
     /**
      * Assert actual xml table function segment is correct with expected xml table function.
      *

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -45,8 +45,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -76,7 +76,7 @@ public final class TableAssert {
                     String.format("Unsupported table segment type `%s`.", actual.getClass()));
         }
     }
-
+    
     /**
      * Assert actual xml table segment is correct with expected xml table.
      *
@@ -91,18 +91,6 @@ public final class TableAssert {
         assertThat(assertContext.getText("Xml table function alias assertion error"), actual.getXmlTableFunctionAlias(), is(expected.getXmlTableFunctionAlias()));
     }
 
-    /**
-     * Assert actual xml table function segment is correct with expected xml table function.
-     *
-     * @param assertContext assert context
-     * @param actual actual xml table function
-     * @param expected expected xml table function
-     */
-    private static void assertXmlTableFunction(final SQLCaseAssertContext assertContext, final XmlTableFunctionSegment actual, final ExpectedXmlTableFunction expected) {
-        assertThat(assertContext.getText("Function name assertion error"), actual.getFunctionName(), is(expected.getFunctionName()));
-        assertThat(assertContext.getText("Function text assert error"), actual.getText(), is(expected.getText()));
-    }
-    
     /**
      * Assert actual table segment is correct with expected table.
      *
@@ -191,5 +179,17 @@ public final class TableAssert {
         } else {
             assertThat(assertContext.getText("Actual join-type should exist."), actual, is(expected));
         }
+    }
+
+    /**
+     * Assert actual xml table function segment is correct with expected xml table function.
+     *
+     * @param assertContext assert context
+     * @param actual actual xml table function
+     * @param expected expected xml table function
+     */
+    private static void assertXmlTableFunction(final SQLCaseAssertContext assertContext, final XmlTableFunctionSegment actual, final ExpectedXmlTableFunction expected) {
+        assertThat(assertContext.getText("Function name assertion error"), actual.getFunctionName(), is(expected.getFunctionName()));
+        assertThat(assertContext.getText("Function text assert error"), actual.getText(), is(expected.getText()));
     }
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/cases/parser/domain/segment/impl/expr/ExpectedXmlTableFunction.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/cases/parser/domain/segment/impl/expr/ExpectedXmlTableFunction.java
@@ -15,30 +15,24 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.table;
+package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.expr;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedSQLSegment;
 
-import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * Expected tables.
+ * Expected xml table function.
  */
 @Getter
 @Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+public final class ExpectedXmlTableFunction extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    @XmlAttribute(name = "function-name")
+    private String functionName;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
-    
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
-    
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    @XmlAttribute
+    private String text;
 }

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/cases/parser/domain/segment/impl/table/ExpectedXmlTable.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/cases/parser/domain/segment/impl/table/ExpectedXmlTable.java
@@ -20,25 +20,27 @@ package org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.s
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.AbstractExpectedDelimiterSQLSegment;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.domain.segment.impl.expr.ExpectedXmlTableFunction;
 
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 
 /**
- * Expected tables.
+ * Expected xml table.
  */
 @Getter
 @Setter
-public final class ExpectedTable extends AbstractExpectedDelimiterSQLSegment {
+public final class ExpectedXmlTable extends AbstractExpectedDelimiterSQLSegment {
     
-    @XmlElement(name = "simple-table")
-    private ExpectedSimpleTable simpleTable;
+    @XmlAttribute(name = "table-name")
+    private String tableName;
     
-    @XmlElement(name = "subquery-table")
-    private ExpectedSubqueryTable subqueryTable;
+    @XmlAttribute(name = "table-alias")
+    private String tableAlias;
     
-    @XmlElement(name = "join-table")
-    private ExpectedJoinTable joinTable;
+    @XmlElement(name = "xml-table-function")
+    private ExpectedXmlTableFunction xmlTableFunction;
     
-    @XmlElement(name = "xml-table")
-    private ExpectedXmlTable xmlTable;
+    @XmlAttribute(name = "xml-table-function-alias")
+    private String xmlTableFunctionAlias;
 }

--- a/test/parser/src/main/resources/case/dml/select.xml
+++ b/test/parser/src/main/resources/case/dml/select.xml
@@ -4778,4 +4778,21 @@
             <simple-table name="b" start-index="103" stop-index="103" />
         </from>
     </select>
+
+    <select sql-case-id="select_from_xmltable_function">
+        <projections start-index="7" stop-index="65">
+            <column-projection name="warehouse_name" alias="warehouse" start-index="7" stop-index="30" />
+            <column-projection name="Water" start-index="33" stop-index="48">
+                <owner name="warehouse2" start-index="33" stop-index="42" />
+            </column-projection>
+            <column-projection name="Rail" start-index="51" stop-index="65">
+                <owner name="warehouse2" start-index="51" stop-index="60" />
+            </column-projection>
+        </projections>
+        <from>
+            <xml-table table-name="warehouses" xml-table-function-alias="warehouse2" start-index="76" stop-index="238">
+                <xml-table-function function-name="XMLTABLE" text="XMLTABLE('/Warehouse' PASSING warehouses.warehouse_spec COLUMNS &quot;Water&quot; varchar2(6) PATH 'WaterAccess',&quot;Rail&quot; varchar2(6) PATH 'RailAccess')" start-index="88" stop-index="227" />
+            </xml-table>
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/parser/src/main/resources/sql/supported/dml/select.xml
@@ -154,4 +154,5 @@
     <sql-case id="select_xmlquery_function" value="SELECT XMLQUERY('//student[@age=20]' PASSING BY VALUE xcol AS x RETURNING CONTENT NULL ON EMPTY) FROM x_table;" db-types="Oracle" />
     <sql-case id="select_xmlroot_function" value="SELECT XMLROOT(XMLType('143598'), VERSION '1.0', STANDALONE YES) AS 'XMLROOT' FROM DUAL;" db-types="Oracle" />
     <sql-case id="select_xmlserialize_function" value="SELECT XMLSERIALIZE(DOCUMENT c2 AS BLOB ENCODING 'UTF-8' VERSION 'a' IDENT SIZE = 0 SHOW DEFAULT) FROM b;" db-types="Oracle" />
+    <sql-case id="select_from_xmltable_function" value="SELECT warehouse_name warehouse, warehouse2.Water, warehouse2.Rail FROM warehouses, XMLTABLE('/Warehouse' PASSING warehouses.warehouse_spec COLUMNS &quot;Water&quot; varchar2(6) PATH 'WaterAccess',&quot;Rail&quot; varchar2(6) PATH 'RailAccess') warehouse2;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #22362.

Ref: https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/XMLTABLE.html#GUID-C4A32C58-33E5-4CF1-A1FE-039550D3ECFA

<img width="838" alt="image" src="https://user-images.githubusercontent.com/57847965/203517069-bb5c4a02-b330-4a6c-9c8e-56b003cb4240.png">

### Btw:  
The Default string clause can only exist one in a XMLnamespaces clause(as figure shown below) we need to throw an exception when the user input more than one Default string clause in a XMLnamespaces. I have marked TODO in XMLnamespaces visitor.

![image](https://user-images.githubusercontent.com/57847965/203722659-12b77706-e4f7-4f5a-b00a-07df720014cf.png)


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
