### PR TITLE
Remove currentRuleConfig non-null judgment for create rule updaters

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryHeartbeatStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryHeartbeatStatementUpdater.java
@@ -42,7 +42,7 @@ public final class CreateDatabaseDiscoveryHeartbeatStatementUpdater implements R
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-            currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
+        currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryHeartbeatStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryHeartbeatStatementUpdater.java
@@ -42,9 +42,7 @@ public final class CreateDatabaseDiscoveryHeartbeatStatementUpdater implements R
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
-        }
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
@@ -99,7 +99,6 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             if (ifNotExists) {
                 removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
             }
@@ -109,7 +108,6 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
             currentRuleConfig.getDataSources().addAll(toBeCreatedRuleConfig.getDataSources());
             currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
             currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
-        }
     }
     
     private void removeDuplicatedRules(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
@@ -99,15 +99,15 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-            if (ifNotExists) {
-                removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
-            }
-            if (toBeCreatedRuleConfig.getDataSources().isEmpty()) {
-                return;
-            }
-            currentRuleConfig.getDataSources().addAll(toBeCreatedRuleConfig.getDataSources());
-            currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
-            currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
+        if (ifNotExists) {
+            removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
+        }
+        if (toBeCreatedRuleConfig.getDataSources().isEmpty()) {
+            return;
+        }
+        currentRuleConfig.getDataSources().addAll(toBeCreatedRuleConfig.getDataSources());
+        currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
+        currentRuleConfig.getDiscoveryHeartbeats().putAll(toBeCreatedRuleConfig.getDiscoveryHeartbeats());
     }
     
     private void removeDuplicatedRules(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryTypeStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryTypeStatementUpdater.java
@@ -77,7 +77,7 @@ public final class CreateDatabaseDiscoveryTypeStatementUpdater implements RuleDe
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-            currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
+        currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryTypeStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryTypeStatementUpdater.java
@@ -77,9 +77,7 @@ public final class CreateDatabaseDiscoveryTypeStatementUpdater implements RuleDe
     
     @Override
     public void updateCurrentRuleConfiguration(final DatabaseDiscoveryRuleConfiguration currentRuleConfig, final DatabaseDiscoveryRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             currentRuleConfig.getDiscoveryTypes().putAll(toBeCreatedRuleConfig.getDiscoveryTypes());
-        }
     }
     
     @Override

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdater.java
@@ -94,14 +94,14 @@ public final class CreateEncryptRuleStatementUpdater implements RuleDefinitionCr
     
     @Override
     public void updateCurrentRuleConfiguration(final EncryptRuleConfiguration currentRuleConfig, final EncryptRuleConfiguration toBeCreatedRuleConfig) {
-            if (ifNotExists) {
-                removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
-            }
-            if (toBeCreatedRuleConfig.getTables().isEmpty()) {
-                return;
-            }
-            currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
-            currentRuleConfig.getEncryptors().putAll(toBeCreatedRuleConfig.getEncryptors());
+        if (ifNotExists) {
+            removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
+        }
+        if (toBeCreatedRuleConfig.getTables().isEmpty()) {
+            return;
+        }
+        currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
+        currentRuleConfig.getEncryptors().putAll(toBeCreatedRuleConfig.getEncryptors());
     }
     
     private void removeDuplicatedRules(final EncryptRuleConfiguration currentRuleConfig, final EncryptRuleConfiguration toBeCreatedRuleConfig) {

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdater.java
@@ -94,7 +94,6 @@ public final class CreateEncryptRuleStatementUpdater implements RuleDefinitionCr
     
     @Override
     public void updateCurrentRuleConfiguration(final EncryptRuleConfiguration currentRuleConfig, final EncryptRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             if (ifNotExists) {
                 removeDuplicatedRules(currentRuleConfig, toBeCreatedRuleConfig);
             }
@@ -103,7 +102,6 @@ public final class CreateEncryptRuleStatementUpdater implements RuleDefinitionCr
             }
             currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
             currentRuleConfig.getEncryptors().putAll(toBeCreatedRuleConfig.getEncryptors());
-        }
     }
     
     private void removeDuplicatedRules(final EncryptRuleConfiguration currentRuleConfig, final EncryptRuleConfiguration toBeCreatedRuleConfig) {

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleStatementUpdater.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleStatementUpdater.java
@@ -78,9 +78,7 @@ public final class CreateMaskRuleStatementUpdater implements RuleDefinitionCreat
     
     @Override
     public void updateCurrentRuleConfiguration(final MaskRuleConfiguration currentRuleConfig, final MaskRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
             currentRuleConfig.getMaskAlgorithms().putAll(toBeCreatedRuleConfig.getMaskAlgorithms());
-        }
     }
 }

--- a/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleStatementUpdater.java
+++ b/features/mask/distsql/handler/src/main/java/org/apache/shardingsphere/mask/distsql/handler/update/CreateMaskRuleStatementUpdater.java
@@ -78,7 +78,7 @@ public final class CreateMaskRuleStatementUpdater implements RuleDefinitionCreat
     
     @Override
     public void updateCurrentRuleConfiguration(final MaskRuleConfiguration currentRuleConfig, final MaskRuleConfiguration toBeCreatedRuleConfig) {
-            currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
-            currentRuleConfig.getMaskAlgorithms().putAll(toBeCreatedRuleConfig.getMaskAlgorithms());
+        currentRuleConfig.getTables().addAll(toBeCreatedRuleConfig.getTables());
+        currentRuleConfig.getMaskAlgorithms().putAll(toBeCreatedRuleConfig.getMaskAlgorithms());
     }
 }

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
@@ -63,14 +63,14 @@ public final class CreateBroadcastTableRuleStatementUpdater implements RuleDefin
     
     @Override
     public void updateCurrentRuleConfiguration(final ShardingRuleConfiguration currentRuleConfig, final ShardingRuleConfiguration toBeCreatedRuleConfig) {
-            if (ifNotExists) {
-                Collection<String> currentBroadCastTables = currentRuleConfig.getBroadcastTables();
-                toBeCreatedRuleConfig.getBroadcastTables().removeIf(currentBroadCastTables::contains);
-            }
-            if (toBeCreatedRuleConfig.getBroadcastTables().isEmpty()) {
-                return;
-            }
-            currentRuleConfig.getBroadcastTables().addAll(toBeCreatedRuleConfig.getBroadcastTables());
+        if (ifNotExists) {
+            Collection<String> currentBroadCastTables = currentRuleConfig.getBroadcastTables();
+            toBeCreatedRuleConfig.getBroadcastTables().removeIf(currentBroadCastTables::contains);
+        }
+        if (toBeCreatedRuleConfig.getBroadcastTables().isEmpty()) {
+            return;
+        }
+        currentRuleConfig.getBroadcastTables().addAll(toBeCreatedRuleConfig.getBroadcastTables());
     }
     
     @Override

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateBroadcastTableRuleStatementUpdater.java
@@ -63,7 +63,6 @@ public final class CreateBroadcastTableRuleStatementUpdater implements RuleDefin
     
     @Override
     public void updateCurrentRuleConfiguration(final ShardingRuleConfiguration currentRuleConfig, final ShardingRuleConfiguration toBeCreatedRuleConfig) {
-        if (null != currentRuleConfig) {
             if (ifNotExists) {
                 Collection<String> currentBroadCastTables = currentRuleConfig.getBroadcastTables();
                 toBeCreatedRuleConfig.getBroadcastTables().removeIf(currentBroadCastTables::contains);
@@ -72,7 +71,6 @@ public final class CreateBroadcastTableRuleStatementUpdater implements RuleDefin
                 return;
             }
             currentRuleConfig.getBroadcastTables().addAll(toBeCreatedRuleConfig.getBroadcastTables());
-        }
     }
     
     @Override

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
@@ -64,9 +64,9 @@ public final class CreateShardingTableReferenceRuleStatementUpdater implements R
     
     private void checkDuplicatedRuleNames(final String databaseName, final CreateShardingTableReferenceRuleStatement sqlStatement,
                                           final ShardingRuleConfiguration currentRuleConfig) throws DuplicateRuleException {
-            Collection<String> currentRuleNames = currentRuleConfig.getBindingTableGroups().stream().map(ShardingTableReferenceRuleConfiguration::getName).collect(Collectors.toSet());
-            Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(TableReferenceRuleSegment::getName).filter(currentRuleNames::contains).collect(Collectors.toList());
-            ShardingSpherePreconditions.checkState(duplicatedRuleNames.isEmpty(), () -> new DuplicateRuleException("sharding table reference", databaseName, duplicatedRuleNames));
+        Collection<String> currentRuleNames = currentRuleConfig.getBindingTableGroups().stream().map(ShardingTableReferenceRuleConfiguration::getName).collect(Collectors.toSet());
+        Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(TableReferenceRuleSegment::getName).filter(currentRuleNames::contains).collect(Collectors.toList());
+        ShardingSpherePreconditions.checkState(duplicatedRuleNames.isEmpty(), () -> new DuplicateRuleException("sharding table reference", databaseName, duplicatedRuleNames));
     }
     
     private void checkDuplicatedTablesInShardingTableReferenceRules(final String databaseName, final CreateShardingTableReferenceRuleStatement sqlStatement,

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateShardingTableReferenceRuleStatementUpdater.java
@@ -64,11 +64,9 @@ public final class CreateShardingTableReferenceRuleStatementUpdater implements R
     
     private void checkDuplicatedRuleNames(final String databaseName, final CreateShardingTableReferenceRuleStatement sqlStatement,
                                           final ShardingRuleConfiguration currentRuleConfig) throws DuplicateRuleException {
-        if (null != currentRuleConfig) {
             Collection<String> currentRuleNames = currentRuleConfig.getBindingTableGroups().stream().map(ShardingTableReferenceRuleConfiguration::getName).collect(Collectors.toSet());
             Collection<String> duplicatedRuleNames = sqlStatement.getRules().stream().map(TableReferenceRuleSegment::getName).filter(currentRuleNames::contains).collect(Collectors.toList());
             ShardingSpherePreconditions.checkState(duplicatedRuleNames.isEmpty(), () -> new DuplicateRuleException("sharding table reference", databaseName, duplicatedRuleNames));
-        }
     }
     
     private void checkDuplicatedTablesInShardingTableReferenceRules(final String databaseName, final CreateShardingTableReferenceRuleStatement sqlStatement,


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove currentRuleConfig non-null judgment for create rule updaters

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
