### PR TITLE
Use GraalVM CE 22.3.1 to fix Nightly Build

### DIFF
--- a/.github/workflows/nightly-build-artifact.yml
+++ b/.github/workflows/nightly-build-artifact.yml
@@ -114,7 +114,7 @@ jobs:
           ref: ${{ inputs.commit-id }}
       - uses: graalvm/setup-graalvm@v1
         with:
-          version: 'dev'
+          version: '22.3.1'
           java-version: '17'
           components: 'native-image'
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -31,7 +31,7 @@
         <native.image.name>apache-shardingsphere-proxy-native</native.image.name>
         <native.image.repository>apache/shardingsphere-proxy-native</native.image.repository>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <native.maven.plugin.version>0.9.17</native.maven.plugin.version>
+        <native.maven.plugin.version>0.9.19</native.maven.plugin.version>
     </properties>
     
     <dependencies>

--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -317,7 +317,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     asm 9.1: https://github.com/llbit/ow2-asm, BSD-3-Clause
     commons-compiler 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
     janino 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
-    opengauss-jdbc 3.0.0: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
+    opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
     postgresql 42.4.1: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
     protobuf-java 3.17.2: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     protobuf-java-util 3.17.2: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -319,7 +319,7 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     asm 9.1: https://github.com/llbit/ow2-asm, BSD-3-Clause
     commons-compiler 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
     janino 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
-    opengauss-jdbc 3.0.0: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
+    opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
     postgresql 42.4.1: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
     protobuf-java 3.19.6: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     protobuf-java-util 3.19.6: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause

--- a/pom.xml
+++ b/pom.xml
@@ -94,14 +94,14 @@
         <lombok.version>1.18.20</lombok.version>
         
         <postgresql.version>42.4.1</postgresql.version>
-        <opengauss.version>3.0.0</opengauss.version>
+        <opengauss.version>3.1.0-og</opengauss.version>
         <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         <h2.version>2.1.214</h2.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>
         
         <hikari-cp.version>4.0.3</hikari-cp.version>
-        <commons-dbcp2.version>2.2.0</commons-dbcp2.version>
+        <commons-dbcp2.version>2.9.0</commons-dbcp2.version>
         
         <junit5.version>5.9.1</junit5.version>
         <junit4.version>4.13.2</junit4.version>


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Use GraalVM CE 22.3.1 instead of GraalVM CE 23.0 Dev. Refer to https://github.com/apache/shardingsphere/actions/runs/3998084528/jobs/6860258580 and https://github.com/graalvm/setup-graalvm/pull/31 .
  - Update OpenGauss JDBC to 3.1.0-og to match GraalVM reachability metadata. Refer to https://github.com/oracle/graalvm-reachability-metadata/pull/168 .
  - Update Commons DBCP2 to 2.9.0 to match GraalVM reachability metadata in the future nativeTest. Refer to https://github.com/oracle/graalvm-reachability-metadata/issues/202 .
  - Update native-maven-plugin to 0.9.19 to output richer Native Image build logs. Refer to https://graalvm.github.io/native-build-tools/latest/index.html#changelog .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
