### PR TITLE
Remove useless ALGORITHM_PROVIDER_ORDER for spring usage

### DIFF
--- a/features/db-discovery/core/src/main/java/org/apache/shardingsphere/dbdiscovery/constant/DatabaseDiscoveryOrder.java
+++ b/features/db-discovery/core/src/main/java/org/apache/shardingsphere/dbdiscovery/constant/DatabaseDiscoveryOrder.java
@@ -30,9 +30,4 @@ public final class DatabaseDiscoveryOrder {
      * Database discovery order.
      */
     public static final int ORDER = 40;
-    
-    /**
-     * Algorithm provider database discovery order.
-     */
-    public static final int ALGORITHM_PROVIDER_ORDER = ORDER + 1;
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptOrder.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptOrder.java
@@ -30,9 +30,4 @@ public final class EncryptOrder {
      * Encrypt order.
      */
     public static final int ORDER = 10;
-    
-    /**
-     * Algorithm provider encrypt order.
-     */
-    public static final int ALGORITHM_PROVIDER_ORDER = ORDER + 1;
 }

--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/constant/ReadwriteSplittingOrder.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/constant/ReadwriteSplittingOrder.java
@@ -30,9 +30,4 @@ public final class ReadwriteSplittingOrder {
      * Readwrite-splitting order.
      */
     public static final int ORDER = 30;
-    
-    /**
-     * Algorithm provider readwrite-splitting order.
-     */
-    public static final int ALGORITHM_PROVIDER_ORDER = ORDER + 1;
 }

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/constant/ShadowOrder.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/constant/ShadowOrder.java
@@ -30,9 +30,4 @@ public final class ShadowOrder {
      * Shadow order.
      */
     public static final int ORDER = 50;
-    
-    /**
-     * Algorithm provider shadow order.
-     */
-    public static final int ALGORITHM_PROVIDER_ORDER = ORDER + 1;
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/constant/ShardingOrder.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/constant/ShardingOrder.java
@@ -30,9 +30,4 @@ public final class ShardingOrder {
      * Sharding order.
      */
     public static final int ORDER = -10;
-    
-    /**
-     * Algorithm provider sharding order.
-     */
-    public static final int ALGORITHM_PROVIDER_ORDER = ORDER + 1;
 }

--- a/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/rule/builder/ShardingCacheRuleBuilder.java
+++ b/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/rule/builder/ShardingCacheRuleBuilder.java
@@ -45,7 +45,7 @@ public final class ShardingCacheRuleBuilder implements DatabaseRuleBuilder<Shard
     
     @Override
     public int getOrder() {
-        return ShardingOrder.ALGORITHM_PROVIDER_ORDER + 1;
+        return ShardingOrder.ORDER + 1;
     }
     
     @Override

--- a/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/yaml/swapper/YamlShardingCacheRuleConfigurationSwapper.java
+++ b/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/yaml/swapper/YamlShardingCacheRuleConfigurationSwapper.java
@@ -54,6 +54,6 @@ public final class YamlShardingCacheRuleConfigurationSwapper implements YamlRule
     
     @Override
     public int getOrder() {
-        return ShardingOrder.ALGORITHM_PROVIDER_ORDER + 1;
+        return ShardingOrder.ORDER + 1;
     }
 }

--- a/features/sharding/plugin/cache/src/test/java/org/apache/shardingsphere/sharding/cache/rule/builder/ShardingCacheRuleBuilderTest.java
+++ b/features/sharding/plugin/cache/src/test/java/org/apache/shardingsphere/sharding/cache/rule/builder/ShardingCacheRuleBuilderTest.java
@@ -52,7 +52,7 @@ public final class ShardingCacheRuleBuilderTest {
     
     @Test
     public void assertGetOrder() {
-        assertThat(new ShardingCacheRuleBuilder().getOrder(), is(-8));
+        assertThat(new ShardingCacheRuleBuilder().getOrder(), is(-9));
     }
     
     @Test

--- a/features/sharding/plugin/cache/src/test/java/org/apache/shardingsphere/sharding/cache/yaml/swapper/YamlShardingCacheRuleConfigurationSwapperTest.java
+++ b/features/sharding/plugin/cache/src/test/java/org/apache/shardingsphere/sharding/cache/yaml/swapper/YamlShardingCacheRuleConfigurationSwapperTest.java
@@ -70,6 +70,6 @@ public final class YamlShardingCacheRuleConfigurationSwapperTest {
     
     @Test
     public void assertGetOrder() {
-        assertThat(new YamlShardingCacheRuleConfigurationSwapper().getOrder(), is(-8));
+        assertThat(new YamlShardingCacheRuleConfigurationSwapper().getOrder(), is(-9));
     }
 }


### PR DESCRIPTION
Changes proposed in this pull request:
  - remove useless ALGORITHM_PROVIDER_ORDER for spring usage

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
