### PR TITLE
ShardingSphere implements Global Logical Time feature.

### DIFF
--- a/kernel/global-logical-time/api/pom.xml
+++ b/kernel/global-logical-time/api/pom.xml
@@ -21,23 +21,24 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-global-logical-time</artifactId>
         <version>5.3.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-kernel</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>shardingsphere-global-logical-time-api</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>parser</module>
-        <module>single</module>
-        <module>authority</module>
-        <module>transaction</module>
-        <module>schedule</module>
-        <module>data-pipeline</module>
-        <module>sql-federation</module>
-        <module>sql-translator</module>
-        <module>traffic</module>
-        <module>global-logical-time</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-common</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-infra-executor</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/config/GlobalLogicalTimeRuleConfiguration.java
+++ b/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/config/GlobalLogicalTimeRuleConfiguration.java
@@ -15,28 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.context.transaction;
+package org.apache.shardingsphere.globallogicaltime.config;
 
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.config.rule.scope.GlobalRuleConfiguration;
 
 /**
- * Transaction connection context.
+ * global logical time rule configuration.
  */
+@RequiredArgsConstructor
 @Getter
-@Setter
-public final class TransactionConnectionContext implements AutoCloseable {
+public class GlobalLogicalTimeRuleConfiguration implements GlobalRuleConfiguration {
     
-    private volatile boolean inTransaction;
+    private final boolean globalLogicalTimeEnabled;
     
-    private volatile long globalCSN;
-    
-    private volatile String readWriteSplitReplicaRoute;
-    
-    @Override
-    public void close() {
-        inTransaction = false;
-        readWriteSplitReplicaRoute = null;
-        globalCSN = 0;
-    }
+    private final RedisConnectionOptionConfiguration redisOption;
 }

--- a/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/config/RedisConnectionOptionConfiguration.java
+++ b/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/config/RedisConnectionOptionConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Redis Connection Config.
+ */
+@RequiredArgsConstructor
+@Getter
+public class RedisConnectionOptionConfiguration {
+    
+    private final String host;
+    
+    private final String port;
+    
+    private final String password;
+    
+    private final int timeoutInterval;
+    
+    private final int maxIdle;
+    
+    private final int maxTotal;
+    
+    private final int lockExpirationTime;
+    
+    @Override
+    public String toString() {
+        return "RedisConnectionOptionConfiguration{"
+                + "host='" + host + '\''
+                + ", port='" + port + '\''
+                + ", password='" + password + '\''
+                + ", timeoutInterval=" + timeoutInterval
+                + ", maxIdle=" + maxIdle
+                + ", maxTotal=" + maxTotal
+                + ", lockExpirationTime=" + lockExpirationTime
+                + '}';
+    }
+}

--- a/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/spi/GlobalLogicalTimeExecutor.java
+++ b/kernel/global-logical-time/api/src/main/java/org/apache/shardingsphere/globallogicaltime/spi/GlobalLogicalTimeExecutor.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.spi;
+
+import org.apache.shardingsphere.infra.context.transaction.TransactionConnectionContext;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroup;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+
+/**
+ * Global logical time executor.
+ */
+public interface GlobalLogicalTimeExecutor {
+    
+    /**
+     * before xa transaction start to commit.
+     *
+     * @param connectionList connection list
+     * @return csnLockId csn lock id
+     * @throws SQLException sql exception
+     */
+    String beforeCommit(Collection<Connection> connectionList) throws SQLException;
+    
+    /**
+     * xa transaction commit completed.
+     *
+     * @param csnLockId csn lock id
+     */
+    void afterCommit(String csnLockId);
+    
+    /**
+     * Get global csn when beginning transaction.
+     *
+     * @param transactionConnectionContext transaction connection context
+     */
+    void getGlobalCSNWhenBeginTransaction(TransactionConnectionContext transactionConnectionContext);
+    
+    /**
+     * send snapshot csn to a dn after cn send "start transaction" to the dn.
+     *
+     * @param connection connection
+     * @param transactionConnectionContext transaction connection context
+     * @throws SQLException sql exception
+     */
+    void sendGlobalCSNAfterStartTransaction(Connection connection, TransactionConnectionContext transactionConnectionContext) throws SQLException;
+    
+    /**
+     * send snapshot csn to each dns in Read Commit isolation level.
+     *
+     * @param inputGroups input groups
+     * @throws SQLException sql exception
+     */
+    void sendSnapshotCSNInReadCommit(Collection<ExecutionGroup<JDBCExecutionUnit>> inputGroups) throws SQLException;
+}

--- a/kernel/global-logical-time/core/pom.xml
+++ b/kernel/global-logical-time/core/pom.xml
@@ -21,23 +21,23 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-global-logical-time</artifactId>
         <version>5.3.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-kernel</artifactId>
-    <packaging>pom</packaging>
+    <artifactId>shardingsphere-global-logcial-time-core</artifactId>
     <name>${project.artifactId}</name>
     
-    <modules>
-        <module>parser</module>
-        <module>single</module>
-        <module>authority</module>
-        <module>transaction</module>
-        <module>schedule</module>
-        <module>data-pipeline</module>
-        <module>sql-federation</module>
-        <module>sql-translator</module>
-        <module>traffic</module>
-        <module>global-logical-time</module>
-    </modules>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-global-logical-time-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>redis</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/GlobalLogicalTimeEngine.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/GlobalLogicalTimeEngine.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime;
+
+import lombok.Getter;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.redis.executor.BasedRedisGlobalLogicalTimeExecutor;
+import org.apache.shardingsphere.globallogicaltime.redis.executor.DefaultGlobalLogicalTimeExecutor;
+import org.apache.shardingsphere.globallogicaltime.spi.GlobalLogicalTimeExecutor;
+
+/**
+ * Global logical time engine.
+ */
+@Getter
+public class GlobalLogicalTimeEngine {
+    
+    private final GlobalLogicalTimeExecutor globalLogicalTimeExecutor;
+    
+    public GlobalLogicalTimeEngine(final GlobalLogicalTimeRuleConfiguration configuration) {
+        if (configuration.isGlobalLogicalTimeEnabled()) {
+            globalLogicalTimeExecutor = new BasedRedisGlobalLogicalTimeExecutor(configuration);
+        } else {
+            globalLogicalTimeExecutor = new DefaultGlobalLogicalTimeExecutor();
+        }
+    }
+    
+    public GlobalLogicalTimeEngine() {
+        globalLogicalTimeExecutor = new DefaultGlobalLogicalTimeExecutor();
+    }
+}

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/constant/GlobalLogicalTimeOrder.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/constant/GlobalLogicalTimeOrder.java
@@ -15,28 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.context.transaction;
+package org.apache.shardingsphere.globallogicaltime.constant;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 /**
- * Transaction connection context.
+ * global logical time order.
  */
-@Getter
-@Setter
-public final class TransactionConnectionContext implements AutoCloseable {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class GlobalLogicalTimeOrder {
     
-    private volatile boolean inTransaction;
-    
-    private volatile long globalCSN;
-    
-    private volatile String readWriteSplitReplicaRoute;
-    
-    @Override
-    public void close() {
-        inTransaction = false;
-        readWriteSplitReplicaRoute = null;
-        globalCSN = 0;
-    }
+    /**
+     * Transaction order.
+     */
+    public static final int ORDER = 605;
 }

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/GlobalLogicalTimeRule.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/GlobalLogicalTimeRule.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule;
+
+import lombok.Getter;
+import org.apache.shardingsphere.globallogicaltime.GlobalLogicalTimeEngine;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.infra.rule.identifier.scope.GlobalRule;
+
+/**
+ * Global logical time rule.
+ */
+@Getter
+public final class GlobalLogicalTimeRule implements GlobalRule {
+    
+    private final GlobalLogicalTimeRuleConfiguration configuration;
+    
+    private final boolean globalLogicalTimeEnabled;
+    
+    private final RedisConnectionOptionConfiguration redisOption;
+    
+    private volatile GlobalLogicalTimeEngine globalLogicalTimeEngine;
+    
+    public GlobalLogicalTimeRule(final GlobalLogicalTimeRuleConfiguration configuration) {
+        this.configuration = configuration;
+        this.globalLogicalTimeEnabled = configuration.isGlobalLogicalTimeEnabled();
+        this.redisOption = configuration.getRedisOption();
+        this.globalLogicalTimeEngine = createGlobalLogicalTimeRuleEngine();
+    }
+    
+    private synchronized GlobalLogicalTimeEngine createGlobalLogicalTimeRuleEngine() {
+        if (configuration == null) {
+            return new GlobalLogicalTimeEngine();
+        } else {
+            return new GlobalLogicalTimeEngine(configuration);
+        }
+    }
+    
+    @Override
+    public String getType() {
+        return GlobalLogicalTimeRule.class.getSimpleName();
+    }
+    
+    /**
+     * Get global logical time engine.
+     *
+     * @return globalLogicalTimeEngine global logical time engine
+     */
+    public GlobalLogicalTimeEngine getGlobalLogicalTimeEngine() {
+        return globalLogicalTimeEngine;
+    }
+}

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/builder/DefaultGlobalLogicalTimeRuleConfigurationBuilder.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/builder/DefaultGlobalLogicalTimeRuleConfigurationBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule.builder;
+
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder;
+
+/**
+ * Default global logical time rule configuration builder.
+ */
+public class DefaultGlobalLogicalTimeRuleConfigurationBuilder implements DefaultGlobalRuleConfigurationBuilder<GlobalLogicalTimeRuleConfiguration, GlobalLogicalTimeRuleBuilder> {
+    
+    public static final RedisConnectionOptionConfiguration REDIS_CONNECTION_OPTION = new RedisConnectionOptionConfiguration(
+            "127.0.0.1", "6379", "", 40000,
+            8, 18, 10);
+    
+    @Override
+    public GlobalLogicalTimeRuleConfiguration build() {
+        return new GlobalLogicalTimeRuleConfiguration(false, REDIS_CONNECTION_OPTION);
+    }
+    
+    @Override
+    public int getOrder() {
+        return GlobalLogicalTimeOrder.ORDER;
+    }
+    
+    @Override
+    public Class<GlobalLogicalTimeRuleBuilder> getTypeClass() {
+        return GlobalLogicalTimeRuleBuilder.class;
+    }
+}

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/builder/GlobalLogicalTimeRuleBuilder.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/rule/builder/GlobalLogicalTimeRuleBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule.builder;
+
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.apache.shardingsphere.globallogicaltime.rule.GlobalLogicalTimeRule;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.rule.builder.global.GlobalRuleBuilder;
+import org.apache.shardingsphere.infra.rule.identifier.scope.GlobalRule;
+
+import java.util.Map;
+
+/**
+ * global logical time rule builder.
+ */
+public class GlobalLogicalTimeRuleBuilder implements GlobalRuleBuilder<GlobalLogicalTimeRuleConfiguration> {
+    
+    @Override
+    public int getOrder() {
+        return GlobalLogicalTimeOrder.ORDER;
+    }
+    
+    @Override
+    public Class<GlobalLogicalTimeRuleConfiguration> getTypeClass() {
+        return GlobalLogicalTimeRuleConfiguration.class;
+    }
+    
+    @Override
+    public GlobalRule build(final GlobalLogicalTimeRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases, final ConfigurationProperties props) {
+        return new GlobalLogicalTimeRule(ruleConfig);
+    }
+}

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/config/YamlGlobalLogicalTimeRuleConfiguration.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/config/YamlGlobalLogicalTimeRuleConfiguration.java
@@ -15,28 +15,27 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.context.transaction;
+package org.apache.shardingsphere.globallogicaltime.yaml.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlGlobalRuleConfiguration;
 
 /**
- * Transaction connection context.
+ * global logical time configuration for YAML.
  */
 @Getter
 @Setter
-public final class TransactionConnectionContext implements AutoCloseable {
+public class YamlGlobalLogicalTimeRuleConfiguration implements YamlGlobalRuleConfiguration {
     
-    private volatile boolean inTransaction;
+    private boolean globalLogicalTimeEnabled;
     
-    private volatile long globalCSN;
-    
-    private volatile String readWriteSplitReplicaRoute;
+    private YamlRedisConnectionOptionConfiguration redisOption;
     
     @Override
-    public void close() {
-        inTransaction = false;
-        readWriteSplitReplicaRoute = null;
-        globalCSN = 0;
+    public Class<? extends RuleConfiguration> getRuleConfigurationType() {
+        return GlobalLogicalTimeRuleConfiguration.class;
     }
 }

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/config/YamlRedisConnectionOptionConfiguration.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/config/YamlRedisConnectionOptionConfiguration.java
@@ -15,28 +15,30 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.context.transaction;
+package org.apache.shardingsphere.globallogicaltime.yaml.config;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
 
 /**
- * Transaction connection context.
+ * redis connection option configuration for YAML.
  */
 @Getter
 @Setter
-public final class TransactionConnectionContext implements AutoCloseable {
+public class YamlRedisConnectionOptionConfiguration implements YamlConfiguration {
     
-    private volatile boolean inTransaction;
+    private String host;
     
-    private volatile long globalCSN;
+    private String port;
     
-    private volatile String readWriteSplitReplicaRoute;
+    private String password;
     
-    @Override
-    public void close() {
-        inTransaction = false;
-        readWriteSplitReplicaRoute = null;
-        globalCSN = 0;
-    }
+    private int timeoutInterval;
+    
+    private int maxIdle;
+    
+    private int maxTotal;
+    
+    private int lockExpirationTime;
 }

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlGlobalLogicalTimeRuleConfigurationSwapper.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlGlobalLogicalTimeRuleConfigurationSwapper.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.yaml.swapper;
+
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.apache.shardingsphere.globallogicaltime.rule.builder.DefaultGlobalLogicalTimeRuleConfigurationBuilder;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlGlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper;
+
+/**
+ * YAML global logical time rule configuration swapper.
+ */
+public class YamlGlobalLogicalTimeRuleConfigurationSwapper implements YamlRuleConfigurationSwapper<YamlGlobalLogicalTimeRuleConfiguration, GlobalLogicalTimeRuleConfiguration> {
+    
+    private final YamlRedisConnectionOptionConfigurationSwapper cacheOptionSwapper = new YamlRedisConnectionOptionConfigurationSwapper();
+    
+    @Override
+    public String getRuleTagName() {
+        return "GLOBAL_LOGICAL_TIME";
+    }
+    
+    @Override
+    public int getOrder() {
+        return GlobalLogicalTimeOrder.ORDER;
+    }
+    
+    @Override
+    public Class<GlobalLogicalTimeRuleConfiguration> getTypeClass() {
+        return GlobalLogicalTimeRuleConfiguration.class;
+    }
+    
+    @Override
+    public YamlGlobalLogicalTimeRuleConfiguration swapToYamlConfiguration(final GlobalLogicalTimeRuleConfiguration data) {
+        YamlGlobalLogicalTimeRuleConfiguration result = new YamlGlobalLogicalTimeRuleConfiguration();
+        result.setGlobalLogicalTimeEnabled(data.isGlobalLogicalTimeEnabled());
+        result.setRedisOption(cacheOptionSwapper.swapToYamlConfiguration(data.getRedisOption()));
+        return result;
+    }
+    
+    @Override
+    public GlobalLogicalTimeRuleConfiguration swapToObject(final YamlGlobalLogicalTimeRuleConfiguration yamlConfig) {
+        RedisConnectionOptionConfiguration configuration = null == yamlConfig.getRedisOption()
+                ? DefaultGlobalLogicalTimeRuleConfigurationBuilder.REDIS_CONNECTION_OPTION
+                : cacheOptionSwapper.swapToObject(yamlConfig.getRedisOption());
+        return new GlobalLogicalTimeRuleConfiguration(yamlConfig.isGlobalLogicalTimeEnabled(), configuration);
+        
+    }
+}

--- a/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlRedisConnectionOptionConfigurationSwapper.java
+++ b/kernel/global-logical-time/core/src/main/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlRedisConnectionOptionConfigurationSwapper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.yaml.swapper;
+
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlRedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
+
+/**
+ * YAML redis connection option configuration swapper.
+ */
+public class YamlRedisConnectionOptionConfigurationSwapper implements YamlConfigurationSwapper<YamlRedisConnectionOptionConfiguration, RedisConnectionOptionConfiguration> {
+    
+    @Override
+    public YamlRedisConnectionOptionConfiguration swapToYamlConfiguration(final RedisConnectionOptionConfiguration data) {
+        YamlRedisConnectionOptionConfiguration result = new YamlRedisConnectionOptionConfiguration();
+        result.setHost(data.getHost());
+        result.setPort(data.getPort());
+        result.setPassword(data.getPassword());
+        result.setTimeoutInterval(data.getTimeoutInterval());
+        result.setMaxIdle(data.getMaxIdle());
+        result.setMaxTotal(data.getMaxTotal());
+        result.setLockExpirationTime(data.getLockExpirationTime());
+        return result;
+    }
+    
+    @Override
+    public RedisConnectionOptionConfiguration swapToObject(final YamlRedisConnectionOptionConfiguration yamlConfig) {
+        return new RedisConnectionOptionConfiguration(yamlConfig.getHost(), yamlConfig.getPort(),
+                yamlConfig.getPassword(), yamlConfig.getTimeoutInterval(),
+                yamlConfig.getMaxIdle(), yamlConfig.getMaxTotal(),
+                yamlConfig.getLockExpirationTime());
+    }
+}

--- a/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder
+++ b/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.global.DefaultGlobalRuleConfigurationBuilder
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.globallogicaltime.rule.builder.DefaultGlobalLogicalTimeRuleConfigurationBuilder

--- a/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.global.GlobalRuleBuilder
+++ b/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.global.GlobalRuleBuilder
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.globallogicaltime.rule.builder.GlobalLogicalTimeRuleBuilder

--- a/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper
+++ b/kernel/global-logical-time/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.globallogicaltime.yaml.swapper.YamlGlobalLogicalTimeRuleConfigurationSwapper
+

--- a/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/GlobalLogicalTimeRuleTest.java
+++ b/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/GlobalLogicalTimeRuleTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule;
+
+import org.apache.shardingsphere.globallogicaltime.GlobalLogicalTimeEngine;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public final class GlobalLogicalTimeRuleTest {
+    
+    private GlobalLogicalTimeRule globalLogicalTimeRule;
+    
+    @Before
+    public void setup() {
+        globalLogicalTimeRule = mockGlobalLogicalTimeRule(new GlobalLogicalTimeRuleConfiguration(
+                true, new RedisConnectionOptionConfiguration("127.0.0.1", "6379", "", 40, 8, 18, 10)));
+    }
+    
+    /**
+     * Mock global logical time rule.
+     *
+     * @param configuration configuration
+     * @return global logical time rule
+     */
+    public GlobalLogicalTimeRule mockGlobalLogicalTimeRule(final GlobalLogicalTimeRuleConfiguration configuration) {
+        GlobalLogicalTimeEngine engine = mock(GlobalLogicalTimeEngine.class);
+        GlobalLogicalTimeRule rule = mock(GlobalLogicalTimeRule.class);
+        
+        when(rule.getGlobalLogicalTimeEngine()).thenReturn(engine);
+        when(rule.isGlobalLogicalTimeEnabled()).thenReturn(configuration.isGlobalLogicalTimeEnabled());
+        when(rule.getType()).thenReturn(rule.getClass().getSimpleName());
+        when(rule.getRedisOption()).thenReturn(configuration.getRedisOption());
+        when(rule.getConfiguration()).thenReturn(configuration);
+        return rule;
+    }
+    
+    @Test
+    public void assertGetGlobalLogicalTimeEngine() {
+        assertNotNull(globalLogicalTimeRule.getGlobalLogicalTimeEngine());
+    }
+    
+    @Test
+    public void assertGetType() {
+        assertEquals(globalLogicalTimeRule.getType(), GlobalLogicalTimeRule.class.getSimpleName());
+    }
+    
+    @Test
+    public void assertFields() {
+        // "127.0.0.1", "6379", "", 40, 8, 18, 10
+        assertTrue(globalLogicalTimeRule.getConfiguration().isGlobalLogicalTimeEnabled());
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getPort(), "6379");
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getPassword(), "");
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getMaxIdle(), 8);
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getMaxTotal(), 18);
+        assertEquals(globalLogicalTimeRule.getConfiguration().getRedisOption().getLockExpirationTime(), 10);
+        
+        assertTrue(globalLogicalTimeRule.isGlobalLogicalTimeEnabled());
+        assertEquals(globalLogicalTimeRule.getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(globalLogicalTimeRule.getRedisOption().getPort(), "6379");
+        assertEquals(globalLogicalTimeRule.getRedisOption().getPassword(), "");
+        assertEquals(globalLogicalTimeRule.getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(globalLogicalTimeRule.getRedisOption().getMaxIdle(), 8);
+        assertEquals(globalLogicalTimeRule.getRedisOption().getMaxTotal(), 18);
+        assertEquals(globalLogicalTimeRule.getRedisOption().getLockExpirationTime(), 10);
+    }
+}

--- a/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/builder/DefaultGlobalLogicalTimeRuleConfigurationBuilderTest.java
+++ b/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/builder/DefaultGlobalLogicalTimeRuleConfigurationBuilderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule.builder;
+
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class DefaultGlobalLogicalTimeRuleConfigurationBuilderTest {
+    
+    @Test
+    public void assertBuild() {
+        GlobalLogicalTimeRuleConfiguration actual = new DefaultGlobalLogicalTimeRuleConfigurationBuilder().build();
+        assertFalse(actual.isGlobalLogicalTimeEnabled());
+        assertEquals(actual.getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(actual.getRedisOption().getPort(), "6379");
+        assertEquals(actual.getRedisOption().getPassword(), "");
+        assertEquals(actual.getRedisOption().getTimeoutInterval(), 40000);
+        assertEquals(actual.getRedisOption().getMaxIdle(), 8);
+        assertEquals(actual.getRedisOption().getMaxTotal(), 18);
+        assertEquals(actual.getRedisOption().getLockExpirationTime(), 10);
+    }
+    
+    @Test
+    public void assertGetOrder() {
+        assertEquals(new DefaultGlobalLogicalTimeRuleConfigurationBuilder().getOrder(), GlobalLogicalTimeOrder.ORDER);
+    }
+    
+    @Test
+    public void assertGetTypeClass() {
+        assertEquals(new DefaultGlobalLogicalTimeRuleConfigurationBuilder().getTypeClass(), GlobalLogicalTimeRuleBuilder.class);
+    }
+}

--- a/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/builder/GlobalLogicalTimeRuleBuilderTest.java
+++ b/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/rule/builder/GlobalLogicalTimeRuleBuilderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.rule.builder;
+
+import org.apache.shardingsphere.globallogicaltime.GlobalLogicalTimeEngine;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.apache.shardingsphere.globallogicaltime.rule.GlobalLogicalTimeRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GlobalLogicalTimeRuleBuilderTest {
+    
+    @Test
+    public void assertGetOrder() {
+        assertEquals(new GlobalLogicalTimeRuleBuilder().getOrder(), GlobalLogicalTimeOrder.ORDER);
+    }
+    
+    @Test
+    public void assetGetTypeClass() {
+        assertEquals(new GlobalLogicalTimeRuleBuilder().getTypeClass(), GlobalLogicalTimeRuleConfiguration.class);
+    }
+    
+    @Test
+    public void assertBuild() {
+        GlobalLogicalTimeRuleConfiguration configuration = new GlobalLogicalTimeRuleConfiguration(
+                true, new RedisConnectionOptionConfiguration("127.0.0.1", "6379", "", 40, 8, 18, 10));
+        GlobalLogicalTimeEngine engine = mock(GlobalLogicalTimeEngine.class);
+        GlobalLogicalTimeRule actual = mock(GlobalLogicalTimeRule.class);
+        
+        when(actual.getGlobalLogicalTimeEngine()).thenReturn(engine);
+        when(actual.isGlobalLogicalTimeEnabled()).thenReturn(configuration.isGlobalLogicalTimeEnabled());
+        when(actual.getType()).thenReturn(actual.getClass().getSimpleName());
+        when(actual.getRedisOption()).thenReturn(configuration.getRedisOption());
+        when(actual.getConfiguration()).thenReturn(configuration);
+        
+        assertTrue(actual.getConfiguration().isGlobalLogicalTimeEnabled());
+        assertEquals(actual.getConfiguration().getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(actual.getConfiguration().getRedisOption().getPort(), "6379");
+        assertEquals(actual.getConfiguration().getRedisOption().getPassword(), "");
+        assertEquals(actual.getConfiguration().getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(actual.getConfiguration().getRedisOption().getMaxIdle(), 8);
+        assertEquals(actual.getConfiguration().getRedisOption().getMaxTotal(), 18);
+        assertEquals(actual.getConfiguration().getRedisOption().getLockExpirationTime(), 10);
+        
+        assertTrue(actual.isGlobalLogicalTimeEnabled());
+        assertEquals(actual.getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(actual.getRedisOption().getPort(), "6379");
+        assertEquals(actual.getRedisOption().getPassword(), "");
+        assertEquals(actual.getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(actual.getRedisOption().getMaxIdle(), 8);
+        assertEquals(actual.getRedisOption().getMaxTotal(), 18);
+        assertEquals(actual.getRedisOption().getLockExpirationTime(), 10);
+    }
+}

--- a/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlGlobalLogicalTimeRuleConfigurationSwapperTest.java
+++ b/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlGlobalLogicalTimeRuleConfigurationSwapperTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.yaml.swapper;
+
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.constant.GlobalLogicalTimeOrder;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlGlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlRedisConnectionOptionConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class YamlGlobalLogicalTimeRuleConfigurationSwapperTest {
+    
+    @Test
+    public void assertSwapToYamlConfiguration() {
+        RedisConnectionOptionConfiguration redisConfiguration = new RedisConnectionOptionConfiguration("127.0.0.1", "6379", "", 40, 8, 18, 10);
+        GlobalLogicalTimeRuleConfiguration gltConfiguration = new GlobalLogicalTimeRuleConfiguration(true, redisConfiguration);
+        YamlGlobalLogicalTimeRuleConfiguration actual = new YamlGlobalLogicalTimeRuleConfigurationSwapper().swapToYamlConfiguration(gltConfiguration);
+        assertTrue(actual.isGlobalLogicalTimeEnabled());
+        assertEquals(actual.getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(actual.getRedisOption().getPort(), "6379");
+        assertEquals(actual.getRedisOption().getPassword(), "");
+        assertEquals(actual.getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(actual.getRedisOption().getMaxIdle(), 8);
+        assertEquals(actual.getRedisOption().getMaxTotal(), 18);
+        assertEquals(actual.getRedisOption().getLockExpirationTime(), 10);
+    }
+    
+    @Test
+    public void assertSwapToObject() {
+        YamlRedisConnectionOptionConfiguration redisConfiguration = new YamlRedisConnectionOptionConfiguration();
+        redisConfiguration.setHost("127.0.0.1");
+        redisConfiguration.setPort("6379");
+        redisConfiguration.setPassword("");
+        redisConfiguration.setTimeoutInterval(40);
+        redisConfiguration.setMaxIdle(8);
+        redisConfiguration.setMaxTotal(18);
+        redisConfiguration.setLockExpirationTime(10);
+        YamlGlobalLogicalTimeRuleConfiguration gltConfiguration = new YamlGlobalLogicalTimeRuleConfiguration();
+        gltConfiguration.setGlobalLogicalTimeEnabled(true);
+        gltConfiguration.setRedisOption(redisConfiguration);
+        
+        GlobalLogicalTimeRuleConfiguration actual = new YamlGlobalLogicalTimeRuleConfigurationSwapper().swapToObject(gltConfiguration);
+        assertTrue(actual.isGlobalLogicalTimeEnabled());
+        assertEquals(actual.getRedisOption().getHost(), "127.0.0.1");
+        assertEquals(actual.getRedisOption().getPort(), "6379");
+        assertEquals(actual.getRedisOption().getPassword(), "");
+        assertEquals(actual.getRedisOption().getTimeoutInterval(), 40);
+        assertEquals(actual.getRedisOption().getMaxIdle(), 8);
+        assertEquals(actual.getRedisOption().getMaxTotal(), 18);
+        assertEquals(actual.getRedisOption().getLockExpirationTime(), 10);
+    }
+    
+    @Test
+    public void assertGetRuleTagName() {
+        assertEquals(new YamlGlobalLogicalTimeRuleConfigurationSwapper().getRuleTagName(), "GLOBAL_LOGICAL_TIME");
+    }
+    
+    @Test
+    public void assertGetOrder() {
+        assertEquals(new YamlGlobalLogicalTimeRuleConfigurationSwapper().getOrder(), GlobalLogicalTimeOrder.ORDER);
+    }
+    
+    @Test
+    public void assertGetTypeClass() {
+        assertEquals(new YamlGlobalLogicalTimeRuleConfigurationSwapper().getTypeClass().toString(), GlobalLogicalTimeRuleConfiguration.class.toString());
+    }
+}

--- a/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlRedisConnectionOptionConfigurationSwapperTest.java
+++ b/kernel/global-logical-time/core/src/test/java/org/apache/shardingsphere/globallogicaltime/yaml/swapper/YamlRedisConnectionOptionConfigurationSwapperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.yaml.swapper;
+
+import org.apache.shardingsphere.globallogicaltime.config.RedisConnectionOptionConfiguration;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlRedisConnectionOptionConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class YamlRedisConnectionOptionConfigurationSwapperTest {
+    
+    @Test
+    public void assertSwapToYamlConfiguration() {
+        RedisConnectionOptionConfiguration redisConnectionOptionConfiguration = new RedisConnectionOptionConfiguration("127.0.0.1", "6379", "", 40, 8, 18, 10);
+        YamlRedisConnectionOptionConfiguration actual = new YamlRedisConnectionOptionConfigurationSwapper().swapToYamlConfiguration(redisConnectionOptionConfiguration);
+        assertEquals(actual.getHost(), "127.0.0.1");
+        assertEquals(actual.getPort(), "6379");
+        assertEquals(actual.getPassword(), "");
+        assertEquals(actual.getTimeoutInterval(), 40);
+        assertEquals(actual.getMaxIdle(), 8);
+        assertEquals(actual.getMaxTotal(), 18);
+        assertEquals(actual.getLockExpirationTime(), 10);
+    }
+    
+    @Test
+    public void assertSwapToObject() {
+        YamlRedisConnectionOptionConfiguration yamlConfig = new YamlRedisConnectionOptionConfiguration();
+        yamlConfig.setHost("127.0.0.1");
+        yamlConfig.setPort("6379");
+        yamlConfig.setPassword("");
+        yamlConfig.setTimeoutInterval(40);
+        yamlConfig.setMaxIdle(8);
+        yamlConfig.setMaxTotal(18);
+        yamlConfig.setLockExpirationTime(10);
+        RedisConnectionOptionConfiguration actual = new YamlRedisConnectionOptionConfigurationSwapper().swapToObject(yamlConfig);
+        assertEquals(actual.getHost(), "127.0.0.1");
+        assertEquals(actual.getPort(), "6379");
+        assertEquals(actual.getPassword(), "");
+        assertEquals(actual.getTimeoutInterval(), 40);
+        assertEquals(actual.getMaxIdle(), 8);
+        assertEquals(actual.getMaxTotal(), 18);
+        assertEquals(actual.getLockExpirationTime(), 10);
+    }
+}

--- a/kernel/global-logical-time/pom.xml
+++ b/kernel/global-logical-time/pom.xml
@@ -21,23 +21,16 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-kernel</artifactId>
         <version>5.3.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-kernel</artifactId>
+    <artifactId>shardingsphere-global-logical-time</artifactId>
     <packaging>pom</packaging>
     <name>${project.artifactId}</name>
     
     <modules>
-        <module>parser</module>
-        <module>single</module>
-        <module>authority</module>
-        <module>transaction</module>
-        <module>schedule</module>
-        <module>data-pipeline</module>
-        <module>sql-federation</module>
-        <module>sql-translator</module>
-        <module>traffic</module>
-        <module>global-logical-time</module>
+        <module>api</module>
+        <module>core</module>
+        <module>redis</module>
     </modules>
 </project>

--- a/kernel/global-logical-time/redis/pom.xml
+++ b/kernel/global-logical-time/redis/pom.xml
@@ -21,23 +21,29 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.apache.shardingsphere</groupId>
-        <artifactId>shardingsphere</artifactId>
+        <artifactId>shardingsphere-global-logical-time</artifactId>
         <version>5.3.2-SNAPSHOT</version>
     </parent>
-    <artifactId>shardingsphere-kernel</artifactId>
-    <packaging>pom</packaging>
-    <name>${project.artifactId}</name>
     
-    <modules>
-        <module>parser</module>
-        <module>single</module>
-        <module>authority</module>
-        <module>transaction</module>
-        <module>schedule</module>
-        <module>data-pipeline</module>
-        <module>sql-federation</module>
-        <module>sql-translator</module>
-        <module>traffic</module>
-        <module>global-logical-time</module>
-    </modules>
+    <artifactId>redis</artifactId>
+    
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-global-logical-time-api</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>4.3.1</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+    
 </project>

--- a/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/connector/GlobalLogicalTimeJedisPoolConfigParams.java
+++ b/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/connector/GlobalLogicalTimeJedisPoolConfigParams.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.redis.connector;
+
+/**
+ * JedisPool config params for global logical time.
+ */
+public class GlobalLogicalTimeJedisPoolConfigParams {
+    
+    // the key of csn saved in redis server
+    public static final String CSN_KEY = "csn";
+    
+    // the key of csn lock
+    public static final String CSN_LOCK_NAME = "csnLock";
+    
+    public static final String TEST_KEY = "test_key";
+    
+    public static final String TEST_VALUE = "test_value";
+    
+    // init csn when redis server doesn't store csnKey
+    public static final long INIT_CSN = 40000;
+    
+    // error csn
+    public static final long ERROR_CSN = 0;
+    
+    // default host of redis server
+    public static final String DEFAULT_HOST = "127.0.0.1";
+    
+    // default port of redis server
+    public static final int DEFAULT_PORT = 6379;
+    
+    // default password of redis server
+    public static final String DEFAULT_PASSWORD = "";
+    
+    // default timeout interval when get connection
+    public static final int DEFAULT_TIME_INTERVAL = 40000;
+    
+    // default max idle redis connection number
+    public static final int DEFAULT_MAX_IDLE = 8;
+    
+    // default max redis connection number
+    public static final int DEFAULT_MAX_TOTAL = 18;
+    
+    // the default expiration time of csn lock, redis will keep the csn lock in lockExpirationTime
+    public static final int DEFAULT_LOCK_EXPIRATION_TIME = 20;
+    
+    // the min expiration time of csn lock
+    public static final int MIN_LOCK_EXPIRATION_TIME = 1;
+    
+    // the max expiration time of csn lock
+    public static final int MAX_LOCK_EXPIRATION_TIME = 1000;
+}

--- a/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/connector/GlobalLogicalTimeRedisConnector.java
+++ b/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/connector/GlobalLogicalTimeRedisConnector.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.redis.connector;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+import redis.clients.jedis.params.SetParams;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.Collections;
+import java.util.Random;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Redis connector for global logical time.
+ */
+@Slf4j
+public class GlobalLogicalTimeRedisConnector {
+    
+    private static final Long RELEASE_SUCCESS = 1L;
+    
+    private static final int TRY_LOCK_TIMEOUT_INTERVAL = 40;
+    
+    private static final Random RETRY_TIME_INTERVAL_RANDOM = new Random();
+    
+    private int lockExpirationTime;
+    
+    private JedisPool jedisPool;
+    
+    private final GlobalLogicalTimeRuleConfiguration configuration;
+    
+    public GlobalLogicalTimeRedisConnector(final GlobalLogicalTimeRuleConfiguration configuration) {
+        this.configuration = configuration;
+        initJedisPool();
+    }
+    
+    private boolean initJedisPool() throws JedisConnectionException {
+        String host;
+        int port;
+        String password;
+        int timeoutInterval;
+        int maxIdle;
+        int maxTotal;
+        
+        // Load configuration of jedis pool.
+        if (configuration == null || configuration.getRedisOption() == null) {
+            host = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_HOST;
+            port = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_PORT;
+            password = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_PASSWORD;
+            timeoutInterval = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_TIME_INTERVAL;
+            maxIdle = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_MAX_IDLE;
+            maxTotal = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_MAX_TOTAL;
+            this.lockExpirationTime = GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_LOCK_EXPIRATION_TIME;
+        } else {
+            host = configuration.getRedisOption().getHost() != null ? configuration.getRedisOption().getHost() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_HOST;
+            port = configuration.getRedisOption().getPort() != null ? Integer.parseInt(configuration.getRedisOption().getPort()) : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_PORT;
+            password = configuration.getRedisOption().getPassword() != null ? configuration.getRedisOption().getPassword() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_PASSWORD;
+            timeoutInterval =
+                    configuration.getRedisOption().getTimeoutInterval() != 0 ? configuration.getRedisOption().getTimeoutInterval() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_TIME_INTERVAL;
+            maxIdle = configuration.getRedisOption().getTimeoutInterval() != 0 ? configuration.getRedisOption().getTimeoutInterval() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_MAX_IDLE;
+            maxTotal = configuration.getRedisOption().getMaxTotal() != 0 ? configuration.getRedisOption().getMaxTotal() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_MAX_TOTAL;
+            this.lockExpirationTime =
+                    configuration.getRedisOption().getLockExpirationTime() != 0 ? configuration.getRedisOption().getMaxTotal() : GlobalLogicalTimeJedisPoolConfigParams.DEFAULT_LOCK_EXPIRATION_TIME;
+        }
+        
+        // Build the jedis pool.
+        JedisPoolConfig config = new JedisPoolConfig();
+        config.setMaxIdle(maxIdle);
+        config.setMaxTotal(maxTotal);
+        if ("".equals(password)) {
+            jedisPool = new JedisPool(config, host, port, timeoutInterval);
+        } else {
+            jedisPool = new JedisPool(config, host, port, timeoutInterval, password);
+        }
+        if (checkJedisPool()) {
+            log.info("create jedis pool, host: {}, port: {}, maxIdle: {}, maxTotal: {}, timeoutInterval: {}", host, port, maxIdle, maxTotal, timeoutInterval);
+            return true;
+        } else {
+            log.error("create jedis pool failed, please check the configuration in 'server.yaml'.");
+            return false;
+        }
+    }
+    
+    private boolean checkJedisPool() throws JedisConnectionException {
+        String setResult;
+        long deleteResult;
+        try (Jedis jedis = jedisPool.getResource()) {
+            setResult = jedis.set(GlobalLogicalTimeJedisPoolConfigParams.TEST_KEY, GlobalLogicalTimeJedisPoolConfigParams.TEST_VALUE);
+            deleteResult = jedis.del(GlobalLogicalTimeJedisPoolConfigParams.TEST_KEY);
+        } catch (JedisConnectionException e) {
+            log.error("create jedis pool failed, please check the configuration of redis.");
+            e.printStackTrace();
+            throw e;
+        }
+        return "OK".equals(setResult) && deleteResult == 1;
+    }
+    
+    /**
+     * Get current global csn from Redis after add 1 to the global csn in Redis.
+     *
+     * @return the global csn after add 1
+     * @throws JedisConnectionException jedis connection exception
+     */
+    public synchronized long getNextCSN() throws JedisConnectionException {
+        Jedis jedis = jedisPool.getResource();
+        long csn;
+        try {
+            csn = jedis.incr(GlobalLogicalTimeJedisPoolConfigParams.CSN_KEY);
+        } finally {
+            jedis.close();
+        }
+        return csn;
+        
+    }
+    
+    /**
+     * Init global csn in redis.
+     *
+     * @return initialized global csn
+     * @throws JedisConnectionException request to redis failed
+     */
+    public synchronized long initCSN() throws JedisConnectionException {
+        Jedis jedis = jedisPool.getResource();
+        String result;
+        try {
+            result = jedis.set(GlobalLogicalTimeJedisPoolConfigParams.CSN_KEY, String.valueOf(GlobalLogicalTimeJedisPoolConfigParams.INIT_CSN));
+        } finally {
+            jedis.close();
+        }
+        if ("OK".equals(result)) {
+            return GlobalLogicalTimeJedisPoolConfigParams.INIT_CSN;
+        } else {
+            return GlobalLogicalTimeJedisPoolConfigParams.ERROR_CSN;
+        }
+    }
+    
+    /**
+     * Get current global csn from redis.
+     *
+     * @return current global csn
+     * @throws JedisConnectionException request to redis failed
+     */
+    public long getCurrentCSN() throws JedisConnectionException {
+        Jedis jedis = jedisPool.getResource();
+        long csn;
+        try {
+            csn = Long.parseLong(jedis.get(GlobalLogicalTimeJedisPoolConfigParams.CSN_KEY));
+        } finally {
+            jedis.close();
+        }
+        if (csn == GlobalLogicalTimeJedisPoolConfigParams.ERROR_CSN) {
+            csn = initCSN();
+        }
+        return csn;
+    }
+    
+    private synchronized boolean tryCSNLock(final String id) {
+        return tryCSNLock(id, lockExpirationTime);
+    }
+    
+    private synchronized boolean tryCSNLock(final String id, final int lockExpirationTime) throws JedisConnectionException {
+        Jedis jedis = jedisPool.getResource();
+        SetParams params = new SetParams();
+        params.ex(lockExpirationTime);
+        params.nx();
+        String back = jedis.set(GlobalLogicalTimeJedisPoolConfigParams.CSN_LOCK_NAME, id, params);
+        jedis.close();
+        return "OK".equals(back);
+    }
+    
+    private boolean isTimeout(final long startTIme, final long endTime) {
+        final double msToS = 1000.0;
+        double interval = (endTime - startTIme) / msToS;
+        return !(interval < TRY_LOCK_TIMEOUT_INTERVAL);
+    }
+    
+    /**
+     * Try csn lock from redis in a loop before timeout.
+     *
+     * @param id cskLock id
+     * @throws TimeoutException trying csn lock timeout
+     * @throws JedisConnectionException request to redis failed
+     */
+    public void lockCSN(final String id) throws TimeoutException, JedisConnectionException {
+        int minRetryTimeInterval = 50;
+        int maxRetryTimeInterval = 100;
+        boolean lockResult = false;
+        try {
+            long startTime = System.currentTimeMillis();
+            while (true) {
+                long endTime = System.currentTimeMillis();
+                if (isTimeout(startTime, endTime)) {
+                    break;
+                }
+                lockResult = tryCSNLock(id);
+                if (lockResult) {
+                    log.debug("get csn lock successfully, id : {}", id);
+                    break;
+                } else {
+                    Thread.sleep(RETRY_TIME_INTERVAL_RANDOM.nextInt(maxRetryTimeInterval - minRetryTimeInterval) + minRetryTimeInterval);
+                }
+            }
+            
+        } catch (JedisConnectionException | InterruptedException e) {
+            e.printStackTrace();
+        }
+        
+        if (!lockResult) {
+            throw new TimeoutException("Get lock failed because of timeout.");
+        }
+    }
+    
+    /**
+     * Unlock csnLock if the held id equal to the saved id.
+     *
+     * @param id csn lock id
+     * @return if csn lock is unlocked successfully
+     * @throws JedisConnectionException request to redis failed
+     */
+    public synchronized boolean unLockCSN(final String id) throws JedisConnectionException {
+        Jedis jedis = jedisPool.getResource();
+        String script = "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+        Object result = jedis.eval(script, Collections.singletonList(GlobalLogicalTimeJedisPoolConfigParams.CSN_LOCK_NAME), Collections.singletonList(id));
+        jedis.close();
+        if (RELEASE_SUCCESS.equals(result)) {
+            log.debug("release csn lock successfully, id : {}", id);
+            return true;
+        } else {
+            log.error("fail to unLock CSN.");
+            return false;
+        }
+    }
+    
+    /**
+     * Generate a csn lock id by process id , timeMillis and random number.
+     *
+     * @return csn lock id
+     */
+    public static String tryCSNLockId() {
+        // get process id
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        String processId = String.valueOf(Integer.valueOf(runtimeMXBean.getName().split("@")[0]).intValue());
+        // get timeMillis
+        String timeMillis = String.valueOf(System.currentTimeMillis());
+        // get random number
+        String seed = String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+        return processId + timeMillis + seed;
+    }
+}

--- a/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/executor/BasedRedisGlobalLogicalTimeExecutor.java
+++ b/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/executor/BasedRedisGlobalLogicalTimeExecutor.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.redis.executor;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.globallogicaltime.config.GlobalLogicalTimeRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.redis.connector.GlobalLogicalTimeRedisConnector;
+import org.apache.shardingsphere.globallogicaltime.spi.GlobalLogicalTimeExecutor;
+import org.apache.shardingsphere.infra.context.transaction.TransactionConnectionContext;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroup;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Global logical time executor based redis.
+ */
+@Slf4j
+public class BasedRedisGlobalLogicalTimeExecutor implements GlobalLogicalTimeExecutor {
+    
+    private GlobalLogicalTimeRedisConnector redisConnector;
+    
+    public BasedRedisGlobalLogicalTimeExecutor(final GlobalLogicalTimeRuleConfiguration configuration) {
+        init(configuration);
+    }
+    
+    private void init(final GlobalLogicalTimeRuleConfiguration configuration) {
+        redisConnector = new GlobalLogicalTimeRedisConnector(configuration);
+    }
+    
+    /**
+     * Try csn lock before transaction starts to  commit, if success get current global csn and send to each dns.
+     *
+     * @param connectionList the connections to each dns
+     * @return csn lock
+     * @throws SQLException SQL exception
+     */
+    @Override
+    public String beforeCommit(final Collection<Connection> connectionList) throws SQLException {
+        // Try csn lock before transaction starts to commit.
+        String csnLockId = GlobalLogicalTimeRedisConnector.tryCSNLockId();
+        try {
+            redisConnector.lockCSN(csnLockId);
+        } catch (TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        
+        // Set commit csn to each dns.
+        String order = "SELECT " + redisConnector.getCurrentCSN() + " AS SETCOMMITCSN;";
+        for (Connection connection : connectionList) {
+            try (Statement statement = connection.createStatement()) {
+                log.debug(order);
+                statement.execute(order);
+            } catch (SQLException e) {
+                e.printStackTrace();
+                log.error("can not send commit csn!");
+                throw new SQLException(e.getMessage());
+            }
+        }
+        return csnLockId;
+    }
+    
+    /**
+     * Add 1 to the global csn in redis, and release csn lock.
+     *
+     * @param csnLockId csn lock id
+     */
+    @Override
+    public void afterCommit(final String csnLockId) {
+        redisConnector.getNextCSN();
+        redisConnector.unLockCSN(csnLockId);
+    }
+    
+    @Override
+    public void getGlobalCSNWhenBeginTransaction(final TransactionConnectionContext transactionConnectionContext) {
+        long csn = redisConnector.getCurrentCSN();
+        transactionConnectionContext.setGlobalCSN(csn);
+    }
+    
+    /**
+     * Send snapshot csn to each dns after cn send "START TRANSACTION" command.
+     *
+     * @param connection connection to dn
+     * @throws SQLException SQL exception
+     */
+    @Override
+    public void sendGlobalCSNAfterStartTransaction(final Connection connection, final TransactionConnectionContext transactionConnectionContext) throws SQLException {
+        long csn = transactionConnectionContext.getGlobalCSN();
+        sendSnapshotCSN(connection, csn);
+    }
+    
+    /**
+     * Send snapshot csn to each dns in Read Commit isolation level.
+     *
+     * @param inputGroups input groups
+     * @throws SQLException SQL Exception
+     */
+    @Override
+    public void sendSnapshotCSNInReadCommit(final Collection<ExecutionGroup<JDBCExecutionUnit>> inputGroups) throws SQLException {
+        List<Connection> connections = new ArrayList<>();
+        for (ExecutionGroup<JDBCExecutionUnit> entry : inputGroups) {
+            List<JDBCExecutionUnit> inputs = entry.getInputs();
+            for (JDBCExecutionUnit input : inputs) {
+                Connection connection = input.getStorageResource().getConnection();
+                connections.add(connection);
+            }
+        }
+        if (!connections.isEmpty()) {
+            // By default, shardingsphere transaction is read-commit level.
+            boolean inTransaction = !connections.get(0).getAutoCommit();
+            // By default, transactions' isolation are read-commit.
+            if (inTransaction) {
+                long csn = redisConnector.getCurrentCSN();
+                for (Connection connection : connections) {
+                    sendSnapshotCSN(connection, csn);
+                }
+            }
+        }
+    }
+    
+    private void sendSnapshotCSN(final Connection connection, final long csn) throws SQLException {
+        String order = "SELECT " + csn + " AS SETSNAPSHOTCSN;";
+        try (Statement statement = connection.createStatement()) {
+            log.debug(order);
+            statement.execute(order);
+        } catch (SQLException e) {
+            e.printStackTrace();
+            log.error("can not send snapshot csn.");
+            throw new SQLException(e);
+        }
+    }
+}

--- a/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/executor/DefaultGlobalLogicalTimeExecutor.java
+++ b/kernel/global-logical-time/redis/src/main/java/org/apache/shardingsphere/globallogicaltime/redis/executor/DefaultGlobalLogicalTimeExecutor.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.globallogicaltime.redis.executor;
+
+import org.apache.shardingsphere.globallogicaltime.spi.GlobalLogicalTimeExecutor;
+import org.apache.shardingsphere.infra.context.transaction.TransactionConnectionContext;
+import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroup;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+
+/**
+ * Default global logical time executor, which is turned off by default.
+ */
+public class DefaultGlobalLogicalTimeExecutor implements GlobalLogicalTimeExecutor {
+    
+    @Override
+    public String beforeCommit(final Collection<Connection> connectionList) throws SQLException {
+        return null;
+    }
+    
+    @Override
+    public void afterCommit(final String csnLockId) {
+        
+    }
+    
+    @Override
+    public void getGlobalCSNWhenBeginTransaction(final TransactionConnectionContext transactionConnectionContext) {
+        
+    }
+    
+    @Override
+    public void sendGlobalCSNAfterStartTransaction(final Connection connection, final TransactionConnectionContext transactionConnectionContext) throws SQLException {
+        
+    }
+    
+    @Override
+    public void sendSnapshotCSNInReadCommit(final Collection<ExecutionGroup<JDBCExecutionUnit>> inputGroups) throws SQLException {
+        
+    }
+}

--- a/kernel/global-logical-time/redis/src/test/java/org/apache/shardingsphere/globallogicaltime/redis/executor/DefaultGlobalLogicalTimeExecutorTest.java
+++ b/kernel/global-logical-time/redis/src/test/java/org/apache/shardingsphere/globallogicaltime/redis/executor/DefaultGlobalLogicalTimeExecutorTest.java
@@ -15,28 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.context.transaction;
+package org.apache.shardingsphere.globallogicaltime.redis.executor;
 
-import lombok.Getter;
-import lombok.Setter;
+import org.junit.Test;
 
-/**
- * Transaction connection context.
- */
-@Getter
-@Setter
-public final class TransactionConnectionContext implements AutoCloseable {
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertNull;
+
+public final class DefaultGlobalLogicalTimeExecutorTest {
     
-    private volatile boolean inTransaction;
-    
-    private volatile long globalCSN;
-    
-    private volatile String readWriteSplitReplicaRoute;
-    
-    @Override
-    public void close() {
-        inTransaction = false;
-        readWriteSplitReplicaRoute = null;
-        globalCSN = 0;
+    @Test
+    public void assertBeforeCommit() throws SQLException {
+        Collection<Connection> connectionList = new ArrayList<>();
+        assertNull(new DefaultGlobalLogicalTimeExecutor().beforeCommit(connectionList));
     }
 }

--- a/proxy/backend/pom.xml
+++ b/proxy/backend/pom.xml
@@ -218,5 +218,11 @@
             <artifactId>HikariCP</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-global-logcial-time-core</artifactId>
+            <version>${project.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/ProxySQLExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/communication/ProxySQLExecutor.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.backend.communication;
 
 import org.apache.shardingsphere.dialect.SQLExceptionTransformEngine;
 import org.apache.shardingsphere.dialect.exception.transaction.TableModifyInTransactionException;
+import org.apache.shardingsphere.globallogicaltime.rule.GlobalLogicalTimeRule;
 import org.apache.shardingsphere.infra.binder.type.TableAvailable;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.context.ConnectionContext;
@@ -226,6 +227,8 @@ public final class ProxySQLExecutor {
         executionGroupContext.setDatabaseName(backendConnection.getConnectionSession().getDatabaseName());
         executionGroupContext.setGrantee(backendConnection.getConnectionSession().getGrantee());
         executionGroupContext.setExecutionID(backendConnection.getConnectionSession().getExecutionId());
+        ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(GlobalLogicalTimeRule.class).getGlobalLogicalTimeEngine()
+                .getGlobalLogicalTimeExecutor().sendSnapshotCSNInReadCommit(executionGroupContext.getInputGroups());
         return jdbcExecutor.execute(executionContext.getQueryContext(), executionGroupContext, isReturnGeneratedKeys, isExceptionThrown);
     }
     

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoader.java
@@ -100,6 +100,9 @@ public final class ProxyConfigurationLoader {
         if (null != serverConfiguration.getCdc()) {
             serverConfiguration.getRules().add(serverConfiguration.getCdc());
         }
+        if (null != serverConfiguration.getGlobalLogicalTime()) {
+            serverConfiguration.getRules().add(serverConfiguration.getGlobalLogicalTime());
+        }
         return serverConfiguration;
     }
     

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyServerConfiguration.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/config/yaml/YamlProxyServerConfiguration.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.authority.yaml.config.YamlAuthorityRuleConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.yaml.config.YamlCDCRuleConfiguration;
+import org.apache.shardingsphere.globallogicaltime.yaml.config.YamlGlobalLogicalTimeRuleConfiguration;
 import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
@@ -53,6 +54,8 @@ public final class YamlProxyServerConfiguration implements YamlConfiguration {
     private YamlTrafficRuleConfiguration traffic;
     
     private YamlCDCRuleConfiguration cdc;
+    
+    private YamlGlobalLogicalTimeRuleConfiguration globalLogicalTime;
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();
     


### PR DESCRIPTION
…imeRule by yaml.

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -
ShardingSphere implements Global Logical Time feature.This is a openGauss + ShardingSphere feature implements distributed transaction fact-time consistency, and some of the code needs to be committed in ShardingSphere.
The basic process of this feature has been completed and the code is being refactored to meet the review requirements. I've now completed the Yaml parsing and GlobalRule initialization parts, and am refactoring the interface and implementation classes for GlobalLogicalTime.
《openGauss Global Logical  Time Feature Design Specification》:
https://www.yuque.com/g/zhoucong-jjxdd/oz9b46/iqy7gdrv1bfd8322/collaborator/join?token=2wHlpJeS6MPCj7In
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
