### PR TITLE
Make ShardingSphereResultSet always tries to transform the target class

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtil.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/type/util/ResultSetUtil.java
@@ -86,7 +86,11 @@ public final class ResultSetUtil {
         if (String.class.equals(convertType)) {
             return value.toString();
         }
-        throw new SQLFeatureNotSupportedException("getObject with type");
+        try {
+            return convertType.cast(value);
+        } catch (ClassCastException cce) {
+            throw new SQLFeatureNotSupportedException("getObject with type");
+        }
     }
     
     private static Object convertURL(final Object value) {
@@ -135,6 +139,9 @@ public final class ResultSetUtil {
         if (Timestamp.class.equals(convertType)) {
             return Timestamp.valueOf(localDateTime);
         }
+        if (String.class.equals(convertType)) {
+            return value.toString();
+        }
         return value;
     }
     
@@ -151,6 +158,9 @@ public final class ResultSetUtil {
         }
         if (OffsetDateTime.class.equals(convertType)) {
             return timestamp.toInstant().atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        }
+        if (String.class.equals(convertType)) {
+            return value.toString();
         }
         return value;
     }

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetTest.java
@@ -42,7 +42,6 @@ import java.sql.Ref;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
@@ -55,8 +54,8 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -207,7 +206,12 @@ public final class ShardingSphereResultSetTest {
     @Test
     public void assertGetStringWithColumnIndex() throws SQLException {
         when(mergeResultSet.getValue(1, String.class)).thenReturn("value");
+        LocalDateTime tempTime = LocalDateTime.of(2022, 12, 14, 0, 0);
+        when(mergeResultSet.getValue(2, String.class)).thenReturn(tempTime);
+        when(mergeResultSet.getValue(3, String.class)).thenReturn(Timestamp.valueOf(tempTime));
         assertThat(shardingSphereResultSet.getString(1), is("value"));
+        assertThat(shardingSphereResultSet.getString(2), is("2022-12-14T00:00"));
+        assertThat(shardingSphereResultSet.getString(3), is("2022-12-14 00:00:00.0"));
     }
     
     @Test
@@ -616,11 +620,11 @@ public final class ShardingSphereResultSetTest {
         assertThat(shardingSphereResultSet.getObject(1, Clob.class), is(result));
     }
     
-    @Test(expected = SQLFeatureNotSupportedException.class)
+    @Test
     public void assertGetObjectWithRef() throws SQLException {
         Ref result = mock(Ref.class);
         when(mergeResultSet.getValue(1, Ref.class)).thenReturn(result);
-        shardingSphereResultSet.getObject(1, Ref.class);
+        assertThat(shardingSphereResultSet.getObject(1, Ref.class), is(result));
     }
     
     @Test


### PR DESCRIPTION
Fixes #22736.

Changes proposed in this pull request:
  - Make ShardingSphereResultSet always tries to transform the target class.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
