### PR TITLE
Update Apache ShardingSphere on Cloud Release Guide

### DIFF
--- a/docs/community/content/involved/release/shardingsphere-on-cloud.cn.md
+++ b/docs/community/content/involved/release/shardingsphere-on-cloud.cn.md
@@ -6,7 +6,11 @@ chapter = true
 
 ## 准备工作
 
-### 1. 确认 Release Note
+### 1. 检查并更新 NOTICE
+
+检查并更新 NOTICE 文件中的年份。
+
+### 2. 确认 Release Note
 
 Release Note 需提供中文/英文两种版本，确认中英文描述是否明确，并按以下标签进行分类：
 
@@ -15,7 +19,7 @@ Release Note 需提供中文/英文两种版本，确认中英文描述是否明
 1. 功能增强
 1. 漏洞修复
 
-### 2. 确认 Issue 列表
+### 3. 确认 Issue 列表
 
 打开 [Github Issues](https://github.com/apache/shardingsphere-on-cloud/issues)，过滤 Milestone 为 `${RELEASE.VERSION}` 且状态为打开的 Issue:
 
@@ -23,7 +27,7 @@ Release Note 需提供中文/英文两种版本，确认中英文描述是否明
 1. 未完成的 Issue 与负责人进行沟通，如果不影响本次发版，修改 Milestone 为下一个版本；
 1. 确认发布版本的 Milestone 下没有打开状态的 Issue。
 
-### 3. 确认 Pull Request 列表
+### 4. 确认 Pull Request 列表
 
 打开 [Github Pull requests](https://github.com/apache/shardingsphere-on-cloud/pulls)，过滤 Milestone 为 `${RELEASE.VERSION}` 且状态为打开的 Pull Request:
 
@@ -31,12 +35,12 @@ Release Note 需提供中文/英文两种版本，确认中英文描述是否明
 1. 无法 Merge 且不影响本次发版的 Pull Request，修改 Milestone 为下一个版本；
 1. 确认发布版本的 Milestone 下没有打开状态的 Pull Request。
 
-### 4. 发送讨论邮件
+### 5. 发送讨论邮件
 
 1. 发送邮件至 [dev@shardingsphere.apache.org](mailto:dev@shardingsphere.apache.org)，在邮件正文中链接 GitHub Discussion；
 1. 关注邮件列表，确认社区开发者对 Release Note 没有任何疑问。
 
-### 5. 关闭 Milestone
+### 6. 关闭 Milestone
 
 打开 [Github Milestone](https://github.com/apache/shardingsphere-on-cloud/milestones)
 
@@ -74,7 +78,7 @@ gpg --gen-key
 
 根据提示完成 key：
 
-> 注意：请使用 Apache mail 生成 GPG 的 Key。
+> 注意：请使用个人 Apache 邮箱生成 GPG 的 Key。
 
 ```shell
 gpg (GnuPG) 2.0.12; Copyright (C) 2009 Free Software Foundation, Inc.
@@ -128,6 +132,8 @@ sub   4096R/0B7EF5B2 2019-03-20
 
 其中 700E6065 为公钥 ID。
 
+或者使用 `gpg --list-signatures` 查看。
+
 ### 4. 导出 v1 版本密钥
 
 ``` shell
@@ -161,10 +167,9 @@ git checkout -b ${RELEASE.VERSION}-release
 git push origin ${RELEASE.VERSION}-release
 ```
 
-### 2. 更新 charts 版本
+### 2. 更新 charts 版本及 release notes
 
-在发布分支上更新 `Chart.yaml` 文件中的版本：
-
+在发布分支上更新文件中的版本，示例：`Chart.yaml`、`values.yaml`、文档。示例：
 ```
 ~/shardingsphere-on-cloud/charts/apache-shardingsphere-operator-charts/Chart.yaml
 ~/shardingsphere-on-cloud/charts/apache-shardingsphere-proxy-charts/Chart.yaml
@@ -172,13 +177,15 @@ git push origin ${RELEASE.VERSION}-release
 
 将 `version` 修改为 `${RELEASE.VERSION}`，`appVersion` 修改为对应的应用版本，并提交 PR 到发布分支。
 
+更新 `RELEASE-NOTES.md`。
+
 ### 3. 创建发布 tag
 
-在发布分支上创建发布 tag，并提交 PR 到发布分支。
+在发布分支上创建发布 tag，并推送到远程仓库。
 
 ```shell
 git tag ${RELEASE.VERSION}
-git push origin --tags
+git push origin ${RELEASE.VERSION}
 ```
 
 ### 4. 打包 charts

--- a/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
+++ b/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
@@ -6,7 +6,11 @@ chapter = true
 
 ## Prepare before release
 
-### 1. Confirm release notes
+### 1. Check and update NOTICE
+
+Check and update year in NOTICE.
+
+### 2. Confirm release notes
 
 The release note should be provided in English / Chinese, confirm whether English and Chinese description are clear,
 and shall be classified according to the following labels:
@@ -16,7 +20,7 @@ and shall be classified according to the following labels:
 1. Enhancement
 1. Bug Fix
 
-### 2. Confirm issue list
+### 3. Confirm issue list
 
 Open [Github Issues](https://github.com/apache/shardingsphere-on-cloud/issues), filter the issue whose milestone is `${RELEASE.VERSION}` and status is open:
 
@@ -24,7 +28,7 @@ Open [Github Issues](https://github.com/apache/shardingsphere-on-cloud/issues), 
 1. For outstanding issues, communicate with the developer in charge. If this release is not affected, modify milestone to the next version;
 1. Confirm that there is no issue in open status under milestone of release version.
 
-### 3. Confirm pull request list
+### 4. Confirm pull request list
 
 Open [Github Pull requests](https://github.com/apache/shardingsphere-on-cloud/pulls), filter pull requests whose milestone is `${RELEASE.VERSION}` and status is open:
 
@@ -32,12 +36,12 @@ Open [Github Pull requests](https://github.com/apache/shardingsphere-on-cloud/pu
 1. For pull requests that cannot merge and do not affect this release, modify milestone to the next version;
 1. Confirm that there is no open pull request under milestone of release version.
 
-### 4. Call for a discussion
+### 5. Call for a discussion
 
 1. Send email to [dev@shardingsphere.apache.org](mailto:dev@shardingsphere.apache.org)
 1. Follow the mailing list and confirm that the community developers have no questions about the release note.
 
-### 5. Close milestone
+### 6. Close milestone
 
 Open [GitHub milestone](https://github.com/apache/shardingsphere-on-cloud/milestones)
 
@@ -75,7 +79,7 @@ gpg --gen-key
 
 Finish the key creation according to instructions:
 
-> To be noticed: Please use Apache mail for key creation.
+> To be noticed: Please use personal Apache email address for key creation.
 
 ```shell
 gpg (GnuPG) 2.0.12; Copyright (C) 2009 Free Software Foundation, Inc.
@@ -129,6 +133,8 @@ sub   4096R/0B7EF5B2 2019-03-20
 
 Among them, 700E6065 is public key ID.
 
+Or run `gpg --list-sigs` to check it.
+
 ### 4. Export v1 version secret
 
 ``` shell
@@ -162,24 +168,25 @@ git pull
 git checkout -b ${RELEASE.VERSION}-release
 git push origin ${RELEASE.VERSION}-release
 ```
-### 2. Update charts version
 
-Update the version in `Chart.yaml` file in release branch:
+### 2. Update charts version and release notes
 
+Update the version of related files in release branch, includes `Chart.yaml`, `values.yaml` and documents. e.g.:
 ```
 ~/shardingsphere-on-cloud/charts/apache-shardingsphere-operator-charts/Chart.yaml
 ~/shardingsphere-on-cloud/charts/apache-shardingsphere-proxy-charts/Chart.yaml
 ```
-
 Modify `version` to `${RELEASE.VERSION}`, `appVersion` to the corresponding application version, and submit a PR to release branch.
+
+Update `RELEASE-NOTES.md` and commit to release branch directly.
 
 ### 3. Create Release Tag
 
-Create a release tag in release branch and submit a PR to release branch.
+Create a release tag in release branch and push to remote repository.
 
 ```shell
 git tag ${RELEASE.VERSION}
-git push origin --tags
+git push origin ${RELEASE.VERSION}
 ```
 
 ### 4. Package charts

--- a/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
+++ b/docs/community/content/involved/release/shardingsphere-on-cloud.en.md
@@ -207,20 +207,16 @@ cd ~/shardingsphere-on-cloud/charts
 helm package --sign --key '${GPG 用户名}' --keyring ~/.gnupg/secring.gpg apache-shardingsphere-operator-charts
 helm package --sign --key '${GPG 用户名}' --keyring ~/.gnupg/secring.gpg apache-shardingsphere-proxy-charts
 ```
-### 5. Upload charts and generate index
 
-1. Upload the tgz file generated in the previous step to the Assets of release
-2. generate index.yaml
-```shell
-cd ~/shardingsphere-on-cloud/charts
-mkdir release
-mv *.tgz release
-git checkout gh-pages 
-mv ~/shardingsphere-on-cloud/index.yaml index.yaml
-helm repo index --url https://github.com/apache/shardingsphere-on-cloud/releases/download/${RELEASE.VERSION}  . --merge index.yaml
-```
-3. Replace the original index.yaml
+### 5. Publish pre-release on GitHub
 
+Click `Draft a new release` on [GitHub Releases](https://github.com/apache/shardingsphere/releases) page.
+
+Input release version and release notes, select `Set as a pre-release`, click `Publish release`.
+
+### 6. Upload charts
+
+Upload the tgz file generated before to the Assets of GitHub release.
 
 ### Check Release
 
@@ -284,24 +280,6 @@ To check the following items:
   *   All software licenses mentioned in `LICENSE`
   *   All the third party dependency licenses are under `licenses` folder
   *   If it depends on Apache license and has a `NOTICE` file, that `NOTICE` file need to be added to `NOTICE` file of the release
-
-### 3. Check products
-
-add repo
-```shell
-helm repo remove apache
-helm repo add apache  https://apache.github.io/shardingsphere-on-cloud
-helm search repo apache
-```
-
-If three products can be queried, the release is successful, and `helm repo add` and `helm search repo -l` will be verified according to the verification value in index.yaml
-
-
-```shell
-NAME                                              	CHART VERSION	           APP VERSION	DESCRIPTION
-apache/apache-shardingsphere-operator-charts     	${RELEASE.VERSION}       	xxx     	A Helm chart for ShardingSphere-Operator
-apache/apache-shardingsphere-proxy-charts        	${RELEASE.VERSION}        	xxx         A Helm chart for ShardingSphere-Proxy-Cluster
-```
 
 ## Call for a Vote
 
@@ -396,9 +374,60 @@ Thank you everyone for taking the time to review the release and help us.
 I will process to publish the release and send ANNOUNCE.
 ```
 
-3. Announce release completed by email
+## Finish the Release
 
-Send e-mail to `dev@shardingsphere.apache.org` and `announce@apache.org` to announce the release is finished
+### 1. Merge release branch to main and delete release branch on GitHub
+
+Create a PR to merge `${RELEASE.VERSION}-release` into `main` on GitHub.
+
+### 2. Generate and replace index.yaml
+
+1. Generate index.yaml
+
+```shell
+cd ~/shardingsphere-on-cloud/charts
+mkdir release
+mv *.tgz release
+git checkout gh-pages
+cd release
+mv ~/shardingsphere-on-cloud/index.yaml .
+helm repo index --url https://github.com/apache/shardingsphere-on-cloud/releases/download/${RELEASE.VERSION} . --merge index.yaml
+```
+
+Check whether new generated url in index.yaml works or not.
+
+2. Replace the original index.yaml
+
+```shell
+cp index.yaml ~/shardingsphere-on-cloud/index.yaml
+```
+
+Submit PR and merge into `gh-pages` branch on GitHub.
+
+### 3. Check products
+
+Update repository and search:
+```shell
+helm repo remove apache
+helm repo add apache  https://apache.github.io/shardingsphere-on-cloud
+helm search repo apache
+```
+`helm repo add` and `helm search repo -l` will be verified according to the verification value in index.yaml.
+
+If search result includes following two products with correct version, then release is successful:
+```shell
+NAME                                              	CHART VERSION	           APP VERSION	DESCRIPTION
+apache/apache-shardingsphere-operator-charts     	${RELEASE.VERSION}       	xxx     	A Helm chart for ShardingSphere-Operator
+apache/apache-shardingsphere-proxy-charts        	${RELEASE.VERSION}        	xxx         A Helm chart for ShardingSphere-Proxy-Cluster
+```
+
+### 4. Update release on GitHub
+
+Edit new release on [GitHub Releases](https://github.com/apache/shardingsphere/releases) page, then select `Set as the latest release` and click `Update release`.
+
+### 5. Announce release completed by email
+
+Send e-mail to `dev@shardingsphere.apache.org` and `announce@apache.org` with **plain text mode** to announce the release is completed.
 
 Announcement e-mail template:
 

--- a/docs/community/content/involved/release/shardingsphere.en.md
+++ b/docs/community/content/involved/release/shardingsphere.en.md
@@ -571,7 +571,7 @@ Go to [Docker Hub](https://hub.docker.com/r/apache/shardingsphere-proxy/) and ch
 docker logout
 ```
 
-### 4. Publish release in GitHub
+### 4. Publish release on GitHub
 
 Click `Draft a new release` in [GitHub Releases](https://github.com/apache/shardingsphere/releases).
 
@@ -610,7 +610,7 @@ If code conflicted, you may merge `master` into `${RELEASE.VERSION}-release` bef
 
 ### 9. Announce release completed by email
 
-Send e-mail to `dev@shardingsphere.apache.org` and `announce@apache.org` with **plain text mode** to announce the release is finished.
+Send e-mail to `dev@shardingsphere.apache.org` and `announce@apache.org` with **plain text mode** to announce the release is completed.
 
 Announcement e-mail template:
 


### PR DESCRIPTION
Update ShardingSphere on Cloud Release Guide based on 0.1.2 release operations.

Changes proposed in this pull request:
- Extend some steps with more details
- Add `Finish the Release` section, includes 5 steps. Some steps are moved here, and some new steps are added

