### PR TITLE
Use is() to replace containsString()

### DIFF
--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/converter/ReadwriteSplittingRuleStatementConverterTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/converter/ReadwriteSplittingRuleStatementConverterTest.java
@@ -32,10 +32,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public final class ReadwriteSplittingRuleStatementConverterTest {
@@ -68,7 +67,7 @@ public final class ReadwriteSplittingRuleStatementConverterTest {
         String actualLoadBalancerName = actualSingleRuleSegmentConvertResultLoadBalancers.keySet().iterator().next();
         assertThat(actualLoadBalancerName, is(expectedLoadBalancerName));
         AlgorithmConfiguration actualSphereAlgorithmConfig = actualSingleRuleSegmentConvertResultLoadBalancers.get(actualLoadBalancerName);
-        assertThat(actualSphereAlgorithmConfig.getType(), containsString(expectedSingleReadwriteSplittingRuleSegment.getLoadBalancer()));
+        assertThat(actualSphereAlgorithmConfig.getType(), is(expectedSingleReadwriteSplittingRuleSegment.getLoadBalancer()));
         assertThat(actualSphereAlgorithmConfig.getProps(), is(expectedSingleReadwriteSplittingRuleSegment.getProps()));
     }
     
@@ -96,7 +95,7 @@ public final class ReadwriteSplittingRuleStatementConverterTest {
                             null == expectedReadwriteSplittingRuleSegment.getReadDataSources() ? Collections.emptyList() : expectedReadwriteSplittingRuleSegment.getReadDataSources()));
                     assertTrue(actualMultipleRuleSegmentConvertResultLoadBalancers.containsKey(expectedLoadBalancerName));
                     AlgorithmConfiguration actualSphereAlgorithmConfig = actualMultipleRuleSegmentConvertResultLoadBalancers.get(actualRuleConfig.getLoadBalancerName());
-                    assertThat(actualSphereAlgorithmConfig.getType(), containsString(expectedReadwriteSplittingRuleSegment.getLoadBalancer()));
+                    assertThat(actualSphereAlgorithmConfig.getType(), is(expectedReadwriteSplittingRuleSegment.getLoadBalancer()));
                     assertThat(actualSphereAlgorithmConfig.getProps(), is(expectedReadwriteSplittingRuleSegment.getProps()));
                 });
     }

--- a/kernel/parser/distsql/handler/src/test/java/org/apache/shardingsphere/parser/distsql/handler/query/SQLParserRuleQueryResultSetTest.java
+++ b/kernel/parser/distsql/handler/src/test/java/org/apache/shardingsphere/parser/distsql/handler/query/SQLParserRuleQueryResultSetTest.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Optional;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
@@ -51,11 +50,9 @@ public final class SQLParserRuleQueryResultSetTest {
         assertThat(rowData.next(), is(Boolean.TRUE.toString()));
         String parseTreeCache = (String) rowData.next();
         assertFalse(resultSet.next());
-        assertThat(parseTreeCache, containsString("initialCapacity: 128"));
-        assertThat(parseTreeCache, containsString("maximumSize: 1024"));
+        assertThat(parseTreeCache, is("initialCapacity: 128, maximumSize: 1024"));
         String sqlStatementCache = (String) rowData.next();
-        assertThat(sqlStatementCache, containsString("initialCapacity: 2000"));
-        assertThat(sqlStatementCache, containsString("maximumSize: 65535"));
+        assertThat(sqlStatementCache, is("initialCapacity: 2000, maximumSize: 65535"));
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:
  - Use is() to replace containsString()
  -
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
