### PR TITLE
Fix AESEncryptAlgorithm decrypt exception when config char type with PostgreSQL and openGauss

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/AESEncryptAlgorithm.java
@@ -74,7 +74,7 @@ public final class AESEncryptAlgorithm implements StandardEncryptAlgorithm<Objec
         if (null == cipherValue) {
             return null;
         }
-        byte[] result = getCipher(Cipher.DECRYPT_MODE).doFinal(Base64.getDecoder().decode(cipherValue));
+        byte[] result = getCipher(Cipher.DECRYPT_MODE).doFinal(Base64.getDecoder().decode(cipherValue.trim()));
         return new String(result, StandardCharsets.UTF_8);
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithm.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/algorithm/encrypt/RC4EncryptAlgorithm.java
@@ -61,7 +61,7 @@ public final class RC4EncryptAlgorithm implements StandardEncryptAlgorithm<Objec
     
     @Override
     public String encrypt(final Object plainValue, final EncryptContext encryptContext) {
-        return null == plainValue ? null : Base64.encodeBase64String(handle(String.valueOf(plainValue).getBytes(StandardCharsets.UTF_8), key));
+        return null == plainValue ? null : Base64.encodeBase64String(handle(String.valueOf(plainValue).getBytes(StandardCharsets.UTF_8)));
     }
     
     @Override
@@ -69,11 +69,11 @@ public final class RC4EncryptAlgorithm implements StandardEncryptAlgorithm<Objec
         if (null == cipherValue) {
             return null;
         }
-        byte[] result = handle(Base64.decodeBase64(cipherValue), key);
+        byte[] result = handle(Base64.decodeBase64(cipherValue));
         return new String(result, StandardCharsets.UTF_8);
     }
     
-    private byte[] handle(final byte[] data, final byte[] key) {
+    private byte[] handle(final byte[] data) {
         return crypt(data);
     }
     

--- a/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/cases/assertion/IntegrationTestCase.java
+++ b/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/cases/assertion/IntegrationTestCase.java
@@ -44,6 +44,9 @@ public final class IntegrationTestCase {
     @XmlAttribute(name = "scenario-types")
     private String scenarioTypes;
     
+    @XmlAttribute(name = "scenario-comments")
+    private String scenarioComments;
+    
     @XmlElement(name = "assertion")
     private Collection<IntegrationTestCaseAssertion> assertions = new LinkedList<>();
 }

--- a/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -1178,4 +1178,24 @@
     <test-case sql="SELECT * FROM (SELECT count(*) as count, id from t_single_table group by id) as temp_table" db-types="MySQL" scenario-types="db">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
+
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in simple select statement when use sharding feature.|Test encrypt table's LIKE operator in simple select statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18' OR telephone LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in simple select statement with or condition when use sharding feature.|Test encrypt table's LIKE operator in simple select statement with or condition when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '%18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator in subquery select statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select join statement when use sharding feature.|Test encrypt table's LIKE operator in select join statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '%18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select group by statement when use sharding feature.|Test encrypt table's LIKE operator in select group by statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
 </integration-test-cases>

--- a/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rules.xml
+++ b/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rules.xml
@@ -37,6 +37,6 @@
     <row values="t_user| pwd| | pwd_cipher| | pwd_plain| | | | AES| aes-key-value=123456abc| | | | | true" />
     <row values="t_user_details| number| | number_cipher| | number_plain| | | | AES| aes-key-value=123456abc| | | | | true" />
     <row values="t_user_details| number_new| | number_new_cipher| | number_new_plain| | | | AES| aes-key-value=123456abc| | | | | true" />
-    <row values="t_merchant| business_code| | business_code_cipher| | business_code_plain| | | | AES| aes-key-value=123456abc| | | | | true" />
-    <row values="t_merchant| telephone| | telephone_cipher| | telephone_plain| | | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_merchant| business_code| | business_code_cipher| | business_code_plain| | | | AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE | mask=4093 | true" />
+    <row values="t_merchant| telephone| | telephone_cipher| | telephone_plain| | | | AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE | mask=4093 | true" />
 </dataset>

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
@@ -38,8 +38,12 @@
         <column name="merchant_id" type="numeric" />
         <column name="country_id" type="numeric" />
         <column name="merchant_name" type="varchar" />
-        <column name="business_code" type="varchar" />
-        <column name="telephone" type="varchar" />
+        <column name="business_code_cipher" type="varchar" />
+        <column name="business_code_like" type="varchar" />
+        <column name="business_code_plain" type="varchar" />
+        <column name="telephone_cipher" type="varchar" />
+        <column name="telephone_like" type="varchar" />
+        <column name="telephone_plain" type="varchar" />
         <column name="creation_date" type="datetime" />
     </metadata>
     <row data-node="encrypt.t_single_table" values="1, 10, init" />
@@ -70,24 +74,24 @@
     <row data-node="encrypt.t_user_item" values="270000, 27, init, 2017-08-08" />
     <row data-node="encrypt.t_user_item" values="280000, 28, init, 2017-08-08" />
     <row data-node="encrypt.t_user_item" values="290000, 29, init, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="1, 86, tencent, 86000001, 86100000001, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="2, 86, haier, 86000002, 86100000002, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="3, 86, huawei, 86000003, 86100000003, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="4, 86, alibaba, 86000004, 86100000004, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="5, 86, lenovo, 86000005, 86100000005, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="6, 86, moutai, 86000006, 86100000006, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="7, 86, baidu, 86000007, 86100000007, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="8, 86, xiaomi, 86000008, 86100000008, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="9, 86, vivo, 86000009, 86100000009, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="10, 86, oppo, 86000010, 86100000010, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="11, 1, google, 01000011, 01100000011, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="12, 1, walmart, 01000012, 01100000012, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="13, 1, amazon, 01000013, 01100000013, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="14, 1, apple, 01000014, 01100000014, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="15, 1, microsoft, 01000015, 01100000015, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="16, 1, dell, 01000016, 01100000016, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="17, 1, johnson, 01000017, 01100000017, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="18, 1, intel, 01000018, 01100000018, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="19, 1, hp, 01000019, 01100000019, 2017-08-08" />
-    <row data-node="encrypt.t_merchant" values="20, 1, tesla, 01000020, 01100000020, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="1, 86, tencent, k/LC4zsaZ+N6RgluwW+8BQ==, 95111110, 86000001, hRoqv9Jw8ZFM6Zdt3PL1Aw==, 95011111110, 86100000001, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="2, 86, haier, RINN9TpLonpAT8bAdJmKbA==, 95111111, 86000002, 9SCFkitrhrqandvIXg2U5Q==, 95011111111, 86100000002, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="3, 86, huawei, 3S6kkaTmrJNzCfuy07df4A==, 95111114, 86000003, L1okJVzt5ixaGjd1fUmujA==, 95011111114, 86100000003, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="4, 86, alibaba, KTWle6y9MyLX/G1uWqkB6Q==, 95111115, 86000004, JM3vuwFKlmUTM2wIxAx4kQ==, 95011111115, 86100000004, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="5, 86, lenovo, jYwQmxM2Hh/wZNFRfZZZog==, 95111114, 86000005, qD8jh5nV00thQ52QUAEMFQ==, 95011111114, 86100000005, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="6, 86, moutai, R9AAlR7vT5BttQCNUa9mFg==, 95111115, 86000006, FTritkoFVdFi7qbxQJbIKg==, 95011111115, 86100000006, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="7, 86, baidu, 6meW3pCZ3AllyhjcJLHfkg==, 95111118, 86000007, 6yJKW9FELJPUhWMD/hwa3g==, 95011111118, 86100000007, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="8, 86, xiaomi, 26tc7cYxmWSVjkCs3hBWfg==, 95111119, 86000008, rlaEwKNsNkpBTTJvX0cBWg==, 95011111119, 86100000008, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="9, 86, vivo, a6qv2URpZefcqeNwzYHYzw==, 95111118, 86000009, 4vSnvL4hUYAgyglex3Mo8g==, 95011111118, 86100000009, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="10, 86, oppo, Ly04f1inKr2V/KXAQbPY6g==, 95111101, 86000010, jNCHGPtcuha18Yxuz0hjjA==, 95011111101, 86100000010, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="11, 1, google, d93wyD7tAh6c0eV4JYgHDw==, 10111100, 01000011, T/8KO+rogDJlR3j0xxdXQQ==, 10011111100, 01100000011, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="12, 1, walmart, zTMndboJn5PRINho8p8vDw==, 10111101, 01000012, u+IOpGrCkTwAZYFDgRHYTg==, 10011111101, 01100000012, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="13, 1, amazon, OmMvy0O8jMH1cI5npzW84g==, 10111104, 01000013, 6xelCVyGaivIe70c5UKgJA==, 10011111104, 01100000013, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="14, 1, apple, aT6NnH1qsdpsLgOY0N1tKA==, 10111105, 01000014, hD+Wuog7jzaBzIyzRL97OA==, 10011111105, 01100000014, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="15, 1, microsoft, FP+W5tbInmmpOt0Nkmu8dw==, 10111104, 01000015, p4Esh1flQZFpApQKvfGkdQ==, 10011111104, 01100000015, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="16, 1, dell, vHvpwT5H2ahx8zrrenQpug==, 10111105, 01000016, LlJDQrh6CCKjRHYTwrJRVA==, 10011111105, 01100000016, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="17, 1, johnson, AbetbVO1CUdPjMv4XYlcaA==, 10111108, 01000017, dvljaVvLyAzW1Kcr4n8SvA==, 10011111108, 01100000017, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="18, 1, intel, PQ32nokZZTz9aFZvB7kwnw==, 10111109, 01000018, E4W6UfdyySk1GZRK5bkKWw==, 10011111109, 01100000018, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="19, 1, hp, uc1BIrytIfjEHdTa8xytlQ==, 10111108, 01000019, moteUYwjL/OtQphkcxsAAQ==, 10011111108, 01100000019, 2017-08-08" />
+    <row data-node="encrypt.t_merchant" values="20, 1, tesla, lRucj/mOJODy3WgRpFS8vQ==, 10111111, 01000020, Blb7lRLTM7cL0f3HhrjtGw==, 10011111111, 01100000020, 2017-08-08" />
 </dataset>

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
@@ -22,6 +22,6 @@ DROP TABLE IF EXISTS t_merchant;
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
@@ -24,6 +24,6 @@ CREATE DATABASE encrypt;
 CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON encrypt.t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -29,6 +29,6 @@ DROP TABLE IF EXISTS t_merchant;
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/oracle/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/oracle/01-actual-init.sql
@@ -21,6 +21,6 @@ CREATE SCHEMA encrypt;
 CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON encrypt.t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -29,6 +29,6 @@ DROP TABLE IF EXISTS t_merchant;
 CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/sqlserver/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/sqlserver/01-actual-init.sql
@@ -21,6 +21,6 @@ CREATE DATABASE encrypt;
 CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
-CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 
 CREATE INDEX user_index_t_user ON encrypt.t_user (user_id);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
@@ -35,6 +35,10 @@ rules:
       type: AES
       props:
         aes-key-value: 123456abc
+    like_encryptor:
+      type: CHAR_DIGEST_LIKE
+      props:
+        mask: 4093
   tables:
     t_user:
       columns:
@@ -57,9 +61,12 @@ rules:
         business_code:
           plainColumn: business_code_plain
           cipherColumn: business_code_cipher
+          likeQueryColumn: business_code_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
         telephone:
           plainColumn: telephone_plain
           cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
           encryptorName: aes_encryptor
-
+          likeQueryEncryptorName: like_encryptor

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
@@ -35,6 +35,10 @@ rules:
       type: AES
       props:
         aes-key-value: 123456abc
+    like_encryptor:
+      type: CHAR_DIGEST_LIKE
+      props:
+        mask: 4093
   tables:
     t_user:
       columns:
@@ -57,9 +61,12 @@ rules:
         business_code:
           plainColumn: business_code_plain
           cipherColumn: business_code_cipher
+          likeQueryColumn: business_code_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
         telephone:
           plainColumn: telephone_plain
           cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
           encryptorName: aes_encryptor
-
+          likeQueryEncryptorName: like_encryptor

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
@@ -35,6 +35,10 @@ rules:
       type: AES
       props:
         aes-key-value: 123456abc
+    like_encryptor:
+      type: CHAR_DIGEST_LIKE
+      props:
+        mask: 4093
   tables:
     t_user:
       columns:
@@ -57,8 +61,12 @@ rules:
         business_code:
           plainColumn: business_code_plain
           cipherColumn: business_code_cipher
+          likeQueryColumn: business_code_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
         telephone:
           plainColumn: telephone_plain
           cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/rules.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/rules.yaml
@@ -22,6 +22,10 @@ rules:
       type: AES
       props:
         aes-key-value: 123456abc
+    like_encryptor:
+      type: CHAR_DIGEST_LIKE
+      props:
+        mask: 4093
   tables:
     t_user:
       columns:
@@ -44,8 +48,12 @@ rules:
         business_code:
           plainColumn: business_code_plain
           cipherColumn: business_code_cipher
+          likeQueryColumn: business_code_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
         telephone:
           plainColumn: telephone_plain
           cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor


### PR DESCRIPTION
Fixes #23003.

Changes proposed in this pull request:
  - fix AESEncryptAlgorithm decrypt exception when config char type with PostgreSQL and openGauss
  - add integration test case for AESEncryptAlgorithm and CharDigestLikeEncryptAlgorithm

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
