### PR TITLE
Optimize the verification of auto table algorithm type

### DIFF
--- a/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/exception/algorithm/InvalidAlgorithmConfigurationException.java
+++ b/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/exception/algorithm/InvalidAlgorithmConfigurationException.java
@@ -33,6 +33,10 @@ public final class InvalidAlgorithmConfigurationException extends RuleDefinition
         super(XOpenSQLState.CHECK_OPTION_VIOLATION, 150, String.format("Invalid %s algorithms `%s`.", algorithmType, algorithms));
     }
     
+    public InvalidAlgorithmConfigurationException(final String algorithmType, final String algorithm, final String message) {
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 150, String.format("Invalid %s algorithm `%s`, %s.", algorithmType, algorithm, message));
+    }
+    
     public InvalidAlgorithmConfigurationException(final String algorithmType, final String algorithm) {
         super(XOpenSQLState.CHECK_OPTION_VIOLATION, 150, String.format("Invalid %s algorithm `%s`.", algorithmType, algorithm));
     }

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/checker/ShardingRuleStatementCheckerTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/checker/ShardingRuleStatementCheckerTest.java
@@ -222,6 +222,22 @@ public final class ShardingRuleStatementCheckerTest {
         ShardingTableRuleStatementChecker.checkCreation(database, rules, shardingRuleConfig);
     }
     
+    @Test(expected = InvalidAlgorithmConfigurationException.class)
+    public void assertCheckAutoTableRuleWithStandardShardingAlgoithm() {
+        AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
+        autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("INLINE", newProperties("algorithm-expression", "ds_${product_id% 2}")));
+        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        ShardingTableRuleStatementChecker.checkCreation(database, rules, shardingRuleConfig);
+    }
+    
+    @Test
+    public void assertCheckAutoTableRuleWithAutoShardingAlgoithm() {
+        AutoTableRuleSegment autoTableRuleSegment = new AutoTableRuleSegment("t_product", Arrays.asList("ds_0", "ds_1"));
+        autoTableRuleSegment.setShardingAlgorithmSegment(new AlgorithmSegment("MOD", newProperties("sharding-count", "4")));
+        List<AbstractTableRuleSegment> rules = Collections.singletonList(autoTableRuleSegment);
+        ShardingTableRuleStatementChecker.checkCreation(database, rules, shardingRuleConfig);
+    }
+    
     private static ShardingRuleConfiguration createShardingRuleConfiguration() {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
         ShardingTableRuleConfiguration tableRuleConfig = new ShardingTableRuleConfiguration("t_order", "ds_${0..1}.t_order${0..1}");

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/segment/table/AutoTableRuleSegment.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/segment/table/AutoTableRuleSegment.java
@@ -47,13 +47,4 @@ public final class AutoTableRuleSegment extends AbstractTableRuleSegment {
         this.shardingColumn = shardingColumn;
         this.shardingAlgorithmSegment = shardingAlgorithm;
     }
-    
-    /**
-     * Determine whether sharding algorithm completed.
-     *
-     * @return completed sharding algorithm or not
-     */
-    public boolean isShardingAlgorithmCompleted() {
-        return null != shardingColumn && null != shardingAlgorithmSegment;
-    }
 }


### PR DESCRIPTION
Fixes #22816.

Changes proposed in this pull request:
  - Optimize the error message when sharding algorithm type does not match

### Before
```sql
CREATE SHARDING TABLE RULE apploginlogs(
RESOURCES(ds_write_test_common),
SHARDING_COLUMN=CreationTime,
TYPE(NAME=“INTERVAL”, PROPERTIES(“datetime-pattern”=“yyyy-MM-dd HH:mm:ss”,“datetime-interval-unit”=“MONTHS”,“datetime-interval-amount”=“1”,“sharding-suffix-pattern”=“yyyyMM”,“datetime-lower”=“2016-01-01 00:00:00”,“datetime-upper”=“2099-12-31 00:00:00”))
);
ERROR 19150 (44000): Invalid sharding algorithms [INTERVAL]
```

### After
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/5668787/207923628-a27de352-5750-4d1a-b882-8413f7c05315.png">

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
