### PR TITLE
Refactor AbstractSimplePipelineJob.execute to blocking

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
@@ -120,7 +120,7 @@ public abstract class AbstractPipelineJob implements PipelineJob {
         if (null != jobBootstrap) {
             jobBootstrap.shutdown();
         }
-        log.info("stop tasks runner, jobId={}", getJobId());
+        log.info("stop tasks runner, jobId={}", jobId);
         for (PipelineTasksRunner each : tasksRunnerMap.values()) {
             each.stop();
         }
@@ -128,7 +128,9 @@ public abstract class AbstractPipelineJob implements PipelineJob {
     
     private void innerClean() {
         tasksRunnerMap.clear();
-        PipelineJobProgressPersistService.removeJobProgressPersistContext(getJobId());
+        if (null != jobId) {
+            PipelineJobProgressPersistService.removeJobProgressPersistContext(jobId);
+        }
     }
     
     protected abstract void doClean();

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/IncrementalTask.java
@@ -126,7 +126,7 @@ public final class IncrementalTask implements PipelineTask, AutoCloseable {
             
             @Override
             public void onFailure(final Throwable throwable) {
-                log.error("incremental dumper onFailure, taskId={}", taskId, throwable);
+                log.error("incremental dumper onFailure, taskId={}", taskId);
                 stop();
                 close();
             }
@@ -139,7 +139,7 @@ public final class IncrementalTask implements PipelineTask, AutoCloseable {
             
             @Override
             public void onFailure(final Throwable throwable) {
-                log.error("importer onFailure, taskId={}", taskId, throwable);
+                log.error("importer onFailure, taskId={}", taskId);
                 stop();
                 close();
             }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/task/InventoryTask.java
@@ -98,7 +98,7 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
             
             @Override
             public void onFailure(final Throwable throwable) {
-                log.error("dumper onFailure, taskId={}", taskId, throwable);
+                log.error("dumper onFailure, taskId={}", taskId);
                 stop();
                 close();
             }
@@ -111,7 +111,7 @@ public final class InventoryTask implements PipelineTask, AutoCloseable {
             
             @Override
             public void onFailure(final Throwable throwable) {
-                log.error("importer onFailure, taskId={}", taskId, throwable);
+                log.error("importer onFailure, taskId={}", taskId);
                 stop();
                 close();
             }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor AbstractSimplePipelineJob.execute to blocking, so elasticjob could know exact lifecycle of job

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
