### PR TITLE
Optimize PostgreSQL, openGauss select fetech statement parse and add more integration test

### DIFF
--- a/sql-parser/dialect/opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
+++ b/sql-parser/dialect/opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
@@ -234,7 +234,7 @@ limitClause
 
 offsetClause
     : OFFSET selectOffsetValue
-    | OFFSET selectFetchFirstValue rowOrRows
+    | OFFSET selectOffsetValue rowOrRows
     ;
 
 selectLimitValue

--- a/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
+++ b/sql-parser/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/impl/OpenGaussStatementSQLVisitor.java
@@ -1327,17 +1327,13 @@ public abstract class OpenGaussStatementSQLVisitor extends OpenGaussStatementBas
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
             }
             if (null != ctx.limitClause().selectFetchFirstValue()) {
-                LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
-                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
+                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
             }
             LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
             return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
         }
-        if (null != ctx.offsetClause().selectOffsetValue()) {
-            LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectOffsetValue());
-            return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
-        }
-        LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectFetchFirstValue());
+        LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectOffsetValue());
         return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
     }
     

--- a/sql-parser/dialect/postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
+++ b/sql-parser/dialect/postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
@@ -228,7 +228,6 @@ valuesClause
 
 limitClause
     : LIMIT selectLimitValue
-    | LIMIT selectOffsetValue COMMA_ selectLimitValue
     | FETCH firstOrNext selectFetchFirstValue rowOrRows ONLY
     | FETCH firstOrNext selectFetchFirstValue rowOrRows WITH TIES
     | FETCH firstOrNext rowOrRows ONLY
@@ -237,7 +236,7 @@ limitClause
 
 offsetClause
     : OFFSET selectOffsetValue
-    | OFFSET selectFetchFirstValue rowOrRows
+    | OFFSET selectOffsetValue rowOrRows
     ;
 
 selectLimitValue

--- a/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/impl/PostgreSQLStatementSQLVisitor.java
@@ -1288,23 +1288,14 @@ public abstract class PostgreSQLStatementSQLVisitor extends PostgreSQLStatementP
     
     private LimitSegment createLimitSegmentWhenRowCountOrOffsetAbsent(final SelectLimitContext ctx) {
         if (null != ctx.limitClause()) {
-            if (null != ctx.limitClause().selectOffsetValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
-                LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectOffsetValue());
-                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
-            }
             if (null != ctx.limitClause().selectFetchFirstValue()) {
-                LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
-                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
+                return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
             }
             LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());
             return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
         }
-        if (null != ctx.offsetClause().selectOffsetValue()) {
-            LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectOffsetValue());
-            return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
-        }
-        LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectFetchFirstValue());
+        LimitValueSegment offset = (LimitValueSegment) visit(ctx.offsetClause().selectOffsetValue());
         return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, null);
     }
     

--- a/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
+++ b/test/e2e/suite/src/test/resources/cases/dql/dql-integration-test-cases.xml
@@ -796,6 +796,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_product p INNER JOIN t_product_detail d USING(product_id) WHERE p.product_id > ? ORDER BY p.product_id DESC FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select inner join fetch statement when use sharding feature and federation executor engine.">
+        <assertion parameters="10:int" expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_order o NATURAL LEFT JOIN t_merchant m WHERE o.user_id = ? ORDER BY o.order_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
@@ -817,6 +822,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_product p NATURAL JOIN t_product_detail d WHERE p.product_id > ? ORDER BY p.product_id FETCH NEXT 3 ROW ONLY" db-types="openGauss" scenario-types="db"
+               scenario-comments="Test select natural join fetch statement when use sharding feature and federation executor engine.">
+        <assertion parameters="10:int" expected-data-source-name="read_dataset" />
+    </test-case>
+
     <test-case sql="SELECT MIN(d.detail_id), MIN(p.category_id), p.product_id FROM t_product p INNER JOIN t_product_detail d ON p.product_id = d.product_id WHERE p.product_id = ? GROUP BY p.product_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
@@ -825,6 +835,11 @@
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_product p CROSS JOIN t_product_detail d WHERE p.product_id = ? ORDER BY d.product_id, 7 FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select cross join fetch statement when use sharding feature and federation executor engine.">
+        <assertion parameters="10:int" expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_product p LEFT JOIN t_product_detail d ON d.product_id = p.product_id WHERE p.category_id = ? ORDER BY p.product_id, 7" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="10:int" expected-data-source-name="read_dataset" />
     </test-case>
@@ -899,6 +914,11 @@
         <assertion parameters="2500:long" expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT o.user_id FROM t_order o WHERE o.order_id > ? UNION ALL SELECT u.user_id FROM t_user u ORDER BY user_id FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select union all fetch statement when use sharding feature and federation executor engine.">
+        <assertion parameters="2500:long" expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT o.user_id FROM t_order o WHERE o.order_id > ? UNION SELECT u.user_id FROM t_user u ORDER BY user_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="2500:long" expected-data-source-name="read_dataset" />
     </test-case>
@@ -908,6 +928,11 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_order INTERSECT ALL SELECT * FROM t_order ORDER BY order_id FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select intersect all fetch statement when use sharding feature and federation executor engine.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_order WHERE order_id > ? INTERSECT SELECT * FROM t_order WHERE order_id > ? ORDER BY order_id" db-types="PostgreSQL,openGauss" scenario-types="db">
         <assertion parameters="2000:long, 1500:long" expected-data-source-name="read_dataset" />
     </test-case>
@@ -1083,6 +1108,11 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_order_item_join_view FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select ... from join view fetch statement when use sharding feature and federation executor engine.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
     <test-case sql="SELECT * FROM t_order_subquery_view ORDER BY order_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
@@ -1092,6 +1122,11 @@
     </test-case>
 
     <test-case sql="SELECT * FROM t_order_subquery_view ORDER BY order_id LIMIT 5, 2" db-types="MySQL,openGauss" scenario-types="db">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM t_order_subquery_view ORDER BY order_id FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select ... from subquery view fetch statement when use sharding feature and federation executor engine.">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
@@ -1107,6 +1142,11 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_order_aggregation_view FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select ... from aggregation view fetch statement when use sharding feature and federation executor engine.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_order_union_view ORDER BY order_id" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
@@ -1119,6 +1159,11 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
 
+    <test-case sql="SELECT * FROM t_order_union_view ORDER BY order_id FETCH NEXT 3 ROW ONLY" db-types="PostgreSQL,openGauss" scenario-types="db"
+               scenario-comments="Test select ... from union view fetch statement when use sharding feature and federation executor engine.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT * FROM t_order ORDER BY merchant_id ASC, order_id ASC" db-types="MySQL,PostgreSQL,openGauss,Oracle,SQLServer" scenario-types="db">
         <assertion expected-data-source-name="read_dataset" />
     </test-case>

--- a/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
+++ b/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
@@ -126,6 +126,7 @@ public final class SQLNodeConverterEngineIT {
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_offset_fetch");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_offset_and_row_count");
         SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_row_count");
+        SUPPORTED_SQL_CASE_IDS.add("select_pagination_with_limit_fetch_count");
         SUPPORTED_SQL_CASE_IDS.add("select_with_null_keyword_in_projection");
         SUPPORTED_SQL_CASE_IDS.add("select_union");
         SUPPORTED_SQL_CASE_IDS.add("select_union_all");

--- a/test/it/parser/src/main/resources/case/dml/select-pagination.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-pagination.xml
@@ -2034,4 +2034,16 @@
             <row-count value="2" start-index="44" stop-index="44" />
         </limit>
     </select>
+
+    <select sql-case-id="select_pagination_with_limit_fetch_count">
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <from>
+            <simple-table name="t_new_order" start-index="14" stop-index="24" />
+        </from>
+        <limit start-index="26" stop-index="46">
+            <row-count value="3" start-index="37" stop-index="37" />
+        </limit>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -4796,18 +4796,6 @@
         </from>
     </select>
 
-    <select sql-case-id="select_with_offset">
-        <projections start-index="7" stop-index="7">
-            <shorthand-projection start-index="7" stop-index="7" />
-        </projections>
-        <from>
-            <simple-table name="t_new_order" start-index="14" stop-index="24" />
-        </from>
-        <limit start-index="26" stop-index="46">
-            <offset value="3" start-index="37" stop-index="37" />
-        </limit>
-    </select>
-
     <select sql-case-id="select_with_null_keyword_in_projection">
         <projections start-index="7" stop-index="31">
             <expression-projection text="null" alias="order_id" start-index="7" stop-index="22">

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-pagination.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-pagination.xml
@@ -37,4 +37,5 @@
     <sql-case id="select_pagination_with_offset_fetch" value="SELECT * FROM t_order ORDER BY order_id OFFSET 0 ROW FETCH NEXT ? ROWS ONLY" db-types="SQLServer" />
     <sql-case id="select_pagination_with_limit_offset_and_row_count" value="SELECT order_id, user_id FROM t_order LIMIT 1, 2" db-types="MySQL,openGauss" />
     <sql-case id="select_pagination_with_limit_row_count" value="SELECT order_id, user_id FROM t_order LIMIT 2" db-types="MySQL" />
+    <sql-case id="select_pagination_with_limit_fetch_count" value="SELECT * FROM t_new_order FETCH NEXT 3 ROW ONLY" db-types="openGauss,PostgreSQL" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -155,6 +155,5 @@
     <sql-case id="select_xmlroot_function" value="SELECT XMLROOT(XMLType('143598'), VERSION '1.0', STANDALONE YES) AS 'XMLROOT' FROM DUAL;" db-types="Oracle" />
     <sql-case id="select_xmlserialize_function" value="SELECT XMLSERIALIZE(DOCUMENT c2 AS BLOB ENCODING 'UTF-8' VERSION 'a' IDENT SIZE = 0 SHOW DEFAULT) FROM b;" db-types="Oracle" />
     <sql-case id="select_from_xmltable_function" value="SELECT warehouse_name warehouse, warehouse2.Water, warehouse2.Rail FROM warehouses, XMLTABLE('/Warehouse' PASSING warehouses.warehouse_spec COLUMNS &quot;Water&quot; varchar2(6) PATH 'WaterAccess',&quot;Rail&quot; varchar2(6) PATH 'RailAccess') warehouse2;" db-types="Oracle" />
-    <sql-case id="select_with_offset" value="select * from t_new_order fetch next 3 row only;" db-types="openGauss,PostgreSQL" />
     <sql-case id="select_with_null_keyword_in_projection" value="select null as order_id, item_id from t_order" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #22822.

Changes proposed in this pull request:
  - Optimize PostgreSQL, openGauss select fetech statement parse
  - add more integration test for fetch statement when use sql federation

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
