### PR TITLE
Rename `resource` to `data source`

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/AlterDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/AlterDatabaseDiscoveryRuleStatementUpdater.java
@@ -54,7 +54,7 @@ public final class AlterDatabaseDiscoveryRuleStatementUpdater implements RuleDef
         String databaseName = database.getName();
         checkCurrentRuleConfiguration(databaseName, currentRuleConfig);
         checkToBeAlteredRules(databaseName, sqlStatement, currentRuleConfig);
-        checkToBeAlteredResources(databaseName, sqlStatement, database.getResourceMetaData());
+        checkToBeAlteredDataSources(databaseName, sqlStatement, database.getResourceMetaData());
         checkDiscoverTypeAndHeartbeat(sqlStatement);
     }
     
@@ -73,12 +73,12 @@ public final class AlterDatabaseDiscoveryRuleStatementUpdater implements RuleDef
         return sqlStatement.getRules().stream().map(AbstractDatabaseDiscoverySegment::getName).collect(Collectors.toList());
     }
     
-    private void checkToBeAlteredResources(final String databaseName, final AlterDatabaseDiscoveryRuleStatement sqlStatement, final ShardingSphereResourceMetaData resourceMetaData) {
-        Collection<String> notExistedResources = resourceMetaData.getNotExistedResources(getToBeAlteredResourceNames(sqlStatement));
-        ShardingSpherePreconditions.checkState(notExistedResources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedResources));
+    private void checkToBeAlteredDataSources(final String databaseName, final AlterDatabaseDiscoveryRuleStatement sqlStatement, final ShardingSphereResourceMetaData resourceMetaData) {
+        Collection<String> notExistedDataSources = resourceMetaData.getNotExistedDataSources(getToBeAlteredDataSourceNames(sqlStatement));
+        ShardingSpherePreconditions.checkState(notExistedDataSources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedDataSources));
     }
     
-    private Collection<String> getToBeAlteredResourceNames(final AlterDatabaseDiscoveryRuleStatement sqlStatement) {
+    private Collection<String> getToBeAlteredDataSourceNames(final AlterDatabaseDiscoveryRuleStatement sqlStatement) {
         Collection<String> result = new LinkedHashSet<>();
         sqlStatement.getRules().forEach(each -> result.addAll(each.getDataSources()));
         return result;

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdater.java
@@ -50,7 +50,7 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
     public void checkSQLStatement(final ShardingSphereDatabase database, final CreateDatabaseDiscoveryRuleStatement sqlStatement, final DatabaseDiscoveryRuleConfiguration currentRuleConfig) {
         String databaseName = database.getName();
         checkDuplicatedRuleNames(databaseName, sqlStatement, currentRuleConfig);
-        checkResources(databaseName, sqlStatement, database.getResourceMetaData());
+        checkDataSources(databaseName, sqlStatement, database.getResourceMetaData());
         checkDiscoverTypeAndHeartbeat(sqlStatement);
     }
     
@@ -98,11 +98,11 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdater implements RuleDe
         return sqlStatement.getRules().stream().map(AbstractDatabaseDiscoverySegment::getName).filter(currentRuleNames::contains).collect(Collectors.toSet());
     }
     
-    private void checkResources(final String databaseName, final CreateDatabaseDiscoveryRuleStatement sqlStatement, final ShardingSphereResourceMetaData resourceMetaData) {
-        Collection<String> resources = new LinkedHashSet<>();
-        sqlStatement.getRules().forEach(each -> resources.addAll(each.getDataSources()));
-        Collection<String> notExistedResources = resourceMetaData.getNotExistedResources(resources);
-        ShardingSpherePreconditions.checkState(notExistedResources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedResources));
+    private void checkDataSources(final String databaseName, final CreateDatabaseDiscoveryRuleStatement sqlStatement, final ShardingSphereResourceMetaData resourceMetaData) {
+        Collection<String> dataSources = new LinkedHashSet<>();
+        sqlStatement.getRules().forEach(each -> dataSources.addAll(each.getDataSources()));
+        Collection<String> notExistedDataSources = resourceMetaData.getNotExistedDataSources(dataSources);
+        ShardingSpherePreconditions.checkState(notExistedDataSources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedDataSources));
     }
     
     private void checkDiscoverTypeAndHeartbeat(final CreateDatabaseDiscoveryRuleStatement sqlStatement) {

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/AlterDatabaseDiscoveryRuleStatementUpdaterTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/AlterDatabaseDiscoveryRuleStatementUpdaterTest.java
@@ -79,7 +79,7 @@ public final class AlterDatabaseDiscoveryRuleStatementUpdaterTest {
     
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertCheckSQLStatementWithoutExistedResources() {
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(Collections.singleton("ds0"));
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(Collections.singleton("ds0"));
         Properties props = new Properties();
         DatabaseDiscoveryDefinitionSegment segment =
                 new DatabaseDiscoveryDefinitionSegment("readwrite_ds", Arrays.asList("ds_read_0", "ds_read_1"), new AlgorithmSegment("MySQL.MGR", props), props);

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdaterTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/update/CreateDatabaseDiscoveryRuleStatementUpdaterTest.java
@@ -78,7 +78,7 @@ public final class CreateDatabaseDiscoveryRuleStatementUpdaterTest {
     
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertCheckSQLStatementWithoutExistedResources() {
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(Collections.singleton("ds_read_0"));
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(Collections.singleton("ds_read_0"));
         Properties props = new Properties();
         DatabaseDiscoveryDefinitionSegment segment =
                 new DatabaseDiscoveryDefinitionSegment("readwrite_ds", Arrays.asList("ds_read_0", "ds_read_1"), new AlgorithmSegment("MySQL.MGR", props), props);

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/checker/ReadwriteSplittingRuleStatementChecker.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/checker/ReadwriteSplittingRuleStatementChecker.java
@@ -151,7 +151,7 @@ public final class ReadwriteSplittingRuleStatementChecker {
                 requiredLogicalDataSources.add(each.getAutoAwareResource());
             }
         });
-        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedResources(requiredDataSources);
+        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedDataSources(requiredDataSources);
         ShardingSpherePreconditions.checkState(notExistedDataSources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedDataSources));
         Collection<String> logicalDataSources = getLogicDataSources(database);
         Collection<String> notExistedLogicalDataSources = requiredLogicalDataSources.stream().filter(each -> !logicalDataSources.contains(each)).collect(Collectors.toSet());

--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/AlterReadwriteSplittingRuleStatementUpdaterTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/AlterReadwriteSplittingRuleStatementUpdaterTest.java
@@ -76,7 +76,7 @@ public final class AlterReadwriteSplittingRuleStatementUpdaterTest {
     
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertCheckSQLStatementWithoutExistedResources() {
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(Collections.singleton("read_ds_0"));
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(Collections.singleton("read_ds_0"));
         updater.checkSQLStatement(database, createSQLStatement("TEST"), createCurrentRuleConfiguration());
     }
     

--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/CreateReadwriteSplittingRuleStatementUpdaterTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/CreateReadwriteSplittingRuleStatementUpdaterTest.java
@@ -86,7 +86,7 @@ public final class CreateReadwriteSplittingRuleStatementUpdaterTest {
     
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertCheckSQLStatementWithoutExistedResources() {
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(Arrays.asList("read_ds_0", "read_ds_1"));
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(Arrays.asList("read_ds_0", "read_ds_1"));
         updater.checkSQLStatement(database, createSQLStatement("TEST"), null);
     }
     

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/checker/ShadowRuleStatementChecker.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/checker/ShadowRuleStatementChecker.java
@@ -54,7 +54,7 @@ public class ShadowRuleStatementChecker {
      * @param database database
      */
     public static void checkStorageUnitsExist(final Collection<String> requiredStorageUnits, final ShardingSphereDatabase database) {
-        Collection<String> notExistedStorageUnits = database.getResourceMetaData().getNotExistedResources(requiredStorageUnits);
+        Collection<String> notExistedStorageUnits = database.getResourceMetaData().getNotExistedDataSources(requiredStorageUnits);
         ShardingSpherePreconditions.checkState(notExistedStorageUnits.isEmpty(), () -> new MissingRequiredStorageUnitsException(database.getName(), notExistedStorageUnits));
     }
     

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/AlterShadowRuleStatementUpdaterTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/AlterShadowRuleStatementUpdaterTest.java
@@ -93,7 +93,7 @@ public final class AlterShadowRuleStatementUpdaterTest {
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertExecuteWithNotExistResource() {
         List<String> dataSources = Arrays.asList("ds", "ds0");
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(dataSources);
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(dataSources);
         AlterShadowRuleStatement sqlStatement = createSQLStatement(new ShadowRuleSegment("initRuleName1", "ds3", null, null));
         updater.checkSQLStatement(database, sqlStatement, currentConfig);
     }

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/CreateShadowRuleStatementUpdaterTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/update/CreateShadowRuleStatementUpdaterTest.java
@@ -80,7 +80,7 @@ public final class CreateShadowRuleStatementUpdaterTest {
     
     @Test(expected = MissingRequiredStorageUnitsException.class)
     public void assertExecuteWithNotExistResource() {
-        when(resourceMetaData.getNotExistedResources(any())).thenReturn(Arrays.asList("ds0", "ds1"));
+        when(resourceMetaData.getNotExistedDataSources(any())).thenReturn(Arrays.asList("ds0", "ds1"));
         CreateShadowRuleStatement sqlStatement = createSQLStatement(false, new ShadowRuleSegment("ruleName", "ds1", null, null));
         updater.checkSQLStatement(database, sqlStatement, currentConfig);
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
@@ -118,7 +118,7 @@ public final class ShardingSphereResourceMetaData {
      * @param resourceNames resource names to be judged
      * @return not existed resource names
      */
-    public Collection<String> getNotExistedResources(final Collection<String> resourceNames) {
+    public Collection<String> getNotExistedDataSources(final Collection<String> resourceNames) {
         return resourceNames.stream().filter(each -> !dataSources.containsKey(each)).collect(Collectors.toSet());
     }
     

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/DatabaseDiscoveryRuleConfigurationImportChecker.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/DatabaseDiscoveryRuleConfigurationImportChecker.java
@@ -56,7 +56,7 @@ public final class DatabaseDiscoveryRuleConfigurationImportChecker {
     private void checkDataSources(final String databaseName, final ShardingSphereDatabase database, final DatabaseDiscoveryRuleConfiguration currentRuleConfig) {
         Collection<String> requiredDataSources = new LinkedHashSet<>();
         currentRuleConfig.getDataSources().forEach(each -> requiredDataSources.addAll(each.getDataSourceNames()));
-        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedResources(requiredDataSources);
+        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedDataSources(requiredDataSources);
         ShardingSpherePreconditions.checkState(notExistedDataSources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedDataSources));
     }
     

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ReadwriteSplittingRuleConfigurationImportChecker.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ReadwriteSplittingRuleConfigurationImportChecker.java
@@ -67,7 +67,7 @@ public final class ReadwriteSplittingRuleConfigurationImportChecker {
                 }
             }
         });
-        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedResources(requiredDataSources);
+        Collection<String> notExistedDataSources = database.getResourceMetaData().getNotExistedDataSources(requiredDataSources);
         ShardingSpherePreconditions.checkState(notExistedDataSources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedDataSources));
         Collection<String> logicalDataSources = getLogicDataSources(database);
         Collection<String> notExistedLogicalDataSources = requiredLogicalDataSources.stream().filter(each -> !logicalDataSources.contains(each)).collect(Collectors.toSet());

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShadowRuleConfigurationImportChecker.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShadowRuleConfigurationImportChecker.java
@@ -56,7 +56,7 @@ public final class ShadowRuleConfigurationImportChecker {
     
     private void checkDataSources(final String databaseName, final ShardingSphereDatabase database, final ShadowRuleConfiguration currentRuleConfig) {
         Collection<String> requiredResource = getRequiredResources(currentRuleConfig);
-        Collection<String> notExistedResources = database.getResourceMetaData().getNotExistedResources(requiredResource);
+        Collection<String> notExistedResources = database.getResourceMetaData().getNotExistedDataSources(requiredResource);
         Collection<String> logicResources = getLogicDataSources(database);
         notExistedResources.removeIf(logicResources::contains);
         ShardingSpherePreconditions.checkState(notExistedResources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedResources));

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShardingRuleConfigurationImportChecker.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShardingRuleConfigurationImportChecker.java
@@ -121,7 +121,7 @@ public final class ShardingRuleConfigurationImportChecker {
     
     private void checkResources(final String databaseName, final ShardingSphereDatabase database, final ShardingRuleConfiguration currentRuleConfig) {
         Collection<String> requiredResource = getRequiredResources(currentRuleConfig);
-        Collection<String> notExistedResources = database.getResourceMetaData().getNotExistedResources(requiredResource);
+        Collection<String> notExistedResources = database.getResourceMetaData().getNotExistedDataSources(requiredResource);
         Collection<String> logicResources = getLogicResources(database);
         notExistedResources.removeIf(logicResources::contains);
         ShardingSpherePreconditions.checkState(notExistedResources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, notExistedResources));

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/AlterReadwriteSplittingStorageUnitStatusStatementHandler.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/AlterReadwriteSplittingStorageUnitStatusStatementHandler.java
@@ -134,7 +134,7 @@ public final class AlterReadwriteSplittingStorageUnitStatusStatementHandler exte
     
     private void checkResourceExists(final ContextManager contextManager, final String databaseName, final String toBeDisabledResource) {
         Collection<String> notExistedResources = contextManager
-                .getMetaDataContexts().getMetaData().getDatabase(databaseName).getResourceMetaData().getNotExistedResources(Collections.singleton(toBeDisabledResource));
+                .getMetaDataContexts().getMetaData().getDatabase(databaseName).getResourceMetaData().getNotExistedDataSources(Collections.singleton(toBeDisabledResource));
         ShardingSpherePreconditions.checkState(notExistedResources.isEmpty(), () -> new MissingRequiredStorageUnitsException(databaseName, Collections.singleton(toBeDisabledResource)));
     }
     

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/database/DatabaseOperateBackendHandlerFactoryTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/database/DatabaseOperateBackendHandlerFactoryTest.java
@@ -154,7 +154,7 @@ public final class DatabaseOperateBackendHandlerFactoryTest extends ProxyContext
     private MetaDataContexts mockMetaDataContexts() {
         MetaDataContexts result = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
         when(result.getMetaData().getDatabase("db").getResourceMetaData().getDataSources()).thenReturn(Collections.emptyMap());
-        when(result.getMetaData().getDatabase("db").getResourceMetaData().getNotExistedResources(any())).thenReturn(Collections.emptyList());
+        when(result.getMetaData().getDatabase("db").getResourceMetaData().getNotExistedDataSources(any())).thenReturn(Collections.emptyList());
         return result;
     }
     

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLBackendHandlerFactoryTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLBackendHandlerFactoryTest.java
@@ -100,7 +100,7 @@ public final class DistSQLBackendHandlerFactoryTest extends ProxyContextRestorer
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(result.getResourceMetaData().getDataSources()).thenReturn(Collections.emptyMap());
-        when(result.getResourceMetaData().getNotExistedResources(any())).thenReturn(Collections.emptyList());
+        when(result.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(Collections.emptyList());
         when(result.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.emptyList()));
         return result;
     }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/DBDiscoveryRuleConfigurationImportCheckerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/DBDiscoveryRuleConfigurationImportCheckerTest.java
@@ -68,7 +68,7 @@ public final class DBDiscoveryRuleConfigurationImportCheckerTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         Collection<String> dataSources = new LinkedList<>();
         dataSources.add("su_1");
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(dataSources);
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(dataSources);
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }
@@ -85,7 +85,7 @@ public final class DBDiscoveryRuleConfigurationImportCheckerTest {
     
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(Collections.emptyList());
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(Collections.emptyList());
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ReadwriteSplittingRuleConfigurationImportCheckerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ReadwriteSplittingRuleConfigurationImportCheckerTest.java
@@ -60,7 +60,7 @@ public final class ReadwriteSplittingRuleConfigurationImportCheckerTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         Collection<String> dataSources = new LinkedList<>();
         dataSources.add("su_1");
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(dataSources);
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(dataSources);
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }
@@ -76,7 +76,7 @@ public final class ReadwriteSplittingRuleConfigurationImportCheckerTest {
     
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(Collections.emptyList());
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(Collections.emptyList());
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShardingRuleConfigurationImportCheckerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/checker/ShardingRuleConfigurationImportCheckerTest.java
@@ -79,14 +79,14 @@ public final class ShardingRuleConfigurationImportCheckerTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         Collection<String> dataSources = new LinkedList<>();
         dataSources.add("su_1");
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(dataSources);
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(dataSources);
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }
     
     private ShardingSphereDatabase mockDatabase() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        when(database.getResourceMetaData().getNotExistedResources(any())).thenReturn(Collections.emptyList());
+        when(database.getResourceMetaData().getNotExistedDataSources(any())).thenReturn(Collections.emptyList());
         when(database.getRuleMetaData().getRules()).thenReturn(Collections.emptyList());
         return database;
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Rename `resource` to `data source`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
