### PR TITLE
Add t_product_category,t_country standard table in readwrite_splitting scenario

### DIFF
--- a/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_broadcast_rules.xml
+++ b/test/integration-test/test-suite/src/test/resources/cases/rql/dataset/readwrite_splitting/show_broadcast_rules.xml
@@ -21,4 +21,6 @@
     </metadata>
     <row values="t_broadcast_table" />
     <row values="t_broadcast_table_for_ddl" />
+    <row values="t_product_category" />
+    <row values="t_country" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/dataset.xml
@@ -30,14 +30,62 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp" />
     </metadata>
+    <metadata data-nodes="db.t_merchant,encrypt_shadow_db.t_merchant">
+        <column name="merchant_id" type="numeric" />
+        <column name="country_id" type="numeric" />
+        <column name="merchant_name" type="varchar" />
+        <column name="business_code" type="varchar" />
+        <column name="telephone" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="db.t_shadow" values="1, 1, C4J8SHnvFT1FDZ3vF2ELDA==, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="db.t_shadow" values="2, 1, C4J8SHnvFT1FDZ3vF2ELDA==, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="db.t_shadow" values="3, 1, C4J8SHnvFT1FDZ3vF2ELDA==, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="db.t_shadow" values="4, 1, C4J8SHnvFT1FDZ3vF2ELDA==, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="db.t_shadow" values="5, 1, C4J8SHnvFT1FDZ3vF2ELDA==, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="db.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="db.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="db.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="db.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="db.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="db.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="db.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="db.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="db.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="db.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="db.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="db.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="db.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="db.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="db.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="db.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="db.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="db.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="db.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="db.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
     <row data-node="encrypt_shadow_db.t_shadow" values="1, 0, OuQCPda97jMdDtibdBO6Jg==, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_db.t_shadow" values="2, 0, OuQCPda97jMdDtibdBO6Jg==, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_db.t_shadow" values="3, 0, OuQCPda97jMdDtibdBO6Jg==, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_db.t_shadow" values="4, 0, OuQCPda97jMdDtibdBO6Jg==, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_db.t_shadow" values="5, 0, OuQCPda97jMdDtibdBO6Jg==, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="encrypt_shadow_db.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/h2/01-actual-init.sql
@@ -15,5 +15,7 @@
 -- limitations under the License.
 --
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/mysql/01-actual-init.sql
@@ -22,8 +22,10 @@ DROP DATABASE IF EXISTS db;
 CREATE DATABASE db;
 
 CREATE TABLE db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 DROP DATABASE IF EXISTS encrypt_shadow_db;
 CREATE DATABASE encrypt_shadow_db;
 
 CREATE TABLE encrypt_shadow_db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -24,15 +24,19 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_shadow_db TO test_user;
 \c db
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 \c encrypt_shadow_db
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/oracle/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/oracle/01-actual-init.sql
@@ -19,9 +19,11 @@ DROP SCHEMA db;
 CREATE SCHEMA db;
 
 CREATE TABLE db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 
 DROP SCHEMA encrypt_shadow_db;
 CREATE SCHEMA encrypt_shadow_db;
 
 CREATE TABLE encrypt_shadow_db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -24,15 +24,19 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_shadow_db TO test_user;
 \c db
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 \c encrypt_shadow_db
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/sqlserver/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/actual/init-sql/sqlserver/01-actual-init.sql
@@ -19,9 +19,10 @@ DROP DATABASE IF EXISTS db;
 CREATE DATABASE db;
 
 CREATE TABLE db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
-
+CREATE TABLE db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 DROP DATABASE IF EXISTS encrypt_shadow_db;
 CREATE DATABASE encrypt_shadow_db;
 
 CREATE TABLE encrypt_shadow_db.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name_cipher VARCHAR(200) NOT NULL, order_name_plain VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_db.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/dataset.xml
@@ -29,14 +29,62 @@
         <column name="type_time" type="time" />
         <column name="type_timestamp" type="timestamp" />
     </metadata>
+    <metadata data-nodes="prod_dataset.t_merchant,encrypt_shadow_dataset.t_merchant">
+        <column name="merchant_id" type="numeric" />
+        <column name="country_id" type="numeric" />
+        <column name="merchant_name" type="varchar" />
+        <column name="business_code" type="varchar" />
+        <column name="telephone" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="prod_dataset.t_shadow" values="1, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="prod_dataset.t_shadow" values="2, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="prod_dataset.t_shadow" values="3, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="prod_dataset.t_shadow" values="4, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="prod_dataset.t_shadow" values="5, 1, pro_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="prod_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="prod_dataset.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
     <row data-node="encrypt_shadow_dataset.t_shadow" values="1, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_dataset.t_shadow" values="2, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_dataset.t_shadow" values="3, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_dataset.t_shadow" values="4, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
     <row data-node="encrypt_shadow_dataset.t_shadow" values="5, 0, shadow_order, S, true, 5, summer, 10.00, 2017-08-08, 18:30:30, 2017-08-08 18:30:30.0" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
+    <row data-node="encrypt_shadow_dataset.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/h2/01-expected-init.sql
@@ -16,5 +16,7 @@
 --
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/mysql/01-expected-init.sql
@@ -23,9 +23,11 @@ DROP DATABASE IF EXISTS prod_dataset;
 CREATE DATABASE prod_dataset;
 
 CREATE TABLE prod_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE prod_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 
 DROP DATABASE IF EXISTS encrypt_shadow_dataset;
 CREATE DATABASE encrypt_shadow_dataset;
 
 CREATE TABLE encrypt_shadow_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -23,9 +23,11 @@ GRANT ALL PRIVILEGES ON DATABASE prod_dataset TO test_user;
 \c prod_dataset;
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 
 DROP DATABASE IF EXISTS encrypt_shadow_dataset;
@@ -36,6 +38,8 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_shadow_dataset TO test_user;
 \c encrypt_shadow_dataset;
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/oracle/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/oracle/01-expected-init.sql
@@ -19,9 +19,10 @@ DROP SCHEMA prod_dataset;
 CREATE SCHEMA prod_dataset;
 
 CREATE TABLE prod_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
-
+CREATE TABLE prod_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 DROP SCHEMA encrypt_shadow_dataset;
 CREATE SCHEMA encrypt_shadow_dataset;
 
 CREATE TABLE encrypt_shadow_dataset.t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -23,10 +23,11 @@ GRANT ALL PRIVILEGES ON DATABASE prod_dataset TO test_user;
 \c prod_dataset;
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
-
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 DROP DATABASE IF EXISTS encrypt_shadow_dataset;
 CREATE DATABASE encrypt_shadow_dataset;
@@ -36,6 +37,8 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt_shadow_dataset TO test_user;
 \c encrypt_shadow_dataset;
 
 DROP TABLE IF EXISTS t_shadow;
+DROP TABLE IF EXISTS t_merchant;
 
 CREATE TYPE season AS ENUM ('spring', 'summer', 'autumn', 'winter');
 CREATE TABLE t_shadow (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum season DEFAULT 'summer', type_decimal NUMERIC(18,2) DEFAULT NULL, type_date DATE DEFAULT NULL, type_time TIME DEFAULT NULL, type_timestamp TIMESTAMP DEFAULT NULL, PRIMARY KEY (order_id));
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/sqlserver/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/data/expected/init-sql/sqlserver/01-expected-init.sql
@@ -19,9 +19,10 @@ DROP DATABASE IF EXISTS prod_dataset;
 CREATE DATABASE prod_dataset;
 
 CREATE TABLE prod_dataset.encrypt_shadow_dataset (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
-
+CREATE TABLE prod_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 DROP DATABASE IF EXISTS encrypt_shadow_dataset;
 CREATE DATABASE encrypt_shadow_dataset;
 
 CREATE TABLE encrypt_shadow_dataset.encrypt_shadow_dataset (order_id BIGINT NOT NULL, user_id INT NOT NULL, order_name VARCHAR(200) NOT NULL, type_char CHAR(1) NOT NULL, type_boolean BOOLEAN NOT NULL, type_smallint SMALLINT NOT NULL, type_enum ENUM('spring', 'summer', 'autumn', 'winter'), type_decimal DECIMAL(18,2) NOT NULL, type_date DATE NOT NULL, type_time TIME NOT NULL, type_timestamp TIMESTAMP NOT NULL, PRIMARY KEY (order_id));
+CREATE TABLE encrypt_shadow_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/mysql/config-encrypt-shadow.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/mysql/config-encrypt-shadow.yaml
@@ -53,6 +53,15 @@ rules:
         - user-id-delete-match-algorithm
         - user-id-select-match-algorithm
         - simple-hint-algorithm
+    t_merchant:
+      dataSourceNames:
+        - shadowDataSource
+      shadowAlgorithmNames:
+        - merchant-id-insert-match-algorithm
+        - merchant-id-update-match-algorithm
+        - merchant-id-delete-match-algorithm
+        - merchant-id-select-match-algorithm
+        - simple-hint-algorithm
   shadowAlgorithms:
     user-id-insert-match-algorithm:
       type: VALUE_MATCH
@@ -82,6 +91,30 @@ rules:
       type: SIMPLE_HINT
       props:
         foo: bar
+    merchant-id-insert-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: insert
+        column: merchant_id
+        value: 0
+    merchant-id-update-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: update
+        column: merchant_id
+        value: 0
+    merchant-id-delete-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: delete
+        column: merchant_id
+        value: 0
+    merchant-id-select-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: select
+        column: merchant_id
+        value: 0
         
 - !ENCRYPT
   encryptors:
@@ -95,4 +128,14 @@ rules:
         order_name:
           plainColumn: order_name_plain
           cipherColumn: order_name_cipher
+          encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
           encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/opengauss/config-encrypt-shadow.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/opengauss/config-encrypt-shadow.yaml
@@ -53,6 +53,15 @@ rules:
         - user-id-delete-match-algorithm
         - user-id-select-match-algorithm
         - simple-hint-algorithm
+    t_merchant:
+      dataSourceNames:
+        - shadowDataSource
+      shadowAlgorithmNames:
+        - merchant-id-insert-match-algorithm
+        - merchant-id-update-match-algorithm
+        - merchant-id-delete-match-algorithm
+        - merchant-id-select-match-algorithm
+        - simple-hint-algorithm
   shadowAlgorithms:
     user-id-insert-match-algorithm:
       type: VALUE_MATCH
@@ -82,6 +91,30 @@ rules:
       type: SIMPLE_HINT
       props:
         foo: bar
+    merchant-id-insert-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: insert
+        column: merchant_id
+        value: 0
+    merchant-id-update-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: update
+        column: merchant_id
+        value: 0
+    merchant-id-delete-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: delete
+        column: merchant_id
+        value: 0
+    merchant-id-select-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: select
+        column: merchant_id
+        value: 0
 - !ENCRYPT
   encryptors:
     aes_encryptor:
@@ -94,4 +127,14 @@ rules:
         order_name:
           plainColumn: order_name_plain
           cipherColumn: order_name_cipher
+          encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
           encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/postgresql/config-encrypt-shadow.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/postgresql/config-encrypt-shadow.yaml
@@ -53,6 +53,15 @@ rules:
         - user-id-delete-match-algorithm
         - user-id-select-match-algorithm
         - simple-hint-algorithm
+    t_merchant:
+      dataSourceNames:
+        - shadowDataSource
+      shadowAlgorithmNames:
+        - merchant-id-insert-match-algorithm
+        - merchant-id-update-match-algorithm
+        - merchant-id-delete-match-algorithm
+        - merchant-id-select-match-algorithm
+        - simple-hint-algorithm
   shadowAlgorithms:
     user-id-insert-match-algorithm:
       type: VALUE_MATCH
@@ -82,6 +91,30 @@ rules:
       type: SIMPLE_HINT
       props:
         foo: bar
+    merchant-id-insert-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: insert
+        column: merchant_id
+        value: 0
+    merchant-id-update-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: update
+        column: merchant_id
+        value: 0
+    merchant-id-delete-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: delete
+        column: merchant_id
+        value: 0
+    merchant-id-select-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: select
+        column: merchant_id
+        value: 0
 - !ENCRYPT
   encryptors:
     aes_encryptor:
@@ -94,4 +127,14 @@ rules:
         order_name:
           plainColumn: order_name_plain
           cipherColumn: order_name_cipher
+          encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
           encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/rules.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/encrypt_shadow/rules.yaml
@@ -31,6 +31,15 @@ rules:
         - user-id-delete-match-algorithm
         - user-id-select-match-algorithm
         - simple-hint-algorithm
+    t_merchant:
+      dataSourceNames:
+        - shadowDataSource
+      shadowAlgorithmNames:
+        - merchant-id-insert-match-algorithm
+        - merchant-id-update-match-algorithm
+        - merchant-id-delete-match-algorithm
+        - merchant-id-select-match-algorithm
+        - simple-hint-algorithm
   shadowAlgorithms:
     user-id-insert-match-algorithm:
       type: VALUE_MATCH
@@ -60,7 +69,31 @@ rules:
       type: SIMPLE_HINT
       props:
         foo: bar
-        
+    merchant-id-insert-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: insert
+        column: merchant_id
+        value: 0
+    merchant-id-update-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: update
+        column: merchant_id
+        value: 0
+    merchant-id-delete-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: delete
+        column: merchant_id
+        value: 0
+    merchant-id-select-match-algorithm:
+      type: VALUE_MATCH
+      props:
+        operation: select
+        column: merchant_id
+        value: 0
+
 - !ENCRYPT
   encryptors:
     aes_encryptor:
@@ -73,4 +106,14 @@ rules:
         order_name:
           plainColumn: order_name_plain
           cipherColumn: order_name_cipher
+          encryptorName: aes_encryptor
+    t_merchant:
+      columns:
+        business_code:
+          plainColumn: business_code_plain
+          cipherColumn: business_code_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
           encryptorName: aes_encryptor

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/dataset.xml
@@ -41,6 +41,19 @@
         <column name="id" type="numeric" />
         <column name="status" type="varchar" />
     </metadata>
+    <metadata data-nodes="write_ds.t_product_category,read_${0..1}.t_product_category">
+        <column name="category_id" type="numeric" />
+        <column name="category_name" type="varchar" />
+        <column name="parent_id" type="numeric" />
+        <column name="level" type="numeric" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <metadata data-nodes="write_ds.t_country,read_${0..1}.t_country">
+        <column name="country_id" type="numeric" />
+        <column name="country_name" type="varchar" />
+        <column name="continent_name" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="write_ds.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="write_ds.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="write_ds.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
@@ -166,6 +179,22 @@
     <row data-node="write_ds.t_single_table" values="3, 1200, init" />
     <row data-node="write_ds.t_single_table" values="4, 1300, init" />
     <row data-node="write_ds.t_broadcast_table" values="1, init" />
+    <row data-node="write_ds.t_product_category" values="1, virtual goods, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="2, prepaid cards, 1, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="3, home appliance, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="4, washing machine, 3, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="5, digital products, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="6, mobile phones, 5, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="7, food and drinks, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="8, drinks, 7, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="9, game console, 5, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="10, computer related, 5, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="11, daily commodities, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="12, shampoo, 11, 2, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="13, transportation, 0, 1, 2017-08-08" />
+    <row data-node="write_ds.t_product_category" values="14, car, 13, 2, 2017-08-08" />
+    <row data-node="write_ds.t_country" values="1, usa, north america, 2017-08-08" />
+    <row data-node="write_ds.t_country" values="86, china, asia, 2017-08-08" />
     <row data-node="read_0.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
     <row data-node="read_0.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
     <row data-node="read_0.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
@@ -291,6 +320,22 @@
     <row data-node="read_0.t_single_table" values="3, 1200, init_read" />
     <row data-node="read_0.t_single_table" values="4, 1300, init_read" />
     <row data-node="read_0.t_broadcast_table" values="1, init_read" />
+    <row data-node="read_0.t_product_category" values="1, virtual goods, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="2, prepaid cards, 1, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="3, home appliance, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="4, washing machine, 3, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="5, digital products, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="6, mobile phones, 5, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="7, food and drinks, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="8, drinks, 7, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="9, game console, 5, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="10, computer related, 5, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="11, daily commodities, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="12, shampoo, 11, 2, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="13, transportation, 0, 1, 2017-08-08" />
+    <row data-node="read_0.t_product_category" values="14, car, 13, 2, 2017-08-08" />
+    <row data-node="read_0.t_country" values="1, usa, north america, 2017-08-08" />
+    <row data-node="read_0.t_country" values="86, china, asia, 2017-08-08" />
     <row data-node="read_1.t_order" values="1000, 10, init_read, 1, test, 2017-08-08" />
     <row data-node="read_1.t_order" values="1001, 10, init_read, 2, test, 2017-08-08" />
     <row data-node="read_1.t_order" values="1100, 11, init_read, 3, test, 2017-08-08" />
@@ -416,4 +461,20 @@
     <row data-node="read_1.t_single_table" values="3, 1200, init_read" />
     <row data-node="read_1.t_single_table" values="4, 1300, init_read" />
     <row data-node="read_1.t_broadcast_table" values="1, init_read" />
+    <row data-node="read_1.t_product_category" values="1, virtual goods, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="2, prepaid cards, 1, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="3, home appliance, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="4, washing machine, 3, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="5, digital products, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="6, mobile phones, 5, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="7, food and drinks, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="8, drinks, 7, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="9, game console, 5, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="10, computer related, 5, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="11, daily commodities, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="12, shampoo, 11, 2, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="13, transportation, 0, 1, 2017-08-08" />
+    <row data-node="read_1.t_product_category" values="14, car, 13, 2, 2017-08-08" />
+    <row data-node="read_1.t_country" values="1, usa, north america, 2017-08-08" />
+    <row data-node="read_1.t_country" values="86, china, asia, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/h2/01-actual-init.sql
@@ -19,10 +19,14 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_broadcast_table;
 DROP TABLE IF EXISTS t_single_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/mysql/01-actual-init.sql
@@ -30,16 +30,22 @@ CREATE TABLE write_ds.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, st
 CREATE TABLE write_ds.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_ds.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_ds.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_ds.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_ds.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON write_ds.t_order (order_id);
 
 CREATE TABLE read_0.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_0.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_0.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_0.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_0.t_order (order_id);
 
 CREATE TABLE read_1.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_1.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_1.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_1.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_1.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -29,11 +29,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
 \c read_0
@@ -42,11 +46,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
 \c read_1
@@ -55,9 +63,13 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/oracle/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/oracle/01-actual-init.sql
@@ -27,16 +27,22 @@ CREATE TABLE write_ds.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, st
 CREATE TABLE write_ds.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_ds.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_ds.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_ds.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_ds.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON write_ds.t_order (order_id);
 
 CREATE TABLE read_0.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_0.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_0.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_0.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_0.t_order (order_id);
 
 CREATE TABLE read_1.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_1.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_1.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_1.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_1.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -29,11 +29,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level SMALLINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
 \c read_0
@@ -42,11 +46,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level SMALLINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
 \c read_1
@@ -55,9 +63,13 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level SMALLINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/sqlserver/01-actual-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/actual/init-sql/sqlserver/01-actual-init.sql
@@ -27,16 +27,22 @@ CREATE TABLE write_ds.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, st
 CREATE TABLE write_ds.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_ds.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_ds.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_ds.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_ds.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON write_ds.t_order (order_id);
 
 CREATE TABLE read_0.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_0.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_0.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_0.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_0.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_0.t_order (order_id);
 
 CREATE TABLE read_1.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_1.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_1.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_1.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_1.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 CREATE INDEX order_index_t_order ON read_1.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/dataset.xml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/dataset.xml
@@ -41,6 +41,19 @@
         <column name="id" type="numeric" />
         <column name="status" type="varchar" />
     </metadata>
+    <metadata data-nodes="write_dataset.t_product_category,read_dataset.t_product_category">
+        <column name="category_id" type="numeric" />
+        <column name="category_name" type="varchar" />
+        <column name="parent_id" type="numeric" />
+        <column name="level" type="numeric" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
+    <metadata data-nodes="write_dataset.t_country,read_dataset.t_country">
+        <column name="country_id" type="numeric" />
+        <column name="country_name" type="varchar" />
+        <column name="continent_name" type="varchar" />
+        <column name="creation_date" type="datetime" />
+    </metadata>
     <row data-node="write_dataset.t_order" values="1000, 10, init, 1, test, 2017-08-08" />
     <row data-node="write_dataset.t_order" values="1001, 10, init, 2, test, 2017-08-08" />
     <row data-node="write_dataset.t_order" values="1100, 11, init, 3, test, 2017-08-08" />
@@ -162,6 +175,22 @@
     <row data-node="write_dataset.t_order_item" values="290101, 2901, 29, 9, 1, 2017-08-08" />
     <row data-node="write_dataset.t_order_item" values="290102, 2901, 29, 10, 1, 2017-08-08" />
     <row data-node="write_dataset.t_broadcast_table" values="1, init" />
+    <row data-node="write_dataset.t_product_category" values="1, virtual goods, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="2, prepaid cards, 1, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="3, home appliance, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="4, washing machine, 3, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="5, digital products, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="6, mobile phones, 5, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="7, food and drinks, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="8, drinks, 7, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="9, game console, 5, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="10, computer related, 5, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="11, daily commodities, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="12, shampoo, 11, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="13, transportation, 0, 1, 2017-08-08" />
+    <row data-node="write_dataset.t_product_category" values="14, car, 13, 2, 2017-08-08" />
+    <row data-node="write_dataset.t_country" values="1, usa, north america, 2017-08-08" />
+    <row data-node="write_dataset.t_country" values="86, china, asia, 2017-08-08" />
     <row data-node="read_dataset.t_single_table" values="1, 1000, init_read" />
     <row data-node="read_dataset.t_single_table" values="2, 1100, init_read" />
     <row data-node="read_dataset.t_single_table" values="3, 1200, init_read" />
@@ -287,4 +316,20 @@
     <row data-node="read_dataset.t_order_item" values="290101, 2901, 29, 9, 1, 2017-08-08" />
     <row data-node="read_dataset.t_order_item" values="290102, 2901, 29, 10, 1, 2017-08-08" />
     <row data-node="read_dataset.t_broadcast_table" values="1, init_read" />
+    <row data-node="read_dataset.t_product_category" values="1, virtual goods, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="2, prepaid cards, 1, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="3, home appliance, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="4, washing machine, 3, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="5, digital products, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="6, mobile phones, 5, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="7, food and drinks, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="8, drinks, 7, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="9, game console, 5, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="10, computer related, 5, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="11, daily commodities, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="12, shampoo, 11, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="13, transportation, 0, 1, 2017-08-08" />
+    <row data-node="read_dataset.t_product_category" values="14, car, 13, 2, 2017-08-08" />
+    <row data-node="read_dataset.t_country" values="1, usa, north america, 2017-08-08" />
+    <row data-node="read_dataset.t_country" values="86, china, asia, 2017-08-08" />
 </dataset>

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/h2/01-expected-init.sql
@@ -19,10 +19,14 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/mysql/01-expected-init.sql
@@ -26,6 +26,8 @@ CREATE TABLE write_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NUL
 CREATE TABLE write_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON write_dataset.t_order (order_id);
 
@@ -37,5 +39,7 @@ CREATE TABLE read_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL
 CREATE TABLE read_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON read_dataset.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -26,11 +26,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
@@ -46,10 +50,14 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/oracle/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/oracle/01-expected-init.sql
@@ -22,6 +22,8 @@ CREATE TABLE write_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NUL
 CREATE TABLE write_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON write_dataset.t_order (order_id);
 
@@ -33,5 +35,7 @@ CREATE TABLE read_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL
 CREATE TABLE read_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON read_dataset.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -26,11 +26,15 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level SMALLINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);
 
@@ -46,10 +50,14 @@ DROP TABLE IF EXISTS t_order;
 DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_broadcast_table;
+DROP TABLE IF EXISTS t_product_category;
+DROP TABLE IF EXISTS t_country;
 
 CREATE TABLE t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT NOT NULL, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level SMALLINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/sqlserver/01-expected-init.sql
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/data/expected/init-sql/sqlserver/01-expected-init.sql
@@ -22,6 +22,8 @@ CREATE TABLE write_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NUL
 CREATE TABLE write_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE write_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE write_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE write_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE write_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON write_dataset.t_order (order_id);
 
@@ -33,5 +35,7 @@ CREATE TABLE read_dataset.t_order(order_id INT PRIMARY KEY, user_id INT NOT NULL
 CREATE TABLE read_dataset.t_order_item(item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE read_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE read_dataset.t_broadcast_table (id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (id));
+CREATE TABLE read_dataset.t_product_category (category_id INT PRIMARY KEY, category_name VARCHAR(50) NOT NULL, parent_id INT NOT NULL, level TINYINT NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE read_dataset.t_country (country_id SMALLINT PRIMARY KEY, country_name VARCHAR(50), continent_name VARCHAR(50), creation_date DATE NOT NULL);
 
 CREATE INDEX order_index_t_order ON read_dataset.t_order (order_id);

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/mysql/config-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/mysql/config-readwrite-splitting.yaml
@@ -72,6 +72,8 @@ rules:
   broadcastTables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
+    - t_product_category
+    - t_country
 
 - !READWRITE_SPLITTING
   dataSources:

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/opengauss/config-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/opengauss/config-readwrite-splitting.yaml
@@ -72,6 +72,8 @@ rules:
   broadcastTables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
+    - t_product_category
+    - t_country
 
 - !READWRITE_SPLITTING
   dataSources:

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/postgresql/config-readwrite-splitting.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/proxy/conf/postgresql/config-readwrite-splitting.yaml
@@ -72,6 +72,8 @@ rules:
   broadcastTables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
+    - t_product_category
+    - t_country
 
 - !READWRITE_SPLITTING
   dataSources:

--- a/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/rules.yaml
+++ b/test/integration-test/test-suite/src/test/resources/env/scenario/readwrite_splitting/rules.yaml
@@ -41,6 +41,8 @@ rules:
   broadcastTables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
+    - t_product_category
+    - t_country
 
 - !READWRITE_SPLITTING
   dataSources:


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/21286.

Changes proposed in this pull request:

- add t_product_category, t_country standard table structure for readwrite_splitting scenario
- add t_product_category, t_country init data for readwrite_splitting scenario
- adjust test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `mvn clean install -B -T2C -DskipTests -Dmaven.javadoc.skip=true -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
