### PR TITLE
Replace `LogicalTableResultSet` with `ShowLogicalTableExecutor`

### DIFF
--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/ShowLogicalTableExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/rule/ShowLogicalTableExecutor.java
@@ -17,55 +17,46 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowLogicalTablesStatement;
 import org.apache.shardingsphere.infra.database.type.SchemaSupportedDatabaseType;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.proxy.backend.util.RegularUtil;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtil;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.stream.Collectors;
 
 /**
- * Result set for show logical table.
+ * Show logical table executor.
  */
-public final class LogicalTableResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<String> data = Collections.emptyIterator();
+public final class ShowLogicalTableExecutor implements RQLExecutor<ShowLogicalTablesStatement> {
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowLogicalTablesStatement sqlStatement) {
         String schemaName = database.getName();
         if (database.getProtocolType() instanceof SchemaSupportedDatabaseType) {
             schemaName = ((SchemaSupportedDatabaseType) database.getProtocolType()).getDefaultSchema();
         }
+        if (null == database.getSchema(schemaName)) {
+            return Collections.emptyList();
+        }
         Collection<String> tables = database.getSchema(schemaName).getAllTableNames();
-        ShowLogicalTablesStatement showLogicalTablesStatement = (ShowLogicalTablesStatement) sqlStatement;
-        if (showLogicalTablesStatement.getLikePattern().isPresent()) {
-            String pattern = SQLUtil.convertLikePatternToRegex(showLogicalTablesStatement.getLikePattern().get());
+        if (sqlStatement.getLikePattern().isPresent()) {
+            String pattern = SQLUtil.convertLikePatternToRegex(sqlStatement.getLikePattern().get());
             tables = tables.stream().filter(each -> RegularUtil.matchesCaseInsensitive(pattern, each)).collect(Collectors.toList());
         }
-        data = tables.iterator();
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        tables.forEach(each -> result.add(new LocalDataQueryResultRow(each)));
+        return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
         return Collections.singletonList("table_name");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        String next = data.next();
-        return Collections.singletonList(next);
     }
     
     @Override

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -20,3 +20,4 @@ org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowSingleTable
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowRulesUsedStorageUnitExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowDefaultSingleTableStorageUnitExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.CountSingleTableExecutor
+org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.ShowLogicalTableExecutor

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.proxy.backend.handler.distsql.rql.rule.LogicalTableResultSet
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowMigrationRuleResultSet


### PR DESCRIPTION
For #23772.

Changes proposed in this pull request:
  - Replace `LogicalTableResultSet` with `ShowLogicalTableExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
