### PR TITLE
Refactor `DatabaseDiscoveryRuleResultSet` 

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
@@ -67,7 +67,8 @@ public final class ShowDatabaseDiscoveryRuleExecutor implements RQLExecutor<Show
         dataSourceRules = ruleConfig.getDataSources().iterator();
         Map<String, AlgorithmConfiguration> discoveryTypes = ruleConfig.getDiscoveryTypes();
         Map<String, DatabaseDiscoveryHeartBeatConfiguration> discoveryHeartbeats = ruleConfig.getDiscoveryHeartbeats();
-        Map<String, String> primaryDataSources = rule.get().getDataSourceRules().entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getPrimaryDataSourceName(), (a, b) -> b));
+        Map<String, String> primaryDataSources = rule.get().getDataSourceRules().entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, entry -> entry.getValue().getPrimaryDataSourceName(), (a, b) -> b));
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         while (dataSourceRules.hasNext()) {
             DatabaseDiscoveryDataSourceRuleConfiguration dataSourceRuleConfig = dataSourceRules.next();

--- a/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -15,6 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.dbdiscovery.distsql.handler.query.DatabaseDiscoveryTypeResultSet
-org.apache.shardingsphere.dbdiscovery.distsql.handler.query.DatabaseDiscoveryHeartbeatResultSet
-org.apache.shardingsphere.dbdiscovery.distsql.handler.query.CountDatabaseDiscoveryRuleResultSet
+org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryRuleExecutor

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
@@ -23,8 +23,9 @@ import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryHe
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryRulesStatement;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryDataSourceRule;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.junit.Test;
 
@@ -32,23 +33,21 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class DatabaseDiscoveryRuleResultSetTest {
+public final class ShowDatabaseDiscoveryRuleExecutorTest {
     
     @Test
-    public void assertInit() {
+    public void assertGetRows() {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         DatabaseDiscoveryRule rule = mock(DatabaseDiscoveryRule.class, RETURNS_DEEP_STUBS);
         when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
@@ -56,19 +55,15 @@ public final class DatabaseDiscoveryRuleResultSetTest {
         when(dataSourceRule.getPrimaryDataSourceName()).thenReturn("ds_0");
         when(rule.getDataSourceRules()).thenReturn(Collections.singletonMap("ms_group", dataSourceRule));
         when(database.getRuleMetaData().findSingleRule(DatabaseDiscoveryRule.class)).thenReturn(Optional.of(rule));
-        DatabaseDistSQLResultSet resultSet = new DatabaseDiscoveryRuleResultSet();
-        resultSet.init(database, mock(ShowDatabaseDiscoveryRulesStatement.class));
-        assertColumns(resultSet.getColumnNames());
-        assertRowData(new ArrayList<>(resultSet.getRowData()));
+        RQLExecutor<ShowDatabaseDiscoveryRulesStatement> executor = new ShowDatabaseDiscoveryRuleExecutor();
+        assertColumns(executor.getColumnNames());
+        assertRowData(new ArrayList<>(executor.getRows(database, mock(ShowDatabaseDiscoveryRulesStatement.class))));
     }
     
     @Test
-    public void assertInitWithNullDatabaseDiscoveryRule() {
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
-        DatabaseDistSQLResultSet resultSet = new DatabaseDiscoveryRuleResultSet();
-        resultSet.init(database, mock(ShowDatabaseDiscoveryRulesStatement.class));
-        assertColumns(resultSet.getColumnNames());
-        assertFalse(resultSet.next());
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowDatabaseDiscoveryRulesStatement> executor = new ShowDatabaseDiscoveryRuleExecutor();
+        assertColumns(executor.getColumnNames());
     }
     
     private DatabaseDiscoveryRuleConfiguration createRuleConfiguration() {
@@ -85,12 +80,13 @@ public final class DatabaseDiscoveryRuleResultSetTest {
         assertTrue(actual.containsAll(Arrays.asList("group_name", "data_source_names", "primary_data_source_name", "discovery_type", "discovery_heartbeat")));
     }
     
-    private void assertRowData(final List<Object> actual) {
-        assertThat(actual.size(), is(5));
-        assertThat(actual.get(0), is("ms_group"));
-        assertThat(actual.get(1), is("ds_0,ds_1"));
-        assertThat(actual.get(2), is("ds_0"));
-        assertThat(actual.get(3).toString(), is("{name=type_test, type=MySQL.MGR, props={}}"));
-        assertThat(actual.get(4).toString(), is("{name=heartbeat_test, props={}}"));
+    private void assertRowData(final Collection<LocalDataQueryResultRow> actual) {
+        assertThat(actual.size(), is(1));
+        LocalDataQueryResultRow row = actual.iterator().next();
+        assertThat(row.getCell(1), is("ms_group"));
+        assertThat(row.getCell(2), is("ds_0,ds_1"));
+        assertThat(row.getCell(3), is("ds_0"));
+        assertThat(row.getCell(4).toString(), is("{name=type_test, type=MySQL.MGR, props={}}"));
+        assertThat(row.getCell(5).toString(), is("{name=heartbeat_test, props={}}"));
     }
 }

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
@@ -26,8 +26,6 @@ import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
 import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
-import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.junit.Test;
@@ -41,7 +39,6 @@ import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -58,11 +55,6 @@ public final class ShowDatabaseDiscoveryRuleExecutorTest {
         when(dataSourceRule.getPrimaryDataSourceName()).thenReturn("ds_0");
         when(rule.getDataSourceRules()).thenReturn(Collections.singletonMap("ms_group", dataSourceRule));
         when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
-        DatabaseDistSQLResultSet resultSet = new DatabaseDiscoveryRuleResultSet();
-        resultSet.init(database, mock(ShowDatabaseDiscoveryRulesStatement.class));
-        assertColumns(resultSet.getColumnNames());
-        assertRowData(new ArrayList<>(resultSet.getRowData()));
-        when(database.getRuleMetaData().findSingleRule(DatabaseDiscoveryRule.class)).thenReturn(Optional.of(rule));
         RQLExecutor<ShowDatabaseDiscoveryRulesStatement> executor = new ShowDatabaseDiscoveryRuleExecutor();
         assertColumns(executor.getColumnNames());
         assertRowData(new ArrayList<>(executor.getRows(database, mock(ShowDatabaseDiscoveryRulesStatement.class))));


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `DatabaseDiscoveryRuleResultSet` with `ShowDatabaseDiscoveryRuleExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
