### PR TITLE
Fix CompletableFuture.anyOf missing callback in tasks runner

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryIncrementalTasksRunner.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.data.pipeline.core.job.progress.PipelineJobProg
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Inventory incremental tasks' runner.
@@ -92,25 +93,26 @@ public final class InventoryIncrementalTasksRunner implements PipelineTasksRunne
             }
             futures.addAll(each.start());
         }
-        CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
-            if (null != throwable) {
-                log.error("onFailure, inventory task execute failed.", throwable);
-                updateLocalAndRemoteJobItemStatus(JobStatus.EXECUTE_INVENTORY_TASK_FAILURE);
-                String jobId = jobItemContext.getJobId();
-                jobAPI.persistJobItemErrorMessage(jobId, jobItemContext.getShardingItem(), throwable);
-                jobAPI.stop(jobId);
-            }
-        });
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
-            if (null == throwable) {
-                if (PipelineJobProgressDetector.allInventoryTasksFinished(inventoryTasks)) {
-                    log.info("onSuccess, all inventory tasks finished.");
-                    executeIncrementalTask();
-                } else {
-                    log.info("onSuccess, inventory tasks not finished");
+        AtomicInteger completedCount = new AtomicInteger(0);
+        for (CompletableFuture<?> each : futures) {
+            each.whenComplete((o, throwable) -> {
+                completedCount.addAndGet(1);
+                if (null != throwable) {
+                    log.error("onFailure, inventory task execute failed.", throwable);
+                    updateLocalAndRemoteJobItemStatus(JobStatus.EXECUTE_INVENTORY_TASK_FAILURE);
+                    String jobId = jobItemContext.getJobId();
+                    jobAPI.persistJobItemErrorMessage(jobId, jobItemContext.getShardingItem(), throwable);
+                    jobAPI.stop(jobId);
+                } else if (completedCount.get() == futures.size()) {
+                    if (PipelineJobProgressDetector.allInventoryTasksFinished(inventoryTasks)) {
+                        log.info("onSuccess, all inventory tasks finished.");
+                        executeIncrementalTask();
+                    } else {
+                        log.info("onSuccess, inventory tasks not finished");
+                    }
                 }
-            }
-        });
+            });
+        }
     }
     
     private void updateLocalAndRemoteJobItemStatus(final JobStatus jobStatus) {
@@ -135,19 +137,20 @@ public final class InventoryIncrementalTasksRunner implements PipelineTasksRunne
             }
             futures.addAll(each.start());
         }
-        CompletableFuture.anyOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
-            if (null != throwable) {
-                log.error("onFailure, incremental task execute failed.", throwable);
-                updateLocalAndRemoteJobItemStatus(JobStatus.EXECUTE_INCREMENTAL_TASK_FAILURE);
-                String jobId = jobItemContext.getJobId();
-                jobAPI.persistJobItemErrorMessage(jobId, jobItemContext.getShardingItem(), throwable);
-                jobAPI.stop(jobId);
-            }
-        });
-        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).whenComplete((unused, throwable) -> {
-            if (null == throwable) {
-                log.info("onSuccess, all incremental tasks finished.");
-            }
-        });
+        AtomicInteger completedCount = new AtomicInteger(0);
+        for (CompletableFuture<?> each : futures) {
+            each.whenComplete((o, throwable) -> {
+                completedCount.addAndGet(1);
+                if (null != throwable) {
+                    log.error("onFailure, incremental task execute failed.", throwable);
+                    updateLocalAndRemoteJobItemStatus(JobStatus.EXECUTE_INCREMENTAL_TASK_FAILURE);
+                    String jobId = jobItemContext.getJobId();
+                    jobAPI.persistJobItemErrorMessage(jobId, jobItemContext.getShardingItem(), throwable);
+                    jobAPI.stop(jobId);
+                } else if (completedCount.get() == futures.size()) {
+                    log.info("onSuccess, all incremental tasks finished.");
+                }
+            });
+        }
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix CompletableFuture.anyOf missing callback in tasks runner

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
