### PR TITLE
Optimize mysql, oracle, sqlserver and sql92 null projection parse and support convert to sqlnode

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptLiteralAssignmentToken.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptLiteralAssignmentToken.java
@@ -62,6 +62,9 @@ public final class EncryptLiteralAssignmentToken extends EncryptAssignmentToken 
         }
         
         private String toString(final Object value) {
+            if (null == value) {
+                return "NULL";
+            }
             return value instanceof String ? "'" + value + "'" : value.toString();
         }
     }

--- a/kernel/sql-federation/executor/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/FilterableTableScanExecutor.java
+++ b/kernel/sql-federation/executor/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/FilterableTableScanExecutor.java
@@ -119,8 +119,8 @@ public final class FilterableTableScanExecutor implements TableScanExecutor {
     
     @Override
     public Enumerable<Object[]> execute(final ShardingSphereTable table, final ScanNodeExecutorContext scanContext) {
-        String databaseName = executorContext.getDatabaseName();
-        String schemaName = executorContext.getSchemaName();
+        String databaseName = executorContext.getDatabaseName().toLowerCase();
+        String schemaName = executorContext.getSchemaName().toLowerCase();
         DatabaseType databaseType = DatabaseTypeEngine.getTrunkDatabaseType(optimizerContext.getParserContext(databaseName).getDatabaseType().getType());
         if (databaseType.getSystemSchemas().contains(schemaName)) {
             return executeByShardingSphereData(databaseName, schemaName, table);

--- a/kernel/sql-federation/executor/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TranslatableTableScanExecutor.java
+++ b/kernel/sql-federation/executor/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TranslatableTableScanExecutor.java
@@ -122,8 +122,8 @@ public final class TranslatableTableScanExecutor implements TableScanExecutor {
     
     @Override
     public Enumerable<Object[]> execute(final ShardingSphereTable table, final ScanNodeExecutorContext scanContext) {
-        String databaseName = executorContext.getDatabaseName();
-        String schemaName = executorContext.getSchemaName();
+        String databaseName = executorContext.getDatabaseName().toLowerCase();
+        String schemaName = executorContext.getSchemaName().toLowerCase();
         DatabaseType databaseType = DatabaseTypeEngine.getTrunkDatabaseType(optimizerContext.getParserContext(databaseName).getDatabaseType().getType());
         SqlString sqlString = createSQLString(table, (TranslatableScanNodeExecutorContext) scanContext, SQLDialectFactory.getSQLDialect(databaseType));
         // TODO replace sql parse with sql convert

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.expr
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.parser.SqlParserPos;
-import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.SQLSegmentConverter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
+import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.SQLSegmentConverter;
 
 import java.util.Optional;
 
@@ -36,7 +36,10 @@ public final class LiteralExpressionConverter implements SQLSegmentConverter<Lit
             return Optional.of(SqlLiteral.createExactNumeric(String.valueOf(segment.getLiterals()), SqlParserPos.ZERO));
         }
         if (String.class == segment.getLiterals().getClass()) {
-            return Optional.of(SqlLiteral.createCharString((String) segment.getLiterals(), SqlParserPos.ZERO));
+            if ("NULL".equalsIgnoreCase(String.valueOf(segment.getLiterals()))) {
+                return Optional.of(SqlLiteral.createNull(SqlParserPos.ZERO));
+            }
+            return Optional.of(SqlLiteral.createCharString(String.valueOf(segment.getLiterals()), SqlParserPos.ZERO));
         }
         return Optional.empty();
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/LiteralExpressionConverter.java
@@ -32,13 +32,13 @@ public final class LiteralExpressionConverter implements SQLSegmentConverter<Lit
     
     @Override
     public Optional<SqlNode> convert(final LiteralExpressionSegment segment) {
-        if (Integer.class == segment.getLiterals().getClass()) {
+        if (null == segment.getLiterals()) {
+            return Optional.of(SqlLiteral.createNull(SqlParserPos.ZERO));
+        }
+        if (segment.getLiterals() instanceof Integer) {
             return Optional.of(SqlLiteral.createExactNumeric(String.valueOf(segment.getLiterals()), SqlParserPos.ZERO));
         }
-        if (String.class == segment.getLiterals().getClass()) {
-            if ("NULL".equalsIgnoreCase(String.valueOf(segment.getLiterals()))) {
-                return Optional.of(SqlLiteral.createNull(SqlParserPos.ZERO));
-            }
+        if (segment.getLiterals() instanceof String) {
             return Optional.of(SqlLiteral.createCharString(String.valueOf(segment.getLiterals()), SqlParserPos.ZERO));
         }
         return Optional.empty();

--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -208,6 +208,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
 import org.apache.shardingsphere.sql.parser.sql.common.value.collection.CollectionValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
@@ -309,8 +310,7 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
     
     @Override
     public final ASTNode visitNullValueLiterals(final NullValueLiteralsContext ctx) {
-        // TODO deal with nullValueLiterals
-        return new OtherLiteralValue(ctx.getText());
+        return new NullLiteralValue(ctx.getText());
     }
     
     @Override

--- a/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleStatementSQLVisitor.java
+++ b/sql-parser/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/impl/OracleStatementSQLVisitor.java
@@ -73,6 +73,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlCol
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlExistsFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlForestFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlFunctionContext;
+import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlNameSpaceStringAsIdentifierContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlNameSpacesClauseContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlParseFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlPiFunctionContext;
@@ -82,7 +83,6 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlSer
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableColumnContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableOptionsContext;
-import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlNameSpaceStringAsIdentifierContext;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.OrderDirection;
@@ -134,6 +134,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.collection.Collecti
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.keyword.KeywordValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
@@ -221,8 +222,7 @@ public abstract class OracleStatementSQLVisitor extends OracleStatementBaseVisit
     
     @Override
     public final ASTNode visitNullValueLiterals(final NullValueLiteralsContext ctx) {
-        // TODO deal with nullValueLiterals
-        return new OtherLiteralValue(ctx.getText());
+        return new NullLiteralValue(ctx.getText());
     }
     
     @Override

--- a/sql-parser/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/impl/SQL92StatementSQLVisitor.java
+++ b/sql-parser/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/impl/SQL92StatementSQLVisitor.java
@@ -93,6 +93,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.collection.Collecti
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.keyword.KeywordValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
@@ -177,8 +178,7 @@ public abstract class SQL92StatementSQLVisitor extends SQL92StatementBaseVisitor
     
     @Override
     public final ASTNode visitNullValueLiterals(final NullValueLiteralsContext ctx) {
-        // TODO deal with nullValueLiterals
-        return new OtherLiteralValue(ctx.getText());
+        return new NullLiteralValue(ctx.getText());
     }
     
     @Override

--- a/sql-parser/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerStatementSQLVisitor.java
+++ b/sql-parser/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/impl/SQLServerStatementSQLVisitor.java
@@ -174,6 +174,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.collection.Collecti
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.keyword.KeywordValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
@@ -262,8 +263,7 @@ public abstract class SQLServerStatementSQLVisitor extends SQLServerStatementBas
     
     @Override
     public final ASTNode visitNullValueLiterals(final NullValueLiteralsContext ctx) {
-        // TODO deal with nullValueLiterals
-        return new OtherLiteralValue(ctx.getText());
+        return new NullLiteralValue(ctx.getText());
     }
     
     @Override

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
@@ -41,6 +41,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertState
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.UpdateStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.BooleanLiteralValue;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NullLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.NumberLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
@@ -270,6 +271,9 @@ public final class SQLUtil {
         }
         if (astNode instanceof BooleanLiteralValue) {
             return new LiteralExpressionSegment(startIndex, stopIndex, ((BooleanLiteralValue) astNode).getValue());
+        }
+        if (astNode instanceof NullLiteralValue) {
+            return new LiteralExpressionSegment(startIndex, stopIndex, ((NullLiteralValue) astNode).getValue());
         }
         if (astNode instanceof OtherLiteralValue) {
             return new CommonExpressionSegment(startIndex, stopIndex, ((OtherLiteralValue) astNode).getValue());

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SQLUtil.java
@@ -273,7 +273,7 @@ public final class SQLUtil {
             return new LiteralExpressionSegment(startIndex, stopIndex, ((BooleanLiteralValue) astNode).getValue());
         }
         if (astNode instanceof NullLiteralValue) {
-            return new LiteralExpressionSegment(startIndex, stopIndex, ((NullLiteralValue) astNode).getValue());
+            return new LiteralExpressionSegment(startIndex, stopIndex, null);
         }
         if (astNode instanceof OtherLiteralValue) {
             return new CommonExpressionSegment(startIndex, stopIndex, ((OtherLiteralValue) astNode).getValue());

--- a/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/NullLiteralValue.java
+++ b/sql-parser/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/value/literal/impl/NullLiteralValue.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.value.literal.LiteralValue;
+
+/**
+ * Null literal value.
+ */
+@RequiredArgsConstructor
+@Getter
+public final class NullLiteralValue implements LiteralValue<String> {
+    
+    private final String value;
+}

--- a/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
+++ b/test/optimize/src/test/java/org/apache/shardingsphere/infra/federation/converter/parameterized/engine/SQLNodeConverterEngineParameterizedTest.java
@@ -125,6 +125,7 @@ public final class SQLNodeConverterEngineParameterizedTest {
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_fetch");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_offset_and_row_count");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_row_count");
+        SUPPORTED_SQL_CASE_IDS.add("select_with_null_keyword_in_projection");
         SUPPORTED_SQL_CASE_IDS.add("select_union");
         SUPPORTED_SQL_CASE_IDS.add("select_union_all");
         SUPPORTED_SQL_CASE_IDS.add("select_union_all_order_by");

--- a/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/expression/ExpressionAssert.java
+++ b/test/parser/src/main/java/org/apache/shardingsphere/test/sql/parser/internal/asserts/segment/expression/ExpressionAssert.java
@@ -106,7 +106,7 @@ public final class ExpressionAssert {
             assertNull(assertContext.getText("Actual literal expression should not exist."), actual);
         } else {
             assertNotNull(assertContext.getText("Actual literal expression should exist."), actual);
-            assertThat(assertContext.getText("Literal assertion error: "), actual.getLiterals().toString(), is(expected.getValue()));
+            assertThat(assertContext.getText("Literal assertion error: "), String.valueOf(actual.getLiterals()), is(expected.getValue()));
             SQLSegmentAssert.assertIs(assertContext, actual, expected);
         }
     }

--- a/test/parser/src/main/resources/case/dml/insert.xml
+++ b/test/parser/src/main/resources/case/dml/insert.xml
@@ -994,7 +994,7 @@
         <values>
             <value>
                 <assignment-value>
-                    <common-expression text="null" start-index="43" stop-index="46" />
+                    <literal-expression value="null" start-index="43" stop-index="46" />
                 </assignment-value>
             </value>
         </values>
@@ -1847,7 +1847,7 @@
                     <literal-expression value="1.2E+3" start-index="178" stop-index="182" />
                 </assignment-value>
                 <assignment-value>
-                    <common-expression text="NULL" start-index="185" stop-index="188" />
+                    <literal-expression value="NULL" start-index="185" stop-index="188" />
                 </assignment-value>
             </value>
         </values>

--- a/test/parser/src/main/resources/case/dml/insert.xml
+++ b/test/parser/src/main/resources/case/dml/insert.xml
@@ -1847,7 +1847,7 @@
                     <literal-expression value="1.2E+3" start-index="178" stop-index="182" />
                 </assignment-value>
                 <assignment-value>
-                    <literal-expression value="NULL" start-index="185" stop-index="188" />
+                    <literal-expression value="null" start-index="185" stop-index="188" />
                 </assignment-value>
             </value>
         </values>

--- a/test/parser/src/main/resources/case/dml/replace.xml
+++ b/test/parser/src/main/resources/case/dml/replace.xml
@@ -715,7 +715,7 @@
         <values>
             <value>
                 <assignment-value>
-                    <common-expression text="null" start-index="44" stop-index="47" />
+                    <literal-expression value="null" start-index="44" stop-index="47" />
                 </assignment-value>
             </value>
         </values>

--- a/test/parser/src/main/resources/case/dml/select.xml
+++ b/test/parser/src/main/resources/case/dml/select.xml
@@ -4807,4 +4807,18 @@
             <offset value="3" start-index="37" stop-index="37" />
         </limit>
     </select>
+
+    <select sql-case-id="select_with_null_keyword_in_projection">
+        <projections start-index="7" stop-index="31">
+            <expression-projection text="null" alias="order_id" start-index="7" stop-index="22">
+                <expr>
+                    <literal-expression value="null" start-index="7" stop-index="10" />
+                </expr>
+            </expression-projection>
+            <column-projection name="item_id" start-index="25" stop-index="31" />
+        </projections>
+        <from>
+            <simple-table name="t_order" start-index="38" stop-index="44" />
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/parser/src/main/resources/case/dml/update.xml
+++ b/test/parser/src/main/resources/case/dml/update.xml
@@ -878,7 +878,7 @@
             <assignment start-index="21" stop-index="41">
                 <column name="commission_pct" start-index="21" stop-index="34" />
                 <assignment-value>
-                    <literal-expression value="NULL" start-index="38" stop-index="41" />
+                    <literal-expression value="null" start-index="38" stop-index="41" />
                 </assignment-value>
             </assignment>
         </set>

--- a/test/parser/src/main/resources/case/dml/update.xml
+++ b/test/parser/src/main/resources/case/dml/update.xml
@@ -878,7 +878,7 @@
             <assignment start-index="21" stop-index="41">
                 <column name="commission_pct" start-index="21" stop-index="34" />
                 <assignment-value>
-                    <common-expression text="NULL" start-index="38" stop-index="41" />
+                    <literal-expression value="NULL" start-index="38" stop-index="41" />
                 </assignment-value>
             </assignment>
         </set>

--- a/test/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/parser/src/main/resources/sql/supported/dml/select.xml
@@ -156,4 +156,5 @@
     <sql-case id="select_xmlserialize_function" value="SELECT XMLSERIALIZE(DOCUMENT c2 AS BLOB ENCODING 'UTF-8' VERSION 'a' IDENT SIZE = 0 SHOW DEFAULT) FROM b;" db-types="Oracle" />
     <sql-case id="select_from_xmltable_function" value="SELECT warehouse_name warehouse, warehouse2.Water, warehouse2.Rail FROM warehouses, XMLTABLE('/Warehouse' PASSING warehouses.warehouse_spec COLUMNS &quot;Water&quot; varchar2(6) PATH 'WaterAccess',&quot;Rail&quot; varchar2(6) PATH 'RailAccess') warehouse2;" db-types="Oracle" />
     <sql-case id="select_with_offset" value="select * from t_new_order fetch next 3 row only;" db-types="openGauss,PostgreSQL" />
+    <sql-case id="select_with_null_keyword_in_projection" value="select null as order_id, item_id from t_order" db-types="MySQL" />
 </sql-cases>

--- a/test/rewrite/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
+++ b/test/rewrite/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/update/update.xml
@@ -66,31 +66,31 @@
     
     <rewrite-assertion id="update_null_to_clear_plain" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL" />
     </rewrite-assertion>
 
     <rewrite-assertion id="update_null_to_clear_plain_with_multi" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL, certificate_number = ''" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL, cipher_certificate_number = 'encrypt_', assisted_query_certificate_number = 'assisted_query_', like_query_certificate_number = 'like_query_', plain_certificate_number = ''" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL, cipher_certificate_number = 'encrypt_', assisted_query_certificate_number = 'assisted_query_', like_query_certificate_number = 'like_query_', plain_certificate_number = ''" />
     </rewrite-assertion>
 
     <rewrite-assertion id="update_null_to_clear_plain_where_is_null" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL WHERE certificate_number IS NULL" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL WHERE assisted_query_certificate_number IS NULL" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL WHERE assisted_query_certificate_number IS NULL" />
     </rewrite-assertion>
 
     <rewrite-assertion id="update_null_to_clear_plain_where_is_null_with_multi" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL WHERE certificate_number IS NULL AND status = 'OK' AND certificate_number = '111X'" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL WHERE assisted_query_certificate_number IS NULL AND status = 'OK' AND assisted_query_certificate_number = 'assisted_query_111X'" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL WHERE assisted_query_certificate_number IS NULL AND status = 'OK' AND assisted_query_certificate_number = 'assisted_query_111X'" />
     </rewrite-assertion>
 
     <rewrite-assertion id="update_null_to_clear_plain_where_is_not_null" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL WHERE certificate_number IS NOT NULL" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL WHERE assisted_query_certificate_number IS NOT NULL" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL WHERE assisted_query_certificate_number IS NOT NULL" />
     </rewrite-assertion>
 
     <rewrite-assertion id="update_null_to_clear_plain_where_is_not_null_with_multi" db-types="MySQL">
         <input sql="UPDATE t_account_bak SET certificate_number = NULL WHERE certificate_number IS NOT NULL AND status = 'OK' AND certificate_number = '111X'" />
-        <output sql="UPDATE t_account_bak SET certificate_number = NULL WHERE assisted_query_certificate_number IS NOT NULL AND status = 'OK' AND assisted_query_certificate_number = 'assisted_query_111X'" />
+        <output sql="UPDATE t_account_bak SET cipher_certificate_number = NULL, assisted_query_certificate_number = NULL, like_query_certificate_number = NULL, plain_certificate_number = NULL WHERE assisted_query_certificate_number IS NOT NULL AND status = 'OK' AND assisted_query_certificate_number = 'assisted_query_111X'" />
     </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #22528.

Changes proposed in this pull request:
  - Optimize mysql, oracle, sqlserver and sql92 null projection parse
  - support convert to sqlnode
  - add sql parse and sql convert test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
