### PR TITLE
Fix encrypt shorthand expansion when execute subquery statement

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/Projection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/Projection.java
@@ -44,4 +44,12 @@ public interface Projection {
      * @return columnLabel
      */
     String getColumnLabel();
+    
+    /**
+     * Clone with owner.
+     * 
+     * @param ownerName owner name
+     * @return new projection
+     */
+    Projection cloneWithOwner(String ownerName);
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.binder.segment.select.projection.impl;
 
 import lombok.Getter;
+import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
 
@@ -48,5 +49,11 @@ public final class AggregationDistinctProjection extends AggregationProjection {
      */
     public String getDistinctColumnLabel() {
         return getAlias().orElse(distinctInnerExpression);
+    }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        // TODO replace column owner when AggregationDistinctProjection contains owner
+        return new AggregationDistinctProjection(startIndex, stopIndex, getType(), getInnerExpression(), getAlias().orElse(null), distinctInnerExpression, getDatabaseType());
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -74,4 +74,13 @@ public class AggregationProjection implements Projection {
         boolean isPostgreSQLOpenGaussStatement = databaseType instanceof PostgreSQLDatabaseType || databaseType instanceof OpenGaussDatabaseType;
         return getAlias().orElseGet(() -> isPostgreSQLOpenGaussStatement ? type.name().toLowerCase() : getExpression());
     }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        // TODO replace column owner when AggregationProjection contains owner
+        AggregationProjection result = new AggregationProjection(type, innerExpression, alias, databaseType);
+        result.setIndex(index);
+        result.getDerivedAggregationProjections().addAll(derivedAggregationProjections);
+        return result;
+    }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ColumnProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ColumnProjection.java
@@ -55,12 +55,8 @@ public final class ColumnProjection implements Projection {
         return Optional.ofNullable(alias);
     }
     
-    /**
-     * Get expression with alias.
-     * 
-     * @return expression with alias
-     */
-    public String getExpressionWithAlias() {
-        return getExpression() + (null == alias ? "" : " AS " + alias);
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        return new ColumnProjection(ownerName, name, alias);
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/DerivedProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/DerivedProjection.java
@@ -50,4 +50,9 @@ public final class DerivedProjection implements Projection {
     public String getColumnLabel() {
         return getAlias().orElse(expression);
     }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        return new DerivedProjection(expression, alias, derivedProjection);
+    }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
@@ -47,4 +47,10 @@ public final class ExpressionProjection implements Projection {
     public String getColumnLabel() {
         return getAlias().orElse(expression);
     }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        // TODO replace column owner when ExpressionProjection contains owner
+        return new ExpressionProjection(expression, alias);
+    }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ParameterMarkerProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ParameterMarkerProjection.java
@@ -56,12 +56,8 @@ public final class ParameterMarkerProjection implements Projection {
         return Optional.ofNullable(alias);
     }
     
-    /**
-     * Get expression with alias.
-     *
-     * @return expression with alias
-     */
-    public String getExpressionWithAlias() {
-        return getExpression() + (null == alias ? "" : " AS " + alias);
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        return new ParameterMarkerProjection(parameterMarkerIndex, parameterMarkerType, alias);
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjection.java
@@ -85,4 +85,9 @@ public final class ShorthandProjection implements Projection {
         }
         return result;
     }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        return new ShorthandProjection(ownerName, actualColumns.values());
+    }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/SubqueryProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/SubqueryProjection.java
@@ -47,4 +47,9 @@ public final class SubqueryProjection implements Projection {
     public String getColumnLabel() {
         return getAlias().orElse(expression);
     }
+    
+    @Override
+    public Projection cloneWithOwner(final String ownerName) {
+        return new SubqueryProjection(expression, alias);
+    }
 }

--- a/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -1187,35 +1187,53 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in simple select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator percentage wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in simple select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in simple select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator underscore wildcard in simple select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in simple select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '%18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in subquery select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '%18')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator percentage wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in subquery select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '_1000018')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in subquery select statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant WHERE merchant_id IN (SELECT merchant_id FROM t_merchant WHERE business_code LIKE '_1000018')" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator underscore wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in subquery select statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select join statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '%18'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator percentage wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select join statement when use encrypt feature.">
+    <test-case sql="SELECT * FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id WHERE m2.business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator underscore wildcard in select join statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '%18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator percentage wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select group by statement when use encrypt feature.">
+    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '%18' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator percentage wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator percentage wildcard in select group by statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
-    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '_1000018' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" scenario-comments="Test single table's LIKE operator underscore wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select group by statement when use encrypt feature.">
+    <test-case sql="SELECT country_id, COUNT(1) FROM t_merchant WHERE business_code LIKE '_1000018' GROUP BY country_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt" 
+               scenario-comments="Test single table's LIKE operator underscore wildcard in select group by statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in select group by statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM (SELECT * FROM t_merchant) temp" db-types="MySQL,PostgreSQL,openGauss" scenario-types="encrypt"
+               scenario-comments="Test encrypt shorthand expansion for subquery with simple select statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM (SELECT m1.* FROM t_merchant m1 INNER JOIN t_merchant m2 ON m1.merchant_id = m2.merchant_id) temp" db-types="MySQL,PostgreSQL,openGauss" scenario-types="encrypt"
+               scenario-comments="Test encrypt shorthand expansion for subquery with select join statement when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -101,4 +101,14 @@
         <input sql="SELECT COUNT(1) AS cnt FROM (SELECT a.amount FROM t_account a ORDER BY a.amount DESC ) AS tmp" />
         <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount FROM t_account a ORDER BY a.cipher_amount DESC ) AS tmp" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_shorthand_from_sub_query_with_simple_select" db-types="MySQL">
+        <input sql="SELECT * FROM (SELECT * FROM t_account a) AS temp" />
+        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account a) AS temp" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_shorthand_from_sub_query_with_select_join" db-types="MySQL">
+        <input sql="SELECT * FROM (SELECT a1.* FROM t_account a1 INNER JOIN t_account a2) AS temp" />
+        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a1`.`account_id`, `a1`.`cipher_certificate_number`, `a1`.`assisted_query_certificate_number`, `a1`.`cipher_password`, `a1`.`assisted_query_password`, `a1`.`cipher_amount` FROM t_account a1 INNER JOIN t_account a2) AS temp" />
+    </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-plain/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-plain/dml/select/select-subquery.xml
@@ -112,4 +112,14 @@
         <input sql="SELECT COUNT(1) AS cnt FROM (SELECT a.amount FROM t_account a ORDER BY a.amount DESC ) AS tmp" />
         <output sql="SELECT COUNT(1) AS cnt FROM (SELECT a.cipher_amount FROM t_account a ORDER BY a.cipher_amount DESC ) AS tmp" />
     </rewrite-assertion>
+
+    <rewrite-assertion id="select_shorthand_from_sub_query_with_simple_select" db-types="MySQL">
+        <input sql="SELECT * FROM (SELECT * FROM t_account a) AS temp" />
+        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account a) AS temp" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_shorthand_from_sub_query_with_select_join" db-types="MySQL">
+        <input sql="SELECT * FROM (SELECT a1.* FROM t_account a1 INNER JOIN t_account a2) AS temp" />
+        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a1`.`account_id`, `a1`.`cipher_certificate_number`, `a1`.`assisted_query_certificate_number`, `a1`.`cipher_password`, `a1`.`assisted_query_password`, `a1`.`cipher_amount` FROM t_account a1 INNER JOIN t_account a2) AS temp" />
+    </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #23163.

Changes proposed in this pull request:
  - fix encrypt shorthand expansion when execute subquery statement
  - add integration test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
