### PR TITLE
Support select join using projection in ResultSetMetaData for MySQL

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -29,10 +29,12 @@ import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.Sho
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.SubqueryProjection;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeEngine;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
+import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationDistinctProjectionSegment;
@@ -187,17 +189,29 @@ public final class ProjectionEngine {
             return Collections.emptyList();
         }
         JoinTableSegment joinTable = (JoinTableSegment) table;
-        Collection<Projection> projections = new LinkedList<>();
-        createProjection(joinTable.getLeft(), projectionSegment).ifPresent(projections::add);
-        createProjection(joinTable.getRight(), projectionSegment).ifPresent(projections::add);
         Collection<Projection> result = new LinkedList<>();
-        for (Projection each : projections) {
+        Collection<Projection> remainingProjections = new LinkedList<>();
+        for (Projection each : getOriginalProjections(joinTable, projectionSegment)) {
+            Collection<Projection> actualProjections = getActualProjections(Collections.singletonList(each));
             if (joinTable.getUsing().isEmpty() || (null != owner && each.getExpression().contains(owner))) {
-                result.addAll(getActualProjections(Collections.singletonList(each)));
+                result.addAll(actualProjections);
             } else {
-                result.addAll(getJoinUsingActualProjections(projections, joinTable.getUsing()));
+                remainingProjections.addAll(actualProjections);
             }
         }
+        result.addAll(getUsingActualProjections(remainingProjections, getUsingColumnNames(joinTable.getUsing())));
+        return result;
+    }
+    
+    private Collection<Projection> getOriginalProjections(final JoinTableSegment joinTable, final ProjectionSegment projectionSegment) {
+        Collection<Projection> result = new LinkedList<>();
+        if (databaseType instanceof MySQLDatabaseType && !joinTable.getUsing().isEmpty() && JoinType.RIGHT.name().equalsIgnoreCase(joinTable.getJoinType())) {
+            createProjection(joinTable.getRight(), projectionSegment).ifPresent(result::add);
+            createProjection(joinTable.getLeft(), projectionSegment).ifPresent(result::add);
+            return result;
+        }
+        createProjection(joinTable.getLeft(), projectionSegment).ifPresent(result::add);
+        createProjection(joinTable.getRight(), projectionSegment).ifPresent(result::add);
         return result;
     }
     
@@ -215,15 +229,6 @@ public final class ProjectionEngine {
         return result;
     }
     
-    private Collection<Projection> getJoinUsingActualProjections(final Collection<Projection> projections, final List<ColumnSegment> usingColumns) {
-        Collection<Projection> result = new LinkedList<>();
-        Collection<Projection> actualColumns = getActualProjections(projections);
-        Collection<String> usingColumnNames = getUsingColumnNames(usingColumns);
-        result.addAll(getJoinUsingColumns(actualColumns, usingColumnNames));
-        result.addAll(getRemainingColumns(actualColumns, usingColumnNames));
-        return result;
-    }
-    
     private Collection<String> getUsingColumnNames(final List<ColumnSegment> usingColumns) {
         Collection<String> result = new LinkedHashSet<>();
         for (ColumnSegment each : usingColumns) {
@@ -232,10 +237,34 @@ public final class ProjectionEngine {
         return result;
     }
     
-    private Collection<Projection> getJoinUsingColumns(final Collection<Projection> actualColumns, final Collection<String> usingColumnNames) {
+    private Collection<Projection> getUsingActualProjections(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
+        Collection<Projection> result = new LinkedList<>();
+        if (databaseType instanceof MySQLDatabaseType) {
+            result.addAll(getJoinUsingColumnsByOriginalColumnSequence(actualProjections, usingColumnNames));
+        } else {
+            result.addAll(getJoinUsingColumnsByUsingColumnSequence(actualProjections, usingColumnNames));
+        }
+        result.addAll(getRemainingColumns(actualProjections, usingColumnNames));
+        return result;
+    }
+    
+    private Collection<Projection> getJoinUsingColumnsByOriginalColumnSequence(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
+        Collection<Projection> result = new LinkedList<>();
+        for (Projection each : actualProjections) {
+            if (result.size() == usingColumnNames.size()) {
+                return result;
+            }
+            if (usingColumnNames.contains(each.getColumnLabel().toLowerCase())) {
+                result.add(each);
+            }
+        }
+        return result;
+    }
+    
+    private Collection<Projection> getJoinUsingColumnsByUsingColumnSequence(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
         Collection<Projection> result = new LinkedList<>();
         for (String each : usingColumnNames) {
-            for (Projection projection : actualColumns) {
+            for (Projection projection : actualProjections) {
                 if (each.equals(projection.getColumnLabel().toLowerCase())) {
                     result.add(projection);
                     break;
@@ -245,9 +274,9 @@ public final class ProjectionEngine {
         return result;
     }
     
-    private Collection<Projection> getRemainingColumns(final Collection<Projection> actualColumns, final Collection<String> usingColumnNames) {
+    private Collection<Projection> getRemainingColumns(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
         Collection<Projection> result = new LinkedList<>();
-        for (Projection each : actualColumns) {
+        for (Projection each : actualProjections) {
             if (usingColumnNames.contains(each.getColumnLabel().toLowerCase())) {
                 continue;
             }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -54,7 +54,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -199,7 +198,7 @@ public final class ProjectionEngine {
                 remainingProjections.addAll(actualProjections);
             }
         }
-        result.addAll(getUsingActualProjections(remainingProjections, getUsingColumnNames(joinTable.getUsing())));
+        result.addAll(getUsingActualProjections(remainingProjections, joinTable.getUsing()));
         return result;
     }
     
@@ -229,15 +228,11 @@ public final class ProjectionEngine {
         return result;
     }
     
-    private Collection<String> getUsingColumnNames(final List<ColumnSegment> usingColumns) {
-        Collection<String> result = new LinkedHashSet<>();
-        for (ColumnSegment each : usingColumns) {
-            result.add(each.getIdentifier().getValue().toLowerCase());
+    private Collection<Projection> getUsingActualProjections(final Collection<Projection> actualProjections, final Collection<ColumnSegment> usingColumns) {
+        if (usingColumns.isEmpty()) {
+            return Collections.emptyList();
         }
-        return result;
-    }
-    
-    private Collection<Projection> getUsingActualProjections(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
+        Collection<String> usingColumnNames = getUsingColumnNames(usingColumns);
         Collection<Projection> result = new LinkedList<>();
         if (databaseType instanceof MySQLDatabaseType) {
             result.addAll(getJoinUsingColumnsByOriginalColumnSequence(actualProjections, usingColumnNames));
@@ -245,6 +240,14 @@ public final class ProjectionEngine {
             result.addAll(getJoinUsingColumnsByUsingColumnSequence(actualProjections, usingColumnNames));
         }
         result.addAll(getRemainingColumns(actualProjections, usingColumnNames));
+        return result;
+    }
+    
+    private Collection<String> getUsingColumnNames(final Collection<ColumnSegment> usingColumns) {
+        Collection<String> result = new LinkedHashSet<>();
+        for (ColumnSegment each : usingColumns) {
+            result.add(each.getIdentifier().getValue().toLowerCase());
+        }
         return result;
     }
     

--- a/test/integration-test/test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -376,8 +376,7 @@
         <assertion parameters="1000:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <!-- TODO support mysql using condition -->
-    <test-case sql="SELECT i.* FROM t_order o JOIN t_order_item i USING(order_id) WHERE o.order_id = ?" db-types="PostgreSQL" scenario-types="tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+    <test-case sql="SELECT i.* FROM t_order o JOIN t_order_item i USING(order_id) WHERE o.order_id = ?" db-types="MySQL,PostgreSQL" scenario-types="tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="1000:int" expected-data-source-name="read_dataset" />
     </test-case>
     
@@ -653,12 +652,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <!-- TODO support MySQL USING statement -->
-    <test-case sql="SELECT * FROM t_order o INNER JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o INNER JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_order o INNER JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7 LIMIT 1, 2" db-types="openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o INNER JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7 LIMIT 1, 2" db-types="MySQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
@@ -691,10 +689,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_order o LEFT JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o LEFT JOIN t_order_item i USING(order_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <!-- TODO support MySQL using statement when calcite support right join using -->
     <test-case sql="SELECT * FROM t_order o RIGHT JOIN t_order_item i USING(order_id) WHERE i.user_id = ? ORDER BY i.item_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
@@ -703,11 +702,11 @@
         <assertion parameters="10:int, 10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <test-case sql="SELECT * FROM t_order o INNER JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o INNER JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_order o INNER JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id LIMIT 1, 2" db-types="openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o INNER JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id LIMIT 1, 2" db-types="MySQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
@@ -739,10 +738,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_order o LEFT JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_order o LEFT JOIN t_merchant m USING(merchant_id) WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <!-- TODO support MySQL using statement when calcite support right join using -->
     <test-case sql="SELECT * FROM t_order o RIGHT JOIN t_merchant m USING(merchant_id) WHERE m.country_id = 1 ORDER BY o.order_id, m.merchant_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
@@ -751,11 +751,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
     
-    <test-case sql="SELECT * FROM t_product p INNER JOIN t_product_detail d USING(product_id) WHERE p.product_id > ? ORDER BY p.product_id DESC" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_product p INNER JOIN t_product_detail d USING(product_id) WHERE p.product_id > ? ORDER BY p.product_id DESC" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_product p INNER JOIN t_product_detail d USING(product_id) WHERE p.product_id > ? ORDER BY p.product_id DESC LIMIT 2, 5" db-types="openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_product p INNER JOIN t_product_detail d USING(product_id) WHERE p.product_id > ? ORDER BY p.product_id DESC LIMIT 2, 5" db-types="MySQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
@@ -779,10 +779,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_product p LEFT JOIN t_product_detail d USING(product_id) WHERE p.category_id = ? ORDER BY p.product_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
+    <test-case sql="SELECT * FROM t_product p LEFT JOIN t_product_detail d USING(product_id) WHERE p.category_id = ? ORDER BY p.product_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <!-- TODO support MySQL using statement when calcite support right join using -->
     <test-case sql="SELECT * FROM t_product p RIGHT JOIN t_product_detail d USING(product_id) WHERE d.detail_id = ? ORDER BY d.product_id, 7" db-types="PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>


### PR DESCRIPTION
Fixes #22355.

Changes proposed in this pull request:
  - support select join using projection in ResultSetMetaData for MySQL
  - add unit test for ProjectionEngine
  - add integration test case for MySQL

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
