### PR TITLE
Refactor : add agent into proxy distribution as default (#23633)

### DIFF
--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/spi/AgentServiceLoaderTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/spi/AgentServiceLoaderTest.java
@@ -28,22 +28,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public final class AgentServiceLoaderTest {
-
+    
     @Test(expected = NullPointerException.class)
     public void assertGetServiceLoaderWithNullValue() {
         AgentServiceLoader.getServiceLoader(null);
     }
-
+    
     @Test(expected = IllegalArgumentException.class)
     public void assertGetServiceLoaderWithNoInterface() {
         AgentServiceLoader.getServiceLoader(Object.class);
     }
-
+    
     @Test
     public void assertGetServiceLoaderWithEmptyInstances() {
         assertTrue(AgentServiceLoader.getServiceLoader(AgentServiceEmptySPIFixture.class).getServices().isEmpty());
     }
-
+    
     @Test
     public void assertGetServiceLoaderWithImplementSPI() {
         AgentServiceLoader<AgentServiceSPIFixture> actual = AgentServiceLoader.getServiceLoader(AgentServiceSPIFixture.class);

--- a/agent/distribution/src/main/assembly/shardingsphere-agent-binary-distribution.xml
+++ b/agent/distribution/src/main/assembly/shardingsphere-agent-binary-distribution.xml
@@ -20,10 +20,10 @@
           xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
     <id>shardingsphere-agent-bin</id>
     <formats>
-        <format>tar.gz</format>
+        <format>dir</format>
     </formats>
     <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>${project.build.finalName}-shardingsphere-agent-bin</baseDirectory>
+    <baseDirectory>agent</baseDirectory>
     
     <fileSets>
         <fileSet>

--- a/distribution/proxy/src/main/assembly/shardingsphere-proxy-binary-distribution.xml
+++ b/distribution/proxy/src/main/assembly/shardingsphere-proxy-binary-distribution.xml
@@ -63,6 +63,13 @@
             </includes>
             <outputDirectory>/</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>../../agent/distribution/target/apache-shardingsphere-${project.version}-shardingsphere-agent-bin/</directory>
+            <includes>
+                <include>**/*</include>
+            </includes>
+            <outputDirectory>/</outputDirectory>
+        </fileSet>
     </fileSets>
     
     <dependencySets>

--- a/test/e2e/agent/plugins/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
+++ b/test/e2e/agent/plugins/zipkin/src/test/java/org/apache/shardingsphere/test/e2e/agent/zipkin/ZipkinPluginE2EIT.java
@@ -93,8 +93,7 @@ public final class ZipkinPluginE2EIT extends BasePluginE2EIT {
                 "INSERT INTO t_order (order_id, user_id, status) VALUES (10, 10, 'INSERT_TEST')",
                 "DELETE FROM t_order WHERE order_id=10",
                 "UPDATE t_order SET status = 'ROLL_BACK' WHERE order_id =1000",
-                "SELECT * FROM t_order"
-        );
+                "SELECT * FROM t_order");
         traceResult.forEach(each -> traceStatement.addAll(extractTraceTags((List<?>) each)));
         sqlList.forEach(each -> assertTrue(String.format("Zipkin trace should contain `%s`.", each), traceStatement.contains(each)));
     }


### PR DESCRIPTION
Fixes #23633.

Changes proposed in this pull request:
  - add agent into proxy distribution as default

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
