### PR TITLE
Improve DistSQL DROP DB_DISCOVERY RULE

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/db-discovery.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/db-discovery.cn.md
@@ -51,7 +51,6 @@ property:
 - 重复的 `ruleName` 将无法被创建；
 - 正在被使用的 `discoveryType` 和 `discoveryHeartbeat` 无法被删除；
 - 带有 `-` 的命名在改动时需要使用 `" "`；
-- 移除 `discoveryRule` 时不会移除被该 `discoveryRule` 使用的 `discoveryType` 和 `discoveryHeartbeat`。
 
 ## 示例
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/db-discovery.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/db-discovery.en.md
@@ -51,7 +51,6 @@ property:
 - Duplicate `ruleName` will not be created
 - The `discoveryType` and `discoveryHeartbeat` being used cannot be deleted
 - Names with `-` need to use `" "` when changing
-- When removing the `discoveryRule`, the `discoveryType` and `discoveryHeartbeat` used by the `discoveryRule` will not be removed
 
 ## Example
 

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/DropDatabaseDiscoveryRuleStatementUpdaterTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/DropDatabaseDiscoveryRuleStatementUpdaterTest.java
@@ -107,8 +107,8 @@ public final class DropDatabaseDiscoveryRuleStatementUpdaterTest {
         DatabaseDiscoveryRuleConfiguration databaseDiscoveryRuleConfig = createCurrentRuleConfiguration();
         updater.updateCurrentRuleConfiguration(createSQLStatement(), databaseDiscoveryRuleConfig);
         assertTrue(databaseDiscoveryRuleConfig.getDataSources().isEmpty());
-        assertThat(databaseDiscoveryRuleConfig.getDiscoveryTypes().size(), is(0));
-        assertThat(databaseDiscoveryRuleConfig.getDiscoveryHeartbeats().size(), is(0));
+        assertTrue(databaseDiscoveryRuleConfig.getDiscoveryTypes().isEmpty());
+        assertTrue(databaseDiscoveryRuleConfig.getDiscoveryHeartbeats().isEmpty());
     }
     
     @Test
@@ -141,8 +141,8 @@ public final class DropDatabaseDiscoveryRuleStatementUpdaterTest {
         Map<String, AlgorithmConfiguration> discoveryTypes = new LinkedHashMap<>(1, 1);
         discoveryTypes.put("readwrite_ds_MGR", new AlgorithmConfiguration("readwrite_ds_MGR", new Properties()));
         Map<String, DatabaseDiscoveryHeartBeatConfiguration> discoveryHeartbeats = new LinkedHashMap<>(1, 1);
-        discoveryTypes.put("unused_heartbeat", new AlgorithmConfiguration("heartbeat", new Properties()));
-        return new DatabaseDiscoveryRuleConfiguration(new LinkedList<>(Collections.singleton(dataSourceRuleConfig)), Collections.emptyMap(), discoveryTypes);
+        discoveryHeartbeats.put("unused_heartbeat", new DatabaseDiscoveryHeartBeatConfiguration(new Properties()));
+        return new DatabaseDiscoveryRuleConfiguration(new LinkedList<>(Collections.singleton(dataSourceRuleConfig)), discoveryHeartbeats, discoveryTypes);
     }
     
     private DatabaseDiscoveryRuleConfiguration createMultipleCurrentRuleConfigurations() {

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/DropDatabaseDiscoveryRuleStatementUpdaterTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/DropDatabaseDiscoveryRuleStatementUpdaterTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.dbdiscovery.distsql.handler.update;
 
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
+import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryHeartBeatConfiguration;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.DropDatabaseDiscoveryRuleStatement;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.distsql.constant.ExportableConstants;
@@ -106,7 +107,8 @@ public final class DropDatabaseDiscoveryRuleStatementUpdaterTest {
         DatabaseDiscoveryRuleConfiguration databaseDiscoveryRuleConfig = createCurrentRuleConfiguration();
         updater.updateCurrentRuleConfiguration(createSQLStatement(), databaseDiscoveryRuleConfig);
         assertTrue(databaseDiscoveryRuleConfig.getDataSources().isEmpty());
-        assertThat(databaseDiscoveryRuleConfig.getDiscoveryTypes().size(), is(1));
+        assertThat(databaseDiscoveryRuleConfig.getDiscoveryTypes().size(), is(0));
+        assertThat(databaseDiscoveryRuleConfig.getDiscoveryHeartbeats().size(), is(0));
     }
     
     @Test
@@ -136,8 +138,10 @@ public final class DropDatabaseDiscoveryRuleStatementUpdaterTest {
     
     private DatabaseDiscoveryRuleConfiguration createCurrentRuleConfiguration() {
         DatabaseDiscoveryDataSourceRuleConfiguration dataSourceRuleConfig = new DatabaseDiscoveryDataSourceRuleConfiguration("ha_group", Collections.emptyList(), "ha_heartbeat", "readwrite_ds_MGR");
-        Map<String, AlgorithmConfiguration> discoveryTypes = Collections.singletonMap(
-                "readwrite_ds_MGR", new AlgorithmConfiguration("readwrite_ds_MGR", new Properties()));
+        Map<String, AlgorithmConfiguration> discoveryTypes = new LinkedHashMap<>(1, 1);
+        discoveryTypes.put("readwrite_ds_MGR", new AlgorithmConfiguration("readwrite_ds_MGR", new Properties()));
+        Map<String, DatabaseDiscoveryHeartBeatConfiguration> discoveryHeartbeats = new LinkedHashMap<>(1, 1);
+        discoveryTypes.put("unused_heartbeat", new AlgorithmConfiguration("heartbeat", new Properties()));
         return new DatabaseDiscoveryRuleConfiguration(new LinkedList<>(Collections.singleton(dataSourceRuleConfig)), Collections.emptyMap(), discoveryTypes);
     }
     


### PR DESCRIPTION
For #22358.

Changes proposed in this pull request:
  - Remove unused discovery type and discovery heartbeat while dropping DB discovery rule
  - Add related test cases
  - Update doucument

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
