### PR TITLE
Refactor : set agent start with proxy if the switch set to -g (#23541)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -45,6 +45,8 @@ apache-shardingsphere-{latest.release.version}-shardingsphere-proxy-bin/agent/sh
 Start agent with `-g` option by bin/start.sh
 ```shell
 sh start.sh -g
+# following commands also work
+sh start.sh --agent
 ```
 
 ### Quick Start with JDBC

--- a/agent/README.md
+++ b/agent/README.md
@@ -45,7 +45,8 @@ apache-shardingsphere-{latest.release.version}-shardingsphere-proxy-bin/agent/sh
 Start agent with `-g` option by bin/start.sh
 ```shell
 sh start.sh -g
-# following commands also work
+
+# following command also works
 sh start.sh --agent
 ```
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -36,10 +36,15 @@ Artifact is `agent/distribution/target/apache-shardingsphere-${latest.release.ve
 
 ### Quick Start with Proxy
 
-Add the javaagent configuration in the Proxy startup script, as follows:
+Add the agent to the Proxy directory, as follows:
 
 ```shell
-nohup $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -javaagent:/xx/xx/shardingsphere-agent-{latest.release.version}.jar -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${STDOUT_FILE} 2>&1 &
+apache-shardingsphere-{latest.release.version}-shardingsphere-proxy-bin/agent/shardingsphere-agent.jar
+```
+
+Start agent with `-g` option by bin/start.sh
+```shell
+sh start.sh -g
 ```
 
 ### Quick Start with JDBC

--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -146,7 +146,7 @@ function set_agent_name() {
     fi
 }
 
-function enable_agent() {
+function set_agent_parameter() {
     AGENT_PARAM="";
     if [ -f "$AGENT_FILE" ]; then
       AGENT_PARAM=" -javaagent:${AGENT_FILE} "
@@ -157,7 +157,7 @@ for arg in $*
 do
   if [ "$arg" == "-g" ] || [ "$arg" == "--agent" ] ; then
     set_agent_name
-    enable_agent
+    set_agent_parameter
     set -- "${params[$PARAM_INDEX]}"
     break
   fi

--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -135,18 +135,28 @@ if [ "$1" == "-v" ] || [ "$1" == "--version" ] ; then
     print_version
 fi
 
+PARAM_INDEX=1
+AGENT_FILE=${DEPLOY_DIR}/agent/shardingsphere-agent.jar
+function set_agent_name() {
+    if [ -d "${DEPLOY_DIR}/agent" ]; then
+        AGENT_NAME=$(ls "${DEPLOY_DIR}/agent/shardingsphere-agent"*)
+        if [ -n "${AGENT_NAME}" ]; then
+          AGENT_FILE=${AGENT_NAME}
+        fi
+    fi
+}
+
 function enable_agent() {
     AGENT_PARAM="";
-    AGENT_FILE="${DEPLOY_DIR}/agent/shardingsphere-agent.jar"
     if [ -f "$AGENT_FILE" ]; then
       AGENT_PARAM=" -javaagent:${AGENT_FILE} "
     fi
 }
 
-PARAM_INDEX=1
 for arg in $*
 do
   if [ "$arg" == "-g" ] || [ "$arg" == "--agent" ] ; then
+    set_agent_name
     enable_agent
     set -- "${params[$PARAM_INDEX]}"
     break

--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -135,7 +135,6 @@ if [ "$1" == "-v" ] || [ "$1" == "--version" ] ; then
     print_version
 fi
 
-
 function enable_agent() {
     AGENT_PARAM="";
     AGENT_FILE="${DEPLOY_DIR}/agent/shardingsphere-agent.jar"
@@ -144,10 +143,16 @@ function enable_agent() {
     fi
 }
 
-if [ "$1" == "-g" ] || [ "$1" == "--agent" ] ; then
+PARAM_INDEX=1
+for arg in $*
+do
+  if [ "$arg" == "-g" ] || [ "$arg" == "--agent" ] ; then
     enable_agent
-    set -- "${params[1]}"
-fi
+    set -- "${params[$PARAM_INDEX]}"
+    break
+  fi
+  let PARAM_INDEX+=1
+done
 
 if [ $# == 0 ]; then
     CLASS_PATH=${DEPLOY_DIR}/conf:${CLASS_PATH}

--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -118,6 +118,7 @@ print_usage() {
     echo "-p  Bind port, default is '3307', which could be changed in server.yaml"
     echo "-c  Path to config directory of ShardingSphere-Proxy, default is 'conf'"
     echo "-f  Force start ShardingSphere-Proxy"
+    echo "-g  Enable agent if shardingsphere-agent deployed in 'agent' directory"
     exit 0
 }
 
@@ -132,6 +133,20 @@ print_version() {
 
 if [ "$1" == "-v" ] || [ "$1" == "--version" ] ; then
     print_version
+fi
+
+
+function enable_agent() {
+    AGENT_PARAM="";
+    AGENT_FILE="${DEPLOY_DIR}/agent/shardingsphere-agent.jar"
+    if [ -f "$AGENT_FILE" ]; then
+      AGENT_PARAM=" -javaagent:${AGENT_FILE} "
+    fi
+}
+
+if [ "$1" == "-g" ] || [ "$1" == "--agent" ] ; then
+    enable_agent
+    set -- "${params[1]}"
 fi
 
 if [ $# == 0 ]; then
@@ -199,7 +214,7 @@ fi
 
 echo -e "Starting the $SERVER_NAME ...\c"
 
-nohup $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} ${MAIN_CLASS} >> ${STDOUT_FILE} 2>&1 &
+nohup $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} ${AGENT_PARAM} ${MAIN_CLASS} >> ${STDOUT_FILE} 2>&1 &
 if [ $? -eq 0 ]; then
   case "$OSTYPE" in
   *solaris*)


### PR DESCRIPTION
Fixes #23541

Changes proposed in this pull request:
  - set agent start with proxy if the switch set to -g

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
