### PR TITLE
Add support for `java.sql.Date` in IntervalShardingAlgorithm

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithm.java
@@ -332,6 +332,9 @@ public final class IntervalShardingAlgorithm implements StandardShardingAlgorith
         if (endpoint instanceof TemporalAccessor) {
             return dateTimeFormatter.format((TemporalAccessor) endpoint);
         }
+        if (endpoint instanceof java.sql.Date) {
+            return dateTimeFormatter.format(((java.sql.Date) endpoint).toLocalDate().atStartOfDay(ZoneId.systemDefault()));
+        }
         if (endpoint instanceof Date) {
             return dateTimeFormatter.format(((Date) endpoint).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime());
         }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/sharding/datetime/IntervalShardingAlgorithmTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.sharding.factory.ShardingAlgorithmFactory;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -447,5 +448,14 @@ public final class IntervalShardingAlgorithmTest {
         Collection<String> actualAsMonthString = shardingAlgorithmByMonthInJSR310.doSharding(availableTablesForMonthInJSR310DataSources,
                 new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO, Range.closed("04", "10")));
         assertThat(actualAsMonthString.size(), is(4));
+    }
+
+    @Test
+    public void assertDateInSqlDate() {
+        Collection<String> actualAsLocalDate = shardingAlgorithmByJDBCDate.doSharding(availableTablesForJDBCDateDataSources,
+                new RangeShardingValue<>("t_order", "create_time", DATA_NODE_INFO,
+                        Range.closed(new Date(LocalDate.of(2021, 6, 15).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()),
+                                new Date(LocalDate.of(2021, 7, 31).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()))));
+        assertThat(actualAsLocalDate.size(), is(24));
     }
 }


### PR DESCRIPTION
For https://github.com/apache/shardingsphere/issues/21347#issuecomment-1330025024 .

Changes proposed in this pull request:
  - Add support for `java.sql.Date` in IntervalShardingAlgorithm
  - Add the corresponding unit test.
  - Refer to #20255 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
