### PR TITLE
fixes sqlCommentParseEnabled default value to `false` for SQL hint.

### DIFF
--- a/proxy/bootstrap/src/main/resources/conf/server.yaml
+++ b/proxy/bootstrap/src/main/resources/conf/server.yaml
@@ -47,7 +47,7 @@
 #  providerType: Atomikos
 #
 #sqlParser:
-#  sqlCommentParseEnabled: true
+#  sqlCommentParseEnabled: false
 #  sqlStatementCache:
 #    initialCapacity: 2000
 #    maximumSize: 65535


### PR DESCRIPTION
For #20736 .

Changes proposed in this pull request:
  - fixes sqlCommentParseEnabled default value to `false` for SQL hint. 

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
