### PR TITLE
Split EncryptAlgorithm to StandardEncryptAlgorithm and LikeEncryptAlgorithm interface

### DIFF
--- a/examples/example-core/config-utility/src/main/java/org/apache/shardingsphere/example/fixture/TestQueryAssistedShardingEncryptAlgorithm.java
+++ b/examples/example-core/config-utility/src/main/java/org/apache/shardingsphere/example/fixture/TestQueryAssistedShardingEncryptAlgorithm.java
@@ -18,13 +18,14 @@
 package org.apache.shardingsphere.example.fixture;
 
 import lombok.Getter;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class TestQueryAssistedShardingEncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class TestQueryAssistedShardingEncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/encrypt/like/LikeEncryptAlgorithm.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/encrypt/like/LikeEncryptAlgorithm.java
@@ -15,12 +15,25 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.encrypt.spi;
+package org.apache.shardingsphere.encrypt.api.encrypt.like;
 
-import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 /**
- * Encrypt algorithm.
+ * Like encrypt algorithm.
+ * 
+ * @param <I> type of plain value
+ * @param <O> type of cipher value
  */
-public interface EncryptAlgorithm extends ShardingSphereAlgorithm {
+public interface LikeEncryptAlgorithm<I, O> extends EncryptAlgorithm {
+    
+    /**
+     * Encrypt.
+     *
+     * @param plainValue plain value
+     * @param encryptContext encrypt context
+     * @return cipher value
+     */
+    O encrypt(I plainValue, EncryptContext encryptContext);
 }

--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/encrypt/standard/StandardEncryptAlgorithm.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/encrypt/standard/StandardEncryptAlgorithm.java
@@ -15,12 +15,34 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.encrypt.spi;
+package org.apache.shardingsphere.encrypt.api.encrypt.standard;
 
-import org.apache.shardingsphere.infra.config.algorithm.ShardingSphereAlgorithm;
+import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 /**
- * Encrypt algorithm.
+ * Standard encrypt algorithm.
+ * 
+ * @param <I> type of plain value
+ * @param <O> type of cipher value
  */
-public interface EncryptAlgorithm extends ShardingSphereAlgorithm {
+public interface StandardEncryptAlgorithm<I, O> extends EncryptAlgorithm {
+    
+    /**
+     * Encrypt.
+     *
+     * @param plainValue plain value
+     * @param encryptContext encrypt context
+     * @return cipher value
+     */
+    O encrypt(I plainValue, EncryptContext encryptContext);
+    
+    /**
+     * Decrypt.
+     *
+     * @param cipherValue cipher value
+     * @param encryptContext encrypt context
+     * @return plain value
+     */
+    I decrypt(O cipherValue, EncryptContext encryptContext);
 }

--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/factory/EncryptAlgorithmFactory.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/factory/EncryptAlgorithmFactory.java
@@ -39,11 +39,9 @@ public final class EncryptAlgorithmFactory {
      * Create new instance of encrypt algorithm.
      * 
      * @param encryptAlgorithmConfig encrypt algorithm configuration
-     * @param <I> type of to be encrypted data
-     * @param <O> type of to be decrypted data
      * @return created instance
      */
-    public static <I, O> EncryptAlgorithm<I, O> newInstance(final AlgorithmConfiguration encryptAlgorithmConfig) {
+    public static EncryptAlgorithm newInstance(final AlgorithmConfiguration encryptAlgorithmConfig) {
         return ShardingSphereAlgorithmFactory.createAlgorithm(encryptAlgorithmConfig, EncryptAlgorithm.class);
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/config/AlgorithmProvidedEncryptRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/config/AlgorithmProvidedEncryptRuleConfiguration.java
@@ -42,7 +42,7 @@ public final class AlgorithmProvidedEncryptRuleConfiguration implements Database
     
     private Collection<EncryptTableRuleConfiguration> tables = new LinkedList<>();
     
-    private Map<String, EncryptAlgorithm<?, ?>> encryptors = new LinkedHashMap<>();
+    private Map<String, EncryptAlgorithm> encryptors = new LinkedHashMap<>();
     
     private boolean queryWithCipherColumn = true;
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithm.java
@@ -21,7 +21,7 @@ import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import javax.crypto.Cipher;
@@ -38,7 +38,7 @@ import java.util.Properties;
 /**
  * AES encrypt algorithm.
  */
-public final class AESEncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class AESEncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     private static final String AES_KEY = "aes-key-value";
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/MD5EncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/MD5EncryptAlgorithm.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.encrypt.algorithm.encrypt;
 
 import lombok.Getter;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
@@ -28,7 +28,7 @@ import java.util.Properties;
  * MD5 encrypt algorithm.
  */
 @Getter
-public final class MD5EncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class MD5EncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithm.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.encrypt.algorithm.encrypt;
 
 import lombok.Getter;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.exception.algorithm.EncryptAlgorithmInitializationException;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.nio.charset.StandardCharsets;
@@ -30,7 +30,7 @@ import java.util.Properties;
 /**
  * RC4 encrypt algorithm.
  */
-public final class RC4EncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class RC4EncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     private static final String RC4_KEY = "rc4-key-value";
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/like/CharDigestLikeEncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/like/CharDigestLikeEncryptAlgorithm.java
@@ -23,8 +23,8 @@ import com.google.common.io.CharStreams;
 import com.google.common.io.LineProcessor;
 import lombok.Getter;
 import lombok.SneakyThrows;
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.exception.algorithm.EncryptAlgorithmInitializationException;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.io.InputStream;
@@ -37,7 +37,7 @@ import java.util.Properties;
  * Char digest like encrypt algorithm.
  */
 @SuppressWarnings("UnstableApiUsage")
-public final class CharDigestLikeEncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class CharDigestLikeEncryptAlgorithm implements LikeEncryptAlgorithm<Object, String> {
     
     private static final String DELTA = "delta";
     
@@ -174,11 +174,6 @@ public final class CharDigestLikeEncryptAlgorithm implements EncryptAlgorithm<Ob
             return (char) (((charIndexes.get(originalChar) + delta) & mask) + start);
         }
         return (char) (((originalChar + delta) & mask) + start);
-    }
-    
-    @Override
-    public String decrypt(final String cipherValue, final EncryptContext encryptContext) {
-        return cipherValue;
     }
     
     @Override

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaData.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaData.java
@@ -18,9 +18,9 @@
 package org.apache.shardingsphere.encrypt.merge.dql;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.context.EncryptContextBuilder;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
@@ -37,6 +37,7 @@ import java.util.Optional;
 /**
  * Encrypt algorithm meta data.
  */
+@SuppressWarnings("rawtypes")
 @RequiredArgsConstructor
 public final class EncryptAlgorithmMetaData {
     
@@ -53,7 +54,7 @@ public final class EncryptAlgorithmMetaData {
      * @param columnName column name
      * @return encryptor
      */
-    public Optional<EncryptAlgorithm> findEncryptor(final String tableName, final String columnName) {
+    public Optional<StandardEncryptAlgorithm> findEncryptor(final String tableName, final String columnName) {
         return encryptRule.findEncryptor(tableName, columnName);
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.encrypt.merge.dql;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
 
 import java.io.InputStream;
@@ -49,7 +49,7 @@ public final class EncryptMergedResult implements MergedResult {
         if (!encryptContext.isPresent() || !metaData.isQueryWithCipherColumn(encryptContext.get().getTableName(), encryptContext.get().getColumnName())) {
             return mergedResult.getValue(columnIndex, type);
         }
-        Optional<EncryptAlgorithm> encryptAlgorithm = metaData.findEncryptor(encryptContext.get().getTableName(), encryptContext.get().getColumnName());
+        Optional<StandardEncryptAlgorithm> encryptAlgorithm = metaData.findEncryptor(encryptContext.get().getTableName(), encryptContext.get().getColumnName());
         if (!encryptAlgorithm.isPresent()) {
             return mergedResult.getValue(columnIndex, type);
         }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertValueParameterRewriter.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/parameter/rewriter/EncryptInsertValueParameterRewriter.java
@@ -19,11 +19,12 @@ package org.apache.shardingsphere.encrypt.rewrite.parameter.rewriter;
 
 import com.google.common.base.Preconditions;
 import lombok.Setter;
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.context.EncryptContextBuilder;
 import org.apache.shardingsphere.encrypt.rewrite.aware.DatabaseNameAware;
-import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementContext;
@@ -75,8 +76,8 @@ public final class EncryptInsertValueParameterRewriter implements ParameterRewri
     }
     
     private void encryptInsertValues(final GroupedParameterBuilder paramBuilder, final InsertStatementContext insertStatementContext,
-                                     final EncryptAlgorithm<?, ?> encryptAlgorithm, final EncryptAlgorithm<?, ?> assistEncryptAlgorithm,
-                                     final EncryptAlgorithm<?, ?> likeEncryptAlgorithm, final EncryptContext encryptContext) {
+                                     final StandardEncryptAlgorithm encryptAlgorithm, final StandardEncryptAlgorithm assistEncryptAlgorithm,
+                                     final LikeEncryptAlgorithm likeEncryptAlgorithm, final EncryptContext encryptContext) {
         int columnIndex = getColumnIndex(paramBuilder, insertStatementContext, encryptContext.getColumnName());
         int count = 0;
         for (List<Object> each : insertStatementContext.getGroupedParameters()) {
@@ -106,10 +107,10 @@ public final class EncryptInsertValueParameterRewriter implements ParameterRewri
     }
     
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private void encryptInsertValue(final EncryptAlgorithm encryptAlgorithm, final EncryptAlgorithm assistEncryptor, final EncryptAlgorithm likeEncryptor,
+    private void encryptInsertValue(final StandardEncryptAlgorithm encryptor, final StandardEncryptAlgorithm assistEncryptor, final LikeEncryptAlgorithm likeEncryptor,
                                     final int paramIndex, final Object originalValue, final StandardParameterBuilder paramBuilder,
                                     final EncryptContext encryptContext) {
-        paramBuilder.addReplacedParameters(paramIndex, encryptAlgorithm.encrypt(originalValue, encryptContext));
+        paramBuilder.addReplacedParameters(paramIndex, encryptor.encrypt(originalValue, encryptContext));
         Collection<Object> addedParams = new LinkedList<>();
         if (null != assistEncryptor) {
             Optional<String> assistedColumnName = encryptRule.findAssistedQueryColumn(encryptContext.getTableName(), encryptContext.getColumnName());

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGenerator.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
 import lombok.Setter;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.exception.metadata.EncryptColumnAlterException;
 import org.apache.shardingsphere.encrypt.exception.metadata.EncryptColumnNotFoundException;
+import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptAlterTableToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.ddl.AlterTableStatementContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.CollectionSQLTokenGenerator;
@@ -109,7 +109,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
         Collection<SQLToken> result = new LinkedList<>();
         for (ColumnDefinitionSegment each : addColumnDefinitionSegment.getColumnDefinitions()) {
             String columnName = each.getColumnName().getIdentifier().getValue();
-            Optional<EncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
+            Optional<StandardEncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
             if (encryptor.isPresent()) {
                 result.addAll(getAddColumnTokens(tableName, columnName, addColumnDefinitionSegment, each));
             }
@@ -142,7 +142,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     
     @SuppressWarnings("rawtypes")
     private Optional<SQLToken> getAddColumnPositionToken(final String tableName, final AddColumnDefinitionSegment addColumnDefinitionSegment) {
-        Optional<EncryptAlgorithm> encryptor = addColumnDefinitionSegment.getColumnPosition().filter(optional -> null != optional.getColumnName())
+        Optional<StandardEncryptAlgorithm> encryptor = addColumnDefinitionSegment.getColumnPosition().filter(optional -> null != optional.getColumnName())
                 .flatMap(optional -> encryptRule.findEncryptor(tableName, optional.getColumnName().getIdentifier().getValue()));
         if (encryptor.isPresent()) {
             return Optional.of(getPositionColumnToken(addColumnDefinitionSegment.getColumnPosition().get(), tableName));
@@ -161,7 +161,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
         for (ModifyColumnDefinitionSegment each : columnDefinitionSegments) {
             ColumnDefinitionSegment segment = each.getColumnDefinition();
             String columnName = segment.getColumnName().getIdentifier().getValue();
-            Optional<EncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
+            Optional<StandardEncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
             if (encryptor.isPresent()) {
                 result.addAll(getModifyColumnTokens(tableName, columnName, each));
             }
@@ -188,7 +188,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     
     @SuppressWarnings("rawtypes")
     private Optional<SQLToken> getColumnPositionToken(final String tableName, final ColumnPositionSegment columnPositionSegment) {
-        Optional<EncryptAlgorithm> encryptor = Optional.of(columnPositionSegment).filter(optional -> null != optional.getColumnName())
+        Optional<StandardEncryptAlgorithm> encryptor = Optional.of(columnPositionSegment).filter(optional -> null != optional.getColumnName())
                 .flatMap(optional -> encryptRule.findEncryptor(tableName, optional.getColumnName().getIdentifier().getValue()));
         return encryptor.isPresent() ? Optional.of(getPositionColumnToken(columnPositionSegment, tableName)) : Optional.empty();
     }
@@ -216,8 +216,8 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     
     @SuppressWarnings("rawtypes")
     private void isSameEncryptColumn(final String tableName, final ChangeColumnDefinitionSegment segment) {
-        Optional<EncryptAlgorithm> previousAlgorithm = encryptRule.findEncryptor(tableName, segment.getPreviousColumn().getIdentifier().getValue());
-        Optional<EncryptAlgorithm> currentAlgorithm = encryptRule.findEncryptor(tableName, segment.getColumnDefinition().getColumnName().getIdentifier().getValue());
+        Optional<StandardEncryptAlgorithm> previousAlgorithm = encryptRule.findEncryptor(tableName, segment.getPreviousColumn().getIdentifier().getValue());
+        Optional<StandardEncryptAlgorithm> currentAlgorithm = encryptRule.findEncryptor(tableName, segment.getColumnDefinition().getColumnName().getIdentifier().getValue());
         if (!previousAlgorithm.isPresent() && !currentAlgorithm.isPresent()) {
             return;
         }
@@ -288,7 +288,7 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
         Collection<SQLToken> result = new LinkedList<>();
         for (ColumnSegment each : dropColumnDefinitionSegment.getColumns()) {
             String columnName = each.getQualifiedName();
-            Optional<EncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
+            Optional<StandardEncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
             if (encryptor.isPresent()) {
                 result.addAll(getDropColumnTokens(tableName, columnName, each, dropColumnDefinitionSegment));
             }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGenerator.java
@@ -18,9 +18,9 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
 import lombok.Setter;
-import org.apache.shardingsphere.encrypt.rule.EncryptRule;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.ddl.CreateTableStatementContext;
@@ -59,7 +59,7 @@ public final class EncryptCreateTableTokenGenerator implements CollectionSQLToke
         for (int index = 0; index < columns.size(); index++) {
             ColumnDefinitionSegment each = columns.get(index);
             String columnName = each.getColumnName().getIdentifier().getValue();
-            Optional<EncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
+            Optional<StandardEncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
             if (encryptor.isPresent()) {
                 result.addAll(getColumnTokens(tableName, columnName, each, columns, index));
             }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptInsertValuesTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptInsertValuesTokenGenerator.java
@@ -18,12 +18,13 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
 import lombok.Setter;
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.context.EncryptContextBuilder;
 import org.apache.shardingsphere.encrypt.rewrite.aware.DatabaseNameAware;
+import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptInsertValuesToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.binder.segment.insert.values.InsertValueContext;
 import org.apache.shardingsphere.infra.binder.segment.insert.values.expression.DerivedLiteralExpressionSegment;
@@ -51,6 +52,7 @@ import java.util.Optional;
 /**
  * Insert values token generator for encrypt.
  */
+@SuppressWarnings({"unchecked", "rawtypes"})
 @Setter
 public final class EncryptInsertValuesTokenGenerator implements OptionalSQLTokenGenerator<InsertStatementContext>, PreviousSQLTokensAware, EncryptRuleAware, DatabaseNameAware {
     
@@ -129,7 +131,7 @@ public final class EncryptInsertValuesTokenGenerator implements OptionalSQLToken
         Iterator<String> descendingColumnNames = insertStatementContext.getDescendingColumnNames();
         while (descendingColumnNames.hasNext()) {
             String columnName = descendingColumnNames.next();
-            Optional<EncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
+            Optional<StandardEncryptAlgorithm> encryptor = encryptRule.findEncryptor(tableName, columnName);
             if (encryptor.isPresent()) {
                 int columnIndex = useDefaultInsertColumnsToken.map(optional -> ((UseDefaultInsertColumnsToken) optional).getColumns().indexOf(columnName))
                         .orElseGet(() -> insertStatementContext.getColumnNames().indexOf(columnName));
@@ -159,8 +161,7 @@ public final class EncryptInsertValuesTokenGenerator implements OptionalSQLToken
         }
     }
     
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private void addAssistedQueryColumn(final InsertValue insertValueToken, final EncryptAlgorithm encryptAlgorithm, final int columnIndex,
+    private void addAssistedQueryColumn(final InsertValue insertValueToken, final StandardEncryptAlgorithm encryptAlgorithm, final int columnIndex,
                                         final EncryptContext encryptContext, final InsertValueContext insertValueContext, final Object originalValue) {
         if (encryptRule.findAssistedQueryColumn(encryptContext.getTableName(), encryptContext.getColumnName()).isPresent()) {
             DerivedSimpleExpressionSegment derivedExpressionSegment = isAddLiteralExpressionSegment(insertValueContext, columnIndex)
@@ -170,7 +171,7 @@ public final class EncryptInsertValuesTokenGenerator implements OptionalSQLToken
         }
     }
     
-    private void addLikeQueryColumn(final InsertValue insertValueToken, final EncryptAlgorithm encryptAlgorithm, final int columnIndex,
+    private void addLikeQueryColumn(final InsertValue insertValueToken, final LikeEncryptAlgorithm encryptAlgorithm, final int columnIndex,
                                     final EncryptContext encryptContext, final InsertValueContext insertValueContext,
                                     final Object originalValue, final int indexDelta) {
         if (encryptRule.findLikeQueryColumn(encryptContext.getTableName(), encryptContext.getColumnName()).isPresent()) {
@@ -196,8 +197,7 @@ public final class EncryptInsertValuesTokenGenerator implements OptionalSQLToken
         return result;
     }
     
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    private void setCipherColumn(final InsertValue insertValueToken, final EncryptAlgorithm encryptAlgorithm, final int columnIndex,
+    private void setCipherColumn(final InsertValue insertValueToken, final StandardEncryptAlgorithm encryptAlgorithm, final int columnIndex,
                                  final EncryptContext encryptContext, final ExpressionSegment valueExpression, final Object originalValue) {
         if (valueExpression instanceof LiteralExpressionSegment) {
             insertValueToken.getValues().set(columnIndex, new LiteralExpressionSegment(

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithmTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithmTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.algorithm.encrypt;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Before;
@@ -27,17 +27,18 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class AESEncryptAlgorithmTest {
     
-    private EncryptAlgorithm<Object, String> encryptAlgorithm;
+    private StandardEncryptAlgorithm<Object, String> encryptAlgorithm;
     
     @Before
     public void setUp() {
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("AES", createProperties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("AES", createProperties()));
     }
     
     private Properties createProperties() {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/MD5EncryptAlgorithmTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/MD5EncryptAlgorithmTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.algorithm.encrypt;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Before;
@@ -27,17 +27,18 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class MD5EncryptAlgorithmTest {
     
-    private EncryptAlgorithm<Object, String> encryptAlgorithm;
+    private StandardEncryptAlgorithm<Object, String> encryptAlgorithm;
     
     @Before
     public void setUp() {
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("MD5", new Properties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("MD5", new Properties()));
     }
     
     @Test

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithmTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithmTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.encrypt.algorithm.encrypt;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.exception.algorithm.EncryptAlgorithmInitializationException;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Before;
@@ -28,17 +28,18 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class RC4EncryptAlgorithmTest {
     
-    private EncryptAlgorithm<Object, String> encryptAlgorithm;
+    private StandardEncryptAlgorithm<Object, String> encryptAlgorithm;
     
     @Before
     public void setUp() {
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("Rc4", createProperties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("Rc4", createProperties()));
     }
     
     private Properties createProperties() {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/like/CharDigestLikeEncryptAlgorithmTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/algorithm/like/CharDigestLikeEncryptAlgorithmTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.encrypt.algorithm.like;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Before;
@@ -31,19 +32,20 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class CharDigestLikeEncryptAlgorithmTest {
     
-    private EncryptAlgorithm<Object, String> encryptAlgorithm;
+    private StandardEncryptAlgorithm<Object, String> encryptAlgorithm;
     
-    private EncryptAlgorithm<Object, String> chineseLikeEncryptAlgorithm;
+    private LikeEncryptAlgorithm<Object, String> chineseLikeEncryptAlgorithm;
     
-    private EncryptAlgorithm<Object, String> koreanLikeEncryptAlgorithm;
+    private LikeEncryptAlgorithm<Object, String> koreanLikeEncryptAlgorithm;
     
     @Before
     public void setUp() {
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", new Properties()));
-        chineseLikeEncryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", new Properties()));
-        koreanLikeEncryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", createProperties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", new Properties()));
+        chineseLikeEncryptAlgorithm = (LikeEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", new Properties()));
+        koreanLikeEncryptAlgorithm = (LikeEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("CHAR_DIGEST_LIKE", createProperties()));
     }
     
     private Properties createProperties() {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreEncryptAlgorithmFixture.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.encrypt.fixture;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class CoreEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class CoreEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreQueryAssistedEncryptAlgorithmFixture.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreQueryAssistedEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.encrypt.fixture;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class CoreQueryAssistedEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class CoreQueryAssistedEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreQueryLikeEncryptAlgorithmFixture.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreQueryLikeEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.encrypt.fixture;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class CoreQueryLikeEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class CoreQueryLikeEncryptAlgorithmFixture implements LikeEncryptAlgorithm<Object, String> {
     
     private Properties props;
     
@@ -36,11 +36,6 @@ public final class CoreQueryLikeEncryptAlgorithmFixture implements EncryptAlgori
     @Override
     public String encrypt(final Object plainValue, final EncryptContext encryptContext) {
         return "likeEncryptValue";
-    }
-    
-    @Override
-    public Object decrypt(final String cipherValue, final EncryptContext encryptContext) {
-        return "decryptValue";
     }
     
     @Override

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreSchemaMetaDataAwareEncryptAlgorithmFixture.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/fixture/CoreSchemaMetaDataAwareEncryptAlgorithmFixture.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.encrypt.fixture;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.SchemaMetaDataAware;
@@ -30,7 +30,7 @@ import java.util.Properties;
 
 @Getter
 @Setter
-public final class CoreSchemaMetaDataAwareEncryptAlgorithmFixture implements EncryptAlgorithm<Integer, Integer>, SchemaMetaDataAware {
+public final class CoreSchemaMetaDataAwareEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Integer, Integer>, SchemaMetaDataAware {
     
     @Setter(AccessLevel.NONE)
     private Properties props;

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaDataTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptAlgorithmMetaDataTest.java
@@ -17,9 +17,9 @@
 
 package org.apache.shardingsphere.encrypt.merge.dql;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.ProjectionsContext;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
@@ -46,8 +46,8 @@ import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -76,7 +76,7 @@ public final class EncryptAlgorithmMetaDataTest {
     @Mock
     private ProjectionsContext projectionsContext;
     
-    private EncryptAlgorithm<?, ?> encryptAlgorithm;
+    private StandardEncryptAlgorithm<?, ?> encryptAlgorithm;
     
     @Before
     public void setUp() {
@@ -88,7 +88,7 @@ public final class EncryptAlgorithmMetaDataTest {
         when(selectStatementContext.getDatabaseType()).thenReturn(new MySQLDatabaseType());
         when(database.getName()).thenReturn(DefaultDatabase.LOGIC_NAME);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(schema);
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("MD5", new Properties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<?, ?>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("MD5", new Properties()));
     }
     
     @Test
@@ -130,7 +130,7 @@ public final class EncryptAlgorithmMetaDataTest {
     public void assertFindEncryptor() {
         when(encryptRule.findEncryptor("t_order", "id")).thenReturn(Optional.of(encryptAlgorithm));
         EncryptAlgorithmMetaData encryptAlgorithmMetaData = new EncryptAlgorithmMetaData(database, encryptRule, selectStatementContext);
-        Optional<EncryptAlgorithm> actualEncryptor = encryptAlgorithmMetaData.findEncryptor("t_order", "id");
+        Optional<StandardEncryptAlgorithm> actualEncryptor = encryptAlgorithmMetaData.findEncryptor("t_order", "id");
         assertTrue(actualEncryptor.isPresent());
         assertThat(actualEncryptor.get().getType(), is("MD5"));
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResultTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.merge.dql;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.context.EncryptContextBuilder;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
 import org.apache.shardingsphere.infra.merge.result.MergedResult;
@@ -34,9 +34,9 @@ import java.util.Date;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +83,7 @@ public final class EncryptMergedResultTest {
     @Test
     public void assertGetValueWithQueryWithCipherColumnAndMatchedEncryptorWithNotNullCiphertext() throws SQLException {
         when(mergedResult.getValue(1, Object.class)).thenReturn("VALUE");
-        EncryptAlgorithm<String, String> encryptAlgorithm = mock(EncryptAlgorithm.class);
+        StandardEncryptAlgorithm<String, String> encryptAlgorithm = mock(StandardEncryptAlgorithm.class);
         EncryptContext encryptContext = EncryptContextBuilder.build(DefaultDatabase.LOGIC_NAME, DefaultDatabase.LOGIC_NAME, "t_encrypt", "order_id");
         when(encryptAlgorithm.decrypt("VALUE", encryptContext)).thenReturn("ORIGINAL_VALUE");
         when(metaData.findEncryptContext(1)).thenReturn(Optional.of(encryptContext));
@@ -95,7 +95,7 @@ public final class EncryptMergedResultTest {
     @SuppressWarnings("unchecked")
     @Test
     public void assertGetValueWithQueryWithCipherColumnAndMatchedEncryptorWithNullCiphertext() throws SQLException {
-        EncryptAlgorithm<String, String> encryptAlgorithm = mock(EncryptAlgorithm.class);
+        StandardEncryptAlgorithm<String, String> encryptAlgorithm = mock(StandardEncryptAlgorithm.class);
         EncryptContext encryptContext = EncryptContextBuilder.build(DefaultDatabase.LOGIC_NAME, DefaultDatabase.LOGIC_NAME, "t_encrypt", "order_id");
         when(metaData.findEncryptContext(1)).thenReturn(Optional.of(encryptContext));
         when(metaData.isQueryWithCipherColumn("t_encrypt", "order_id")).thenReturn(true);

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptAlterTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptAlterTableTokenGeneratorTest.java
@@ -17,12 +17,12 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.impl;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptAlterTableTokenGenerator;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptAlterTableToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.statement.ddl.AlterTableStatementContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.RemoveToken;
@@ -66,7 +66,7 @@ public final class EncryptAlterTableTokenGeneratorTest {
         when(result.findPlainColumn("t_encrypt", "certificate_number")).thenReturn(Optional.of("certificate_number_plain"));
         EncryptTable encryptTable = mock(EncryptTable.class);
         when(encryptTable.getLogicColumns()).thenReturn(Collections.singleton("t_encrypt"));
-        EncryptAlgorithm<?, ?> encryptAlgorithm = mock(EncryptAlgorithm.class);
+        StandardEncryptAlgorithm<?, ?> encryptAlgorithm = mock(StandardEncryptAlgorithm.class);
         when(result.findEncryptor("t_encrypt", "certificate_number")).thenReturn(Optional.of(encryptAlgorithm));
         when(result.findEncryptor("t_encrypt", "certificate_number_new")).thenReturn(Optional.of(encryptAlgorithm));
         when(result.findEncryptTable("t_encrypt")).thenReturn(Optional.of(encryptTable));

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptCreateTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptCreateTableTokenGeneratorTest.java
@@ -17,12 +17,11 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.impl;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptCreateTableTokenGenerator;
 import org.apache.shardingsphere.encrypt.rule.EncryptColumn;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
-
 import org.apache.shardingsphere.infra.binder.statement.ddl.CreateTableStatementContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.RemoveToken;
@@ -94,7 +93,7 @@ public final class EncryptCreateTableTokenGeneratorTest {
         EncryptRule result = mock(EncryptRule.class);
         EncryptTable encryptTable = mock(EncryptTable.class);
         when(encryptTable.getLogicColumns()).thenReturn(Collections.singletonList("t_encrypt"));
-        when(result.findEncryptor("t_encrypt", "certificate_number")).thenReturn(Optional.of(mock(EncryptAlgorithm.class)));
+        when(result.findEncryptor("t_encrypt", "certificate_number")).thenReturn(Optional.of(mock(StandardEncryptAlgorithm.class)));
         when(result.findEncryptTable("t_encrypt")).thenReturn(Optional.of(encryptTable));
         EncryptColumn column = mockEncryptColumn();
         when(result.getCipherColumn("t_encrypt", "certificate_number")).thenReturn(column.getCipherColumn());

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptOrderByItemTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/impl/EncryptOrderByItemTokenGeneratorTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.impl;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptOrderByItemTokenGenerator;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.segment.select.orderby.OrderByItem;
 import org.apache.shardingsphere.infra.binder.segment.table.TablesContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
@@ -86,7 +86,7 @@ public final class EncryptOrderByItemTokenGeneratorTest {
         when(result.findAssistedQueryColumn("t_encrypt", "certificate_number")).thenReturn(Optional.of("assisted_certificate_number"));
         when(result.findPlainColumn("t_encrypt", "certificate_number")).thenReturn(Optional.of("certificate_number_plain"));
         when(encryptTable.findEncryptorName("certificate_number")).thenReturn(Optional.of("encryptor_name"));
-        when(result.findEncryptor("t_encrypt", "certificate_number")).thenReturn(Optional.of(mock(EncryptAlgorithm.class)));
+        when(result.findEncryptor("t_encrypt", "certificate_number")).thenReturn(Optional.of(mock(StandardEncryptAlgorithm.class)));
         when(result.findEncryptTable("t_encrypt")).thenReturn(Optional.of(encryptTable));
         return result;
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptInsertOnUpdateTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/EncryptInsertOnUpdateTokenGeneratorTest.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rewrite.token.generator.EncryptInsertOnUpdateTokenGenerator;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptAssignmentToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.AssignmentSegment;
@@ -44,8 +44,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -64,8 +64,8 @@ public final class EncryptInsertOnUpdateTokenGeneratorTest {
     private EncryptRule mockEncryptRule() {
         EncryptRule result = mock(EncryptRule.class);
         when(result.getCipherColumn("t_user", "mobile")).thenReturn("cipher_mobile");
-        when(result.findEncryptor("t_user", "mobile")).thenReturn(Optional.of(mock(EncryptAlgorithm.class)));
-        when(result.findEncryptor("t_user", "cipher_mobile")).thenReturn(Optional.of(mock(EncryptAlgorithm.class)));
+        when(result.findEncryptor("t_user", "mobile")).thenReturn(Optional.of(mock(StandardEncryptAlgorithm.class)));
+        when(result.findEncryptor("t_user", "cipher_mobile")).thenReturn(Optional.of(mock(StandardEncryptAlgorithm.class)));
         when(result.getEncryptValues(null, "db_test", "t_user", "mobile", Collections.singletonList(0))).thenReturn(Collections.singletonList("encryptValue"));
         return result;
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAssignmentTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAssignmentTokenGeneratorTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.UpdateStatementContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.AssignmentSegment;
@@ -72,7 +72,7 @@ public final class EncryptAssignmentTokenGeneratorTest {
         when(updateStatement.getAllTables().iterator().next().getTableName().getIdentifier().getValue()).thenReturn("table");
         when(updateStatement.getSqlStatement().getSetAssignment().getAssignments()).thenReturn(Collections.singletonList(assignmentSegment));
         when(assignmentSegment.getColumns().get(0).getIdentifier().getValue()).thenReturn("columns");
-        when(encryptRule.findEncryptor(eq("table"), eq("columns"))).thenReturn(Optional.of(mock(EncryptAlgorithm.class)));
+        when(encryptRule.findEncryptor(eq("table"), eq("columns"))).thenReturn(Optional.of(mock(StandardEncryptAlgorithm.class)));
         when(insertStatement.getAllTables().iterator().next().getTableName().getIdentifier().getValue()).thenReturn("table");
         when(setAssignmentSegment.getAssignments()).thenReturn(Collections.singletonList(assignmentSegment));
     }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptRuleTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rule/EncryptRuleTest.java
@@ -21,9 +21,9 @@ import org.apache.shardingsphere.encrypt.algorithm.config.AlgorithmProvidedEncry
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.fixture.CoreEncryptAlgorithmFixture;
 import org.apache.shardingsphere.encrypt.fixture.CoreSchemaMetaDataAwareEncryptAlgorithmFixture;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
@@ -40,9 +40,9 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -190,7 +190,7 @@ public final class EncryptRuleTest {
         EncryptRule encryptRule = new EncryptRule(createEncryptRuleConfiguration());
         ShardingSphereSchema schema = mock(ShardingSphereSchema.class);
         encryptRule.setSchemaMetaData("foo_db", Collections.singletonMap("foo_schema", schema));
-        Optional<EncryptAlgorithm> actual = encryptRule.findEncryptor("t_encrypt", "name");
+        Optional<StandardEncryptAlgorithm> actual = encryptRule.findEncryptor("t_encrypt", "name");
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(CoreSchemaMetaDataAwareEncryptAlgorithmFixture.class));
         assertThat(((CoreSchemaMetaDataAwareEncryptAlgorithmFixture) actual.get()).getDatabaseName(), is("foo_db"));

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleAlgorithmProviderConfigurationSwapperTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleAlgorithmProviderConfigurationSwapperTest.java
@@ -53,7 +53,7 @@ public final class YamlEncryptRuleAlgorithmProviderConfigurationSwapperTest {
     
     private AlgorithmProvidedEncryptRuleConfiguration createAlgorithmProvidedEncryptRuleConfiguration() {
         Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("tbl", Collections.emptyList(), null));
-        Map<String, EncryptAlgorithm<?, ?>> encryptors = new LinkedHashMap<>();
+        Map<String, EncryptAlgorithm> encryptors = new LinkedHashMap<>();
         return new AlgorithmProvidedEncryptRuleConfiguration(tables, encryptors, true);
     }
     

--- a/features/encrypt/plugin/sm/src/main/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM3EncryptAlgorithm.java
+++ b/features/encrypt/plugin/sm/src/main/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM3EncryptAlgorithm.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.encrypt.sm.algorithm;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.bouncycastle.crypto.digests.SM3Digest;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -32,7 +32,7 @@ import java.util.Properties;
 /**
  * SM3 encrypt algorithm.
  */
-public final class SM3EncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class SM3EncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     static {
         Security.addProvider(new BouncyCastleProvider());

--- a/features/encrypt/plugin/sm/src/main/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM4EncryptAlgorithm.java
+++ b/features/encrypt/plugin/sm/src/main/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM4EncryptAlgorithm.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.encrypt.sm.algorithm;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.pqc.math.linearalgebra.ByteUtils;
@@ -40,7 +40,7 @@ import java.util.Set;
 /**
  * SM4 encrypt algorithm.
  */
-public final class SM4EncryptAlgorithm implements EncryptAlgorithm<Object, String> {
+public final class SM4EncryptAlgorithm implements StandardEncryptAlgorithm<Object, String> {
     
     static {
         Security.addProvider(new BouncyCastleProvider());

--- a/features/encrypt/plugin/sm/src/test/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM3EncryptAlgorithmTest.java
+++ b/features/encrypt/plugin/sm/src/test/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM3EncryptAlgorithmTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.sm.algorithm;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Before;
@@ -27,17 +27,18 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class SM3EncryptAlgorithmTest {
     
-    private EncryptAlgorithm<Object, String> encryptAlgorithm;
+    private StandardEncryptAlgorithm<Object, String> encryptAlgorithm;
     
     @Before
     public void setUp() {
-        encryptAlgorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM3", createProperties()));
+        encryptAlgorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM3", createProperties()));
     }
     
     private Properties createProperties() {

--- a/features/encrypt/plugin/sm/src/test/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM4EncryptAlgorithmTest.java
+++ b/features/encrypt/plugin/sm/src/test/java/org/apache/shardingsphere/encrypt/sm/algorithm/SM4EncryptAlgorithmTest.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.encrypt.sm.algorithm;
 
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.factory.EncryptAlgorithmFactory;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.junit.Test;
@@ -26,15 +26,16 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
+@SuppressWarnings("unchecked")
 public final class SM4EncryptAlgorithmTest {
     
     @Test(expected = IllegalArgumentException.class)
     public void assertInitWithoutKey() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
         algorithm.init(createInvalidProperties());
     }
     
@@ -47,25 +48,25 @@ public final class SM4EncryptAlgorithmTest {
     
     @Test
     public void assertEncryptNullValue() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
         assertNull(algorithm.encrypt(null, mock(EncryptContext.class)));
     }
     
     @Test
     public void assertEncryptWithECBMode() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
         assertThat(algorithm.encrypt("test", mock(EncryptContext.class)), is("028654f2ca4f575dee9e1faae85dadde"));
     }
     
     @Test
     public void assertDecryptNullValue() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
         assertNull(algorithm.decrypt(null, mock(EncryptContext.class)));
     }
     
     @Test
     public void assertDecryptWithECBMode() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createECBProperties()));
         assertThat(algorithm.decrypt("028654f2ca4f575dee9e1faae85dadde", mock(EncryptContext.class)).toString(), is("test"));
     }
     
@@ -79,13 +80,13 @@ public final class SM4EncryptAlgorithmTest {
     
     @Test
     public void assertEncryptWithCBCMode() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createCBCProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createCBCProperties()));
         assertThat(algorithm.encrypt("test", mock(EncryptContext.class)), is("dca2127b57ba8cac36a0914e0208dc11"));
     }
     
     @Test
     public void assertDecrypt() {
-        EncryptAlgorithm<Object, String> algorithm = EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createCBCProperties()));
+        StandardEncryptAlgorithm<Object, String> algorithm = (StandardEncryptAlgorithm<Object, String>) EncryptAlgorithmFactory.newInstance(new AlgorithmConfiguration("SM4", createCBCProperties()));
         assertThat(algorithm.decrypt("dca2127b57ba8cac36a0914e0208dc11", mock(EncryptContext.class)).toString(), is("test"));
     }
     

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/fixture/encrypt/JDBCEncryptAlgorithmFixture.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/fixture/encrypt/JDBCEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.driver.fixture.encrypt;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class JDBCEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class JDBCEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/fixture/encrypt/JDBCQueryAssistedEncryptAlgorithmFixture.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/fixture/encrypt/JDBCQueryAssistedEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.driver.fixture.encrypt;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class JDBCQueryAssistedEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class JDBCQueryAssistedEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/kernel/data-pipeline/scenario/consistencycheck/pom.xml
+++ b/kernel/data-pipeline/scenario/consistencycheck/pom.xml
@@ -16,13 +16,12 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>shardingsphere-data-pipeline-scenario</artifactId>
         <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-data-pipeline-scenario</artifactId>
         <version>5.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>shardingsphere-data-pipeline-scenario-consistencycheck</artifactId>

--- a/kernel/data-pipeline/scenario/migration/pom.xml
+++ b/kernel/data-pipeline/scenario/migration/pom.xml
@@ -16,13 +16,12 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>shardingsphere-data-pipeline-scenario</artifactId>
         <groupId>org.apache.shardingsphere</groupId>
+        <artifactId>shardingsphere-data-pipeline-scenario</artifactId>
         <version>5.2.2-SNAPSHOT</version>
     </parent>
     <artifactId>shardingsphere-data-pipeline-scenario-migration</artifactId>

--- a/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteNormalEncryptAlgorithmFixture.java
+++ b/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteNormalEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.sharding.rewrite.fixture.encrypt;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class RewriteNormalEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class RewriteNormalEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteQueryAssistedEncryptAlgorithmFixture.java
+++ b/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteQueryAssistedEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.sharding.rewrite.fixture.encrypt;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class RewriteQueryAssistedEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class RewriteQueryAssistedEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String> {
     
     private Properties props;
     

--- a/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteQueryLikeEncryptAlgorithmFixture.java
+++ b/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteQueryLikeEncryptAlgorithmFixture.java
@@ -18,13 +18,13 @@
 package org.apache.shardingsphere.sharding.rewrite.fixture.encrypt;
 
 import lombok.Getter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 
 import java.util.Properties;
 
 @Getter
-public final class RewriteQueryLikeEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String> {
+public final class RewriteQueryLikeEncryptAlgorithmFixture implements LikeEncryptAlgorithm<Object, String> {
     
     private Properties props;
     
@@ -39,11 +39,6 @@ public final class RewriteQueryLikeEncryptAlgorithmFixture implements EncryptAlg
             return null;
         }
         return "like_query_" + plainValue;
-    }
-    
-    @Override
-    public Object decrypt(final String cipherValue, final EncryptContext encryptContext) {
-        return cipherValue;
     }
     
     @Override

--- a/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteSchemaMetaDataAwareEncryptAlgorithmFixture.java
+++ b/test/rewrite/src/test/java/org/apache/shardingsphere/sharding/rewrite/fixture/encrypt/RewriteSchemaMetaDataAwareEncryptAlgorithmFixture.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sharding.rewrite.fixture.encrypt;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.spi.context.EncryptContext;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.decorator.model.ShardingSphereTable;
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.infra.rewrite.sql.token.generator.aware.SchemaM
 import java.util.Map;
 import java.util.Properties;
 
-public final class RewriteSchemaMetaDataAwareEncryptAlgorithmFixture implements EncryptAlgorithm<Object, String>, SchemaMetaDataAware {
+public final class RewriteSchemaMetaDataAwareEncryptAlgorithmFixture implements StandardEncryptAlgorithm<Object, String>, SchemaMetaDataAware {
     
     @Getter
     private Properties props;


### PR DESCRIPTION
Fixes #22098.

Changes proposed in this pull request:
  - split EncryptAlgorithm to StandardEncryptAlgorithm and LikeEncryptAlgorithm interface
  - update related unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
