### PR TITLE
Keep column labels when the result set of querying metadata is empty.

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
@@ -63,7 +63,7 @@ public final class CreateShardingTableReferenceRuleStatementUpdater implements R
     }
     
     private void checkDuplicatedRuleNames(final String databaseName, final CreateShardingTableReferenceRuleStatement sqlStatement,
-                                         final ShardingRuleConfiguration currentRuleConfig) throws DuplicateRuleException {
+                                          final ShardingRuleConfiguration currentRuleConfig) throws DuplicateRuleException {
         if (null != currentRuleConfig) {
             Collection<String> currentRuleNames = currentRuleConfig.getBindingTableGroups().stream().map(ShardingTableReferenceRuleConfiguration::getName).collect(Collectors.toSet());
             Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(TableReferenceRuleSegment::getName).filter(currentRuleNames::contains).collect(Collectors.toList());


### PR DESCRIPTION
Fixes #23115.

### Before
```sql
--
(0 rows)
```

### After
```sql
 table_schema | table_name | column_name | data_type | type_type | character_maximum_length | column_comment | modifier | is_nullable | column_default | is_autoinc | sequence_name | enum_values | numeric_precision | numeric_scale | size | is_pkey | dimension 
--------------+------------+-------------+-----------+-----------+--------------------------+----------------+----------+-------------+----------------+------------+---------------+-------------+-------------------+---------------+------+---------+-----------
(0 rows)
```


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
