### PR TITLE
Unify `table` and `rule` in DistSQL parser test cases

### DIFF
--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropEncryptRuleStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropEncryptRuleStatementAssert.java
@@ -46,7 +46,7 @@ public final class DropEncryptRuleStatementAssert {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
-            assertThat(assertContext.getText("encrypt rule assertion error: "), actual.getTables(), is(expected.getTables()));
+            assertThat(assertContext.getText("encrypt rule assertion error: "), actual.getTables(), is(expected.getRuleNames()));
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropMaskRuleStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropMaskRuleStatementAssert.java
@@ -46,7 +46,7 @@ public final class DropMaskRuleStatementAssert {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
-            assertThat(assertContext.getText("Mask rule assertion error: "), actual.getTables(), is(expected.getRules()));
+            assertThat(assertContext.getText("Mask rule assertion error: "), actual.getTables(), is(expected.getRuleNames()));
         }
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShadowRuleStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShadowRuleStatementAssert.java
@@ -46,7 +46,7 @@ public final class DropShadowRuleStatementAssert {
             assertNull(assertContext.getText("Actual statement should not exist."), actual);
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
-            assertThat(assertContext.getText("Shadow rule assertion error: "), actual.getNames(), is(expected.getNames()));
+            assertThat(assertContext.getText("Shadow rule assertion error: "), actual.getNames(), is(expected.getRuleNames()));
             assertThat(assertContext.getText("Shadow rule assertion error: "), actual.isIfExists(), is(expected.isIfExists()));
         }
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShardingTableReferenceRulesStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShardingTableReferenceRulesStatementAssert.java
@@ -42,7 +42,7 @@ public final class DropShardingTableReferenceRulesStatementAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final DropShardingTableReferenceRuleStatement actual, final DropShardingTableReferenceRuleStatementTestCase expected) {
         assertNotNull(assertContext.getText("Actual statement should exist."), actual);
-        assertThat(assertContext.getText("Sharding table reference rule assertion error: "), actual.getNames(), is(expected.getNames()));
+        assertThat(assertContext.getText("Sharding table reference rule assertion error: "), actual.getNames(), is(expected.getRuleNames()));
         assertThat(assertContext.getText("Sharding table reference rule assertion error: "), actual.isIfExists(), is(expected.isIfExists()));
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShardingTableRuleStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/rdl/drop/impl/DropShardingTableRuleStatementAssert.java
@@ -49,7 +49,7 @@ public final class DropShardingTableRuleStatementAssert {
         } else {
             assertNotNull(assertContext.getText("Actual statement should exist."), actual);
             assertThat(assertContext.getText("Sharding table rule assertion error: "), actual.getTableNames().stream().map(each -> each.getIdentifier().getValue()).collect(Collectors.toList()),
-                    is(expected.getTables()));
+                    is(expected.getRuleNames()));
             assertThat(assertContext.getText("Sharding table rule assertion error: "), actual.isIfExists(), is(expected.isIfExists()));
         }
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/dbdiscovery/DropDatabaseDiscoveryRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/dbdiscovery/DropDatabaseDiscoveryRuleStatementTestCase.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Setter
 public final class DropDatabaseDiscoveryRuleStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "name")
+    @XmlElement(name = "rule-name")
     private final List<String> names = new LinkedList<>();
     
     @XmlAttribute(name = "if-exists")

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/encrypt/DropEncryptRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/encrypt/DropEncryptRuleStatementTestCase.java
@@ -36,6 +36,6 @@ public final class DropEncryptRuleStatementTestCase extends SQLParserTestCase {
     @XmlAttribute(name = "if-exists")
     private boolean ifExists;
     
-    @XmlElement(name = "table")
-    private final List<String> tables = new LinkedList<>();
+    @XmlElement(name = "rule-name")
+    private final List<String> ruleNames = new LinkedList<>();
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/mask/DropMaskRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/mask/DropMaskRuleStatementTestCase.java
@@ -36,6 +36,6 @@ public final class DropMaskRuleStatementTestCase extends SQLParserTestCase {
     @XmlAttribute(name = "if-exists")
     private boolean ifExists;
     
-    @XmlElement(name = "rule")
-    private final List<String> rules = new LinkedList<>();
+    @XmlElement(name = "rule-name")
+    private final List<String> ruleNames = new LinkedList<>();
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/readwritesplitting/DropReadwriteSplittingRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/readwritesplitting/DropReadwriteSplittingRuleStatementTestCase.java
@@ -33,7 +33,7 @@ import java.util.List;
 @Setter
 public final class DropReadwriteSplittingRuleStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "name")
+    @XmlElement(name = "rule-name")
     private final List<String> names = new LinkedList<>();
     
     @XmlAttribute(name = "if-exists")

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/shadow/DropShadowRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/shadow/DropShadowRuleStatementTestCase.java
@@ -36,6 +36,6 @@ public final class DropShadowRuleStatementTestCase extends SQLParserTestCase {
     @XmlAttribute(name = "if-exists")
     private boolean ifExists;
     
-    @XmlElement(name = "name")
-    private final List<String> names = new LinkedList<>();
+    @XmlElement(name = "rule-name")
+    private final List<String> ruleNames = new LinkedList<>();
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/sharding/DropShardingTableReferenceRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/sharding/DropShardingTableReferenceRuleStatementTestCase.java
@@ -33,8 +33,8 @@ import java.util.List;
 @Setter
 public final class DropShardingTableReferenceRuleStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "name")
-    private final List<String> names = new LinkedList<>();
+    @XmlElement(name = "rule-name")
+    private final List<String> ruleNames = new LinkedList<>();
     
     @XmlAttribute(name = "if-exists")
     private boolean ifExists;

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/sharding/DropShardingTableRuleStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/rdl/rule/sharding/DropShardingTableRuleStatementTestCase.java
@@ -33,8 +33,8 @@ import java.util.List;
 @Setter
 public final class DropShardingTableRuleStatementTestCase extends SQLParserTestCase {
     
-    @XmlElement(name = "table")
-    private final List<String> tables = new LinkedList<>();
+    @XmlElement(name = "rule-name")
+    private final List<String> ruleNames = new LinkedList<>();
     
     @XmlAttribute(name = "if-exists")
     private boolean ifExists;

--- a/test/it/parser/src/main/resources/case/rdl/drop.xml
+++ b/test/it/parser/src/main/resources/case/rdl/drop.xml
@@ -36,21 +36,21 @@
     </unregister-storage-unit>
     
     <drop-sharding-table-rule sql-case-id="drop-sharding-table-rule" >
-        <table>t_order</table>
-        <table>t_order_item</table>
+        <rule-name>t_order</rule-name>
+        <rule-name>t_order_item</rule-name>
     </drop-sharding-table-rule>
     
     <drop-sharding-table-rule sql-case-id="drop-sharding-table-rule-if-exists" if-exists="true">
-        <table>t_order</table>
-        <table>t_order_item</table>
+        <rule-name>t_order</rule-name>
+        <rule-name>t_order_item</rule-name>
     </drop-sharding-table-rule>
     
     <drop-sharding-table-reference-rule sql-case-id="drop-sharding-table-reference-rule">
-        <name>reference_0</name>
+        <rule-name>reference_0</rule-name>
     </drop-sharding-table-reference-rule>
     
     <drop-sharding-table-reference-rule sql-case-id="drop-sharding-table-reference-rule-if-exists" if-exists="true">
-        <name>reference_1</name>
+        <rule-name>reference_1</rule-name>
     </drop-sharding-table-reference-rule>
     
     <drop-broadcast-table-rule sql-case-id="drop-broadcast-table-rule" >
@@ -67,23 +67,23 @@
     </drop-broadcast-table-rule>
     
     <drop-readwrite-splitting-rule sql-case-id="drop-readwrite-splitting-rule">
-        <name>ms_group_0</name>
-        <name>ms_group_1</name>
+        <rule-name>ms_group_0</rule-name>
+        <rule-name>ms_group_1</rule-name>
     </drop-readwrite-splitting-rule>
 
     <drop-readwrite-splitting-rule sql-case-id="drop-readwrite-splitting-rule-if-exists" if-exists="true">
-        <name>ms_group_0</name>
-        <name>ms_group_1</name>
+        <rule-name>ms_group_0</rule-name>
+        <rule-name>ms_group_1</rule-name>
     </drop-readwrite-splitting-rule>
     
     <drop-database-discovery-rule sql-case-id="drop-database-discovery-rule">
-        <name>ha_group_0</name>
-        <name>ha_group_1</name>
+        <rule-name>ha_group_0</rule-name>
+        <rule-name>ha_group_1</rule-name>
     </drop-database-discovery-rule>
     
     <drop-database-discovery-rule sql-case-id="drop-database-discovery-rule-if-exists" if-exists="true">
-        <name>ha_group_0</name>
-        <name>ha_group_1</name>
+        <rule-name>ha_group_0</rule-name>
+        <rule-name>ha_group_1</rule-name>
     </drop-database-discovery-rule>
     
     <drop-database-discovery-type sql-case-id="drop-database-discovery-type">
@@ -107,23 +107,23 @@
     </drop-database-discovery-heartbeat>
     
     <drop-encrypt-rule sql-case-id="drop-encrypt-rule">
-        <table>t_encrypt</table>
-        <table>t_encrypt_order</table>
+        <rule-name>t_encrypt</rule-name>
+        <rule-name>t_encrypt_order</rule-name>
     </drop-encrypt-rule>
     
     <drop-encrypt-rule sql-case-id="drop-encrypt-rule-if-exists" if-exists="true">
-        <table>t_encrypt</table>
-        <table>t_encrypt_order</table>
+        <rule-name>t_encrypt</rule-name>
+        <rule-name>t_encrypt_order</rule-name>
     </drop-encrypt-rule>
     
     <drop-shadow-rule sql-case-id="drop-shadow-rule">
-        <name>shadow_rule_1</name>
-        <name>shadow_rule_2</name>
+        <rule-name>shadow_rule_1</rule-name>
+        <rule-name>shadow_rule_2</rule-name>
     </drop-shadow-rule>
     
     <drop-shadow-rule sql-case-id="drop-shadow-rule-if-exists" if-exists="true">
-        <name>shadow_rule_1</name>
-        <name>shadow_rule_2</name>
+        <rule-name>shadow_rule_1</rule-name>
+        <rule-name>shadow_rule_2</rule-name>
     </drop-shadow-rule>
     
     <drop-shadow-algorithm sql-case-id="drop-shadow-algorithm">
@@ -163,12 +163,12 @@
     </drop-sharding-algorithm>
     
     <drop-mask-rule sql-case-id="drop-mask-rule" if-exists="false">
-        <rule>t_mask</rule>
-        <rule>t_order</rule>
+        <rule-name>t_mask</rule-name>
+        <rule-name>t_order</rule-name>
     </drop-mask-rule>
     
     <drop-mask-rule sql-case-id="drop-mask-rule-if-exists" if-exists="true">
-        <rule>t_mask</rule>
-        <rule>t_order</rule>
+        <rule-name>t_mask</rule-name>
+        <rule-name>t_order</rule-name>
     </drop-mask-rule>
 </sql-parser-test-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Unify `table` and `rule` to `rule-name` in DistSQL `drop rule` parser test cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
