### PR TITLE
Add `IF NOT EXISTS` to `create db_discovery rule`

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.infra.util.exception.ShardingSpherePrecondition
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -48,10 +49,15 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     
     private static final String RULE_TYPE = "Database discovery";
     
+    private boolean ifNotExists;
+    
     @Override
     public void checkSQLStatement(final ShardingSphereDatabase database, final CreateDatabaseDiscoveryRuleStatement sqlStatement, final DatabaseDiscoveryRuleConfiguration currentRuleConfig) {
         String databaseName = database.getName();
-        checkDuplicateRuleNames(databaseName, sqlStatement, currentRuleConfig);
+        ifNotExists = sqlStatement.isIfNotExists();
+        if (!ifNotExists) {
+            checkDuplicateRuleNames(databaseName, sqlStatement, currentRuleConfig);
+        }
         checkResources(databaseName, sqlStatement, database.getResourceMetaData());
         checkDiscoverTypeAndHeartbeat(databaseName, sqlStatement, currentRuleConfig);
     }
@@ -95,10 +101,32 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
         if (null != currentRuleConfig) {
+            if (ifNotExists) {
+                removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
+            }
+            if (toBeCreatedRuleConfig.getDataSources().isEmpty()) {
+                return;
+            }
             currentRuleConfig.getDataSources().addAll(toBeCreatedRuleConfig.getDataSources());
             currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
             currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
         }
+    }
+    
+    private void removeDuplicatedRules(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
+        Collection<String> currentRules = new LinkedList<>();
+        Collection<String> toBeRemovedHeartBeats = new LinkedList<>();
+        Collection<String> toBeRemovedTypes = new LinkedList<>();
+        currentRuleConfig.getDataSources().forEach(each -> currentRules.add(each.getGroupName()));
+        toBeCreatedRuleConfig.getDataSources().forEach(each -> {
+            if (currentRules.contains(each.getGroupName())) {
+                toBeRemovedHeartBeats.add(each.getDiscoveryHeartbeatName());
+                toBeRemovedTypes.add(each.getDiscoveryTypeName());
+                toBeCreatedRuleConfig.getDataSources().remove(each);
+            }
+        });
+        toBeCreatedRuleConfig.getDiscoveryHeartbeats().keySet().removeIf(toBeRemovedHeartBeats::contains);
+        toBeCreatedRuleConfig.getDiscoveryTypes().keySet().removeIf(toBeRemovedTypes::contains);
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
@@ -115,6 +115,7 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     
     private void removeDuplicatedRules(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
         Collection<String> currentRules = new LinkedList<>();
+        Collection<String> toBeRemovedDataSources = new LinkedList<>();
         Collection<String> toBeRemovedHeartBeats = new LinkedList<>();
         Collection<String> toBeRemovedTypes = new LinkedList<>();
         currentRuleConfig.getDataSources().forEach(each -> currentRules.add(each.getGroupName()));
@@ -122,9 +123,10 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
             if (currentRules.contains(each.getGroupName())) {
                 toBeRemovedHeartBeats.add(each.getDiscoveryHeartbeatName());
                 toBeRemovedTypes.add(each.getDiscoveryTypeName());
-                toBeCreatedRuleConfig.getDataSources().remove(each);
+                toBeRemovedDataSources.add(each.getGroupName());
             }
         });
+        toBeCreatedRuleConfig.getDataSources().removeIf(each -> toBeRemovedDataSources.contains(each.getGroupName()));
         toBeCreatedRuleConfig.getDiscoveryHeartbeats().keySet().removeIf(toBeRemovedHeartBeats::contains);
         toBeCreatedRuleConfig.getDiscoveryTypes().keySet().removeIf(toBeRemovedTypes::contains);
     }

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdaterTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdaterTest.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.distsql.handler.exception.algorithm.InvalidAlgo
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.distsql.handler.exception.storageunit.MissingRequiredStorageUnitsException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
-import org.apache.shardingsphere.distsql.handler.exception.algorithm.InvalidAlgorithmConfigurationException;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.resource.ShardingSphereResourceMetaData;
 import org.junit.Before;

--- a/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/Keyword.g4
+++ b/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/Keyword.g4
@@ -106,3 +106,7 @@ COUNT
 MYSQLMGR
     : M Y S Q L DOT_ M G R
     ;
+
+NOT
+    : N O T
+    ;

--- a/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/RDLStatement.g4
+++ b/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/RDLStatement.g4
@@ -20,7 +20,7 @@ grammar RDLStatement;
 import BaseRule;
 
 createDatabaseDiscoveryRule
-    : CREATE DB_DISCOVERY RULE databaseDiscoveryRule (COMMA_ databaseDiscoveryRule)*
+    : CREATE DB_DISCOVERY RULE ifNotExists? databaseDiscoveryRule (COMMA_ databaseDiscoveryRule)*
     ;
 
 alterDatabaseDiscoveryRule
@@ -69,4 +69,8 @@ discoveryHeartbeatName
 
 ifExists
     : IF EXISTS
+    ;
+
+ifNotExists
+    : IF NOT EXISTS
     ;

--- a/features/db-discovery/distsql/parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
+++ b/features/db-discovery/distsql/parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
@@ -63,7 +63,8 @@ public final class DatabaseDiscoveryDistSQLStatementVisitor extends DatabaseDisc
     
     @Override
     public ASTNode visitCreateDatabaseDiscoveryRule(final CreateDatabaseDiscoveryRuleContext ctx) {
-        return new CreateDatabaseDiscoveryRuleStatement(ctx.databaseDiscoveryRule().stream().map(each -> (AbstractDatabaseDiscoverySegment) visit(each)).collect(Collectors.toList()));
+        return new CreateDatabaseDiscoveryRuleStatement(null != ctx.ifNotExists(),
+                ctx.databaseDiscoveryRule().stream().map(each -> (AbstractDatabaseDiscoverySegment) visit(each)).collect(Collectors.toList()));
     }
     
     @Override

--- a/features/db-discovery/distsql/statement/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/statement/CreateDatabaseDiscoveryRuleStatement.java
+++ b/features/db-discovery/distsql/statement/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/statement/CreateDatabaseDiscoveryRuleStatement.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.dbdiscovery.distsql.parser.statement;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.segment.AbstractDatabaseDiscoverySegment;
 import org.apache.shardingsphere.distsql.parser.statement.rdl.create.CreateRuleStatement;
 
@@ -27,9 +26,13 @@ import java.util.Collection;
 /**
  * Create database discovery rule statement.
  */
-@RequiredArgsConstructor
 @Getter
 public final class CreateDatabaseDiscoveryRuleStatement extends CreateRuleStatement {
     
     private final Collection<AbstractDatabaseDiscoverySegment> rules;
+    
+    public CreateDatabaseDiscoveryRuleStatement(final boolean ifNotExists, final Collection<AbstractDatabaseDiscoverySegment> rules) {
+        super(ifNotExists);
+        this.rules = rules;
+    }
 }


### PR DESCRIPTION
The seventh task of #22844.

Changes proposed in this pull request:
  - Add `IF NOT EXISTS` to `create db_discovery rule`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
