### PR TITLE
Add `MaskRuleStatementConverter` unit test

### DIFF
--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/converter/MaskRuleStatementConverterTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/converter/MaskRuleStatementConverterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mask.distsql.handler.converter;
+
+import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
+import org.apache.shardingsphere.mask.api.config.MaskRuleConfiguration;
+import org.apache.shardingsphere.mask.distsql.parser.segment.MaskColumnSegment;
+import org.apache.shardingsphere.mask.distsql.parser.segment.MaskRuleSegment;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public final class MaskRuleStatementConverterTest {
+    
+    @Test
+    public void assertCovert() {
+        MaskRuleConfiguration actual = MaskRuleStatementConverter.convert(Collections.singleton(new MaskRuleSegment("t_mask", createColumns())));
+        assertThat(actual.getTables().iterator().next().getName(), is("t_mask"));
+        assertThat(actual.getTables().iterator().next().getColumns().iterator().next().getLogicColumn(), is("user_id"));
+        assertThat(actual.getTables().iterator().next().getColumns().iterator().next().getMaskAlgorithm(), is("t_mask_user_id_md5"));
+        assertThat(actual.getMaskAlgorithms().keySet().iterator().next(), is("t_mask_user_id_md5"));
+        assertTrue(actual.getMaskAlgorithms().values().iterator().next().getType().contains("MD5"));
+    }
+    
+    private Collection<MaskColumnSegment> createColumns() {
+        return Collections.singleton(new MaskColumnSegment("user_id", new AlgorithmSegment("MD5", createProperties())));
+    }
+    
+    private Properties createProperties() {
+        Properties result = new Properties();
+        result.setProperty("MD5-key", "MD5-value");
+        return result;
+    }
+}

--- a/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/converter/MaskRuleStatementConverterTest.java
+++ b/features/mask/distsql/handler/src/test/java/org/apache/shardingsphere/mask/distsql/handler/converter/MaskRuleStatementConverterTest.java
@@ -49,7 +49,7 @@ public final class MaskRuleStatementConverterTest {
     
     private Properties createProperties() {
         Properties result = new Properties();
-        result.setProperty("MD5-key", "MD5-value");
+        result.setProperty("salt", "test_salt");
         return result;
     }
 }


### PR DESCRIPTION
Ref: #23138.

Changes proposed in this pull request:
  - Add `MaskRuleStatementConverter` unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
