### PR TITLE
SHOW COMPUTE NODES support display ShardingSphere-Proxy & ShardingSphere-JDBC version

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactory.java
@@ -55,6 +55,6 @@ public final class InstanceMetaDataBuilderFactory {
      * @return created instance meta data
      */
     public static InstanceMetaData create(final String instanceId, final InstanceType instanceType, final String attributes, final String version) {
-        return InstanceType.JDBC == instanceType ? new JDBCInstanceMetaData(instanceId) : new ProxyInstanceMetaData(instanceId, attributes, version);
+        return InstanceType.JDBC == instanceType ? new JDBCInstanceMetaData(instanceId, version) : new ProxyInstanceMetaData(instanceId, attributes, version);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactory.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactory.java
@@ -51,9 +51,10 @@ public final class InstanceMetaDataBuilderFactory {
      * @param instanceId instance ID
      * @param instanceType instance type 
      * @param attributes attributes
+     * @param version version
      * @return created instance meta data
      */
-    public static InstanceMetaData create(final String instanceId, final InstanceType instanceType, final String attributes) {
-        return InstanceType.JDBC == instanceType ? new JDBCInstanceMetaData(instanceId) : new ProxyInstanceMetaData(instanceId, attributes);
+    public static InstanceMetaData create(final String instanceId, final InstanceType instanceType, final String attributes, final String version) {
+        return InstanceType.JDBC == instanceType ? new JDBCInstanceMetaData(instanceId) : new ProxyInstanceMetaData(instanceId, attributes, version);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/jdbc/JDBCInstanceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/jdbc/JDBCInstanceMetaData.java
@@ -38,7 +38,13 @@ public final class JDBCInstanceMetaData implements InstanceMetaData {
     public JDBCInstanceMetaData(final String id) {
         this.id = id;
         ip = IpUtils.getIp();
-        version = ShardingSphereVersion.VERSION;
+        this.version = ShardingSphereVersion.VERSION;
+    }
+    
+    public JDBCInstanceMetaData(final String id, final String version) {
+        this.id = id;
+        ip = IpUtils.getIp();
+        this.version = version;
     }
     
     @Override

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/jdbc/JDBCInstanceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/jdbc/JDBCInstanceMetaData.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.instance.metadata.jdbc;
 
 import lombok.Getter;
+import org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceType;
 import org.apache.shardingsphere.infra.instance.utils.IpUtils;
@@ -32,9 +33,12 @@ public final class JDBCInstanceMetaData implements InstanceMetaData {
     
     private final String ip;
     
+    private final String version;
+    
     public JDBCInstanceMetaData(final String id) {
         this.id = id;
         ip = IpUtils.getIp();
+        version = ShardingSphereVersion.VERSION;
     }
     
     @Override

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/proxy/ProxyInstanceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/instance/metadata/proxy/ProxyInstanceMetaData.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.instance.metadata.proxy;
 
 import com.google.common.base.Joiner;
 import lombok.Getter;
+import org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceType;
 import org.apache.shardingsphere.infra.instance.utils.IpUtils;
@@ -37,17 +38,21 @@ public final class ProxyInstanceMetaData implements InstanceMetaData {
     
     private final int port;
     
+    private final String version;
+    
     public ProxyInstanceMetaData(final String id, final int port) {
         this.id = id;
         ip = IpUtils.getIp();
         this.port = port;
+        version = ShardingSphereVersion.VERSION;
     }
     
-    public ProxyInstanceMetaData(final String id, final String attributes) {
+    public ProxyInstanceMetaData(final String id, final String attributes, final String version) {
         this.id = id;
         String[] attributesList = attributes.split(DELIMITER);
         ip = attributesList[0];
         port = Integer.parseInt(attributesList[1]);
+        this.version = version;
     }
     
     @Override

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactoryTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/instance/metadata/InstanceMetaDataBuilderFactoryTest.java
@@ -48,20 +48,22 @@ public final class InstanceMetaDataBuilderFactoryTest {
     
     @Test
     public void assertCreateJDBCInstanceMetaDataWithInstanceId() {
-        InstanceMetaData actual = InstanceMetaDataBuilderFactory.create("foo_id", InstanceType.JDBC, "");
+        InstanceMetaData actual = InstanceMetaDataBuilderFactory.create("foo_id", InstanceType.JDBC, "", "foo_version");
         assertThat(actual.getId(), is("foo_id"));
         assertNotNull(actual.getIp());
         assertThat(actual.getAttributes(), is(""));
+        assertThat(actual.getVersion(), is("foo_version"));
         assertThat(actual.getType(), is(InstanceType.JDBC));
     }
     
     @Test
     public void assertCreateProxyInstanceMetaDataWithInstanceId() {
-        ProxyInstanceMetaData actual = (ProxyInstanceMetaData) InstanceMetaDataBuilderFactory.create("foo_id", InstanceType.PROXY, "127.0.0.1@3307");
+        ProxyInstanceMetaData actual = (ProxyInstanceMetaData) InstanceMetaDataBuilderFactory.create("foo_id", InstanceType.PROXY, "127.0.0.1@3307", "foo_version");
         assertThat(actual.getId(), is("foo_id"));
         assertThat(actual.getIp(), is("127.0.0.1"));
         assertThat(actual.getPort(), is(3307));
         assertThat(actual.getAttributes(), is("127.0.0.1@3307"));
+        assertThat(actual.getVersion(), is("foo_version"));
         assertThat(actual.getType(), is(InstanceType.PROXY));
     }
 }

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/connection/ConnectionManagerTest.java
@@ -91,7 +91,7 @@ public final class ConnectionManagerTest {
         when(globalRuleMetaData.getSingleRule(TransactionRule.class)).thenReturn(mock(TransactionRule.class, RETURNS_DEEP_STUBS));
         when(globalRuleMetaData.getSingleRule(TrafficRule.class)).thenReturn(mock(TrafficRule.class, RETURNS_DEEP_STUBS));
         when(result.getInstanceContext().getAllClusterInstances(InstanceType.PROXY, Arrays.asList("OLTP", "OLAP"))).thenReturn(
-                Collections.singletonList(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307")));
+                Collections.singletonList(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307", "foo_version")));
         dataSourcePoolCreator = mockStatic(DataSourcePoolCreator.class);
         Map<String, DataSource> trafficDataSourceMap = mockTrafficDataSourceMap();
         when(DataSourcePoolCreator.create((Map) any())).thenReturn(trafficDataSourceMap);

--- a/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/engine/TrafficEngineTest.java
+++ b/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/engine/TrafficEngineTest.java
@@ -102,8 +102,8 @@ public final class TrafficEngineTest {
     
     private List<InstanceMetaData> mockComputeNodeInstances() {
         List<InstanceMetaData> result = new ArrayList<>();
-        result.add(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307"));
-        result.add(new ProxyInstanceMetaData("bar_id", "127.0.0.1@3308"));
+        result.add(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307", "foo_version"));
+        result.add(new ProxyInstanceMetaData("bar_id", "127.0.0.1@3308", "foo_version"));
         return result;
     }
 }

--- a/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithmTest.java
+++ b/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RandomTrafficLoadBalanceAlgorithmTest.java
@@ -31,7 +31,8 @@ public final class RandomTrafficLoadBalanceAlgorithmTest {
     @Test
     public void assertGetInstanceId() {
         RandomTrafficLoadBalanceAlgorithm randomAlgorithm = new RandomTrafficLoadBalanceAlgorithm();
-        List<InstanceMetaData> instances = Arrays.asList(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307"), new ProxyInstanceMetaData("bar_id", "127.0.0.1@3308"));
+        List<InstanceMetaData> instances = Arrays.asList(new ProxyInstanceMetaData("foo_id", "127.0.0.1@3307", "foo_verison"),
+                new ProxyInstanceMetaData("bar_id", "127.0.0.1@3308", "foo_verison"));
         assertTrue(instances.contains(randomAlgorithm.getInstanceId("simple_traffic", instances)));
         assertTrue(instances.contains(randomAlgorithm.getInstanceId("simple_traffic", instances)));
         assertTrue(instances.contains(randomAlgorithm.getInstanceId("simple_traffic", instances)));

--- a/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
+++ b/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/algorithm/loadbalance/RoundRobinTrafficLoadBalanceAlgorithmTest.java
@@ -31,8 +31,8 @@ public final class RoundRobinTrafficLoadBalanceAlgorithmTest {
     
     @Test
     public void assertGetInstanceId() {
-        InstanceMetaData instance1 = new ProxyInstanceMetaData("127.0.0.1@3307", "127.0.0.1@3307");
-        InstanceMetaData instance2 = new ProxyInstanceMetaData("127.0.0.1@3308", "127.0.0.1@3308");
+        InstanceMetaData instance1 = new ProxyInstanceMetaData("127.0.0.1@3307", "127.0.0.1@3307", "foo_version");
+        InstanceMetaData instance2 = new ProxyInstanceMetaData("127.0.0.1@3308", "127.0.0.1@3308", "foo_version");
         List<InstanceMetaData> instances = Arrays.asList(instance1, instance2);
         RoundRobinTrafficLoadBalanceAlgorithm roundRobinAlgorithm = new RoundRobinTrafficLoadBalanceAlgorithm();
         assertThat(roundRobinAlgorithm.getInstanceId("simple_traffic", instances), is(instance1));

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/pojo/ComputeNodeData.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/pojo/ComputeNodeData.java
@@ -15,45 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.instance.metadata;
+package org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.pojo;
 
-/**
- * Instance meta data.
- */
-public interface InstanceMetaData {
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public final class ComputeNodeData {
     
-    /**
-     * Get instance ID.
-     * 
-     * @return instance ID
-     */
-    String getId();
+    private String attribute;
     
-    /**
-     * Get instance type.
-     * 
-     * @return instance type
-     */
-    InstanceType getType();
+    private String version;
     
-    /**
-     * Get IP.
-     * 
-     * @return IP
-     */
-    String getIp();
-    
-    /**
-     * Get attributes.
-     * 
-     * @return attributes
-     */
-    String getAttributes();
-    
-    /**
-     * Get version.
-     *
-     * @return version
-     */
-    String getVersion();
+    public ComputeNodeData(final String attribute, final String version) {
+        this.attribute = attribute;
+        this.version = version;
+    }
 }

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusService.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusService.java
@@ -20,12 +20,14 @@ package org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.stat
 import com.google.common.base.Strings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.infra.autogen.version.ShardingSphereVersion;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaDataBuilderFactory;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceType;
 import org.apache.shardingsphere.infra.state.StateContext;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.pojo.ComputeNodeData;
 import org.apache.shardingsphere.mode.metadata.persist.node.ComputeNode;
 import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
 
@@ -34,7 +36,6 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Compute node status service.
@@ -51,7 +52,8 @@ public final class ComputeNodeStatusService {
      * @param instanceMetaData instance definition
      */
     public void registerOnline(final InstanceMetaData instanceMetaData) {
-        repository.persistEphemeral(ComputeNode.getOnlineInstanceNodePath(instanceMetaData.getId(), instanceMetaData.getType()), instanceMetaData.getAttributes());
+        repository.persistEphemeral(ComputeNode.getOnlineInstanceNodePath(instanceMetaData.getId(), instanceMetaData.getType()),
+                YamlEngine.marshal(new ComputeNodeData(instanceMetaData.getAttributes(), ShardingSphereVersion.VERSION)));
     }
     
     /**
@@ -139,9 +141,16 @@ public final class ComputeNodeStatusService {
     }
     
     private Collection<ComputeNodeInstance> loadComputeNodeInstances(final InstanceType instanceType) {
-        Collection<String> onlineComputeNodes = repository.getChildrenKeys(ComputeNode.getOnlineNodePath(instanceType));
-        return onlineComputeNodes.stream().map(each -> loadComputeNodeInstance(
-                InstanceMetaDataBuilderFactory.create(each, instanceType, repository.getDirectly(ComputeNode.getOnlineInstanceNodePath(each, instanceType))))).collect(Collectors.toList());
+        Collection<ComputeNodeInstance> result = new LinkedList<>();
+        for (String each : repository.getChildrenKeys(ComputeNode.getOnlineNodePath(instanceType))) {
+            String value = repository.getDirectly(ComputeNode.getOnlineInstanceNodePath(each, instanceType));
+            if (Strings.isNullOrEmpty(value)) {
+                continue;
+            }
+            ComputeNodeData instanceIdentity = YamlEngine.unmarshal(value, ComputeNodeData.class);
+            result.add(loadComputeNodeInstance(InstanceMetaDataBuilderFactory.create(each, instanceType, instanceIdentity.getAttribute(), instanceIdentity.getVersion())));
+        }
+        return result;
     }
     
     /**

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusService.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusService.java
@@ -147,8 +147,8 @@ public final class ComputeNodeStatusService {
             if (Strings.isNullOrEmpty(value)) {
                 continue;
             }
-            ComputeNodeData instanceIdentity = YamlEngine.unmarshal(value, ComputeNodeData.class);
-            result.add(loadComputeNodeInstance(InstanceMetaDataBuilderFactory.create(each, instanceType, instanceIdentity.getAttribute(), instanceIdentity.getVersion())));
+            ComputeNodeData computeNodeData = YamlEngine.unmarshal(value, ComputeNodeData.class);
+            result.add(loadComputeNodeInstance(InstanceMetaDataBuilderFactory.create(each, instanceType, computeNodeData.getAttribute(), computeNodeData.getVersion())));
         }
         return result;
     }

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/watcher/ComputeNodeStateChangedWatcher.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/watcher/ComputeNodeStateChangedWatcher.java
@@ -91,9 +91,9 @@ public final class ComputeNodeStateChangedWatcher implements GovernanceWatcher<G
     private Optional<GovernanceEvent> createInstanceEvent(final DataChangedEvent event) {
         Matcher matcher = matchInstanceOnlinePath(event.getKey());
         if (matcher.find()) {
-            ComputeNodeData ComputeNodeData = YamlEngine.unmarshal(event.getValue(), ComputeNodeData.class);
+            ComputeNodeData computeNodeData = YamlEngine.unmarshal(event.getValue(), ComputeNodeData.class);
             InstanceMetaData instanceMetaData = InstanceMetaDataBuilderFactory.create(matcher.group(2),
-                    InstanceType.valueOf(matcher.group(1).toUpperCase()), ComputeNodeData.getAttribute(), ComputeNodeData.getVersion());
+                    InstanceType.valueOf(matcher.group(1).toUpperCase()), computeNodeData.getAttribute(), computeNodeData.getVersion());
             if (Type.ADDED == event.getType()) {
                 return Optional.of(new InstanceOnlineEvent(instanceMetaData));
             }

--- a/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/watcher/ComputeNodeStateChangedWatcher.java
+++ b/mode/type/cluster/core/src/main/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/watcher/ComputeNodeStateChangedWatcher.java
@@ -33,6 +33,7 @@ import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.statu
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.ShowProcessListUnitCompleteEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.StateEvent;
 import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.event.WorkerIdEvent;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.pojo.ComputeNodeData;
 import org.apache.shardingsphere.mode.metadata.persist.node.ComputeNode;
 import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent;
 import org.apache.shardingsphere.mode.repository.cluster.listener.DataChangedEvent.Type;
@@ -90,7 +91,9 @@ public final class ComputeNodeStateChangedWatcher implements GovernanceWatcher<G
     private Optional<GovernanceEvent> createInstanceEvent(final DataChangedEvent event) {
         Matcher matcher = matchInstanceOnlinePath(event.getKey());
         if (matcher.find()) {
-            InstanceMetaData instanceMetaData = InstanceMetaDataBuilderFactory.create(matcher.group(2), InstanceType.valueOf(matcher.group(1).toUpperCase()), event.getValue());
+            ComputeNodeData ComputeNodeData = YamlEngine.unmarshal(event.getValue(), ComputeNodeData.class);
+            InstanceMetaData instanceMetaData = InstanceMetaDataBuilderFactory.create(matcher.group(2),
+                    InstanceType.valueOf(matcher.group(1).toUpperCase()), ComputeNodeData.getAttribute(), ComputeNodeData.getVersion());
             if (Type.ADDED == event.getType()) {
                 return Optional.of(new InstanceOnlineEvent(instanceMetaData));
             }

--- a/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusServiceTest.java
+++ b/mode/type/cluster/core/src/test/java/org/apache/shardingsphere/mode/manager/cluster/coordinator/registry/status/compute/service/ComputeNodeStatusServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.instance.utils.IpUtils;
 import org.apache.shardingsphere.infra.state.StateContext;
 import org.apache.shardingsphere.infra.state.StateType;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
+import org.apache.shardingsphere.mode.manager.cluster.coordinator.registry.status.compute.pojo.ComputeNodeData;
 import org.apache.shardingsphere.mode.metadata.persist.node.ComputeNode;
 import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepository;
 import org.junit.Test;
@@ -113,7 +114,10 @@ public final class ComputeNodeStatusServiceTest {
     public void assertLoadAllComputeNodeInstances() {
         when(repository.getChildrenKeys("/nodes/compute_nodes/online/jdbc")).thenReturn(Collections.singletonList("foo_instance_3307"));
         when(repository.getChildrenKeys("/nodes/compute_nodes/online/proxy")).thenReturn(Collections.singletonList("foo_instance_3308"));
-        when(repository.getDirectly("/nodes/compute_nodes/online/proxy/foo_instance_3308")).thenReturn("127.0.0.1@3308");
+        when(repository.getDirectly("/nodes/compute_nodes/online/jdbc/foo_instance_3307"))
+                .thenReturn(YamlEngine.marshal(new ComputeNodeData("127.0.0.1@3307", "foo_version")));
+        when(repository.getDirectly("/nodes/compute_nodes/online/proxy/foo_instance_3308"))
+                .thenReturn(YamlEngine.marshal(new ComputeNodeData("127.0.0.1@3308", "foo_version")));
         List<ComputeNodeInstance> actual = new ArrayList<>(new ComputeNodeStatusService(repository).loadAllComputeNodeInstances());
         assertThat(actual.size(), is(2));
         assertThat(actual.get(0).getMetaData().getId(), is("foo_instance_3307"));

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodeInfoHandler.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodeInfoHandler.java
@@ -48,9 +48,11 @@ public final class ShowComputeNodeInfoHandler extends QueryableRALBackendHandler
     
     private static final String LABELS = "labels";
     
+    private static final String VERSION = "version";
+    
     @Override
     protected Collection<String> getColumnNames() {
-        return Arrays.asList(ID, HOST, PORT, STATUS, MODE_TYPE, WORKER_ID, LABELS);
+        return Arrays.asList(ID, HOST, PORT, STATUS, MODE_TYPE, WORKER_ID, LABELS, VERSION);
     }
     
     @Override
@@ -60,6 +62,7 @@ public final class ShowComputeNodeInfoHandler extends QueryableRALBackendHandler
         String modeType = contextManager.getInstanceContext().getModeConfiguration().getType();
         return Collections.singletonList(new LocalDataQueryResultRow(instanceMetaData.getId(), instanceMetaData.getIp(),
                 instanceMetaData instanceof ProxyInstanceMetaData ? ((ProxyInstanceMetaData) instanceMetaData).getPort() : -1,
-                instance.getState().getCurrentState().name(), modeType, instance.getWorkerId(), String.join(",", instance.getLabels())));
+                instance.getState().getCurrentState().name(), modeType, instance.getWorkerId(), String.join(",", instance.getLabels()),
+                instanceMetaData.getVersion()));
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodesHandler.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodesHandler.java
@@ -51,9 +51,11 @@ public final class ShowComputeNodesHandler extends QueryableRALBackendHandler<Sh
     
     private static final String LABELS = "labels";
     
+    private static final String VERSION = "version";
+    
     @Override
     protected Collection<String> getColumnNames() {
-        return Arrays.asList(ID, HOST, PORT, STATUS, MODE_TYPE, WORKER_ID, LABELS);
+        return Arrays.asList(ID, HOST, PORT, STATUS, MODE_TYPE, WORKER_ID, LABELS, VERSION);
     }
     
     @Override
@@ -72,6 +74,6 @@ public final class ShowComputeNodesHandler extends QueryableRALBackendHandler<Sh
         InstanceMetaData instanceMetaData = instance.getMetaData();
         return new LocalDataQueryResultRow(instanceMetaData.getId(), instanceMetaData.getIp(),
                 instanceMetaData instanceof ProxyInstanceMetaData ? ((ProxyInstanceMetaData) instanceMetaData).getPort() : -1,
-                instance.getState().getCurrentState().name(), modeType, instance.getWorkerId(), labels);
+                instance.getState().getCurrentState().name(), modeType, instance.getWorkerId(), labels, instanceMetaData.getVersion());
     }
 }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodeInfoHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodeInfoHandlerTest.java
@@ -51,7 +51,7 @@ public final class ShowComputeNodeInfoHandlerTest extends ProxyContextRestorer {
         handler.execute();
         handler.next();
         List<Object> data = handler.getRowData().getData();
-        assertThat(data.size(), is(7));
+        assertThat(data.size(), is(8));
         assertThat(data.get(0), is("127.0.0.1@3309"));
         assertThat(data.get(1), is("127.0.0.1"));
         assertThat(data.get(2), is(3309));
@@ -59,11 +59,12 @@ public final class ShowComputeNodeInfoHandlerTest extends ProxyContextRestorer {
         assertThat(data.get(4), is("Standalone"));
         assertThat(data.get(5), is(0));
         assertThat(data.get(6), is(""));
+        assertThat(data.get(7), is("foo_version"));
     }
     
     private InstanceContext createInstanceContext() {
         InstanceContext result = mock(InstanceContext.class, RETURNS_DEEP_STUBS);
-        when(result.getInstance().getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3309", "127.0.0.1@3309"));
+        when(result.getInstance().getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3309", "127.0.0.1@3309", "foo_version"));
         when(result.getInstance().getState()).thenReturn(new StateContext());
         when(result.getModeConfiguration()).thenReturn(new ModeConfiguration("Standalone", new StandalonePersistRepositoryConfiguration("H2", new Properties())));
         when(result.getInstance().getWorkerId()).thenReturn(0);

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodesHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowComputeNodesHandlerTest.java
@@ -55,7 +55,7 @@ public final class ShowComputeNodesHandlerTest extends ProxyContextRestorer {
         handler.execute();
         handler.next();
         List<Object> data = handler.getRowData().getData();
-        assertThat(data.size(), is(7));
+        assertThat(data.size(), is(8));
         assertThat(data.get(0), is("127.0.0.1@3308"));
         assertThat(data.get(1), is("127.0.0.1"));
         assertThat(data.get(2), is(3308));
@@ -63,6 +63,7 @@ public final class ShowComputeNodesHandlerTest extends ProxyContextRestorer {
         assertThat(data.get(4), is("Standalone"));
         assertThat(data.get(5), is(0));
         assertThat(data.get(6), is(""));
+        assertThat(data.get(7), is("foo_version"));
     }
     
     @Test
@@ -75,7 +76,7 @@ public final class ShowComputeNodesHandlerTest extends ProxyContextRestorer {
         handler.execute();
         handler.next();
         List<Object> data = handler.getRowData().getData();
-        assertThat(data.size(), is(7));
+        assertThat(data.size(), is(8));
         assertThat(data.get(0), is("127.0.0.1@3309"));
         assertThat(data.get(1), is("127.0.0.1"));
         assertThat(data.get(2), is(3309));
@@ -83,11 +84,12 @@ public final class ShowComputeNodesHandlerTest extends ProxyContextRestorer {
         assertThat(data.get(4), is("Cluster"));
         assertThat(data.get(5), is(1));
         assertThat(data.get(6), is(""));
+        assertThat(data.get(7), is("foo_version"));
     }
     
     private InstanceContext createStandaloneInstanceContext() {
         InstanceContext result = mock(InstanceContext.class, RETURNS_DEEP_STUBS);
-        when(result.getInstance().getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3308", "127.0.0.1@3308"));
+        when(result.getInstance().getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3308", "127.0.0.1@3308", "foo_version"));
         when(result.getInstance().getState()).thenReturn(new StateContext());
         when(result.getModeConfiguration()).thenReturn(new ModeConfiguration("Standalone", new StandalonePersistRepositoryConfiguration("H2", new Properties())));
         when(result.getInstance().getWorkerId()).thenReturn(0);
@@ -98,7 +100,7 @@ public final class ShowComputeNodesHandlerTest extends ProxyContextRestorer {
         InstanceContext result = mock(InstanceContext.class, RETURNS_DEEP_STUBS);
         when(result.getModeConfiguration()).thenReturn(new ModeConfiguration("Cluster", mock(PersistRepositoryConfiguration.class)));
         ComputeNodeInstance computeNodeInstance = mock(ComputeNodeInstance.class, RETURNS_DEEP_STUBS);
-        when(computeNodeInstance.getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3309", "127.0.0.1@3309"));
+        when(computeNodeInstance.getMetaData()).thenReturn(new ProxyInstanceMetaData("127.0.0.1@3309", "127.0.0.1@3309", "foo_version"));
         when(computeNodeInstance.getState()).thenReturn(new StateContext());
         when(computeNodeInstance.getWorkerId()).thenReturn(1);
         when(result.getAllClusterInstances()).thenReturn(Collections.singleton(computeNodeInstance));

--- a/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/cluster/show_compute_nodes.xml
+++ b/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/cluster/show_compute_nodes.xml
@@ -24,6 +24,7 @@
         <column name="mode_type" />
         <column name="worker_id" />
         <column name="labels" />
+        <column name="version" assertion="false"/>
     </metadata>
-    <row values=" | | 3307| OK| Cluster| 0| " />
+    <row values=" | | 3307| OK| Cluster| 0| |" />
 </dataset>

--- a/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/standalone/show_compute_nodes.xml
+++ b/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/standalone/show_compute_nodes.xml
@@ -24,6 +24,7 @@
         <column name="mode_type" />
         <column name="worker_id" />
         <column name="labels" />
+        <column name="version" assertion="false"/>
     </metadata>
-    <row values=" | | 3307| OK| Standalone| 0| " />
+    <row values=" | | 3307| OK| Standalone| 0| |" />
 </dataset>


### PR DESCRIPTION
Fixes #22918 .

```
mysql> show compute nodes;
+--------------------------------------+---------------+------+--------+-----------+-----------+--------+----------------+
| instance_id                          | host          | port | status | mode_type | worker_id | labels | version        |
+--------------------------------------+---------------+------+--------+-----------+-----------+--------+----------------+
| 563b7e44-89e7-4b98-b837-588461fea09b | 192.168.0.105 | 3307 | OK     | Cluster   | -1        |        | 5.3.1-SNAPSHOT |
| d3a2a283-effb-4c21-991e-f6ebfcd4f606 | 192.168.0.105 | 3307 | OK     | Cluster   | -1        |        | 5.3.1-SNAPSHOT |
+--------------------------------------+---------------+------+--------+-----------+-----------+--------+----------------+
```