### PR TITLE
Migrate openjdk to eclipse-temurin

### DIFF
--- a/distribution/proxy/Dockerfile
+++ b/distribution/proxy/Dockerfile
@@ -22,7 +22,7 @@ ENV LOCAL_PATH /opt/shardingsphere-proxy
 ADD target/${APP_NAME}.tar.gz /opt
 RUN mv /opt/${APP_NAME} ${LOCAL_PATH} && mkdir -p ${LOCAL_PATH}/ext-lib
 
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
 
 ENV LOCAL_PATH /opt/shardingsphere-proxy

--- a/test/e2e/agent/plugins/jaeger/Dockerfile
+++ b/test/e2e/agent/plugins/jaeger/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG APP_NAME
 ENV WAIT_VERSION 2.7.2

--- a/test/e2e/agent/plugins/metrics/Dockerfile
+++ b/test/e2e/agent/plugins/metrics/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG APP_NAME
 ENV WAIT_VERSION 2.7.2

--- a/test/e2e/agent/plugins/opentelemetry/Dockerfile
+++ b/test/e2e/agent/plugins/opentelemetry/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG APP_NAME
 ENV WAIT_VERSION 2.7.2

--- a/test/e2e/agent/plugins/zipkin/Dockerfile
+++ b/test/e2e/agent/plugins/zipkin/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 ARG APP_NAME
 ENV WAIT_VERSION 2.7.2

--- a/test/e2e/fixture/Dockerfile
+++ b/test/e2e/fixture/Dockerfile
@@ -27,7 +27,7 @@ RUN cat bin/start.sh | tr -d '\r' > _start.sh && mv _start.sh bin/start.sh
 RUN cat bin/stop.sh | tr -d '\r' > _stop.sh && mv _stop.sh bin/stop.sh
 RUN chmod +x -R ./bin
 
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 COPY --from=prepare /opt/shardingsphere-proxy /opt/shardingsphere-proxy
 


### PR DESCRIPTION
Fixes #23486.

Changes proposed in this pull request:
- `openjdk:8-jdk-alpine` -> `eclipse-temurin:8-jdk-alpine`
- `openjdk:17-jdk-slim` -> `eclipse-temurin:17-jdk`