### PR TITLE
Refactor `DatabaseDiscoveryHeartbeatResultSet`

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryHeartbeatExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryHeartbeatExecutor.java
@@ -21,44 +21,37 @@ import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleCon
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryHeartBeatConfiguration;
 import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryHeartbeatsStatement;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.Map.Entry;
 
 /**
- * Result set for show database discovery heartbeat.
+ * Show database discovery heartbeat executor.
  */
-public final class DatabaseDiscoveryHeartbeatResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Entry<String, DatabaseDiscoveryHeartBeatConfiguration>> data = Collections.emptyIterator();
+public final class ShowDatabaseDiscoveryHeartbeatExecutor implements RQLExecutor<ShowDatabaseDiscoveryHeartbeatsStatement> {
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowDatabaseDiscoveryHeartbeatsStatement sqlStatement) {
         DatabaseDiscoveryRule rule = database.getRuleMetaData().getSingleRule(DatabaseDiscoveryRule.class);
         DatabaseDiscoveryRuleConfiguration ruleConfig = (DatabaseDiscoveryRuleConfiguration) rule.getConfiguration();
-        data = ruleConfig.getDiscoveryHeartbeats().entrySet().iterator();
+        Iterator<Entry<String, DatabaseDiscoveryHeartBeatConfiguration>> data = ruleConfig.getDiscoveryHeartbeats().entrySet().iterator();
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        while (data.hasNext()) {
+            Entry<String, DatabaseDiscoveryHeartBeatConfiguration> entry = data.next();
+            result.add(new LocalDataQueryResultRow(entry.getKey(), entry.getValue().getProps().toString()));
+        }
+        return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
         return Arrays.asList("name", "props");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        Entry<String, DatabaseDiscoveryHeartBeatConfiguration> entry = data.next();
-        return Arrays.asList(entry.getKey(), entry.getValue().getProps());
     }
     
     @Override

--- a/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryRuleExecutor
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryTypeExecutor
+org.apache.shardingsphere.dbdiscovery.distsql.handler.query.ShowDatabaseDiscoveryHeartbeatExecutor

--- a/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/db-discovery/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -15,5 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.dbdiscovery.distsql.handler.query.DatabaseDiscoveryHeartbeatResultSet
 org.apache.shardingsphere.dbdiscovery.distsql.handler.query.CountDatabaseDiscoveryRuleResultSet

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryHeartbeatResultSetTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/DatabaseDiscoveryHeartbeatResultSetTest.java
@@ -20,21 +20,21 @@ package org.apache.shardingsphere.dbdiscovery.distsql.handler.query;
 import org.apache.shardingsphere.dbdiscovery.api.config.DatabaseDiscoveryRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryDataSourceRuleConfiguration;
 import org.apache.shardingsphere.dbdiscovery.api.config.rule.DatabaseDiscoveryHeartBeatConfiguration;
-import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryRulesStatement;
+import org.apache.shardingsphere.dbdiscovery.distsql.parser.statement.ShowDatabaseDiscoveryHeartbeatsStatement;
 import org.apache.shardingsphere.dbdiscovery.rule.DatabaseDiscoveryRule;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -51,14 +51,23 @@ public final class DatabaseDiscoveryHeartbeatResultSetTest {
         DatabaseDiscoveryRule rule = mock(DatabaseDiscoveryRule.class);
         when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
         when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
-        DatabaseDistSQLResultSet resultSet = new DatabaseDiscoveryHeartbeatResultSet();
-        resultSet.init(database, mock(ShowDatabaseDiscoveryRulesStatement.class));
-        Collection<String> columnNames = resultSet.getColumnNames();
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(columnNames.size(), is(2));
-        assertThat(actual.size(), is(2));
-        assertThat(actual.get(0), is("test_name"));
-        assertThat(actual.get(1).toString(), is("{type_key=type_value}"));
+        RQLExecutor<ShowDatabaseDiscoveryHeartbeatsStatement> executor = new ShowDatabaseDiscoveryHeartbeatExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(database, mock(ShowDatabaseDiscoveryHeartbeatsStatement.class));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("test_name"));
+        assertThat(row.getCell(2), is("{type_key=type_value}"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowDatabaseDiscoveryHeartbeatsStatement> executor = new ShowDatabaseDiscoveryHeartbeatExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(2));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("name"));
+        assertThat(iterator.next(), is("props"));
     }
     
     private RuleConfiguration createRuleConfiguration() {

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryHeartbeatExecutorTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryHeartbeatExecutorTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class DatabaseDiscoveryHeartbeatResultSetTest {
+public final class ShowDatabaseDiscoveryHeartbeatExecutorTest {
     
     @Test
     public void assertGetRowData() {


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `DatabaseDiscoveryHeartbeatResultSet` with `ShowDatabaseDiscoveryHeartbeatExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
