### PR TITLE
Use gson JSONParser for asserting JSON equality deterministically

### DIFF
--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/advance/ParseDistSQLHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/advance/ParseDistSQLHandlerTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.advance;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import org.apache.shardingsphere.distsql.parser.statement.rul.sql.ParseStatement;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
@@ -76,7 +77,7 @@ public final class ParseDistSQLHandlerTest extends ProxyContextRestorer {
         parseDistSQLHandler.next();
         SQLStatement statement = sqlParserRule.getSQLParserEngine("MySQL").parse(sql, false);
         assertThat(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getFirst(), is("MySQLSelectStatement"));
-        assertThat(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getLast(), is(new Gson().toJson(statement)));
+        assertThat(JsonParser.parseString(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getLast().toString()), is(JsonParser.parseString(new Gson().toJson(statement))));
     }
     
     @Test
@@ -89,8 +90,7 @@ public final class ParseDistSQLHandlerTest extends ProxyContextRestorer {
         parseDistSQLHandler.execute();
         parseDistSQLHandler.next();
         SQLStatement statement = sqlParserRule.getSQLParserEngine("PostgreSQL").parse(sql, false);
-        assertThat(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getFirst(), is("PostgreSQLSelectStatement"));
-        assertThat(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getLast(), is(new Gson().toJson(statement)));
+        assertThat(JsonParser.parseString(new LinkedList<>(parseDistSQLHandler.getRowData().getData()).getLast().toString()), is(JsonParser.parseString(new Gson().toJson(statement))));
     }
     
     @Test(expected = SQLParsingException.class)


### PR DESCRIPTION
Fixes #22518.

Changes proposed in this pull request:
  -
The flakiness of the tests is because Json objects are being compared and the ordering of the elements in the generated json strings may not be deterministic.
Using the gson [JsonParser](https://stackoverflow.com/questions/2253750/testing-two-json-objects-for-equality-ignoring-child-order-in-java/9065247#9065247).parseString(), the json strings are converted to json parse trees. 

The generated parse trees are then compared for equality in the assertions, ignoring the order of the child elements. 
The tests pass using [NonDex](https://github.com/TestingResearchIllinois/NonDex) after this change.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
