### PR TITLE
Add t_merchant standard table in encrypt_and_readwrite_splitting scenario

### DIFF
--- a/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/count_single_table_rule.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/count_single_table_rule.xml
@@ -21,5 +21,5 @@
         <column name="database" />
         <column name="count" />
     </metadata>
-    <row values="single_table| encrypt_and_readwrite_splitting| 10" />
+    <row values="single_table| encrypt_and_readwrite_splitting| 11" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_encrypt_rules.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_encrypt_rules.xml
@@ -35,4 +35,6 @@
     <row values="t_user_details| number_new| | number_new_cipher| | number_new_plain| | | | AES| aes-key-value=123456abc| true" />
     <row values="t_user_encrypt_federate| pwd| | cipher_pwd| | plain_pwd| | | | AES| aes-key-value=123456abc| true" />
     <row values="t_user_encrypt_federate_sharding| pwd| | cipher_pwd| | plain_pwd| | | | AES| aes-key-value=123456abc| true" />
+    <row values="t_merchant| business_code| | business_code_cipher| | business_code_plain| | | | AES| aes-key-value=123456abc| true" />
+    <row values="t_merchant| telephone| | telephone_cipher| | telephone_plain| | | | AES| aes-key-value=123456abc| true" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_single_tables.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/encrypt_and_readwrite_splitting/show_single_tables.xml
@@ -20,6 +20,7 @@
         <column name="table_name" />
         <column name="resource_name" />
     </metadata>
+    <row values="t_merchant| readwrite_ds" />
     <row values="t_order_federate| readwrite_ds" />
     <row values="t_order_federate_sharding| readwrite_ds" />
     <row values="t_order_item_federate| readwrite_ds" />

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/dataset.xml
@@ -73,6 +73,14 @@
         <column name="user_id" type="numeric" />
         <column name="information" type="varchar" />
     </metadata>
+    <metadata data-nodes="encrypt_write_ds.t_merchant,encrypt_read_ds.t_merchant">
+        <column name="merchant_id" type="numeric" />
+        <column name="country_id" type="numeric" />
+        <column name="merchant_name" type="varchar" />
+        <column name="business_code" type="varchar" />
+        <column name="telephone" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="encrypt_write_ds.t_single_table" values="1, 0, init" />
     <row data-node="encrypt_write_ds.t_single_table" values="2, 11, init" />
     <row data-node="encrypt_write_ds.t_single_table" values="3, 22, init" />
@@ -307,6 +315,26 @@
     <row data-node="encrypt_write_ds.t_user_encrypt_federate" values="3, plain password4, uqObdVp9XTGZ4Mnw0LolHg==, Ross" />
     <row data-node="encrypt_write_ds.t_user_encrypt_federate" values="4, plain password5, uqObdVp9XTGZ4Mnw0LolHg==, Chandler" />
     <row data-node="encrypt_write_ds.t_user_encrypt_federate" values="5, plain password6, uqObdVp9XTGZ4Mnw0LolHg==, Joey" />
+    <row data-node="encrypt_write_ds.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="encrypt_write_ds.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
     <row data-node="encrypt_read_ds.t_single_table" values="1, 0, init_read" />
     <row data-node="encrypt_read_ds.t_single_table" values="2, 11, init_read" />
     <row data-node="encrypt_read_ds.t_single_table" values="3, 22, init_read" />
@@ -541,4 +569,24 @@
     <row data-node="encrypt_read_ds.t_user_encrypt_federate" values="3, plain password4, uqObdVp9XTGZ4Mnw0LolHg==, Ross" />
     <row data-node="encrypt_read_ds.t_user_encrypt_federate" values="4, plain password5, uqObdVp9XTGZ4Mnw0LolHg==, Chandler" />
     <row data-node="encrypt_read_ds.t_user_encrypt_federate" values="5, plain password6, uqObdVp9XTGZ4Mnw0LolHg==, Joey" />
+    <row data-node="encrypt_read_ds.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="encrypt_read_ds.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_read_ds-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_read_ds-init.sql
@@ -23,6 +23,7 @@ DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_order_federate;
 DROP TABLE IF EXISTS t_single_table;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
@@ -32,3 +33,4 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_write_ds-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/h2/actual-encrypt_write_ds-init.sql
@@ -23,6 +23,7 @@ DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
 DROP TABLE IF EXISTS t_order_federate;
 DROP TABLE IF EXISTS t_single_table;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
@@ -32,3 +33,4 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
@@ -34,6 +34,7 @@ CREATE TABLE encrypt_write_ds.t_order_federate_sharding (order_id_sharding INT N
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_write_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_write_ds.t_user (user_id);
 
 CREATE TABLE encrypt_read_ds.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
@@ -46,4 +47,5 @@ CREATE TABLE encrypt_read_ds.t_order_federate_sharding (order_id_sharding INT NO
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_read_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_read_ds.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -33,6 +33,7 @@ DROP TABLE IF EXISTS t_order_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
@@ -44,6 +45,7 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
 \c encrypt_read_ds
@@ -58,6 +60,7 @@ DROP TABLE IF EXISTS t_order_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
@@ -69,4 +72,5 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/oracle/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/oracle/01-actual-init.sql
@@ -31,6 +31,7 @@ CREATE TABLE encrypt_write_ds.t_order_federate_sharding (order_id_sharding INT N
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_write_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_write_ds.t_user (user_id);
 
 CREATE TABLE encrypt_read_ds.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
@@ -43,4 +44,5 @@ CREATE TABLE encrypt_read_ds.t_order_federate_sharding (order_id_sharding INT NO
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_read_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_read_ds.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -33,6 +33,7 @@ DROP TABLE IF EXISTS t_order_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
@@ -44,6 +45,7 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
 \c encrypt_read_ds
@@ -58,6 +60,7 @@ DROP TABLE IF EXISTS t_order_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
@@ -69,4 +72,5 @@ CREATE TABLE t_order_federate_sharding (order_id_sharding INT NOT NULL, user_id 
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/sqlserver/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/actual/init-sql/sqlserver/01-actual-init.sql
@@ -31,6 +31,7 @@ CREATE TABLE encrypt_write_ds.t_order_federate_sharding (order_id_sharding INT N
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_write_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_write_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_write_ds.t_user (user_id);
 
 CREATE TABLE encrypt_read_ds.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
@@ -43,4 +44,5 @@ CREATE TABLE encrypt_read_ds.t_order_federate_sharding (order_id_sharding INT NO
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate_sharding (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_encrypt_federate (user_id INT NOT NULL, plain_pwd VARCHAR(45) NULL, cipher_pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt_read_ds.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt_read_ds.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE INDEX user_index_t_user ON encrypt_read_ds.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/dataset.xml
@@ -70,6 +70,14 @@
         <column name="user_id" type="numeric" />
         <column name="information" type="varchar" />
     </metadata>
+    <metadata data-nodes="write_dataset.t_merchant,read_dataset.t_merchant">
+        <column name="merchant_id" type="numeric" />
+        <column name="country_id" type="numeric" />
+        <column name="merchant_name" type="varchar" />
+        <column name="business_code" type="varchar" />
+        <column name="telephone" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="write_dataset.t_user" values="0, 10000, a00, init" />
     <row data-node="write_dataset.t_user" values="1, 11000, b01, init" />
     <row data-node="write_dataset.t_user" values="2, 12000, c02, init" />
@@ -300,6 +308,26 @@
     <row data-node="write_dataset.t_user_encrypt_federate" values="3, decryptValue, Ross" />
     <row data-node="write_dataset.t_user_encrypt_federate" values="4, decryptValue, Chandler" />
     <row data-node="write_dataset.t_user_encrypt_federate" values="5, decryptValue, Joey" />
+    <row data-node="write_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="write_dataset.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
     <row data-node="read_dataset.t_single_table" values="1, 0, init_read" />
     <row data-node="read_dataset.t_single_table" values="2, 11, init_read" />
     <row data-node="read_dataset.t_single_table" values="3, 22, init_read" />
@@ -534,4 +562,24 @@
     <row data-node="read_dataset.t_user_encrypt_federate" values="3, decryptValue, Ross" />
     <row data-node="read_dataset.t_user_encrypt_federate" values="4, decryptValue, Chandler" />
     <row data-node="read_dataset.t_user_encrypt_federate" values="5, decryptValue, Joey" />
+    <row data-node="read_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="read_dataset.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
@@ -25,6 +25,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
@@ -36,5 +37,6 @@ CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VAR
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
@@ -32,6 +32,7 @@ CREATE TABLE write_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NU
 CREATE TABLE write_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE write_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON write_dataset.t_user (user_id);
 
@@ -50,5 +51,6 @@ CREATE TABLE read_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VAR
 CREATE TABLE read_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(32) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE read_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON read_dataset.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -32,6 +32,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
@@ -43,6 +44,7 @@ CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VAR
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
@@ -64,6 +66,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
@@ -75,5 +78,6 @@ CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VAR
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/oracle/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/oracle/01-expected-init.sql
@@ -28,6 +28,7 @@ CREATE TABLE write_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NU
 CREATE TABLE write_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE write_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON write_dataset.t_user (user_id);
 
@@ -45,5 +46,6 @@ CREATE TABLE read_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NUL
 CREATE TABLE read_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE read_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON read_dataset.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -32,6 +32,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
@@ -43,6 +44,7 @@ CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VAR
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);
 
@@ -64,6 +66,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_user_encrypt_federate;
 DROP TABLE IF EXISTS t_user_encrypt_federate_sharding;
 DROP TABLE IF EXISTS t_user_info;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_order_federate (order_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (order_id));
@@ -75,5 +78,6 @@ CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VAR
 CREATE TABLE t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/sqlserver/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/data/expected/init-sql/sqlserver/01-expected-init.sql
@@ -28,6 +28,7 @@ CREATE TABLE write_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NU
 CREATE TABLE write_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE write_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE write_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON write_dataset.t_user (user_id);
 
@@ -45,5 +46,6 @@ CREATE TABLE read_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NUL
 CREATE TABLE read_dataset.t_user_encrypt_federate (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_user_encrypt_federate_sharding (user_id INT NOT NULL, pwd VARCHAR(45) NULL, username VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE read_dataset.t_user_info (user_id INT NOT NULL, information VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE read_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON read_dataset.t_user (user_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/mysql/config-encrypt-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/mysql/config-encrypt-readwrite-splitting.yaml
@@ -86,3 +86,13 @@ rules:
           plainColumn: plain_pwd
           cipherColumn: cipher_pwd
           encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/opengauss/config-encrypt-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/opengauss/config-encrypt-readwrite-splitting.yaml
@@ -86,3 +86,13 @@ rules:
           plainColumn: plain_pwd
           cipherColumn: cipher_pwd
           encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/postgresql/config-encrypt-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/postgresql/config-encrypt-readwrite-splitting.yaml
@@ -86,3 +86,13 @@ rules:
           plainColumn: plain_pwd
           cipherColumn: cipher_pwd
           encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/rules.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/rules.yaml
@@ -64,6 +64,16 @@ rules:
           plainColumn: plain_pwd
           cipherColumn: cipher_pwd
           encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          encryptorName: aes_encryptor
 
 props:
   sql-federation-type: ADVANCED


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/21286.

Changes proposed in this pull request:

- add t_merchant standard table structure for encrypt_and_readwrite_splitting scenario
- add t_merchant init data for encrypt_and_readwrite_splitting scenario
- adjust test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
