### PR TITLE
Make sure ShardingSphereDriver can load configuration file from classpath with mutiple ClassLoaders

### DIFF
--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURL.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURL.java
@@ -54,12 +54,12 @@ public final class ShardingSphereDriverURL {
     
     /**
      * Generate to configuration bytes.
-     * 
+     *
      * @return generated configuration bytes
      */
     @SneakyThrows(IOException.class)
     public byte[] toConfigurationBytes() {
-        try (InputStream stream = inClasspath ? ShardingSphereDriverURL.class.getResourceAsStream("/" + file) : Files.newInputStream(new File(file).toPath())) {
+        try (InputStream stream = inClasspath ? getResourceAsStream(file) : Files.newInputStream(new File(file).toPath())) {
             Objects.requireNonNull(stream, String.format("Can not find configuration file `%s`.", file));
             BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8));
             StringBuilder builder = new StringBuilder();
@@ -71,5 +71,23 @@ public final class ShardingSphereDriverURL {
             }
             return builder.toString().getBytes(StandardCharsets.UTF_8);
         }
+    }
+
+    private InputStream getResourceAsStream(final String resource) throws IOException {
+        ClassLoader[] classLoaders = new ClassLoader[]{
+                Thread.currentThread().getContextClassLoader(), getClass().getClassLoader(), ClassLoader.getSystemClassLoader(),
+        };
+        for (ClassLoader each : classLoaders) {
+            if (null != each) {
+                InputStream result = each.getResourceAsStream(resource);
+                if (null == result) {
+                    result = each.getResourceAsStream("/" + resource);
+                }
+                if (null != result) {
+                    return result;
+                }
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
fromclasspath with mutiple ClassLoaders

Fixes #22658
Changes proposed in this pull request:
  - Add `getResourceAsStream` to load configuration file from classpath by using mutiple ClassLoaders which could be helpful to fix https://github.com/quarkiverse/quarkus-shardingsphere-jdbc/issues/74

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
