### PR TITLE
Add eot and ttf file to .gitattributes to avoid newline formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,3 +19,5 @@
 *.jpg -text
 *.jpeg -text
 *.png -text
+*.eot -text
+*.ttf -text


### PR DESCRIPTION
Changes proposed in this pull request:
  - add eot and ttf file to .gitattributes to avoid newline formatting

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
