### PR TITLE
Refactor `DatabaseDiscoveryTypeResultSet` 

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutor.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 import java.util.Map.Entry;
 
 /**
- * Result set for show database discovery type.
+ * Show database discovery type executor.
  */
 public final class ShowDatabaseDiscoveryTypeExecutor implements RQLExecutor<ShowDatabaseDiscoveryTypesStatement> {
     

--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutor.java
@@ -20,44 +20,37 @@ package org.apache.shardingsphere.dbdiscovery.distsql.handler.query;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryTypesStatement;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map.Entry;
 
 /**
  * Result set for show database discovery type.
  */
-public final class DatabaseDiscoveryTypeResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Entry<String, AlgorithmConfiguration>> data = Collections.emptyIterator();
+public final class ShowDatabaseDiscoveryTypeExecutor implements RQLExecutor<ShowDatabaseDiscoveryTypesStatement> {
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowDatabaseDiscoveryTypesStatement sqlStatement) {
         DatabaseDiscoveryRule rule = database.getRuleMetaData().getSingleRule(DatabaseDiscoveryRule.class);
-        data = ((DatabaseDiscoveryRuleConfiguration) rule.getConfiguration()).getDiscoveryTypes().entrySet().iterator();
+        Iterator<Entry<String, AlgorithmConfiguration>> data = ((DatabaseDiscoveryRuleConfiguration) rule.getConfiguration()).getDiscoveryTypes().entrySet().iterator();
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        while (data.hasNext()) {
+            Entry<String, AlgorithmConfiguration> entry = data.next();
+            result.add(new LocalDataQueryResultRow(entry.getKey(), entry.getValue().getType(), entry.getValue().getProps()));
+        }
+        return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
         return Arrays.asList("name", "type", "props");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        Entry<String, AlgorithmConfiguration> entry = data.next();
-        return Arrays.asList(entry.getKey(), entry.getValue().getType(), entry.getValue().getProps());
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryRuleExecutor
+org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryTypeExecutor

--- a/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -15,6 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.dbdiscovery.distsql.handler.query.DatabaseDiscoveryTypeResultSet
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.DatabaseDiscoveryHeartbeatResultSet
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.CountDatabaseDiscoveryRuleResultSet

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryTypeResultSetTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryTypeResultSetTest.java
@@ -19,22 +19,22 @@ package org.apache.shardingsphere.dbdiscovery.distsql.handler.query;
 
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
-import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryRulesStatement;
+import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryTypesStatement;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -51,15 +51,25 @@ public final class DatabaseDiscoveryTypeResultSetTest {
         DatabaseDiscoveryRule rule = mock(DatabaseDiscoveryRule.class);
         when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
         when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
-        DatabaseDistSQLResultSet resultSet = new DatabaseDiscoveryTypeResultSet();
-        resultSet.init(database, mock(ShowDatabaseDiscoveryRulesStatement.class));
-        Collection<String> columnNames = resultSet.getColumnNames();
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(columnNames.size(), is(3));
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("test_name"));
-        assertThat(actual.get(1), is("MySQL.MGR"));
-        assertThat(actual.get(2).toString(), is("{type_key=type_value}"));
+        RQLExecutor<ShowDatabaseDiscoveryTypesStatement> executor = new ShowDatabaseDiscoveryTypeExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(database, mock(ShowDatabaseDiscoveryTypesStatement.class));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("test_name"));
+        assertThat(row.getCell(2), is("MySQL.MGR"));
+        assertThat(row.getCell(3).toString(), is("{type_key=type_value}"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowDatabaseDiscoveryTypesStatement> executor = new ShowDatabaseDiscoveryTypeExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(3));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("name"));
+        assertThat(iterator.next(), is("type"));
+        assertThat(iterator.next(), is("props"));
     }
     
     private RuleConfiguration createRuleConfiguration() {

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutorTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryTypeExecutorTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class DatabaseDiscoveryTypeResultSetTest {
+public final class ShowDatabaseDiscoveryTypeExecutorTest {
     
     @Test
     public void assertGetRowData() {

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
@@ -274,8 +274,9 @@ public final class ContextManager implements AutoCloseable {
             MetaDataContexts reloadMetaDataContexts = createMetaDataContexts(databaseName, switchingResource, null);
             reloadMetaDataContexts.getMetaData().getDatabase(databaseName).getSchemas().forEach((schemaName, schema) -> reloadMetaDataContexts.getPersistService().getDatabaseMetaDataService()
                     .persist(reloadMetaDataContexts.getMetaData().getActualDatabaseName(databaseName), schemaName, schema));
-            Optional.ofNullable(reloadMetaDataContexts.getShardingSphereData().getDatabaseData().get(databaseName)).ifPresent(optional -> optional.getSchemaData().forEach((schemaName, schemaData) ->
-                    reloadMetaDataContexts.getPersistService().getShardingSphereDataPersistService().persist(databaseName, schemaName, schemaData, metaDataContexts.getMetaData().getDatabases())));
+            Optional.ofNullable(reloadMetaDataContexts.getShardingSphereData().getDatabaseData().get(databaseName))
+                    .ifPresent(optional -> optional.getSchemaData().forEach((schemaName, schemaData) -> reloadMetaDataContexts.getPersistService().getShardingSphereDataPersistService()
+                            .persist(databaseName, schemaName, schemaData, metaDataContexts.getMetaData().getDatabases())));
             alterSchemaMetaData(databaseName, reloadMetaDataContexts.getMetaData().getDatabase(databaseName), metaDataContexts.getMetaData().getDatabase(databaseName));
             metaDataContexts = reloadMetaDataContexts;
             metaDataContexts.getMetaData().getDatabases().putAll(newShardingSphereDatabase(metaDataContexts.getMetaData().getDatabase(databaseName)));


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `DatabaseDiscoveryTypeResultSet` with `ShowDatabaseDiscoveryTypeExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
