### PR TITLE
Add jaeger compose

### DIFF
--- a/test/e2e/agent/plugins/jaeger/pom.xml
+++ b/test/e2e/agent/plugins/jaeger/pom.xml
@@ -138,7 +138,7 @@
                         <groupId>com.spotify</groupId>
                         <artifactId>dockerfile-maven-plugin</artifactId>
                         <configuration>
-                            <repository>apache/shardingsphere-proxy-agent-jaeger-test</repository>
+                            <repository>apache/shardingsphere-proxy-agent-tracing-jaeger-test</repository>
                             <tag>${project.version}</tag>
                             <tag>latest</tag>
                             <buildArgs>

--- a/test/e2e/agent/plugins/jaeger/src/test/assembly/bin/start.sh
+++ b/test/e2e/agent/plugins/jaeger/src/test/assembly/bin/start.sh
@@ -70,6 +70,6 @@ fi
 
 echo "The classpath is ${CLASS_PATH}"
 
-nohup java ${JAVA_OPTS} ${JAVA_MEM_OPTS} -javaagent:/opt/shardingsphere-proxy-agent-jaeger/agent/shardingsphere-agent.jar  -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${STDOUT_FILE} 2>&1 &
+nohup java ${JAVA_OPTS} ${JAVA_MEM_OPTS} -javaagent:/opt/shardingsphere-proxy-agent-tracing-jaeger/agent/shardingsphere-agent.jar  -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${STDOUT_FILE} 2>&1 &
 sleep 1
 echo "Please check the STDOUT file: $STDOUT_FILE"

--- a/test/e2e/agent/plugins/jaeger/src/test/assembly/shardingsphere-proxy-agent-jaeger-assembly.xml
+++ b/test/e2e/agent/plugins/jaeger/src/test/assembly/shardingsphere-proxy-agent-jaeger-assembly.xml
@@ -25,17 +25,31 @@
 
     <fileSets>
         <fileSet>
-            <directory>${project.basedir}/../../../../../agent/plugins/tracing/target/plugins</directory>
-            <outputDirectory>./agent/plugins</outputDirectory>
-            <includes>
-                <include>shardingsphere-agent-tracing-jaeger-*.jar</include>
-            </includes>
-        </fileSet>
-        <fileSet>
             <directory>${project.basedir}/../../../../../agent/core/target</directory>
             <outputDirectory>./agent</outputDirectory>
             <includes>
                 <include>shardingsphere-agent.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../../../../agent/plugins/tracing/type/target/plugins</directory>
+            <outputDirectory>./agent/plugins</outputDirectory>
+            <includes>
+                <include>shardingsphere-agent-tracing-jaeger-${project.version}.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../../../../agent/plugins/core/target/lib</directory>
+            <outputDirectory>./agent/lib</outputDirectory>
+            <includes>
+                <include>**.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${project.basedir}/../../../../../agent/plugins/logging/type/target/plugins</directory>
+            <outputDirectory>./agent/lib</outputDirectory>
+            <includes>
+                <include>**.jar</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/test/e2e/agent/plugins/jaeger/src/test/resources/docker/agent/conf/agent.yaml
+++ b/test/e2e/agent/plugins/jaeger/src/test/resources/docker/agent/conf/agent.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+plugins:
+  logging:
+    File:
+      props:
+        level: "INFO"
+  metrics:
+#    Prometheus:
+#      host: "localhost"
+#      port: 18090
+#      props:
+#        jvm-information-collector-enabled: "true"
+  tracing:
+    Jaeger:
+      host: "jaeger.agent.tracing.jaeger.host"
+      port: 5775
+      props:
+        service-name: "shardingsphere"
+        jaeger-sampler-type: "const"
+        jaeger-sampler-param: "1"
+        jaeger-reporter-log-spans: "true"
+        jaeger-reporter-flush-interval: "1"
+    Zipkin:
+      props:
+        service-name: "shardingsphere"
+        url-version: "/api/v2/spans"
+        sampler-type: "const"
+        sampler-param: "1"
+#    OpenTracing:
+#      props:
+#        opentracing-tracer-class-name: "org.apache.skywalking.apm.toolkit.opentracing.SkywalkingTracer"
+#    OpenTelemetry:
+#      props:
+#        otel-resource-attributes: "service.name=shardingsphere"
+#        otel-traces-exporter: "zipkin"
+#        otel-exporter-zipkin-endpoint: "http://zipkin.agent.tracing.opentelemetry.host:9411/api/v2/spans"

--- a/test/e2e/agent/plugins/jaeger/src/test/resources/docker/docker-compose.yml
+++ b/test/e2e/agent/plugins/jaeger/src/test/resources/docker/docker-compose.yml
@@ -1,0 +1,58 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: "2.1"
+
+services:
+  mysql:
+    image: "mysql/mysql-server:5.7"
+    container_name: agent-tracing-jaeger-mysql
+    command: ['--sql_mode=', '--default-authentication-plugin=mysql_native_password']
+    volumes:
+      - ../env/mysql:/docker-entrypoint-initdb.d/
+    ports:
+      - "43061:3306"
+    environment:
+      - LANG=C.UTF-8
+
+  jaeger:
+    image: "jaegertracing/all-in-one:1.41"
+    container_name: agent-tracing-jaeger
+    ports:
+      - "15775:5775"
+      - "26686:16686"
+
+  shardingsphere-proxy-agent-tracing:
+    image: apache/shardingsphere-proxy-agent-tracing-jaeger-test
+    container_name: shardingsphere-proxy-agent-tracing-jaeger-test
+    ports:
+      - "43071:3307"
+      - "43081:3308"
+    links:
+      - "mysql:mysql.agent.tracing.jaeger.host"
+      - "jaeger:jaeger.agent.tracing.jaeger.host"
+    volumes:
+      - ./proxy/conf:/opt/shardingsphere-proxy-agent-tracing-jaeger/conf
+      - ./agent/conf:/opt/shardingsphere-proxy-agent-tracing-jaeger/agent/conf
+    depends_on:
+      - mysql
+      - jaeger
+    environment:
+      - WAIT_HOSTS=mysql:3306, jaeger:16686
+      - WAIT_HOSTS_TIMEOUT=300
+      - WAIT_SLEEP_INTERVAL=5
+      - WAIT_HOST_CONNECT_TIMEOUT=30

--- a/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/config-db.yaml
+++ b/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/config-db.yaml
@@ -1,0 +1,70 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+databaseName: agent-tracing-jaeger-db
+
+dataSources:
+  ds_0:
+    url: jdbc:mysql://mysql.agent.tracing.jaeger.host:3306/agent_jaeger_db_0?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    username: root
+    password:
+    connectionTimeoutMilliseconds: 30000
+    idleTimeoutMilliseconds: 60000
+    maxLifetimeMilliseconds: 1800000
+    maxPoolSize: 10
+    minPoolSize: 2
+  ds_1:
+    url: jdbc:mysql://mysql.agent.tracing.jaeger.host:3306/agent_jaeger_db_1?serverTimezone=UTC&useSSL=false&characterEncoding=utf-8
+    username: root
+    password:
+    connectionTimeoutMilliseconds: 30000
+    idleTimeoutMilliseconds: 60000
+    maxLifetimeMilliseconds: 1800000
+    maxPoolSize: 10
+    minPoolSize: 2
+
+rules:
+  - !SHARDING
+    tables:
+      t_order:
+        actualDataNodes: ds_${0..1}.t_order_${0..1}
+        tableStrategy:
+          standard:
+            shardingColumn: order_id
+            shardingAlgorithmName: t_order_inline
+        keyGenerateStrategy:
+          column: order_id
+          keyGeneratorName: snowflake
+    defaultDatabaseStrategy:
+      standard:
+        shardingColumn: user_id
+        shardingAlgorithmName: database_inline
+    defaultTableStrategy:
+      none:
+    shardingAlgorithms:
+      database_inline:
+        type: INLINE
+        props:
+          algorithm-expression: ds_${user_id % 2}
+      t_order_inline:
+        type: INLINE
+        props:
+          algorithm-expression: t_order_${order_id % 2}
+
+    keyGenerators:
+      snowflake:
+        type: SNOWFLAKE

--- a/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/logback.xml
+++ b/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/logback.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="org.apache.shardingsphere" level="info" additivity="false">
+        <appender-ref ref="console" />
+    </logger>
+    
+    <root>
+        <level value="info" />
+        <appender-ref ref="console" />
+    </root>
+</configuration> 

--- a/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/server.yaml
+++ b/test/e2e/agent/plugins/jaeger/src/test/resources/docker/proxy/conf/server.yaml
@@ -15,13 +15,16 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+authority:
+  users:
+    - user: root
+      password: root
+  privilege:
+    type: ALL_PERMITTED
 
-ARG APP_NAME
-ENV WAIT_VERSION 2.7.2
-
-ADD target/${APP_NAME}.tar.gz /opt
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
-RUN chmod +x /wait
-RUN mv /opt/${APP_NAME} /opt/shardingsphere-proxy-agent-tracing-jaeger
-ENTRYPOINT /wait && /opt/shardingsphere-proxy-agent-tracing-jaeger/bin/start.sh && tail -f /opt/shardingsphere-proxy-agent-tracing-jaeger/logs/stdout.log
+props:
+  max-connections-size-per-query: 1
+  kernel-executor-size: 16  # Infinite by default.
+  proxy-frontend-flush-threshold: 128  # The default value is 128.
+  proxy-hint-enabled: false
+  sql-show: true

--- a/test/e2e/agent/plugins/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
+++ b/test/e2e/agent/plugins/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
@@ -51,7 +51,7 @@ public final class ZipkinPluginE2EIT extends BasePluginE2EIT {
     public void assertProxyWithAgent() throws IOException {
         super.assertProxyWithAgent();
         try {
-            // TODO this needs to refactor, replace Sleeping with Polling not.
+            // TODO this needs to refactor, replace sleep with polling.
             Thread.sleep(Long.parseLong(props.getProperty("zipkin.waitMs", "60000")));
         } catch (final InterruptedException ignore) {
         }


### PR DESCRIPTION
for #23135 

Changes proposed in this pull request:
  - add compose file and config files for jaeger E2E test

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
