### PR TITLE
Refactor `ReadwriteSplittingRuleResultSet`

### DIFF
--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
@@ -18,44 +18,43 @@
 package org.apache.shardingsphere.readwritesplitting.distsql.handler.query;
 
 import com.google.common.base.Joiner;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.rule.identifier.type.exportable.constant.ExportableConstants;
 import org.apache.shardingsphere.infra.rule.identifier.type.exportable.constant.ExportableItemConstants;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.props.PropertiesConverter;
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.api.rule.ReadwriteSplittingDataSourceRuleConfiguration;
 import org.apache.shardingsphere.readwritesplitting.distsql.parser.statement.ShowReadwriteSplittingRulesStatement;
 import org.apache.shardingsphere.readwritesplitting.rule.ReadwriteSplittingRule;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Optional;
 
 /**
- * Result set for show readwrite splitting rule.
+ * Show readwrite splitting rule executor.
  */
-public final class ReadwriteSplittingRuleResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Collection<Object>> data = Collections.emptyIterator();
+public final class ShowReadwriteSplittingRuleExecutor implements RQLExecutor<ShowReadwriteSplittingRulesStatement> {
     
     private Map<String, Map<String, String>> exportableAutoAwareDataSource = Collections.emptyMap();
     
     private Map<String, Map<String, String>> exportableDataSourceMap = Collections.emptyMap();
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowReadwriteSplittingRulesStatement sqlStatement) {
         Optional<ReadwriteSplittingRule> rule = database.getRuleMetaData().findSingleRule(ReadwriteSplittingRule.class);
-        rule.ifPresent(optional -> {
-            buildExportableMap(optional);
-            data = buildData(optional).iterator();
-        });
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        if (rule.isPresent()) {
+            buildExportableMap(rule.get());
+            result = buildData(rule.get());
+        }
+        return result;
     }
     
     @SuppressWarnings("unchecked")
@@ -65,20 +64,20 @@ public final class ReadwriteSplittingRuleResultSet implements DatabaseDistSQLRes
         exportableDataSourceMap = (Map<String, Map<String, String>>) exportedData.get(ExportableConstants.EXPORT_STATIC_READWRITE_SPLITTING_RULE);
     }
     
-    private Collection<Collection<Object>> buildData(final ReadwriteSplittingRule rule) {
-        Collection<Collection<Object>> result = new LinkedList<>();
+    private Collection<LocalDataQueryResultRow> buildData(final ReadwriteSplittingRule rule) {
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         ((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()).getDataSources().forEach(each -> {
-            Collection<Object> dataItem = buildDataItem(each, getLoadBalancers((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()));
+            LocalDataQueryResultRow dataItem = buildDataItem(each, getLoadBalancers((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()));
             result.add(dataItem);
         });
         return result;
     }
     
-    private Collection<Object> buildDataItem(final ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig, final Map<String, AlgorithmConfiguration> loadBalancers) {
+    private LocalDataQueryResultRow buildDataItem(final ReadwriteSplittingDataSourceRuleConfiguration dataSourceRuleConfig, final Map<String, AlgorithmConfiguration> loadBalancers) {
         String name = dataSourceRuleConfig.getName();
         Map<String, String> exportDataSources = null == dataSourceRuleConfig.getDynamicStrategy() ? exportableDataSourceMap.get(name) : exportableAutoAwareDataSource.get(name);
         Optional<AlgorithmConfiguration> loadBalancer = Optional.ofNullable(loadBalancers.get(dataSourceRuleConfig.getLoadBalancerName()));
-        return Arrays.asList(name,
+        return new LocalDataQueryResultRow(name,
                 getAutoAwareDataSourceName(dataSourceRuleConfig),
                 getWriteDataSourceQueryEnabled(dataSourceRuleConfig),
                 getWriteDataSourceName(dataSourceRuleConfig, exportDataSources),
@@ -114,16 +113,6 @@ public final class ReadwriteSplittingRuleResultSet implements DatabaseDistSQLRes
     public Collection<String> getColumnNames() {
         return Arrays.asList("name", "auto_aware_data_source_name", "write_data_source_query_enabled",
                 "write_storage_unit_name", "read_storage_unit_names", "load_balancer_type", "load_balancer_props");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        return data.next();
     }
     
     @Override

--- a/features/readwrite-splitting/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/readwrite-splitting/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.readwritesplitting.distsql.handler.query.CountReadwriteSplittingRuleResultSet
+org.apache.shardingsphere.readwritesplitting.distsql.handler.query.ShowReadwriteSplittingRuleExecutor


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `ReadwriteSplittingRuleResultSet` with `ShowReadwriteSplittingRuleExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
