### PR TITLE
Support MySQL, PostgreSQL and openGauss natural join sql statement convert to sql node

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/JoinTableConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/JoinTableConverter.java
@@ -47,7 +47,7 @@ public final class JoinTableConverter implements SQLSegmentConverter<JoinTableSe
         Optional<SqlNode> condition = convertJoinCondition(segment);
         SqlLiteral conditionType = convertConditionType(segment);
         SqlLiteral joinType = JoinType.valueOf(segment.getJoinType()).symbol(SqlParserPos.ZERO);
-        return Optional.of(new SqlJoin(SqlParserPos.ZERO, left, SqlLiteral.createBoolean(false, SqlParserPos.ZERO), joinType, right, conditionType, condition.orElse(null)));
+        return Optional.of(new SqlJoin(SqlParserPos.ZERO, left, SqlLiteral.createBoolean(segment.isNatural(), SqlParserPos.ZERO), joinType, right, conditionType, condition.orElse(null)));
     }
     
     private static SqlLiteral convertConditionType(final JoinTableSegment segment) {

--- a/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
+++ b/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
@@ -37,10 +37,10 @@ import org.apache.shardingsphere.sql.parser.api.SQLVisitorEngine;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.dialect.OptimizerSQLDialectBuilderFactory;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.SQLNodeConverterEngine;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.sql.registry.SQLCasesRegistry;
-import org.apache.shardingsphere.test.sql.parser.internal.cases.sql.domain.SQLCaseType;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.registry.SQLParserTestCasesRegistry;
 import org.apache.shardingsphere.test.sql.parser.internal.cases.parser.registry.SQLParserTestCasesRegistryFactory;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.sql.domain.SQLCaseType;
+import org.apache.shardingsphere.test.sql.parser.internal.cases.sql.registry.SQLCasesRegistry;
 import org.apache.shardingsphere.test.sql.parser.internal.loader.SQLCasesLoader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -140,6 +140,11 @@ public final class SQLNodeConverterEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_minus_order_by");
         SUPPORTED_SQL_CASE_IDS.add("select_minus_order_by_limit");
         SUPPORTED_SQL_CASE_IDS.add("select_projections_with_only_expr_for_postgres");
+        SUPPORTED_SQL_CASE_IDS.add("select_natural_join");
+        SUPPORTED_SQL_CASE_IDS.add("select_natural_inner_join");
+        SUPPORTED_SQL_CASE_IDS.add("select_natural_left_join");
+        SUPPORTED_SQL_CASE_IDS.add("select_natural_right_join");
+        SUPPORTED_SQL_CASE_IDS.add("select_natural_full_join");
     }
     // CHECKSTYLE:ON
     


### PR DESCRIPTION
Ref #22359.

Changes proposed in this pull request:
  - support MySQL, PostgreSQL and openGauss natural join sql statement convert to sql node
  - add sql node convert test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
