### PR TITLE
Add KeyGenerateAlgorithmInitializationException, MissingRequiredShardingAlgorithmException and MissingRequiredShardingConfigurationException to handle related exceptions

### DIFF
--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -176,6 +176,7 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match. |
 | HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s. |
 | 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`. |
+| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s. |
 | HY000     | 20099       | Sharding plugin error, reason is: %s |
 
 ### 读写分离

--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -143,41 +143,42 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 
 ### 数据分片
 
-| SQL State | Vendor Code | 错误信息                                                                                                                       |
-| --------- |-------------|----------------------------------------------------------------------------------------------------------------------------|
-| 44000     | 20000       | Can not find table rule with logic tables \`%s\`.                                                                          |
+| SQL State | Vendor Code | 错误信息                                                                                                                         |
+| --------- |-------------|------------------------------------------------------------------------------------------------------------------------------|
+| 44000     | 20000       | Can not find table rule with logic tables \`%s\`.                                                                            |
 | 44000     | 20001       | Can not get uniformed table structure for logic table \`%s\`, it has different meta data of actual tables are as follows: %s |
-| 42S02     | 20002       | Can not find data source in sharding rule, invalid actual data node \`%s\`. |
-| 44000     | 20003       | Data nodes must be configured for sharding table \`%s\`. |
-| 44000     | 20004       | Actual table \`%s.%s\` is not in table rule configuration. |
-| 44000     | 20005       | Can not find binding actual table, data source is \`%s\`, logic table is \`%s\`, other actual table is \`%s\`. |
-| 44000     | 20006       | Actual tables \`%s\` are in use. |
-| 42S01     | 20007       | Index \`%s\` already exists. |
-| 42S02     | 20008       | Index \`%s\` does not exist. |
-| 42S01     | 20009       | View name has to bind to %s tables. |
-| 44000     | 20020       | Sharding value can't be null in insert statement. |
-| HY004     | 20021       | Found different types for sharding value \`%s\`. |
-| HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`. |
-| 0A000     | 20040       | Can not support operation \`%s\` with sharding table \`%s\`. |
-| 44000     | 20041       | Can not update sharding value for table \`%s\`. |
-| 0A000     | 20042       | The CREATE VIEW statement contains unsupported query statement. |
-| 44000     | 20043       | PREPARE statement can not support sharding tables route to same data sources. |
-| 44000     | 20044       | The table inserted and the table selected must be the same or bind tables. |
-| 0A000     | 20045       | Can not support DML operation with multiple tables \`%s\`. |
-| 42000     | 20046       | %s ... LIMIT can not support route to multiple data nodes. |
-| 44000     | 20047       | Can not find actual data source intersection for logic tables \`%s\`. |
-| 42000     | 20048       | INSERT INTO ... SELECT can not support applying key generator with absent generate key column. |
-| 0A000     | 20049       | Alter view rename .. to .. statement should have same config for \`%s\` and \`%s\`. |
-| HY000     | 20060       | \`%s %s\` can not route correctly for %s \`%s\`. |
-| 42S02     | 20061       | Can not get route result, please check your sharding rule configuration. |
-| 34000     | 20062       | Can not get cursor name from fetch statement. |
-| HY000     | 20080       | Sharding algorithm class \`%s\` should be implement \`%s\`. |
-| HY000     | 20081       | Routed target \`%s\` does not exist, available targets are \`%s\`. |
-| 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match. |
-| HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s. |
-| 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`. |
-| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s. |
-| HY000     | 20099       | Sharding plugin error, reason is: %s |
+| 42S02     | 20002       | Can not find data source in sharding rule, invalid actual data node \`%s\`.                                                  |
+| 44000     | 20003       | Data nodes must be configured for sharding table \`%s\`.                                                                     |
+| 44000     | 20004       | Actual table \`%s.%s\` is not in table rule configuration.                                                                   |
+| 44000     | 20005       | Can not find binding actual table, data source is \`%s\`, logic table is \`%s\`, other actual table is \`%s\`.               |
+| 44000     | 20006       | Actual tables \`%s\` are in use.                                                                                             |
+| 42S01     | 20007       | Index \`%s\` already exists.                                                                                                 |
+| 42S02     | 20008       | Index \`%s\` does not exist.                                                                                                 |
+| 42S01     | 20009       | View name has to bind to %s tables.                                                                                          |
+| 44000     | 20010       | Can not find logic table \`%s\` in database \`%s\`.                                                                          |
+| 44000     | 20020       | Sharding value can't be null in insert statement.                                                                            |
+| HY004     | 20021       | Found different types for sharding value \`%s\`.                                                                             |
+| HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`.                                                              |
+| 0A000     | 20040       | Can not support operation \`%s\` with sharding table \`%s\`.                                                                 |
+| 44000     | 20041       | Can not update sharding value for table \`%s\`.                                                                              |
+| 0A000     | 20042       | The CREATE VIEW statement contains unsupported query statement.                                                              |
+| 44000     | 20043       | PREPARE statement can not support sharding tables route to same data sources.                                                |
+| 44000     | 20044       | The table inserted and the table selected must be the same or bind tables.                                                   |
+| 0A000     | 20045       | Can not support DML operation with multiple tables \`%s\`.                                                                   |
+| 42000     | 20046       | %s ... LIMIT can not support route to multiple data nodes.                                                                   |
+| 44000     | 20047       | Can not find actual data source intersection for logic tables \`%s\`.                                                        |
+| 42000     | 20048       | INSERT INTO ... SELECT can not support applying key generator with absent generate key column.                               |
+| 0A000     | 20049       | Alter view rename .. to .. statement should have same config for \`%s\` and \`%s\`.                                          |
+| HY000     | 20060       | \`%s %s\` can not route correctly for %s \`%s\`.                                                                             |
+| 42S02     | 20061       | Can not get route result, please check your sharding rule configuration.                                                     |
+| 34000     | 20062       | Can not get cursor name from fetch statement.                                                                                |
+| HY000     | 20080       | Sharding algorithm class \`%s\` should be implement \`%s\`.                                                                  |
+| HY000     | 20081       | Routed target \`%s\` does not exist, available targets are \`%s\`.                                                           |
+| 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match.                                        |
+| HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s.                                                              |
+| 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`.                                                                   |
+| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s.                                                          |
+| HY000     | 20099       | Sharding plugin error, reason is: %s                                                                                         |
 
 ### 读写分离
 

--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -155,7 +155,8 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 42S01     | 20007       | Index \`%s\` already exists.                                                                                                 |
 | 42S02     | 20008       | Index \`%s\` does not exist.                                                                                                 |
 | 42S01     | 20009       | View name has to bind to %s tables.                                                                                          |
-| 44000     | 20010       | Can not find logic table \`%s\` in database \`%s\`.                                                                          |
+| 44000     | 20010       | \`%s\` sharding algorithm does not exist in database \`%s\`.                                                                 |
+| 44000     | 20011       | \`%s\` sharding configuration does not exist in database \`%s\`.                                                             |
 | 44000     | 20020       | Sharding value can't be null in insert statement.                                                                            |
 | HY004     | 20021       | Found different types for sharding value \`%s\`.                                                                             |
 | HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`.                                                              |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -143,41 +143,42 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 
 ### Data Sharding
 
-| SQL State | Vendor Code | Reason |
-| --------- |-------------| ------ |
-| 44000     | 20000       | Can not find table rule with logic tables \`%s\`. |
+| SQL State | Vendor Code | Reason                                                                                                                       |
+| --------- |-------------|------------------------------------------------------------------------------------------------------------------------------|
+| 44000     | 20000       | Can not find table rule with logic tables \`%s\`.                                                                            |
 | 44000     | 20001       | Can not get uniformed table structure for logic table \`%s\`, it has different meta data of actual tables are as follows: %s |
-| 42S02     | 20002       | Can not find data source in sharding rule, invalid actual data node \`%s\`. |
-| 44000     | 20003       | Data nodes must be configured for sharding table \`%s\`. |
-| 44000     | 20004       | Actual table \`%s.%s\` is not in table rule configuration. |
-| 44000     | 20005       | Can not find binding actual table, data source is \`%s\`, logic table is \`%s\`, other actual table is \`%s\`. |
-| 44000     | 20006       | Actual tables \`%s\` are in use. |
-| 42S01     | 20007       | Index \`%s\` already exists. |
-| 42S02     | 20008       | Index \`%s\` does not exist. |
-| 42S01     | 20009       | View name has to bind to %s tables. |
-| 44000     | 20020       | Sharding value can't be null in insert statement. |
-| HY004     | 20021       | Found different types for sharding value \`%s\`. |
-| HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`. |
-| 0A000     | 20040       | Can not support operation \`%s\` with sharding table \`%s\`. |
-| 44000     | 20041       | Can not update sharding value for table \`%s\`. |
-| 0A000     | 20042       | The CREATE VIEW statement contains unsupported query statement. |
-| 44000     | 20043       | PREPARE statement can not support sharding tables route to same data sources. |
-| 44000     | 20044       | The table inserted and the table selected must be the same or bind tables. |
-| 0A000     | 20045       | Can not support DML operation with multiple tables \`%s\`. |
-| 42000     | 20046       | %s ... LIMIT can not support route to multiple data nodes. |
-| 44000     | 20047       | Can not find actual data source intersection for logic tables \`%s\`. |
-| 42000     | 20048       | INSERT INTO ... SELECT can not support applying key generator with absent generate key column. |
-| 0A000     | 20049       | Alter view rename .. to .. statement should have same config for \`%s\` and \`%s\`. |
-| HY000     | 20060       | \`%s %s\` can not route correctly for %s \`%s\`. |
-| 42S02     | 20061       | Can not get route result, please check your sharding rule configuration. |
-| 34000     | 20062       | Can not get cursor name from fetch statement. |
-| HY000     | 20080       | Sharding algorithm class \`%s\` should be implement \`%s\`. |
-| HY000     | 20081       | Routed target \`%s\` does not exist, available targets are \`%s\`. |
-| 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match. |
-| HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s. |
-| 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`. |
-| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s. |
-| HY000     | 20099       | Sharding plugin error, reason is: %s |
+| 42S02     | 20002       | Can not find data source in sharding rule, invalid actual data node \`%s\`.                                                  |
+| 44000     | 20003       | Data nodes must be configured for sharding table \`%s\`.                                                                     |
+| 44000     | 20004       | Actual table \`%s.%s\` is not in table rule configuration.                                                                   |
+| 44000     | 20005       | Can not find binding actual table, data source is \`%s\`, logic table is \`%s\`, other actual table is \`%s\`.               |
+| 44000     | 20006       | Actual tables \`%s\` are in use.                                                                                             |
+| 42S01     | 20007       | Index \`%s\` already exists.                                                                                                 |
+| 42S02     | 20008       | Index \`%s\` does not exist.                                                                                                 |
+| 42S01     | 20009       | View name has to bind to %s tables.                                                                                          |
+| 44000     | 20010       | Can not find logic table \`%s\` in database \`%s\`.                                                                          |
+| 44000     | 20020       | Sharding value can't be null in insert statement.                                                                            |
+| HY004     | 20021       | Found different types for sharding value \`%s\`.                                                                             |
+| HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`.                                                              |
+| 0A000     | 20040       | Can not support operation \`%s\` with sharding table \`%s\`.                                                                 |
+| 44000     | 20041       | Can not update sharding value for table \`%s\`.                                                                              |
+| 0A000     | 20042       | The CREATE VIEW statement contains unsupported query statement.                                                              |
+| 44000     | 20043       | PREPARE statement can not support sharding tables route to same data sources.                                                |
+| 44000     | 20044       | The table inserted and the table selected must be the same or bind tables.                                                   |
+| 0A000     | 20045       | Can not support DML operation with multiple tables \`%s\`.                                                                   |
+| 42000     | 20046       | %s ... LIMIT can not support route to multiple data nodes.                                                                   |
+| 44000     | 20047       | Can not find actual data source intersection for logic tables \`%s\`.                                                        |
+| 42000     | 20048       | INSERT INTO ... SELECT can not support applying key generator with absent generate key column.                               |
+| 0A000     | 20049       | Alter view rename .. to .. statement should have same config for \`%s\` and \`%s\`.                                          |
+| HY000     | 20060       | \`%s %s\` can not route correctly for %s \`%s\`.                                                                             |
+| 42S02     | 20061       | Can not get route result, please check your sharding rule configuration.                                                     |
+| 34000     | 20062       | Can not get cursor name from fetch statement.                                                                                |
+| HY000     | 20080       | Sharding algorithm class \`%s\` should be implement \`%s\`.                                                                  |
+| HY000     | 20081       | Routed target \`%s\` does not exist, available targets are \`%s\`.                                                           |
+| 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match.                                        |
+| HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s.                                                              |
+| 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`.                                                                   |
+| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s.                                                          |
+| HY000     | 20099       | Sharding plugin error, reason is: %s                                                                                         |
 
 ### Readwrite Splitting
 

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -155,7 +155,8 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | 42S01     | 20007       | Index \`%s\` already exists.                                                                                                 |
 | 42S02     | 20008       | Index \`%s\` does not exist.                                                                                                 |
 | 42S01     | 20009       | View name has to bind to %s tables.                                                                                          |
-| 44000     | 20010       | Can not find logic table \`%s\` in database \`%s\`.                                                                          |
+| 44000     | 20010       | \`%s\` sharding algorithm does not exist in database \`%s\`.                                                                 |
+| 44000     | 20011       | \`%s\` sharding configuration does not exist in database \`%s\`.                                                             |
 | 44000     | 20020       | Sharding value can't be null in insert statement.                                                                            |
 | HY004     | 20021       | Found different types for sharding value \`%s\`.                                                                             |
 | HY004     | 20022       | Invalid %s, datetime pattern should be \`%s\`, value is \`%s\`.                                                              |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -144,7 +144,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 ### Data Sharding
 
 | SQL State | Vendor Code | Reason |
-| --------- | ----------- | ------ |
+| --------- |-------------| ------ |
 | 44000     | 20000       | Can not find table rule with logic tables \`%s\`. |
 | 44000     | 20001       | Can not get uniformed table structure for logic table \`%s\`, it has different meta data of actual tables are as follows: %s |
 | 42S02     | 20002       | Can not find data source in sharding rule, invalid actual data node \`%s\`. |
@@ -176,6 +176,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | 44000     | 20082       | Inline sharding algorithms expression \`%s\` and sharding column \`%s\` do not match. |
 | HY000     | 20083       | Sharding algorithm \`%s\` initialization failed, reason is: %s. |
 | 44000     | 20090       | Can not find strategy for generate keys with table \`%s\`. |
+| HY000     | 20091       | Key generate algorithm \`%s\` initialization failed, reason is: %s. |
 | HY000     | 20099       | Sharding plugin error, reason is: %s |
 
 ### Readwrite Splitting

--- a/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/config/rule/ShardingAutoTableRuleConfiguration.java
+++ b/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/config/rule/ShardingAutoTableRuleConfiguration.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.sharding.api.config.rule;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sharding.api.config.strategy.audit.ShardingAuditStrategyConfiguration;
@@ -43,7 +41,6 @@ public final class ShardingAutoTableRuleConfiguration {
     private ShardingAuditStrategyConfiguration auditStrategy;
     
     public ShardingAutoTableRuleConfiguration(final String logicTable, final String actualDataSources) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(logicTable), "LogicTable is required.");
         this.logicTable = logicTable;
         this.actualDataSources = actualDataSources;
     }

--- a/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/config/rule/ShardingTableRuleConfiguration.java
+++ b/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/config/rule/ShardingTableRuleConfiguration.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.sharding.api.config.rule;
 
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sharding.api.config.strategy.audit.ShardingAuditStrategyConfiguration;
@@ -49,7 +47,6 @@ public final class ShardingTableRuleConfiguration {
     }
     
     public ShardingTableRuleConfiguration(final String logicTable, final String actualDataNodes) {
-        Preconditions.checkArgument(!Strings.isNullOrEmpty(logicTable), "LogicTable is required.");
         this.logicTable = logicTable;
         this.actualDataNodes = actualDataNodes;
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithm.java
@@ -21,8 +21,10 @@ import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.SneakyThrows;
-import org.apache.shardingsphere.infra.instance.InstanceContextAware;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.infra.instance.InstanceContextAware;
+import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.sharding.exception.algorithm.keygen.KeyGenerateAlgorithmInitializationException;
 import org.apache.shardingsphere.sharding.spi.KeyGenerateAlgorithm;
 
 import java.util.Calendar;
@@ -108,7 +110,7 @@ public final class SnowflakeKeyGenerateAlgorithm implements KeyGenerateAlgorithm
     
     private int getMaxVibrationOffset(final Properties props) {
         int result = Integer.parseInt(props.getOrDefault(MAX_VIBRATION_OFFSET_KEY, DEFAULT_VIBRATION_VALUE).toString());
-        Preconditions.checkArgument(result >= 0 && result <= SEQUENCE_MASK, "Illegal max vibration offset.");
+        ShardingSpherePreconditions.checkState(result >= 0 && result <= SEQUENCE_MASK, () -> new KeyGenerateAlgorithmInitializationException(getType(), "Illegal max vibration offset."));
         return result;
     }
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
@@ -87,7 +87,6 @@ public final class ShardingRuleConfigurationChecker implements RuleConfiguration
         if (null == auditStrategy) {
             return;
         }
-        ShardingSpherePreconditions.checkNotNull(auditStrategy.getAuditorNames(), () -> new MissingRequiredShardingConfigurationException("auditorNames", databaseName));
         ShardingSpherePreconditions.checkState(auditors.containsAll(auditStrategy.getAuditorNames()),
                 () -> new MissingRequiredShardingAlgorithmException(Joiner.on(",").join(auditStrategy.getAuditorNames()), databaseName));
     }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.sharding.checker;
 
-import com.google.common.base.Preconditions;
+import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
@@ -30,7 +30,8 @@ import org.apache.shardingsphere.sharding.api.config.strategy.keygen.KeyGenerate
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.constant.ShardingOrder;
-import org.apache.shardingsphere.sharding.exception.metadata.LogicTableNotFoundException;
+import org.apache.shardingsphere.sharding.exception.metadata.MissingRequiredShardingAlgorithmException;
+import org.apache.shardingsphere.sharding.exception.metadata.MissingRequiredShardingConfigurationException;
 
 import javax.sql.DataSource;
 import java.util.Collection;
@@ -71,31 +72,32 @@ public final class ShardingRuleConfigurationChecker implements RuleConfiguration
     }
     
     private void checkLogicTable(final String databaseName, final String logicTable) {
-        ShardingSpherePreconditions.checkState(!Strings.isNullOrEmpty(logicTable), () -> new LogicTableNotFoundException(databaseName, logicTable));
+        ShardingSpherePreconditions.checkState(!Strings.isNullOrEmpty(logicTable), () -> new MissingRequiredShardingConfigurationException("logicTable", databaseName));
     }
     
     private void checkKeyGenerateStrategy(final String databaseName, final KeyGenerateStrategyConfiguration keyGenerateStrategy, final Collection<String> keyGenerators) {
         if (null == keyGenerateStrategy) {
             return;
         }
-        Preconditions.checkState(keyGenerators.contains(keyGenerateStrategy.getKeyGeneratorName()),
-                "Can not find keyGenerator `%s` in database `%s`.", keyGenerateStrategy.getKeyGeneratorName(), databaseName);
+        ShardingSpherePreconditions.checkState(keyGenerators.contains(keyGenerateStrategy.getKeyGeneratorName()),
+                () -> new MissingRequiredShardingAlgorithmException(keyGenerateStrategy.getKeyGeneratorName(), databaseName));
     }
     
     private void checkAuditStrategy(final String databaseName, final ShardingAuditStrategyConfiguration auditStrategy, final Collection<String> auditors) {
         if (null == auditStrategy) {
             return;
         }
-        Preconditions.checkState(auditors.containsAll(auditStrategy.getAuditorNames()),
-                "Can not find all auditors `%s` in database `%s`.", auditStrategy.getAuditorNames(), databaseName);
+        ShardingSpherePreconditions.checkNotNull(auditStrategy.getAuditorNames(), () -> new MissingRequiredShardingConfigurationException("auditorNames", databaseName));
+        ShardingSpherePreconditions.checkState(auditors.containsAll(auditStrategy.getAuditorNames()),
+                () -> new MissingRequiredShardingAlgorithmException(Joiner.on(",").join(auditStrategy.getAuditorNames()), databaseName));
     }
     
     private void checkShardingStrategy(final String databaseName, final ShardingStrategyConfiguration shardingStrategy, final Collection<String> shardingAlgorithms) {
         if (null == shardingStrategy || shardingStrategy instanceof NoneShardingStrategyConfiguration) {
             return;
         }
-        Preconditions.checkState(shardingAlgorithms.contains(shardingStrategy.getShardingAlgorithmName()),
-                "Can not find shardingAlgorithm `%s` in database `%s`.", shardingStrategy.getShardingAlgorithmName(), databaseName);
+        ShardingSpherePreconditions.checkState(shardingAlgorithms.contains(shardingStrategy.getShardingAlgorithmName()),
+                () -> new MissingRequiredShardingAlgorithmException(shardingStrategy.getShardingAlgorithmName(), databaseName));
     }
     
     @Override

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationChecker.java
@@ -18,8 +18,10 @@
 package org.apache.shardingsphere.sharding.checker;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfiguration;
@@ -28,6 +30,7 @@ import org.apache.shardingsphere.sharding.api.config.strategy.keygen.KeyGenerate
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.constant.ShardingOrder;
+import org.apache.shardingsphere.sharding.exception.metadata.LogicTableNotFoundException;
 
 import javax.sql.DataSource;
 import java.util.Collection;
@@ -53,16 +56,22 @@ public final class ShardingRuleConfigurationChecker implements RuleConfiguration
     private void checkTableConfiguration(final String databaseName, final Collection<ShardingTableRuleConfiguration> tables, final Collection<ShardingAutoTableRuleConfiguration> autoTables,
                                          final Collection<String> keyGenerators, final Collection<String> auditors, final Collection<String> shardingAlgorithms) {
         for (ShardingTableRuleConfiguration each : tables) {
+            checkLogicTable(databaseName, each.getLogicTable());
             checkKeyGenerateStrategy(databaseName, each.getKeyGenerateStrategy(), keyGenerators);
             checkAuditStrategy(databaseName, each.getAuditStrategy(), auditors);
             checkShardingStrategy(databaseName, each.getDatabaseShardingStrategy(), shardingAlgorithms);
             checkShardingStrategy(databaseName, each.getTableShardingStrategy(), shardingAlgorithms);
         }
         for (ShardingAutoTableRuleConfiguration each : autoTables) {
+            checkLogicTable(databaseName, each.getLogicTable());
             checkKeyGenerateStrategy(databaseName, each.getKeyGenerateStrategy(), keyGenerators);
             checkAuditStrategy(databaseName, each.getAuditStrategy(), auditors);
             checkShardingStrategy(databaseName, each.getShardingStrategy(), shardingAlgorithms);
         }
+    }
+    
+    private void checkLogicTable(final String databaseName, final String logicTable) {
+        ShardingSpherePreconditions.checkState(!Strings.isNullOrEmpty(logicTable), () -> new LogicTableNotFoundException(databaseName, logicTable));
     }
     
     private void checkKeyGenerateStrategy(final String databaseName, final KeyGenerateStrategyConfiguration keyGenerateStrategy, final Collection<String> keyGenerators) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/algorithm/keygen/KeyGenerateAlgorithmInitializationException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/algorithm/keygen/KeyGenerateAlgorithmInitializationException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.exception.algorithm.keygen;
+
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.sharding.exception.ShardingSQLException;
+
+/**
+ * Key generate algorithm initialization exception.
+ */
+public final class KeyGenerateAlgorithmInitializationException extends ShardingSQLException {
+    
+    private static final long serialVersionUID = -9046956561006694072L;
+    
+    public KeyGenerateAlgorithmInitializationException(final String keyGenerateType, final String reason) {
+        super(XOpenSQLState.GENERAL_ERROR, 91, "Key generate algorithm `%s` initialization failed, reason is: %s.", keyGenerateType, reason);
+    }
+}

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/LogicTableNotFoundException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/LogicTableNotFoundException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.exception.metadata;
+
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.sharding.exception.ShardingSQLException;
+
+/**
+ * Logic table not found exception.
+ */
+public final class LogicTableNotFoundException extends ShardingSQLException {
+    
+    private static final long serialVersionUID = -4116538141188859881L;
+    
+    public LogicTableNotFoundException(final String databaseName, final String logicTable) {
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 10, "Can not find logic table `%s` in database `%s`.", databaseName, logicTable);
+    }
+}

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/MissingRequiredShardingAlgorithmException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/MissingRequiredShardingAlgorithmException.java
@@ -21,13 +21,13 @@ import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpe
 import org.apache.shardingsphere.sharding.exception.ShardingSQLException;
 
 /**
- * Logic table not found exception.
+ * Missing required sharding algorithm exception.
  */
-public final class LogicTableNotFoundException extends ShardingSQLException {
+public final class MissingRequiredShardingAlgorithmException extends ShardingSQLException {
     
-    private static final long serialVersionUID = -4116538141188859881L;
+    private static final long serialVersionUID = -1844741171173351747L;
     
-    public LogicTableNotFoundException(final String databaseName, final String logicTable) {
-        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 10, "Can not find logic table `%s` in database `%s`.", databaseName, logicTable);
+    public MissingRequiredShardingAlgorithmException(final String algorithmName, final String databaseName) {
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 10, "`%s` sharding algorithm does not exist in database `%s`.", algorithmName, databaseName);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/MissingRequiredShardingConfigurationException.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/exception/metadata/MissingRequiredShardingConfigurationException.java
@@ -15,25 +15,19 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.sharding.api.config.strategy.audit;
+package org.apache.shardingsphere.sharding.exception.metadata;
 
-import lombok.Getter;
-
-import java.util.Collection;
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.sharding.exception.ShardingSQLException;
 
 /**
- * Sharding audit strategy configuration.
+ * Missing required sharding configuration exception.
  */
-
-@Getter
-public final class ShardingAuditStrategyConfiguration {
+public final class MissingRequiredShardingConfigurationException extends ShardingSQLException {
     
-    private final Collection<String> auditorNames;
+    private static final long serialVersionUID = -7307832800220432407L;
     
-    private final boolean allowHintDisable;
-    
-    public ShardingAuditStrategyConfiguration(final Collection<String> auditorNames, final boolean allowHintDisable) {
-        this.auditorNames = auditorNames;
-        this.allowHintDisable = allowHintDisable;
+    public MissingRequiredShardingConfigurationException(final String configKey, final String databaseName) {
+        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 11, "`%s` sharding configuration does not exist in database `%s`.", configKey, databaseName);
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithmTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/algorithm/keygen/SnowflakeKeyGenerateAlgorithmTest.java
@@ -30,6 +30,7 @@ import org.apache.shardingsphere.infra.lock.LockContext;
 import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 import org.apache.shardingsphere.sharding.algorithm.keygen.fixture.FixedTimeService;
 import org.apache.shardingsphere.sharding.algorithm.keygen.fixture.WorkerIdGeneratorFixture;
+import org.apache.shardingsphere.sharding.exception.algorithm.keygen.KeyGenerateAlgorithmInitializationException;
 import org.apache.shardingsphere.sharding.spi.KeyGenerateAlgorithm;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
@@ -208,7 +209,7 @@ public final class SnowflakeKeyGenerateAlgorithmTest {
         algorithm.generateKey();
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = KeyGenerateAlgorithmInitializationException.class)
     public void assertSetMaxVibrationOffsetFailureWhenNegative() {
         ((KeyGenerateAlgorithm) ShardingSphereAlgorithmFactory.createAlgorithm(
                 new AlgorithmConfiguration("SNOWFLAKE", PropertiesBuilder.build(new Property("max-vibration-offset", "-1"))), KeyGenerateAlgorithm.class)).generateKey();
@@ -223,7 +224,7 @@ public final class SnowflakeKeyGenerateAlgorithmTest {
         algorithm.generateKey();
     }
     
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = KeyGenerateAlgorithmInitializationException.class)
     public void assertSetMaxVibrationOffsetFailureWhenOutOfRange() {
         ((KeyGenerateAlgorithm) ShardingSphereAlgorithmFactory.createAlgorithm(
                 new AlgorithmConfiguration("SNOWFLAKE", PropertiesBuilder.build(new Property("max-vibration-offset", "4096"))), KeyGenerateAlgorithm.class)).generateKey();

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationCheckerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/checker/ShardingRuleConfigurationCheckerTest.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfi
 import org.apache.shardingsphere.sharding.api.config.strategy.audit.ShardingAuditStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.keygen.KeyGenerateStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
+import org.apache.shardingsphere.sharding.exception.metadata.MissingRequiredShardingAlgorithmException;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -49,7 +50,7 @@ public final class ShardingRuleConfigurationCheckerTest {
     }
     
     @SuppressWarnings("unchecked")
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = MissingRequiredShardingAlgorithmException.class)
     public void assertCheckTableConfigurationFailed() {
         ShardingRuleConfiguration ruleConfig = createRuleConfiguration();
         ruleConfig.setTables(Collections.singletonList(createShardingTableRuleConfiguration(null, null, null)));
@@ -89,6 +90,7 @@ public final class ShardingRuleConfigurationCheckerTest {
                                                                                         final ShardingAuditStrategyConfiguration shardingAuditStrategyConfig,
                                                                                         final KeyGenerateStrategyConfiguration keyGenerateStrategyConfig) {
         ShardingAutoTableRuleConfiguration result = mock(ShardingAutoTableRuleConfiguration.class);
+        when(result.getLogicTable()).thenReturn("foo_tbl");
         when(result.getShardingStrategy()).thenReturn(null == shardingStrategyConfig ? mock(ShardingStrategyConfiguration.class) : shardingStrategyConfig);
         when(result.getAuditStrategy()).thenReturn(null == shardingAuditStrategyConfig ? mock(ShardingAuditStrategyConfiguration.class) : shardingAuditStrategyConfig);
         when(result.getKeyGenerateStrategy()).thenReturn(null == keyGenerateStrategyConfig ? mock(KeyGenerateStrategyConfiguration.class) : keyGenerateStrategyConfig);

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/strategy/YamlShardingAuditStrategyConfigurationSwapperTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/strategy/YamlShardingAuditStrategyConfigurationSwapperTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public final class YamlShardingAuditStrategyConfigurationSwapperTest {
@@ -48,11 +48,5 @@ public final class YamlShardingAuditStrategyConfigurationSwapperTest {
         assertThat(actual.getAuditorNames().size(), is(2));
         assertTrue(actual.getAuditorNames().containsAll(Arrays.asList("audit_algorithm1", "audit_algorithm2")));
         assertFalse(actual.isAllowHintDisable());
-    }
-    
-    @Test(expected = NullPointerException.class)
-    public void assertSwapToObjectWithNull() {
-        YamlShardingAuditStrategyConfiguration yamlShardingAuditStrategyConfig = new YamlShardingAuditStrategyConfiguration();
-        new YamlShardingAuditStrategyConfigurationSwapper().swapToObject(yamlShardingAuditStrategyConfig);
     }
 }


### PR DESCRIPTION
Ref #20036.

Changes proposed in this pull request:
  - Add KeyGenerateAlgorithmInitializationException, MissingRequiredShardingAlgorithmException and MissingRequiredShardingConfigurationException to handle related exceptions

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
