### PR TITLE
fix(sec): upgrade org.postgresql:postgresql to 

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -44,7 +44,7 @@
         <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
-        <postgresql.version>42.4.1</postgresql.version>
+        <postgresql.version>42.5.1</postgresql.version>
         <h2.version>2.1.214</h2.version>
         <slf4j.version>1.7.7</slf4j.version>
         <logback.version>1.2.10</logback.version>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         
         <lombok.version>1.18.20</lombok.version>
         
-        <postgresql.version>42.4.1</postgresql.version>
+        <postgresql.version>42.5.1</postgresql.version>
         <opengauss.version>3.0.0</opengauss.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.postgresql:postgresql 42.4.1
- [CVE-2022-41946](https://www.oscs1024.com/hd/CVE-2022-41946)


### What did I do？
Upgrade org.postgresql:postgresql from 42.4.1 to  for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS