### PR TITLE
Fix DistSQL documents display order issue

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/reserved-word.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/reserved-word.cn.md
@@ -1,6 +1,6 @@
 +++
 title = "保留字"
-weight = 2
+weight = 5
 +++
 
 ## RDL

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/reserved-word.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/reserved-word.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Reserved word"
-weight = 2
+weight = 5
 +++
 
 ## RDL

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/usage/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/usage/_index.cn.md
@@ -1,6 +1,6 @@
 +++
 title = "使用"
-weight = 1
+weight = 2
 chapter = true
 +++
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/usage/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/usage/_index.en.md
@@ -1,6 +1,6 @@
 +++
 title = "Usage"
-weight = 1
+weight = 2
 chapter = true
 +++
 


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix DistSQL documents display order issue

![image](https://user-images.githubusercontent.com/57847965/210363997-1bede242-760b-46b9-b063-75fd773aeb99.png)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
