### PR TITLE
Fix unit test documentation typo

### DIFF
--- a/docs/community/content/involved/conduct/code.cn.md
+++ b/docs/community/content/involved/conduct/code.cn.md
@@ -83,7 +83,7 @@ chapter = true
  - 单数据断言，应使用 `assertTrue`，`assertFalse`，`assertNull` 和 `assertNotNull`。
  - 多数据断言，应使用 `assertThat`。
  - 精确断言，尽量不使用 `not`，`containsString` 断言。
- - 测试用例的真实值应名为为 actual XXX，期望值应命名为 expected XXX。
+ - 测试用例的真实值应命名为 actual XXX，期望值应命名为 expected XXX。
  - 测试类和 `@Test` 标注的方法无需 javadoc。
  - 使用 Mockito mockStatic 和 mockConstruction 方法必须搭配 try-with-resource 或在清理方法中关闭，避免泄漏。
 


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix unit test documentation typo
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
