### PR TITLE
Refactor `DefaultSingleTableStorageUnitResultSet`

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/ShowDefaultSingleTableStorageUnitExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/ShowDefaultSingleTableStorageUnitExecutor.java
@@ -17,28 +17,20 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule;
 
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowDefaultSingleTableStorageUnitStatement;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.single.rule.SingleRule;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.LinkedList;
 
 /**
- * Result set for show default single table storage unit.
+ * Show default single table storage unit executor.
  */
-public final class SingleTableRuleResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<String> data = Collections.emptyIterator();
-    
-    @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
-        SingleRule rule = database.getRuleMetaData().getSingleRule(SingleRule.class);
-        data = Collections.singleton(rule.getConfiguration().getDefaultDataSource().orElse("RANDOM")).iterator();
-    }
+public final class ShowDefaultSingleTableStorageUnitExecutor implements RQLExecutor<ShowDefaultSingleTableStorageUnitStatement> {
     
     @Override
     public Collection<String> getColumnNames() {
@@ -46,13 +38,11 @@ public final class SingleTableRuleResultSet implements DatabaseDistSQLResultSet 
     }
     
     @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        return Collections.singletonList(data.next());
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase shardingSphereDatabase, final ShowDefaultSingleTableStorageUnitStatement sqlStatement) {
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        SingleRule rule = shardingSphereDatabase.getRuleMetaData().getSingleRule(SingleRule.class);
+        result.add(new LocalDataQueryResultRow(rule.getConfiguration().getDefaultDataSource().orElse("RANDOM")));
+        return result;
     }
     
     @Override

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.storage.unit.ShowStorageUnitExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowSingleTableExecutor
+org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowDefaultSingleTableStorageUnitExecutor

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -16,7 +16,6 @@
 #
 
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.LogicalTableResultSet
-org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.SingleTableRuleResultSet
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.RulesUsedStorageUnitResultSet
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableResultSet
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowMigrationRuleResultSet

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/ProxyBackendHandlerFactoryTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/ProxyBackendHandlerFactoryTest.java
@@ -38,7 +38,7 @@ import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.QueryableGlob
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.QueryableRALBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.hint.HintRALBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.SetDistVariableHandler;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.RQLResultSetBackendHandler;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.RQLBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.rul.SQLRULBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.skip.SkipBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.transaction.TransactionBackendHandler;
@@ -261,7 +261,7 @@ public final class ProxyBackendHandlerFactoryTest extends ProxyContextRestorer {
         when(connectionSession.getTransactionStatus().isInTransaction()).thenReturn(true);
         String sql = "SHOW DEFAULT SINGLE TABLE STORAGE UNIT";
         ProxyBackendHandler actual = ProxyBackendHandlerFactory.newInstance(databaseType, sql, connectionSession);
-        assertThat(actual, instanceOf(RQLResultSetBackendHandler.class));
+        assertThat(actual, instanceOf(RQLBackendHandler.class));
     }
     
     @Test

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowDefaultSingleTableStorageUnitExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowDefaultSingleTableStorageUnitExecutorTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql.rql;
 
-import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowSingleTableStatement;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
+import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowDefaultSingleTableStorageUnitStatement;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.SingleTableRuleResultSet;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowDefaultSingleTableStorageUnitExecutor;
 import org.apache.shardingsphere.single.api.config.SingleRuleConfiguration;
 import org.apache.shardingsphere.single.rule.SingleRule;
 import org.junit.Test;
@@ -34,16 +35,26 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class SingleTableRuleResultSetTest {
+public final class ShowDefaultSingleTableStorageUnitExecutorTest {
     
     @Test
     public void assertGetRowData() {
-        DatabaseDistSQLResultSet resultSet = new SingleTableRuleResultSet();
-        resultSet.init(mockDatabase(), mock(ShowSingleTableStatement.class));
-        Collection<Object> actual = resultSet.getRowData();
+        RQLExecutor<ShowDefaultSingleTableStorageUnitStatement> executor = new ShowDefaultSingleTableStorageUnitExecutor();
+        executor.getRows(mockDatabase(), mock(ShowDefaultSingleTableStorageUnitStatement.class));
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(ShowDefaultSingleTableStorageUnitStatement.class));
         assertThat(actual.size(), is(1));
-        Iterator<Object> rowData = actual.iterator();
-        assertThat(rowData.next(), is("foo_ds"));
+        Iterator<LocalDataQueryResultRow> rowData = actual.iterator();
+        String defaultSingleTableStorageUnit = (String) rowData.next().getCell(1);
+        assertThat(defaultSingleTableStorageUnit, is("foo_ds"));
+    }
+    
+    @Test
+    public void assertGetColumns() {
+        RQLExecutor<ShowDefaultSingleTableStorageUnitStatement> executor = new ShowDefaultSingleTableStorageUnitExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(1));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("storage_unit_name"));
     }
     
     private ShardingSphereDatabase mockDatabase() {

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowSingleTableExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowSingleTableExecutorTest.java
@@ -135,6 +135,7 @@ public final class ShowSingleTableExecutorTest {
     public void assertGetColumns() {
         RQLExecutor<ShowSingleTableStatement> executor = new ShowSingleTableExecutor();
         Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(2));
         Iterator<String> iterator = columns.iterator();
         assertThat(iterator.next(), is("table_name"));
         assertThat(iterator.next(), is("storage_unit_name"));


### PR DESCRIPTION

Changes proposed in this pull request:
  - Replace `DefaultSingleTableStorageUnitResultSet` with `ShowDefaultSingleTableStorageUnitExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
