### PR TITLE
Improve DistSQL DROP DEFAULT SHARDING (DATABASE | TABLE) STRATEGY

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AbstractDropShardingRuleUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AbstractDropShardingRuleUpdater.java
@@ -31,11 +31,11 @@ import java.util.stream.Collectors;
 public abstract class AbstractDropShardingRuleUpdater {
     
     /**
-     * Drop unused algorithms.
+     * Drop unused algorithm.
      * 
      * @param currentRuleConfig current sharding rule configuration
      */
-    public void dropUnusedAlgorithms(final ShardingRuleConfiguration currentRuleConfig) {
+    public void dropUnusedAlgorithm(final ShardingRuleConfiguration currentRuleConfig) {
         Collection<String> inUsedAlgorithms = currentRuleConfig.getTables().stream().map(each -> Arrays.asList(each.getTableShardingStrategy(), each.getDatabaseShardingStrategy()))
                 .flatMap(Collection::stream).filter(Objects::nonNull).map(ShardingStrategyConfiguration::getShardingAlgorithmName).collect(Collectors.toSet());
         inUsedAlgorithms.addAll(currentRuleConfig.getAutoTables().stream().map(each -> each.getShardingStrategy().getShardingAlgorithmName()).collect(Collectors.toSet()));

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AbstractDropShardingRuleUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/AbstractDropShardingRuleUpdater.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.distsql.handler.update;
+
+import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Abstract drop sharding table rule updater.
+ */
+public abstract class AbstractDropShardingRuleUpdater {
+    
+    /**
+     * Drop unused algorithms.
+     * 
+     * @param currentRuleConfig current sharding rule configuration
+     */
+    public void dropUnusedAlgorithms(final ShardingRuleConfiguration currentRuleConfig) {
+        Collection<String> inUsedAlgorithms = currentRuleConfig.getTables().stream().map(each -> Arrays.asList(each.getTableShardingStrategy(), each.getDatabaseShardingStrategy()))
+                .flatMap(Collection::stream).filter(Objects::nonNull).map(ShardingStrategyConfiguration::getShardingAlgorithmName).collect(Collectors.toSet());
+        inUsedAlgorithms.addAll(currentRuleConfig.getAutoTables().stream().map(each -> each.getShardingStrategy().getShardingAlgorithmName()).collect(Collectors.toSet()));
+        if (null != currentRuleConfig.getDefaultTableShardingStrategy()) {
+            inUsedAlgorithms.add(currentRuleConfig.getDefaultTableShardingStrategy().getShardingAlgorithmName());
+        }
+        if (null != currentRuleConfig.getDefaultDatabaseShardingStrategy()) {
+            inUsedAlgorithms.add(currentRuleConfig.getDefaultDatabaseShardingStrategy().getShardingAlgorithmName());
+        }
+        Collection<String> unusedAlgorithms = currentRuleConfig.getShardingAlgorithms().keySet().stream().filter(each -> !inUsedAlgorithms.contains(each)).collect(Collectors.toSet());
+        unusedAlgorithms.forEach(each -> currentRuleConfig.getShardingAlgorithms().remove(each));
+    }
+}

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 /**
  * Drop sharding table rule statement updater.
  */
-public final class DropDefaultStrategyStatementUpdater implements RuleDefinitionDropUpdater<DropDefaultShardingStrategyStatement, ShardingRuleConfiguration> {
+public final class DropDefaultStrategyStatementUpdater extends AbstractDropShardingRuleUpdater implements RuleDefinitionDropUpdater<DropDefaultShardingStrategyStatement, ShardingRuleConfiguration> {
     
     @Override
     public void checkSQLStatement(final ShardingSphereDatabase database, final DropDefaultShardingStrategyStatement sqlStatement,
@@ -79,6 +79,7 @@ public final class DropDefaultStrategyStatementUpdater implements RuleDefinition
         } else {
             currentRuleConfig.setDefaultDatabaseShardingStrategy(null);
         }
+        dropUnusedAlgorithms(currentRuleConfig);
         return false;
     }
     

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropDefaultStrategyStatementUpdater.java
@@ -79,7 +79,7 @@ public final class DropDefaultStrategyStatementUpdater extends AbstractDropShard
         } else {
             currentRuleConfig.setDefaultDatabaseShardingStrategy(null);
         }
-        dropUnusedAlgorithms(currentRuleConfig);
+        dropUnusedAlgorithm(currentRuleConfig);
         return false;
     }
     

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingTableRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingTableRuleStatementUpdater.java
@@ -114,7 +114,7 @@ public final class DropShardingTableRuleStatementUpdater extends AbstractDropSha
     public boolean updateCurrentRuleConfiguration(final DropShardingTableRuleStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
         Collection<String> toBeDroppedShardingTableNames = getToBeDroppedShardingTableNames(sqlStatement);
         toBeDroppedShardingTableNames.forEach(each -> dropShardingTable(currentRuleConfig, each));
-        dropUnusedAlgorithms(currentRuleConfig);
+        dropUnusedAlgorithm(currentRuleConfig);
         dropUnusedKeyGenerator(currentRuleConfig);
         dropUnusedAuditor(currentRuleConfig);
         return false;

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingTableRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/DropShardingTableRuleStatementUpdater.java
@@ -28,10 +28,8 @@ import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.keygen.KeyGenerateStrategyConfiguration;
-import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.DropShardingTableRuleStatement;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -41,7 +39,7 @@ import java.util.stream.Collectors;
 /**
  * Drop sharding table rule statement updater.
  */
-public final class DropShardingTableRuleStatementUpdater implements RuleDefinitionDropUpdater<DropShardingTableRuleStatement, ShardingRuleConfiguration> {
+public final class DropShardingTableRuleStatementUpdater extends AbstractDropShardingRuleUpdater implements RuleDefinitionDropUpdater<DropShardingTableRuleStatement, ShardingRuleConfiguration> {
     
     @Override
     public void checkSQLStatement(final ShardingSphereDatabase database,
@@ -121,21 +119,7 @@ public final class DropShardingTableRuleStatementUpdater implements RuleDefiniti
         dropUnusedAuditor(currentRuleConfig);
         return false;
     }
-    
-    private void dropUnusedAlgorithms(final ShardingRuleConfiguration currentRuleConfig) {
-        Collection<String> inUsedAlgorithms = currentRuleConfig.getTables().stream().map(each -> Arrays.asList(each.getTableShardingStrategy(), each.getDatabaseShardingStrategy()))
-                .flatMap(Collection::stream).filter(Objects::nonNull).map(ShardingStrategyConfiguration::getShardingAlgorithmName).collect(Collectors.toSet());
-        inUsedAlgorithms.addAll(currentRuleConfig.getAutoTables().stream().map(each -> each.getShardingStrategy().getShardingAlgorithmName()).collect(Collectors.toSet()));
-        if (null != currentRuleConfig.getDefaultTableShardingStrategy()) {
-            inUsedAlgorithms.add(currentRuleConfig.getDefaultTableShardingStrategy().getShardingAlgorithmName());
-        }
-        if (null != currentRuleConfig.getDefaultDatabaseShardingStrategy()) {
-            inUsedAlgorithms.add(currentRuleConfig.getDefaultDatabaseShardingStrategy().getShardingAlgorithmName());
-        }
-        Collection<String> unusedAlgorithms = currentRuleConfig.getShardingAlgorithms().keySet().stream().filter(each -> !inUsedAlgorithms.contains(each)).collect(Collectors.toSet());
-        unusedAlgorithms.forEach(each -> currentRuleConfig.getShardingAlgorithms().remove(each));
-    }
-    
+
     private void dropUnusedKeyGenerator(final ShardingRuleConfiguration currentRuleConfig) {
         Collection<String> inUsedKeyGenerators = currentRuleConfig.getTables().stream().map(ShardingTableRuleConfiguration::getKeyGenerateStrategy).filter(Objects::nonNull)
                 .map(KeyGenerateStrategyConfiguration::getKeyGeneratorName).collect(Collectors.toSet());

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropDefaultShardingStrategyStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/DropDefaultShardingStrategyStatementUpdaterTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.sharding.distsql.update;
 
+import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.distsql.exception.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
@@ -29,7 +30,14 @@ import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public final class DropDefaultShardingStrategyStatementUpdaterTest {
@@ -60,6 +68,15 @@ public final class DropDefaultShardingStrategyStatementUpdaterTest {
         ShardingRuleConfiguration currentRuleConfig = createCurrentRuleConfiguration();
         updater.updateCurrentRuleConfiguration(createSQLStatement("Database"), currentRuleConfig);
         assertNull(currentRuleConfig.getDefaultDatabaseShardingStrategy());
+        assertTrue(currentRuleConfig.getShardingAlgorithms().isEmpty());
+    }
+    
+    @Test
+    public void assertUpdateCurrentRuleConfigurationWithInUsedAlgorithm() {
+        ShardingRuleConfiguration currentRuleConfig = createMultipleCurrentRuleConfiguration();
+        updater.updateCurrentRuleConfiguration(createSQLStatement("Table"), currentRuleConfig);
+        assertNull(currentRuleConfig.getDefaultTableShardingStrategy());
+        assertThat(currentRuleConfig.getShardingAlgorithms().size(), is(1));
     }
     
     private DropDefaultShardingStrategyStatement createSQLStatement(final String defaultType) {
@@ -69,6 +86,19 @@ public final class DropDefaultShardingStrategyStatementUpdaterTest {
     private ShardingRuleConfiguration createCurrentRuleConfiguration() {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
         result.setDefaultDatabaseShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "algorithm_name"));
+        Map<String, AlgorithmConfiguration> stringAlgorithms = new LinkedHashMap<>();
+        stringAlgorithms.put("algorithm_name", new AlgorithmConfiguration("INLINE", new Properties()));
+        result.setShardingAlgorithms(stringAlgorithms);
+        return result;
+    }
+    
+    private ShardingRuleConfiguration createMultipleCurrentRuleConfiguration() {
+        ShardingRuleConfiguration result = new ShardingRuleConfiguration();
+        result.setDefaultDatabaseShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "algorithm_name"));
+        result.setDefaultTableShardingStrategy(new StandardShardingStrategyConfiguration("user_id", "algorithm_name"));
+        Map<String, AlgorithmConfiguration> stringAlgorithms = new LinkedHashMap<>();
+        stringAlgorithms.put("algorithm_name", new AlgorithmConfiguration("INLINE", new Properties()));
+        result.setShardingAlgorithms(stringAlgorithms);
         return result;
     }
 }


### PR DESCRIPTION
For #22358.

Changes proposed in this pull request:
  - Remove unused algorithms while dropping the default sharding strategy
  - Add related test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
