### PR TITLE
Fix connection is closed exception caused by TrafficExecutor close logic

### DIFF
--- a/kernel/traffic/core/src/main/java/org/apache/shardingsphere/traffic/executor/TrafficExecutor.java
+++ b/kernel/traffic/core/src/main/java/org/apache/shardingsphere/traffic/executor/TrafficExecutor.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.traffic.executor;
 import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
 
-import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -77,9 +76,7 @@ public final class TrafficExecutor implements AutoCloseable {
     @Override
     public void close() throws SQLException {
         if (null != statement) {
-            Connection connection = statement.getConnection();
             statement.close();
-            connection.close();
         }
     }
 }

--- a/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/executor/TrafficExecutorTest.java
+++ b/kernel/traffic/core/src/test/java/org/apache/shardingsphere/traffic/executor/TrafficExecutorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.traffic.executor;
+
+import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
+import org.apache.shardingsphere.infra.executor.sql.context.SQLUnit;
+import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public final class TrafficExecutorTest {
+    
+    @Test
+    public void assertClose() throws SQLException {
+        Statement statement = mock(Statement.class, RETURNS_DEEP_STUBS);
+        try (TrafficExecutor trafficExecutor = new TrafficExecutor()) {
+            JDBCExecutionUnit executionUnit = mock(JDBCExecutionUnit.class);
+            when(executionUnit.getExecutionUnit()).thenReturn(new ExecutionUnit("oltp_proxy_instance_id", new SQLUnit("SELECT 1", Collections.emptyList())));
+            when(executionUnit.getStorageResource()).thenReturn(statement);
+            trafficExecutor.execute(executionUnit, Statement::executeQuery);
+        }
+        verify(statement, times(1)).close();
+        verify(statement, times(0)).getConnection();
+    }
+}


### PR DESCRIPTION
Fixes #23653.

Changes proposed in this pull request:
  - fix connection is closed exception caused by TrafficExecutor close logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
