### PR TITLE
Refactor ShardingTableNodesResultSet to depend on ShardingRule

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableNodesResultSet.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShardingTableNodesResultSet.java
@@ -17,21 +17,12 @@
 
 package org.apache.shardingsphere.sharding.distsql.handler.query;
 
-import com.google.common.base.Strings;
 import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
-import org.apache.shardingsphere.infra.algorithm.ShardingSphereAlgorithmFactory;
-import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.util.expr.InlineExpressionParser;
-import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPIRegistry;
-import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
-import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
-import org.apache.shardingsphere.sharding.api.sharding.ShardingAutoTableAlgorithm;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.ShowShardingTableNodesStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
-import org.apache.shardingsphere.sharding.spi.ShardingAlgorithm;
+import org.apache.shardingsphere.sharding.rule.TableRule;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
@@ -39,11 +30,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -59,71 +47,24 @@ public final class ShardingTableNodesResultSet implements DatabaseDistSQLResultS
     
     @Override
     public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
-        Optional<ShardingRule> rule = database.getRuleMetaData().findSingleRule(ShardingRule.class);
-        rule.ifPresent(optional -> data = getData((ShardingRuleConfiguration) optional.getConfiguration(), (ShowShardingTableNodesStatement) sqlStatement).entrySet().iterator());
-    }
-    
-    private Map<String, String> getData(final ShardingRuleConfiguration config, final ShowShardingTableNodesStatement sqlStatement) {
-        String tableName = sqlStatement.getTableName();
-        Map<String, String> dataNodes = config.getTables().stream().filter(each -> null == tableName || each.getLogicTable().equals(tableName))
-                .collect(Collectors.toMap(ShardingTableRuleConfiguration::getLogicTable, this::getDataNodes, (x, y) -> x, LinkedHashMap::new));
-        Map<String, String> autoTables = config.getAutoTables().stream().filter(each -> null == tableName || each.getLogicTable().equals(tableName))
-                .collect(Collectors.toMap(ShardingAutoTableRuleConfiguration::getLogicTable, each -> getDataNodes(each, getTotalShardingCount(config, each)), (x, y) -> x, LinkedHashMap::new));
+        ShardingRule shardingRule = (ShardingRule) database.getRuleMetaData().getRules().stream().filter(each -> each instanceof ShardingRule).findFirst().orElse(null);
+        if (null == shardingRule) {
+            return;
+        }
         Map<String, String> result = new LinkedHashMap<>();
-        result.putAll(dataNodes);
-        result.putAll(autoTables);
-        return result;
-    }
-    
-    private int getTotalShardingCount(final ShardingRuleConfiguration ruleConfig, final ShardingAutoTableRuleConfiguration shardingAutoTableRuleConfig) {
-        Map<String, AlgorithmConfiguration> shardingAlgorithms = ruleConfig.getShardingAlgorithms();
-        ShardingStrategyConfiguration shardingStrategy = shardingAutoTableRuleConfig.getShardingStrategy();
-        if (useDefaultStrategy(shardingStrategy, ruleConfig)) {
-            int tableCount = getShardingCount(shardingAlgorithms.get(ruleConfig.getDefaultTableShardingStrategy().getShardingAlgorithmName()));
-            int databaseCount = getShardingCount(shardingAlgorithms.get(ruleConfig.getDefaultDatabaseShardingStrategy().getShardingAlgorithmName()));
-            return tableCount * databaseCount;
-        }
-        return getShardingCount(shardingAlgorithms.get(shardingStrategy.getShardingAlgorithmName()));
-    }
-    
-    private boolean useDefaultStrategy(final ShardingStrategyConfiguration currentShardingStrategy, final ShardingRuleConfiguration ruleConfig) {
-        return (null == currentShardingStrategy || Strings.isNullOrEmpty(currentShardingStrategy.getShardingAlgorithmName()))
-                && null != ruleConfig.getDefaultDatabaseShardingStrategy() && null != ruleConfig.getDefaultTableShardingStrategy();
-    }
-    
-    private int getShardingCount(final AlgorithmConfiguration algorithmConfig) {
-        if (null == algorithmConfig) {
-            return 0;
-        }
-        if (TypedSPIRegistry.findRegisteredService(ShardingAlgorithm.class, algorithmConfig.getType()).isPresent()) {
-            ShardingAlgorithm shardingAlgorithm = ShardingSphereAlgorithmFactory.createAlgorithm(algorithmConfig, ShardingAlgorithm.class);
-            if (shardingAlgorithm instanceof ShardingAutoTableAlgorithm) {
-                shardingAlgorithm.init(algorithmConfig.getProps());
-                return ((ShardingAutoTableAlgorithm) shardingAlgorithm).getAutoTablesAmount();
+        String tableName = ((ShowShardingTableNodesStatement) sqlStatement).getTableName();
+        if (null == tableName) {
+            for (Entry<String, TableRule> entry : shardingRule.getTableRules().entrySet()) {
+                result.put(entry.getKey(), getTableNodes(entry.getValue()));
             }
+        } else {
+            result.put(tableName, getTableNodes(shardingRule.getTableRule(tableName)));
         }
-        return 0;
+        data = result.entrySet().iterator();
     }
     
-    private String getDataNodes(final ShardingAutoTableRuleConfiguration shardingAutoTableRuleConfig, final int shardingCount) {
-        List<String> dataSources = new InlineExpressionParser(shardingAutoTableRuleConfig.getActualDataSources()).splitAndEvaluate();
-        return fillDataSourceNames(shardingAutoTableRuleConfig.getLogicTable(), shardingCount, dataSources);
-    }
-    
-    private String getDataNodes(final ShardingTableRuleConfiguration shardingTableRuleConfig) {
-        return String.join(", ", new InlineExpressionParser(shardingTableRuleConfig.getActualDataNodes()).splitAndEvaluate());
-    }
-    
-    private String fillDataSourceNames(final String logicTable, final int amount, final List<String> dataSources) {
-        List<String> result = new LinkedList<>();
-        Iterator<String> iterator = dataSources.iterator();
-        for (int i = 0; i < amount; i++) {
-            if (!iterator.hasNext()) {
-                iterator = dataSources.iterator();
-            }
-            result.add(String.format("%s.%s_%s", iterator.next(), logicTable, i));
-        }
-        return String.join(", ", result);
+    private String getTableNodes(final TableRule tableRule) {
+        return tableRule.getActualDataNodes().stream().map(DataNode::format).collect(Collectors.joining(", "));
     }
     
     @Override

--- a/features/sharding/distsql/handler/src/test/resources/yaml/config_sharding_for_table_nodes.yaml
+++ b/features/sharding/distsql/handler/src/test/resources/yaml/config_sharding_for_table_nodes.yaml
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+rules:
+  - !SHARDING
+    autoTables:
+      t_order:
+        actualDataSources: ds_1,ds_2
+        keyGenerateStrategy:
+          column: order_id
+          keyGeneratorName: t_order_snowflake
+        logicTable: t_order
+        shardingStrategy:
+          standard:
+            shardingAlgorithmName: t_order_hash_mod
+            shardingColumn: order_id
+      t_order_item:
+        actualDataSources: ds_2,ds_3
+        keyGenerateStrategy:
+          column: order_id
+          keyGeneratorName: t_order_item_snowflake
+        logicTable: t_order_item
+        shardingStrategy:
+          standard:
+            shardingAlgorithmName: t_order_item_hash_mod
+            shardingColumn: order_id
+    keyGenerators:
+      t_order_snowflake:
+        type: snowflake
+      t_order_item_snowflake:
+        type: snowflake
+    shardingAlgorithms:
+      t_order_hash_mod:
+        props:
+          sharding-count: '6'
+        type: hash_mod
+      t_order_item_hash_mod:
+        props:
+          sharding-count: '6'
+        type: hash_mod


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor ShardingTableNodesResultSet to depend on ShardingRule

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
