### PR TITLE
Correct the RE expression at the language.html

### DIFF
--- a/docs/document/themes/hugo-theme-learn/layouts/partials/language.html
+++ b/docs/document/themes/hugo-theme-learn/layouts/partials/language.html
@@ -16,9 +16,9 @@
               {{ range $versions }}
                 {{ $version := . }}
                 {{ if strings.HasSuffix $permalink $version }}
-                  <option id="{{ $version }}" value="{{ replaceRE "document/[\\w|-]*" (printf "document/%s" $version) $permalink }}" selected>{{ $version }}</option>
+                  <option id="{{ $version }}" value="{{ replaceRE "document/[^/]*" (printf "document/%s" $version) $permalink }}" selected>{{ $version }}</option>
                 {{ else }}
-                  <option id="{{ $version }}" value="{{ replaceRE "document/[\\w|-]*" (printf "document/%s" $version) $permalink }}" >{{ $version }}</option>
+                  <option id="{{ $version }}" value="{{ replaceRE "document/[^/]*" (printf "document/%s" $version) $permalink }}" >{{ $version }}</option>
                 {{ end }}
               {{ end }}
                 </select>


### PR DESCRIPTION
Signed-off-by: Junfeng <i@jacob953.com>

Fixes #22827.

Changes proposed in this pull request:
  - replace 'document/[\w|-]\*' with 'document/[^/]\*'.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
