### PR TITLE
Replace `CountSingleTableResultSet` with `CountSingleTableExecutor`

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/CountSingleTableExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/CountSingleTableExecutor.java
@@ -17,57 +17,40 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.CountSingleTableStatement;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.single.rule.SingleRule;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
+import java.util.LinkedList;
 import java.util.Optional;
 
 /**
- * Result set for single table.
+ * Count single table executor.
  */
-public final class CountSingleTableResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Entry<String, Integer>> data = Collections.emptyIterator();
+public final class CountSingleTableExecutor implements RQLExecutor<CountSingleTableStatement> {
     
     private String databaseName;
+    
+    @Override
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final CountSingleTableStatement sqlStatement) {
+        Optional<SingleRule> rule = database.getRuleMetaData().findSingleRule(SingleRule.class);
+        databaseName = database.getName();
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        rule.ifPresent(optional -> addSingleTableData(result, databaseName, rule.get()));
+        return result;
+    }
     
     @Override
     public Collection<String> getColumnNames() {
         return Arrays.asList("database", "count");
     }
     
-    @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
-        Optional<SingleRule> rule = database.getRuleMetaData().findSingleRule(SingleRule.class);
-        databaseName = database.getName();
-        Map<String, Integer> result = new LinkedHashMap<>();
-        rule.ifPresent(optional -> addSingleTableData(result, databaseName, rule.get()));
-        data = result.entrySet().iterator();
-    }
-    
-    private void addSingleTableData(final Map<String, Integer> rowMap, final String databaseName, final SingleRule rule) {
-        rowMap.put(databaseName, rule.getAllTables().size());
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        Entry<String, Integer> entry = data.next();
-        return Arrays.asList(entry.getKey(), entry.getValue());
+    private void addSingleTableData(final Collection<LocalDataQueryResultRow> row, final String databaseName, final SingleRule rule) {
+        row.add(new LocalDataQueryResultRow(databaseName, rule.getAllTables().size()));
     }
     
     @Override

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -19,3 +19,4 @@ org.apache.shardingsphere.proxy.backend.handler.distsql.rql.storage.unit.ShowSto
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowSingleTableExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowRulesUsedStorageUnitExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowDefaultSingleTableStorageUnitExecutor
+org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableExecutor

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -16,5 +16,4 @@
 #
 
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.LogicalTableResultSet
-org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableResultSet
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowMigrationRuleResultSet

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/CountSingleTableExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/CountSingleTableExecutorTest.java
@@ -17,38 +17,47 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql.rql;
 
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.CountSingleTableStatement;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableResultSet;
+import org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableExecutor;
 import org.apache.shardingsphere.single.rule.SingleRule;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class CountSingleTableResultSetTest {
+public final class CountSingleTableExecutorTest {
     
     @Test
     public void assertGetRowData() {
-        CountSingleTableResultSet resultSet = new CountSingleTableResultSet();
-        resultSet.init(mockDatabase(), mock(CountSingleTableStatement.class));
-        assertTrue(resultSet.next());
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(2));
-        assertThat(actual.get(0), is("db_1"));
-        assertThat(actual.get(1), is(2));
-        assertFalse(resultSet.next());
+        RQLExecutor<CountSingleTableStatement> executor = new CountSingleTableExecutor();
+        Collection<LocalDataQueryResultRow> rowData = executor.getRows(mockDatabase(), mock(CountSingleTableStatement.class));
+        assertThat(rowData.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = rowData.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("db_1"));
+        assertThat(row.getCell(2), is(2));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<CountSingleTableStatement> executor = new CountSingleTableExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(2));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("database"));
+        assertThat(iterator.next(), is("count"));
     }
     
     private ShardingSphereDatabase mockDatabase() {

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/CountSingleTableExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/CountSingleTableExecutorTest.java
@@ -42,9 +42,9 @@ public final class CountSingleTableExecutorTest {
     @Test
     public void assertGetRowData() {
         RQLExecutor<CountSingleTableStatement> executor = new CountSingleTableExecutor();
-        Collection<LocalDataQueryResultRow> rowData = executor.getRows(mockDatabase(), mock(CountSingleTableStatement.class));
-        assertThat(rowData.size(), is(1));
-        Iterator<LocalDataQueryResultRow> iterator = rowData.iterator();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(CountSingleTableStatement.class));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
         LocalDataQueryResultRow row = iterator.next();
         assertThat(row.getCell(1), is("db_1"));
         assertThat(row.getCell(2), is(2));


### PR DESCRIPTION

For: #23772 

Changes proposed in this pull request:
  - Replace `CountSingleTableResultSet` with `CountSingleTableExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
