### PR TITLE
fix `show sharding table rule` DistSQL document

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding/show-sharding-table-rule.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rql/rule-query/sharding/show-sharding-table-rule.cn.md
@@ -12,10 +12,7 @@ weight = 2
 <<<<<<< HEAD
 {{< tabs >}}
 {{% tab name="语法" %}}
-```
-=======
 ```sql
->>>>>>> 731b174a28364b0ec70755800459edb332b68209
 ShowShardingTableRule ::=
   'SHOW' 'SHARDING' 'TABLE' ('RULE' tableName | 'RULES') ('FROM' databaseName)?
 


### PR DESCRIPTION

Changes proposed in this pull request:
  - fix `show sharding table rule` DistSQL document
![image](https://user-images.githubusercontent.com/57847965/212807357-215f7a44-e1c1-43a0-a7d8-2ea2cd997010.png)


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
