### PR TITLE
Force to build on JDK 11+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        java-version: [ 8, 19 ]
+        java-version: [ 11, 19 ]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -78,6 +78,13 @@ jobs:
         run: ./mvnw -T1C -B -ntp clean install
       - name: Build examples with Maven
         run: ./mvnw -T1C -B -f examples/pom.xml clean package -DskipTests
+      - name: Setup JDK 8 for Test
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Run tests with JDK 8
+        run: ./mvnw -T1C -B -ntp -fae test
 
   test-coverage:
     if: github.repository == 'apache/shardingsphere'
@@ -95,8 +102,15 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
+          java-version: 11
+      - name: Build with Maven
+        run: ./mvnw -T1C -B -ntp clean install -DskipTests
+      - name: Setup JDK 8 for Test
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
           java-version: 8
       - name: Test with Maven
-        run: ./mvnw -T1C -B -ntp clean install cobertura:cobertura -Djacoco.skip=false
+        run: ./mvnw -T1C -B -ntp test cobertura:cobertura -Djacoco.skip=false
       - name: Upload to Codecov
         run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Set environment
         run: export MAVEN_OPTS=' -Dmaven.javadoc.skip=true -Djacoco.skip=true $MAVEN_OPTS'
       - name: Build docker image

--- a/.github/workflows/e2e-agent.yml
+++ b/.github/workflows/e2e-agent.yml
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -80,6 +80,11 @@ jobs:
       - name: Build Project
         run: |
           ./mvnw -B clean install -DskipITs -DskipTests -Prelease
+      - name: Setup JDK 8 for Test
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
       - name: Run E2E Test
         run: |
           ./mvnw -B clean install -f test/e2e/agent/plugins/tracing/${{ matrix.plugin }}/pom.xml -Dspotless.apply.skip=true -Pit.env.${{ matrix.plugin }}
@@ -105,6 +110,11 @@ jobs:
       - name: Build Project
         run: |
           ./mvnw -B clean install -DskipITs -DskipTests -Prelease
+      - name: Setup JDK 8 for Test
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
       - name: Run E2E Test
         run: |
           ./mvnw -B clean install -f test/e2e/agent/plugins/metrics/${{ matrix.plugin }}/pom.xml -Dspotless.apply.skip=true -Pit.env.${{ matrix.plugin }}

--- a/.github/workflows/e2e-discovery.yml
+++ b/.github/workflows/e2e-discovery.yml
@@ -78,12 +78,17 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-it-cache
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
-      - name: Set up JDK 8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build Discovery IT image
+        run: ./mvnw -B clean install -am -pl test/e2e/discovery -Pit.env.docker -DskipTests
+      - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Build Discovery IT image
-        run: ./mvnw -B clean install -am -pl test/e2e/discovery -Pit.env.docker -DskipTests
       - name: Run MySQL Discovery E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/discovery/pom.xml -Dit.env.type=docker -Dit.docker.mysql.version=mysql:5.7

--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -90,13 +90,18 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-it-cache-
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
-      - name: Set up JDK 8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build Pipeline IT image
+        run: ./mvnw -B clean install -am -pl test/e2e/pipeline -Pit.env.docker -DskipTests
+      - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Build Pipeline IT image
-        run: ./mvnw -B clean install -am -pl test/e2e/pipeline -Pit.env.docker -DskipTests
       - name: Run Pipeline MySQL E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/pipeline/pom.xml -Dpipeline.it.env.type=docker -Dpipeline.it.docker.mysql.version=${{ env.mysql_version }}
       - name: Run Pipeline PostgreSQL E2E Test
@@ -123,13 +128,18 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-it-cache-
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
-      - name: Set up JDK 8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build Pipeline IT image
+        run: ./mvnw -B clean install -am -pl test/e2e/pipeline -Pit.env.docker -DskipTests
+      - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Build Pipeline IT image
-        run: ./mvnw -B clean install -am -pl test/e2e/pipeline -Pit.env.docker -DskipTests
       - name: Run Pipeline Daily MySQL E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/pipeline/pom.xml -Dpipeline.it.env.type=docker -Dpipeline.it.docker.mysql.version=${{ env.mysql_version }}
       - name: Run Pipeline Daily PostgreSQL E2E Test

--- a/.github/workflows/e2e-showprocesslist.yml
+++ b/.github/workflows/e2e-showprocesslist.yml
@@ -76,12 +76,17 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-it-cache
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
-      - name: Set up JDK 8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build ShowProcesslist IT image
+        run: ./mvnw -B clean install -am -pl test/e2e/showprocesslist -Pit.env.docker -DskipTests
+      - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Build ShowProcesslist IT image
-        run: ./mvnw -B clean install -am -pl test/e2e/showprocesslist -Pit.env.docker -DskipTests
       - name: Run MySQL ShowProcesslist E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/showprocesslist/pom.xml -Dit.env.type=docker -Dit.scenarios=cluster_jdbc_proxy -Dit.run.modes=${{ matrix.mode }}

--- a/.github/workflows/e2e-transaction.yml
+++ b/.github/workflows/e2e-transaction.yml
@@ -79,13 +79,18 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-it-cache
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
-      - name: Set up JDK 8
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build Transaction IT image
+        run: ./mvnw -B clean install -am -pl test/e2e/transaction -Pit.env.docker -DskipTests
+      - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
-      - name: Build Transaction IT image
-        run: ./mvnw -B clean install -am -pl test/e2e/transaction -Pit.env.docker -DskipTests
       - name: Run MySQL Transaction E2E Test
         run: ./mvnw -nsu -B install -f test/e2e/transaction/pom.xml -Dtransaction.it.env.type=docker -Dtransaction.it.env.transtypes=LOCAL,XA -Dtransaction.it.env.xa.providers=Atomikos,Narayana -Dtransaction.it.docker.mysql.version=${{ env.mysql_version }}
       - name: Run PostgreSQL Transaction E2E Test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/nightly-build-artifact.yml
+++ b/.github/workflows/nightly-build-artifact.yml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Build project
         run: |
           ./mvnw -B clean install -Prelease
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Cache Maven Repos
         uses: actions/cache@v3
         with:

--- a/.github/workflows/nightly-build-example.yml
+++ b/.github/workflows/nightly-build-example.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -96,7 +96,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 8, 17, 19 ]
+        java-version: [ 11, 17, 19 ]
     steps:
       - name: Support long paths in Windows
         if: matrix.os == 'windows-latest'

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Download IT image
         if: matrix.adapter == 'proxy'
         uses: actions/download-artifact@v3
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Download IT image
         if: matrix.adapter == 'proxy'
         uses: actions/download-artifact@v3
@@ -161,7 +161,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 11
       - name: Download IT image
         if: matrix.adapter == 'proxy'
         uses: actions/download-artifact@v3

--- a/.github/workflows/nightly-sql-parser.yml
+++ b/.github/workflows/nightly-sql-parser.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: [ 8 ]
+        java-version: [ 11 ]
         database: [ mysql, postgresql ]
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -1193,6 +1193,9 @@
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
+            <properties>
+                <maven.compiler.release>8</maven.compiler.release>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>


### PR DESCRIPTION
It sould be helpful to fix https://github.com/apache/shardingsphere/issues/19990 and https://github.com/apache/shardingsphere/issues/20935

Changes proposed in this pull request:
  - Force to use `JDK 11` above to build shardingsphere
  - We still run all the e2e tests on `JDK 8` to make sure there is no compatitable issues.
  - https://github.com/apache/shardingsphere/issues/19990 which needs to run `antlr-maven-plugin` to generate the parser classes. The antlr Tool are only for `JDK 11` after upgrading to 4.10.1. So if upgrading `antlr`, it will force user to build shardingsphere with `JDK 11`

It seems that we need to support  `JDK 8` for a long time. There is no such plan to drop it, see the relevant discussion https://lists.apache.org/thread/kgtfx5vnw73o61lkvdshyfvjfvvzk3js

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
