### PR TITLE
Replace `EncryptRuleResultSet` with `ShowEncryptRuleExecutor`

### DIFF
--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutor.java
@@ -45,7 +45,6 @@ public final class ShowEncryptRuleExecutor implements RQLExecutor<ShowEncryptRul
     public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowEncryptRulesStatement sqlStatement) {
         Optional<EncryptRule> rule = database.getRuleMetaData().findSingleRule(EncryptRule.class);
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
-        
         if (rule.isPresent()) {
             result = buildData((EncryptRuleConfiguration) rule.get().getConfiguration(), sqlStatement);
         }

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutor.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutor.java
@@ -17,21 +17,19 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.query;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.distsql.parser.statement.ShowEncryptRulesStatement;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.props.PropertiesConverter;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
@@ -39,31 +37,34 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * Result set for show encrypt rule.
+ * Show encrypt rule executor.
  */
-public final class EncryptRuleResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Collection<Object>> data = Collections.emptyIterator();
+public final class ShowEncryptRuleExecutor implements RQLExecutor<ShowEncryptRulesStatement> {
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowEncryptRulesStatement sqlStatement) {
         Optional<EncryptRule> rule = database.getRuleMetaData().findSingleRule(EncryptRule.class);
-        rule.ifPresent(optional -> data = buildData((EncryptRuleConfiguration) optional.getConfiguration(), (ShowEncryptRulesStatement) sqlStatement).iterator());
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        
+        if (rule.isPresent()) {
+            result = buildData((EncryptRuleConfiguration) rule.get().getConfiguration(), sqlStatement);
+        }
+        return result;
     }
     
-    private Collection<Collection<Object>> buildData(final EncryptRuleConfiguration ruleConfig, final ShowEncryptRulesStatement sqlStatement) {
+    private Collection<LocalDataQueryResultRow> buildData(final EncryptRuleConfiguration ruleConfig, final ShowEncryptRulesStatement sqlStatement) {
         return ruleConfig.getTables().stream().filter(each -> Objects.isNull(sqlStatement.getTableName()) || each.getName().equals(sqlStatement.getTableName()))
                 .map(each -> buildColumnData(each, ruleConfig.getEncryptors(), ruleConfig.isQueryWithCipherColumn())).flatMap(Collection::stream).collect(Collectors.toList());
     }
     
-    private Collection<Collection<Object>> buildColumnData(final EncryptTableRuleConfiguration tableRuleConfig, final Map<String, AlgorithmConfiguration> algorithmMap,
-                                                           final boolean queryWithCipherColumn) {
-        Collection<Collection<Object>> result = new LinkedList<>();
+    private Collection<LocalDataQueryResultRow> buildColumnData(final EncryptTableRuleConfiguration tableRuleConfig, final Map<String, AlgorithmConfiguration> algorithmMap,
+                                                                final boolean queryWithCipherColumn) {
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         tableRuleConfig.getColumns().forEach(each -> {
             AlgorithmConfiguration encryptorAlgorithmConfig = algorithmMap.get(each.getEncryptorName());
             AlgorithmConfiguration assistedQueryEncryptorAlgorithmConfig = algorithmMap.get(each.getAssistedQueryEncryptorName());
             AlgorithmConfiguration likeQueryEncryptorAlgorithmConfig = algorithmMap.get(each.getLikeQueryEncryptorName());
-            result.add(Arrays.asList(tableRuleConfig.getName(), each.getLogicColumn(),
+            result.add(new LocalDataQueryResultRow(Arrays.asList(tableRuleConfig.getName(), each.getLogicColumn(),
                     each.getCipherColumn(),
                     nullToEmptyString(each.getPlainColumn()),
                     nullToEmptyString(each.getAssistedQueryColumn()),
@@ -73,7 +74,7 @@ public final class EncryptRuleResultSet implements DatabaseDistSQLResultSet {
                     Objects.isNull(assistedQueryEncryptorAlgorithmConfig) ? nullToEmptyString(null) : PropertiesConverter.convert(assistedQueryEncryptorAlgorithmConfig.getProps()),
                     Objects.isNull(likeQueryEncryptorAlgorithmConfig) ? nullToEmptyString(null) : likeQueryEncryptorAlgorithmConfig.getType(),
                     Objects.isNull(likeQueryEncryptorAlgorithmConfig) ? nullToEmptyString(null) : PropertiesConverter.convert(likeQueryEncryptorAlgorithmConfig.getProps()),
-                    isQueryWithCipherColumn(queryWithCipherColumn, tableRuleConfig, each).toString()));
+                    isQueryWithCipherColumn(queryWithCipherColumn, tableRuleConfig, each).toString())));
         });
         return result;
     }
@@ -97,16 +98,6 @@ public final class EncryptRuleResultSet implements DatabaseDistSQLResultSet {
         return Arrays.asList("table", "logic_column", "cipher_column", "plain_column",
                 "assisted_query_column", "like_query_column", "encryptor_type", "encryptor_props",
                 "assisted_query_type", "assisted_query_props", "like_query_type", "like_query_props", "query_with_cipher_column");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        return data.next();
     }
     
     @Override

--- a/features/encrypt/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/encrypt/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.encrypt.distsql.handler.query.CountEncryptRuleResultSet
+org.apache.shardingsphere.encrypt.distsql.handler.query.ShowEncryptRuleExecutor

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutorTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/query/ShowEncryptRuleExecutorTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.query;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
@@ -25,37 +25,66 @@ import org.apache.shardingsphere.encrypt.distsql.parser.statement.ShowEncryptRul
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class EncryptRuleResultSetTest {
+public final class ShowEncryptRuleExecutorTest {
     
     @Test
     public void assertGetRowData() {
         ShardingSphereDatabase database = mockDatabase();
-        DatabaseDistSQLResultSet resultSet = new EncryptRuleResultSet();
-        resultSet.init(database, mock(ShowEncryptRulesStatement.class));
-        Collection<Object> actual = resultSet.getRowData();
-        assertThat(actual.size(), is(13));
-        assertTrue(actual.contains("t_encrypt"));
-        assertTrue(actual.contains("user_id"));
-        assertTrue(actual.contains("user_cipher"));
-        assertTrue(actual.contains("user_plain"));
-        assertTrue(actual.contains("user_assisted"));
-        assertTrue(actual.contains("user_like"));
-        assertTrue(actual.contains("md5"));
+        RQLExecutor<ShowEncryptRulesStatement> executor = new ShowEncryptRuleExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(database, mock(ShowEncryptRulesStatement.class));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("t_encrypt"));
+        assertThat(row.getCell(2), is("user_id"));
+        assertThat(row.getCell(3), is("user_cipher"));
+        assertThat(row.getCell(4), is("user_plain"));
+        assertThat(row.getCell(5), is("user_assisted"));
+        assertThat(row.getCell(6), is("user_like"));
+        assertThat(row.getCell(7), is("md5"));
+        assertThat(row.getCell(8), is(""));
+        assertThat(row.getCell(9), is(""));
+        assertThat(row.getCell(10), is(""));
+        assertThat(row.getCell(11), is(""));
+        assertThat(row.getCell(12), is(""));
+        assertThat(row.getCell(13), is("true"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowEncryptRulesStatement> executor = new ShowEncryptRuleExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(13));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("table"));
+        assertThat(iterator.next(), is("logic_column"));
+        assertThat(iterator.next(), is("cipher_column"));
+        assertThat(iterator.next(), is("plain_column"));
+        assertThat(iterator.next(), is("assisted_query_column"));
+        assertThat(iterator.next(), is("like_query_column"));
+        assertThat(iterator.next(), is("encryptor_type"));
+        assertThat(iterator.next(), is("encryptor_props"));
+        assertThat(iterator.next(), is("assisted_query_type"));
+        assertThat(iterator.next(), is("assisted_query_props"));
+        assertThat(iterator.next(), is("like_query_type"));
+        assertThat(iterator.next(), is("like_query_props"));
+        assertThat(iterator.next(), is("query_with_cipher_column"));
     }
     
     private ShardingSphereDatabase mockDatabase() {


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `EncryptRuleResultSet` with `ShowEncryptRuleExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
