### PR TITLE
Refactor t_user init sql and data in encrypt scenario and adjust some encrypt test case

### DIFF
--- a/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -491,26 +491,34 @@
     <test-case sql="SELECT * FROM t_broadcast_table" scenario-types="db,tbl,dbtbl_with_readwrite_splitting">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
-    <test-case sql="SELECT * FROM t_user WHERE user_id &lt;= 15 ORDER BY user_id" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
-        <assertion expected-data-source-name="read_dataset" />
-    </test-case>
     
-    <test-case sql="SELECT user_id, pwd FROM t_user WHERE pwd = 'a10'" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user WHERE user_id &lt;= 15 ORDER BY user_id" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
-    
-    <test-case sql="SELECT user_id FROM t_user WHERE pwd in ('a10', 'b11')" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user WHERE password = '111111'" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
-    
-    <test-case sql="SELECT user_id FROM t_user WHERE pwd in ('a10', 'b11') and user_id = 10" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user WHERE password IN ('222222', '333333')" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
-    <test-case sql="SELECT * FROM t_user WHERE pwd in ('a10', 'b11') OR user_id = 10" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user WHERE password IN ('222222', '333333') AND user_id = 12" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
-    
-    <test-case sql="SELECT * FROM t_user u INNER JOIN t_user_item m ON u.user_id=m.user_id WHERE u.user_id IN (0, 11)" scenario-types="encrypt,dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting">
+
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user WHERE password IN ('222222', '333333') OR user_id = 10" scenario-types="encrypt">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <!-- TODO add dbtbl_with_readwrite_splitting_and_encrypt,sharding_and_encrypt,encrypt_and_readwrite_splitting scenario when use standard t_user table in issue#21286 -->
+    <test-case sql="SELECT * FROM t_user u INNER JOIN t_user_item m ON u.user_id = m.user_id WHERE u.user_id IN (10, 11)" scenario-types="encrypt">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     
@@ -1179,39 +1187,35 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in simple select statement when use sharding feature.|Test encrypt table's LIKE operator in simple select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in simple select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '_18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in simple select statement when use sharding feature.|Test encrypt table's LIKE operator in simple select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in simple select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18' OR telephone LIKE '_18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in simple select statement with or condition when use sharding feature.|Test encrypt table's LIKE operator in simple select statement with or condition when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '%18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in subquery select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '%18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator in subquery select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '_1000018')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in subquery select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '__18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator in subquery select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select join statement when use sharding feature.|Test encrypt table's LIKE operator in select join statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '_18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select join statement when use sharding feature.|Test encrypt table's LIKE operator in select join statement when use encrypt feature.">
+    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '%18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select group by statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '%18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select group by statement when use sharding feature.|Test encrypt table's LIKE operator in select group by statement when use encrypt feature.">
-        <assertion expected-data-source-name="read_dataset" />
-    </test-case>
-
-    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '_18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator in select group by statement when use sharding feature.|Test encrypt table's LIKE operator in select group by statement when use encrypt feature.">
+    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '_1000018' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select group by statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 </integration-test-cases>

--- a/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rule.xml
+++ b/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rule.xml
@@ -31,5 +31,8 @@
         <column name="like_query_props" />
         <column name="query_with_cipher_column" />
     </metadata>
-    <row values="t_user| pwd| pwd_cipher| pwd_plain| | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| user_name| user_name_cipher| user_name_plain| | user_name_like| AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE| mask=4093| true" />
+    <row values="t_user| password| password_cipher| | | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| email| email_cipher| | | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| telephone| telephone_cipher| telephone_plain| | telephone_like| AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE| mask=4093| true" />
 </dataset>

--- a/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rules.xml
+++ b/test/e2e/suite/src/test/resources/cases/rql/dataset/encrypt/show_encrypt_rules.xml
@@ -31,7 +31,10 @@
         <column name="like_query_props" />
         <column name="query_with_cipher_column" />
     </metadata>
-    <row values="t_user| pwd| pwd_cipher| pwd_plain| | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| user_name| user_name_cipher| user_name_plain| | user_name_like| AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE| mask=4093| true" />
+    <row values="t_user| password| password_cipher| | | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| email| email_cipher| | | | AES| aes-key-value=123456abc| | | | | true" />
+    <row values="t_user| telephone| telephone_cipher| telephone_plain| | telephone_like| AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE| mask=4093| true" />
     <row values="t_user_details| number| number_cipher| number_plain| | | AES| aes-key-value=123456abc| | | | | true" />
     <row values="t_user_details| number_new| number_new_cipher| number_new_plain| | | AES| aes-key-value=123456abc| | | | | true" />
     <row values="t_merchant| business_code| business_code_cipher| business_code_plain| | business_code_like| AES| aes-key-value=123456abc| | | CHAR_DIGEST_LIKE | mask=4093 | true" />

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/dataset.xml
@@ -18,10 +18,15 @@
 <dataset>
     <metadata data-nodes="encrypt.t_user">
         <column name="user_id" type="numeric" />
-        <column name="address_id" type="numeric" />
-        <column name="pwd_plain" type="varchar" />
-        <column name="pwd_cipher" type="varchar" />
-        <column name="status" type="varchar" />
+        <column name="user_name_cipher" type="varchar" />
+        <column name="user_name_like" type="varchar" />
+        <column name="user_name_plain" type="varchar" />
+        <column name="password_cipher" type="varchar" />
+        <column name="email_cipher" type="varchar" />
+        <column name="telephone_cipher" type="varchar" />
+        <column name="telephone_like" type="varchar" />
+        <column name="telephone_plain" type="varchar" />
+        <column name="creation_date" type="datetime" />
     </metadata>
     <metadata data-nodes="encrypt.t_user_item">
         <column name="item_id" type="numeric" />
@@ -50,10 +55,26 @@
     <row data-node="encrypt.t_single_table" values="2, 11, init" />
     <row data-node="encrypt.t_single_table" values="3, 12, init" />
     <row data-node="encrypt.t_single_table" values="4, 13, init" />
-    <row data-node="encrypt.t_user" values="10, 10000, null, yK+tn8E43EyCEgbqNOrJ4w==, init" />
-    <row data-node="encrypt.t_user" values="11, 11000, null, CIbxTwI742pGwxb18lQLkQ==, init" />
-    <row data-node="encrypt.t_user" values="12, 12000, null, VCHpNlwod9AiuS1V+7DSLw==, init" />
-    <row data-node="encrypt.t_user" values="13, 13000, null, 8uxRFhW4c2rtSOoesudk/A==, init" />
+    <row data-node="encrypt.t_user" values="10, sVq8Lmm+j6bZE5EKSilJEQ==, yi`mht`m, zhangsan, aQol0b6th65d0aXe+zFPsQ==, WM0fHOH91JNWnHTkiqBdyNmzk4uJ7CCz4mB1va9Ya1M=, kLjLJIMnfyHT2nA+viaoaQ==, 1454589811, 12345678900,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="11, fQ7IzBxKVuNHtUF6h6WSBg==, mhth, lisi, wuhmEKgdgrWQYt+Ev0hgGA==, svATu3uWv9KfiloWJeWx3A==, 0kDFxndQdzauFwL/wyCsNQ==, 1454589810, 12345678901,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="12, AQRWSlufQPog/b64YRhu6Q==, x`mhxt, wangwu, x7A+2jq9B6DSOSFtSOibdA==, nHJv9e6NiClIuGHOjHLvCAq2ZLhWcqfQ8/EQnIqMx+g=, a/SzSJLapt5iBXvF2c9ycw==, 1454589811, 12345678902,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="13, 5NqS4YvpT+mHBFqZOZ3QDA==, yi`pmht, zhaoliu, zi6b4xYRjjV+bBk2R4wB+w==, MLBZczLjriUXvg3aM5QPTxMJbLjNh8yeNrSNBek/VTw=, b6VVhG+F6ujG8IMUZJAIFg==, 1454589814, 12345678903,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="14, qeIY9od3u1KwhjihzLQUTQ==, yitph, zhuqi, 51UmlLAC+tUvdOAj8CjWfQ==, JCmeNdPyrKO5BW5zvhAA+g==, f995xinpZdKMVU5J5/yv3w==, 1454589815, 12345678904,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="15, VbNUtguwtpeGhHGnPJ3aXg==, mha`, liba, +3/5CVbqoKhg3sqznKTFFQ==, T+X+e3Q3+ZNIXXmg/80uxg==, GETj+S6DrO042E7NuBXLBQ==, 1454589814, 12345678905,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="16, U0/Ao/w1u7L5avR3fAH2Og==, x`mhiht, wangjiu, jFfFMYxv02DjaFRuAoCDGw==, RNW/KRq5HeL2YTfAdXSyARMJbLjNh8yeNrSNBek/VTw=, +lbvjJwO7VO4HUKc0Mw0NA==, 1454589815, 12345678906,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="17, zb1sgBigoMi7JPSoY4bAVw==, yite`, zhuda, VFIjocgjujJCJc6waWXqJA==, 1vF/ET3nBxt7T7vVfAndZQ==, wFvs5BH6OikgveBeTEBwsQ==, 1454589818, 12345678907,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="18, rJzNIrFEnx296kW+N1YmMw==, ttmdq, suner, LaODSKGyR7vZ1IvmBOe9vA==, 5u4GIQkJsWRmnJHWaHNSjg==, uwqm2O1Lv2tNTraJX1ym7Q==, 1454589819, 12345678908,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="19, qHwpQ9kteL8VX6iTUhNdbQ==, yiptt`m, zhousan, MyOShk4kjRnds7CZfU5NCw==, HmYCo7QBfJ2E0EvaGHBCOBMJbLjNh8yeNrSNBek/VTw=, YLNQuuUPMGA21nhKWPzzsg==, 1454589818, 12345678909,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="20, qCCmvf7OWRxbVbtLb0az1g==, upl, tom, fzdTMkzpBvgNYmKSQAp8Fg==, gOoP4Mf0P4ISOJp6A4sRmg==, l4xa4HwOfs/jusoJon9Wzw==, 1454589801, 12345678910,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="21, IYJ1COaRQ0gSjWMC/UAeMg==, lpad, kobe, 1uEDMeYh2jstbOf6kx/cqw==, tikMAFiQ37u2VgWqUT38Eg==, rGpr30UXfczXjCjdvPN+BA==, 1454589800, 12345678911,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="22, 7wvZZ7NVHgk6m1vB/sTC1Q==, idqqx, jerry, OirN3gvz9uBnrq88nfa1wQ==, T7K/Uz1O2m+3xvB0+c4nGQ==, 7+fCU+VbQZKgLJXZPTTegA==, 1454589801, 12345678912,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="23, SbVQWl8JbnxflCfGJ7KZdA==, i`ldt, james, hWVVYdkdTUTgm08haeq+tw==, Uk3ju6GteCD1qEHns5ZhKA==, DpnV86FZefwBRmIAVBh2gg==, 1454589804, 12345678913,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="24, fx7OfSAYqVpjNa7LoKhXvw==, x`ed, wade, N2W9ijAXNkBxhkvJiIwp0A==, lAAGItVLmb1H69++1MDrIA==, QrE62wAb8B+2cEPcs4Lm1Q==, 1454589805, 12345678914,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="25, wH3/LdWShD9aCb8eCIm3Tg==, qptd, rose, GDixtt6NzPOVv6H0dmov5g==, T1yfJSyVxumZUfkDnmUQxA==, iU+AsGczboCRfU+Zr7mcpw==, 1454589804, 12345678915,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="26, GgJQTndbxyBZ2tECS8SmqQ==, apti, bosh, gLgVFLFIyyKwdQCXaw78Ag==, O+JIn9XZ3yq6RnKElHuqlA==, kwYlbu9aF7ndvMTcj8QBSg==, 1454589805, 12345678916,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="27, lv8w8g32kuTXNvSUUypOig==, i`dl, jack, 8i0YH2mn6kXSyvBjM5p+Yg==, gqRoJF5S66SvBalc2RCo1A==, 2ob/3UYqRsZA5VdScnaWxQ==, 1454589808, 12345678917,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="28, P9YCbFvWCIhcS99KyKH2zA==, ipqe`m, jordan, PRrI4z4FrWwLvcHPx9g4og==, y8q31Jj4PFSyZHiLVIxKEQq2ZLhWcqfQ8/EQnIqMx+g=, kDF2za26uOerlNYWYHRT2Q==, 1454589809, 12345678918,  2017-08-08" />
+    <row data-node="encrypt.t_user" values="29, 5wu9XvlJAVtjKijhxt6SQQ==, itmhd, julie, O4pgkLgz34N+C4bIUOQVnA==, UH7ihg16J61Np/EYMQnXIA==, z2hbJQD4dRkVVITNxAac5Q==, 1454589808, 12345678919,  2017-08-08" />
     <row data-node="encrypt.t_user_item" values="100000, 10, init, 2017-08-08" />
     <row data-node="encrypt.t_user_item" values="110000, 11, init, 2017-08-08" />
     <row data-node="encrypt.t_user_item" values="120000, 12, init, 2017-08-08" />

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
@@ -19,7 +19,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/mysql/01-actual-init.sql
@@ -21,7 +21,7 @@ SET character_set_server='utf8';
 DROP DATABASE IF EXISTS encrypt;
 CREATE DATABASE encrypt;
 
-CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt.t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -26,7 +26,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/oracle/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/oracle/01-actual-init.sql
@@ -18,7 +18,7 @@
 DROP SCHEMA encrypt;
 CREATE SCHEMA encrypt;
 
-CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt.t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -26,7 +26,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/sqlserver/01-actual-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/actual/init-sql/sqlserver/01-actual-init.sql
@@ -18,7 +18,7 @@
 DROP DATABASE IF EXISTS encrypt;
 CREATE DATABASE encrypt;
 
-CREATE TABLE encrypt.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd_plain VARCHAR(45) NULL, pwd_cipher VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE encrypt.t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, user_name_plain VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE encrypt.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE encrypt.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE encrypt.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code_cipher VARCHAR(50) NOT NULL, business_code_like VARCHAR(50) NOT NULL, business_code_plain VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, telephone_plain CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/dataset.xml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/dataset.xml
@@ -18,9 +18,11 @@
 <dataset>
     <metadata data-nodes="expected_dataset.t_user">
         <column name="user_id" type="numeric" />
-        <column name="address_id" type="numeric" />
-        <column name="pwd" type="varchar" />
-        <column name="status" type="varchar" />
+        <column name="user_name" type="varchar" />
+        <column name="password" type="varchar" />
+        <column name="email" type="varchar" />
+        <column name="telephone" type="varchar" />
+        <column name="creation_date" type="datetime" />
     </metadata>
     <metadata data-nodes="expected_dataset.t_user_item">
         <column name="item_id" type="numeric" />
@@ -45,10 +47,26 @@
     <row data-node="expected_dataset.t_single_table" values="2, 11, init" />
     <row data-node="expected_dataset.t_single_table" values="3, 12, init" />
     <row data-node="expected_dataset.t_single_table" values="4, 13, init" />
-    <row data-node="expected_dataset.t_user" values="10, 10000, a10, init" />
-    <row data-node="expected_dataset.t_user" values="11, 11000, b11, init" />
-    <row data-node="expected_dataset.t_user" values="12, 12000, c12, init" />
-    <row data-node="expected_dataset.t_user" values="13, 13000, d13, init" />
+    <row data-node="expected_dataset.t_user" values="10, zhangsan, 111111, zhangsan@gmail.com, 12345678900, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="11, lisi, 222222, lisi@gmail.com, 12345678901, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="12, wangwu, 333333, wangwu@gmail.com, 12345678902, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="13, zhaoliu, 444444, zhaoliu@gmail.com, 12345678903, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="14, zhuqi, 555555, zhuqi@gmail.com, 12345678904, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="15, liba, 666666, liba@gmail.com, 12345678905, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="16, wangjiu, 777777, wangjiu@gmail.com, 12345678906, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="17, zhuda, 888888, zhuda@gmail.com, 12345678907, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="18, suner, 999999, suner@gmail.com, 12345678908, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="19, zhousan, 123456, zhousan@gmail.com, 12345678909, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="20, tom, 234567, tom@gmail.com, 12345678910, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="21, kobe, 345678, kobe@gmail.com, 12345678911, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="22, jerry, 456789, jerry@gmail.com, 12345678912, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="23, james, 567890, james@gmail.com, 12345678913, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="24, wade, 012345, wade@gmail.com, 12345678914, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="25, rose, 000000, rose@gmail.com, 12345678915, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="26, bosh, 111222, bosh@gmail.com, 12345678916, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="27, jack, 222333, jack@gmail.com, 12345678917, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="28, jordan, 333444, jordan@gmail.com, 12345678918, 2017-08-08" />
+    <row data-node="expected_dataset.t_user" values="29, julie, 444555, julie@gmail.com, 12345678919, 2017-08-08" />
     <row data-node="expected_dataset.t_user_item" values="100000, 10, init, 2017-08-08" />
     <row data-node="expected_dataset.t_user_item" values="110000, 11, init, 2017-08-08" />
     <row data-node="expected_dataset.t_user_item" values="120000, 12, init, 2017-08-08" />

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
@@ -20,7 +20,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/mysql/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/mysql/01-expected-init.sql
@@ -21,7 +21,7 @@ SET character_set_server='utf8';
 DROP DATABASE IF EXISTS expected_dataset;
 CREATE DATABASE expected_dataset;
 
-CREATE TABLE expected_dataset.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE expected_dataset.t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE expected_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE expected_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE expected_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -27,7 +27,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/oracle/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/oracle/01-expected-init.sql
@@ -18,7 +18,7 @@
 DROP SCHEMA expected_dataset;
 CREATE SCHEMA expected_dataset;
 
-CREATE TABLE expected_dataset.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE expected_dataset.t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE expected_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE expected_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE expected_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -27,7 +27,7 @@ DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
-CREATE TABLE t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/sqlserver/01-expected-init.sql
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/data/expected/init-sql/sqlserver/01-expected-init.sql
@@ -19,7 +19,7 @@ DROP DATABASE IF EXISTS expected_dataset;
 
 CREATE DATABASE expected_dataset;
 
-CREATE TABLE expected_dataset.t_user (user_id INT NOT NULL, address_id INT NOT NULL, pwd VARCHAR(45) NULL, status VARCHAR(45) NULL, PRIMARY KEY (user_id));
+CREATE TABLE expected_dataset.t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE expected_dataset.t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE expected_dataset.t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));
 CREATE TABLE expected_dataset.t_merchant (merchant_id INT PRIMARY KEY, country_id SMALLINT NOT NULL, merchant_name VARCHAR(50) NOT NULL, business_code VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
@@ -42,10 +42,24 @@ rules:
   tables:
     t_user:
       columns:
-        pwd:
-          plainColumn: pwd_plain
-          cipherColumn: pwd_cipher
+        user_name:
+          plainColumn: user_name_plain
+          cipherColumn: user_name_cipher
+          likeQueryColumn: user_name_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
+        password:
+          cipherColumn: password_cipher
+          encryptorName: aes_encryptor
+        email:
+          cipherColumn: email_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
+          encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
     t_user_details:
       columns:
         number:

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
@@ -42,10 +42,24 @@ rules:
   tables:
     t_user:
       columns:
-        pwd:
-          plainColumn: pwd_plain
-          cipherColumn: pwd_cipher
+        user_name:
+          plainColumn: user_name_plain
+          cipherColumn: user_name_cipher
+          likeQueryColumn: user_name_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
+        password:
+          cipherColumn: password_cipher
+          encryptorName: aes_encryptor
+        email:
+          cipherColumn: email_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
+          encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
     t_user_details:
       columns:
         number:

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
@@ -42,10 +42,24 @@ rules:
   tables:
     t_user:
       columns:
-        pwd:
-          plainColumn: pwd_plain
-          cipherColumn: pwd_cipher
+        user_name:
+          plainColumn: user_name_plain
+          cipherColumn: user_name_cipher
+          likeQueryColumn: user_name_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
+        password:
+          cipherColumn: password_cipher
+          encryptorName: aes_encryptor
+        email:
+          cipherColumn: email_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
+          encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
     t_user_details:
       columns:
         number:

--- a/test/e2e/suite/src/test/resources/env/scenario/encrypt/rules.yaml
+++ b/test/e2e/suite/src/test/resources/env/scenario/encrypt/rules.yaml
@@ -29,10 +29,24 @@ rules:
   tables:
     t_user:
       columns:
-        pwd:
-          plainColumn: pwd_plain
-          cipherColumn: pwd_cipher
+        user_name:
+          plainColumn: user_name_plain
+          cipherColumn: user_name_cipher
+          likeQueryColumn: user_name_like
           encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
+        password:
+          cipherColumn: password_cipher
+          encryptorName: aes_encryptor
+        email:
+          cipherColumn: email_cipher
+          encryptorName: aes_encryptor
+        telephone:
+          plainColumn: telephone_plain
+          cipherColumn: telephone_cipher
+          likeQueryColumn: telephone_like
+          encryptorName: aes_encryptor
+          likeQueryEncryptorName: like_encryptor
     t_user_details:
       columns:
         number:


### PR DESCRIPTION
Ref #21286.

Changes proposed in this pull request:
  - refactor t_user init sql and data in encrypt scenario
  - adjust some encrypt test case and modify comments

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
