### PR TITLE
Improve MySQL incremental client reconnect and close

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
@@ -29,6 +29,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.util.concurrent.DefaultPromise;
 import io.netty.util.concurrent.Promise;
+import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.BinlogSyncChannelAlreadyClosedException;
@@ -276,13 +277,10 @@ public final class MySQLClient {
         }
     }
     
+    @AllArgsConstructor
     private final class MySQLBinlogEventHandler extends ChannelInboundHandlerAdapter {
         
-        private AbstractBinlogEvent lastBinlogEvent;
-        
-        MySQLBinlogEventHandler(final AbstractBinlogEvent lastBinlogEvent) {
-            this.lastBinlogEvent = lastBinlogEvent;
-        }
+        private volatile AbstractBinlogEvent lastBinlogEvent;
         
         @Override
         public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
@@ -105,6 +105,8 @@ public final class MySQLClient {
                     }
                 }).connect(connectInfo.getHost(), connectInfo.getPort()).channel();
         serverInfo = waitExpectedResponse(ServerInfo.class);
+        reconnectTimes.set(0);
+        running = true;
     }
     
     /**
@@ -157,8 +159,6 @@ public final class MySQLClient {
         registerSlave();
         dumpBinlog(binlogFileName, binlogPosition, queryChecksumLength());
         log.info("subscribe binlog file: {}, position: {}", binlogFileName, binlogPosition);
-        reconnectTimes.set(0);
-        running = true;
     }
     
     private void initDumpConnectSession() {
@@ -283,7 +283,7 @@ public final class MySQLClient {
         MySQLBinlogEventHandler(final AbstractBinlogEvent lastBinlogEvent) {
             this.lastBinlogEvent = lastBinlogEvent;
         }
-    
+        
         @Override
         public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
             if (!running) {

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
@@ -99,7 +99,7 @@ public final class PasswordEncryption {
     }
     
     private static RSAPublicKey parseRSAPublicKey(final String key) throws GeneralSecurityException {
-        byte[] certificateData = Base64.getDecoder().decode(formatKey(key));
+        byte[] certificateData = Base64.getDecoder().decode(formatKey(key.trim()));
         X509EncodedKeySpec spec = new X509EncodedKeySpec(certificateData);
         KeyFactory kf = KeyFactory.getInstance("RSA");
         return (RSAPublicKey) kf.generatePublic(spec);
@@ -107,7 +107,7 @@ public final class PasswordEncryption {
     
     private static byte[] formatKey(final String key) {
         int start = key.indexOf("\n") + 1;
-        int end = key.endsWith("\n") ? key.substring(0, key.length() - 2).lastIndexOf("\n") : key.lastIndexOf("\n");
+        int end = key.lastIndexOf("\n");
         return key.substring(start, end).replace("\n", "").getBytes();
     }
     

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
@@ -107,7 +107,7 @@ public final class PasswordEncryption {
     
     private static byte[] formatKey(final String key) {
         int start = key.indexOf("\n") + 1;
-        int end = key.lastIndexOf("\n");
+        int end = key.endsWith("\n") ? key.substring(0, key.length() - 2).lastIndexOf("\n") : key.lastIndexOf("\n");
         return key.substring(start, end).replace("\n", "").getBytes();
     }
     

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryption.java
@@ -99,16 +99,14 @@ public final class PasswordEncryption {
     }
     
     private static RSAPublicKey parseRSAPublicKey(final String key) throws GeneralSecurityException {
-        byte[] certificateData = Base64.getDecoder().decode(formatKey(key.trim()));
+        byte[] certificateData = Base64.getDecoder().decode(formatKey(key));
         X509EncodedKeySpec spec = new X509EncodedKeySpec(certificateData);
         KeyFactory kf = KeyFactory.getInstance("RSA");
         return (RSAPublicKey) kf.generatePublic(spec);
     }
     
     private static byte[] formatKey(final String key) {
-        int start = key.indexOf("\n") + 1;
-        int end = key.lastIndexOf("\n");
-        return key.substring(start, end).replace("\n", "").getBytes();
+        return key.replace("-----BEGIN PUBLIC KEY-----", "").replace("-----END PUBLIC KEY-----", "").trim().replace("\n", "").getBytes();
     }
     
     private static byte[] concatSeed(final MessageDigest messageDigest, final byte[] seed, final byte[] passwordSha1) {

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryptionTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/PasswordEncryptionTest.java
@@ -72,6 +72,6 @@ public final class PasswordEncryptionTest {
                 + "XaUZwZHdXjEme0/D8p8KBXdMipanZXwHdL+LOBSACj3/FwHn+6oZO2k02g80uofs\n"
                 + "zFdWMjpPVqVCqe85GRFzEY73wDYEItl0d+9a9OV3FFZqVgC2FLk3cD5qajPtyo6v\n"
                 + "UQIDAQAB\n"
-                + "-----END PUBLIC KEY-----";
+                + "-----END PUBLIC KEY-----\n";
     }
 }


### PR DESCRIPTION
1. avoid `lastBinlogEvent` is null when init
2. triggers reconnection when timeout happened,  no reconnection when manually stopped



Changes proposed in this pull request:
  - Improve MySQL incremental client reconnect and close

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
