### PR TITLE
Refactor : exclude H2 dependency from agent plugins (#23318)

### DIFF
--- a/agent/plugins/metrics/type/prometheus/pom.xml
+++ b/agent/plugins/metrics/type/prometheus/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>shardingsphere-proxy-bootstrap</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
@@ -56,12 +62,24 @@
             <artifactId>shardingsphere-proxy-backend</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-infra-context</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>

--- a/agent/plugins/tracing/type/pom.xml
+++ b/agent/plugins/tracing/type/pom.xml
@@ -45,6 +45,12 @@
             <artifactId>shardingsphere-proxy-frontend-core</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -77,8 +77,6 @@
                             <filter>
                                 <artifact>*:*</artifact>
                                 <excludes>
-                                    <!-- TODO H2 data.zip file may exclude from the proxy dependency -->
-                                    <exclude>org/h2/util/data.zip</exclude>
                                     <exclude>mozilla/public-suffix-list.txt</exclude>
                                 </excludes>
                             </filter>


### PR DESCRIPTION
Fixes #23318.

Changes proposed in this pull request:
  - exclude H2 dependency from agent plugins

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.

---
## Local test
### Zipkin
<img width="1445" alt="image" src="https://user-images.githubusercontent.com/4112856/210483167-8cefc1f0-c897-4ee5-a860-73e83ed97354.png">

### Metrics
<img width="830" alt="image" src="https://user-images.githubusercontent.com/4112856/210483227-8c2b1d19-7203-441b-9e1f-2f468df314f2.png">



