### PR TITLE
Migration support for tables without primary key

### DIFF
--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
@@ -27,9 +27,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum DataConsistencyCheckIgnoredType {
     
-    UNKNOWN("Unknown data consistency check ignored type"),
-    
-    NONE_PRIMARY_KEY("Data consistency check are not supported for tables without primary keys");
+    NO_UNIQUE_KEY("Data consistency check are not supported for tables without unique key");
     
     private final String message;
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
@@ -21,15 +21,15 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Data consistency ignore type.
+ * Data consistency check ignored type.
  */
 @RequiredArgsConstructor
 @Getter
 public enum DataConsistencyCheckIgnoredType {
     
-    UNKNOWN("Unknown ignored type"),
+    UNKNOWN("Unknown data consistency check ignored type"),
     
-    NONE_PRIMARY_KEY("Data consistency checks are not supported for tables without primary keys");
+    NONE_PRIMARY_KEY("Data consistency check are not supported for tables without primary keys");
     
     private final String message;
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckIgnoredType.java
@@ -15,39 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.api.job.progress;
+package org.apache.shardingsphere.data.pipeline.api.check.consistency;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
-
-import java.util.Map;
 
 /**
- * Data consistency check job item progress.
+ * Data consistency ignore type.
  */
-// TODO move package
-@Getter
 @RequiredArgsConstructor
-@ToString
-public final class ConsistencyCheckJobItemProgress implements PipelineJobItemProgress {
+@Getter
+public enum DataConsistencyCheckIgnoredType {
     
-    @Setter
-    private JobStatus status = JobStatus.RUNNING;
+    UNKNOWN("Unknown ignored type"),
     
-    private final String tableNames;
+    NONE_PRIMARY_KEY("Data consistency checks are not supported for tables without primary keys");
     
-    private final String ignoredTableNames;
-    
-    private final Long checkedRecordsCount;
-    
-    private final Long recordsCount;
-    
-    private final Long checkBeginTimeMillis;
-    
-    private final Long checkEndTimeMillis;
-    
-    private final Map<String, Object> tableCheckPositions;
+    private final String message;
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
@@ -27,20 +27,20 @@ import lombok.ToString;
 @ToString
 public final class DataConsistencyCheckResult {
     
-    private final DataConsistencyCheckIgnoredType checkIgnoredType;
+    private final DataConsistencyCheckIgnoredType ignoredType;
     
     private final DataConsistencyCountCheckResult countCheckResult;
     
     private final DataConsistencyContentCheckResult contentCheckResult;
     
     public DataConsistencyCheckResult(final DataConsistencyCountCheckResult countCheckResult, final DataConsistencyContentCheckResult contentCheckResult) {
-        checkIgnoredType = null;
+        ignoredType = null;
         this.countCheckResult = countCheckResult;
         this.contentCheckResult = contentCheckResult;
     }
     
-    public DataConsistencyCheckResult(final DataConsistencyCheckIgnoredType checkIgnoredType) {
-        this.checkIgnoredType = checkIgnoredType;
+    public DataConsistencyCheckResult(final DataConsistencyCheckIgnoredType ignoredType) {
+        this.ignoredType = ignoredType;
         countCheckResult = null;
         contentCheckResult = null;
     }
@@ -51,7 +51,7 @@ public final class DataConsistencyCheckResult {
      * @return ignored or not
      */
     public boolean isIgnored() {
-        return checkIgnoredType != null;
+        return null != ignoredType;
     }
     
     /**
@@ -60,7 +60,7 @@ public final class DataConsistencyCheckResult {
      * @return matched or not
      */
     public boolean isMatched() {
-        if (null != checkIgnoredType) {
+        if (null != ignoredType) {
             return false;
         }
         return countCheckResult.isMatched() && contentCheckResult.isMatched();

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
@@ -18,13 +18,11 @@
 package org.apache.shardingsphere.data.pipeline.api.check.consistency;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 /**
  * Data consistency check result.
  */
-@RequiredArgsConstructor
 @Getter
 @ToString
 public final class DataConsistencyCheckResult {
@@ -33,12 +31,33 @@ public final class DataConsistencyCheckResult {
     
     private final DataConsistencyContentCheckResult contentCheckResult;
     
+    private final DataConsistencyCheckIgnoredType checkIgnoredType;
+    
+    private final boolean ignored;
+    
+    public DataConsistencyCheckResult(final DataConsistencyCountCheckResult countCheckResult, final DataConsistencyContentCheckResult contentCheckResult) {
+        this.countCheckResult = countCheckResult;
+        this.contentCheckResult = contentCheckResult;
+        checkIgnoredType = null;
+        ignored = false;
+    }
+    
+    public DataConsistencyCheckResult(final DataConsistencyCheckIgnoredType checkIgnoredType) {
+        this.checkIgnoredType = checkIgnoredType;
+        ignored = true;
+        countCheckResult = null;
+        contentCheckResult = null;
+    }
+    
     /**
      * Is count and content matched.
      *
      * @return matched or not
      */
     public boolean isMatched() {
+        if (ignored || null == countCheckResult || null == contentCheckResult) {
+            return false;
+        }
         return countCheckResult.isMatched() && contentCheckResult.isMatched();
     }
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/check/consistency/DataConsistencyCheckResult.java
@@ -27,26 +27,31 @@ import lombok.ToString;
 @ToString
 public final class DataConsistencyCheckResult {
     
+    private final DataConsistencyCheckIgnoredType checkIgnoredType;
+    
     private final DataConsistencyCountCheckResult countCheckResult;
     
     private final DataConsistencyContentCheckResult contentCheckResult;
     
-    private final DataConsistencyCheckIgnoredType checkIgnoredType;
-    
-    private final boolean ignored;
-    
     public DataConsistencyCheckResult(final DataConsistencyCountCheckResult countCheckResult, final DataConsistencyContentCheckResult contentCheckResult) {
+        checkIgnoredType = null;
         this.countCheckResult = countCheckResult;
         this.contentCheckResult = contentCheckResult;
-        checkIgnoredType = null;
-        ignored = false;
     }
     
     public DataConsistencyCheckResult(final DataConsistencyCheckIgnoredType checkIgnoredType) {
         this.checkIgnoredType = checkIgnoredType;
-        ignored = true;
         countCheckResult = null;
         contentCheckResult = null;
+    }
+    
+    /**
+     * Is ignored.
+     *
+     * @return ignored or not
+     */
+    public boolean isIgnored() {
+        return checkIgnoredType != null;
     }
     
     /**
@@ -55,7 +60,7 @@ public final class DataConsistencyCheckResult {
      * @return matched or not
      */
     public boolean isMatched() {
-        if (ignored || null == countCheckResult || null == contentCheckResult) {
+        if (null != checkIgnoredType) {
             return false;
         }
         return countCheckResult.isMatched() && contentCheckResult.isMatched();

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NoUniqueKeyPosition.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NoUniqueKeyPosition.java
@@ -20,25 +20,23 @@ package org.apache.shardingsphere.data.pipeline.api.ingest.position;
 import lombok.RequiredArgsConstructor;
 
 /**
- * None primary key position.
+ * No unique key position.
  */
 @RequiredArgsConstructor
-public final class NonePrimaryKeyPosition extends PrimaryKeyPosition<Integer> implements IngestPosition<NonePrimaryKeyPosition> {
-    
-    private final int offset;
+public final class NoUniqueKeyPosition extends PrimaryKeyPosition<Void> implements IngestPosition<NoUniqueKeyPosition> {
     
     @Override
-    public Integer getBeginValue() {
-        return offset;
+    public Void getBeginValue() {
+        return null;
     }
     
     @Override
-    public Integer getEndValue() {
-        return Integer.MAX_VALUE;
+    public Void getEndValue() {
+        return null;
     }
     
     @Override
-    protected Integer convert(final String value) {
+    protected Void convert(final String value) {
         throw new UnsupportedOperationException();
     }
     
@@ -48,7 +46,7 @@ public final class NonePrimaryKeyPosition extends PrimaryKeyPosition<Integer> im
     }
     
     @Override
-    public int compareTo(final NonePrimaryKeyPosition position) {
+    public int compareTo(final NoUniqueKeyPosition position) {
         return 0;
     }
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NonePrimaryKeyPosition.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NonePrimaryKeyPosition.java
@@ -39,7 +39,7 @@ public final class NonePrimaryKeyPosition extends PrimaryKeyPosition<Integer> im
     
     @Override
     protected Integer convert(final String value) {
-        return null;
+        throw new UnsupportedOperationException();
     }
     
     @Override

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NonePrimaryKeyPosition.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/NonePrimaryKeyPosition.java
@@ -15,39 +15,40 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.data.pipeline.api.job.progress;
+package org.apache.shardingsphere.data.pipeline.api.ingest.position;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
-
-import java.util.Map;
 
 /**
- * Data consistency check job item progress.
+ * None primary key position.
  */
-// TODO move package
-@Getter
 @RequiredArgsConstructor
-@ToString
-public final class ConsistencyCheckJobItemProgress implements PipelineJobItemProgress {
+public final class NonePrimaryKeyPosition extends PrimaryKeyPosition<Integer> implements IngestPosition<NonePrimaryKeyPosition> {
     
-    @Setter
-    private JobStatus status = JobStatus.RUNNING;
+    private final int offset;
     
-    private final String tableNames;
+    @Override
+    public Integer getBeginValue() {
+        return offset;
+    }
     
-    private final String ignoredTableNames;
+    @Override
+    public Integer getEndValue() {
+        return Integer.MAX_VALUE;
+    }
     
-    private final Long checkedRecordsCount;
+    @Override
+    protected Integer convert(final String value) {
+        return null;
+    }
     
-    private final Long recordsCount;
+    @Override
+    protected char getType() {
+        return 'n';
+    }
     
-    private final Long checkBeginTimeMillis;
-    
-    private final Long checkEndTimeMillis;
-    
-    private final Map<String, Object> tableCheckPositions;
+    @Override
+    public int compareTo(final NonePrimaryKeyPosition position) {
+        return 0;
+    }
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/PrimaryKeyPositionFactory.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/PrimaryKeyPositionFactory.java
@@ -44,7 +44,7 @@ public final class PrimaryKeyPositionFactory {
             case 's':
                 return new StringPrimaryKeyPosition(beginValue, endValue);
             case 'n':
-                return new NonePrimaryKeyPosition(Integer.parseInt(beginValue));
+                return new NoUniqueKeyPosition();
             default:
                 throw new IllegalArgumentException("Unknown primary key position type: " + type);
         }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/PrimaryKeyPositionFactory.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/ingest/position/PrimaryKeyPositionFactory.java
@@ -43,6 +43,8 @@ public final class PrimaryKeyPositionFactory {
                 return new IntegerPrimaryKeyPosition(Long.parseLong(beginValue), Long.parseLong(endValue));
             case 's':
                 return new StringPrimaryKeyPosition(beginValue, endValue);
+            case 'n':
+                return new NonePrimaryKeyPosition(Integer.parseInt(beginValue));
             default:
                 throw new IllegalArgumentException("Unknown primary key position type: " + type);
         }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/pojo/ConsistencyCheckJobItemInfo.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/pojo/ConsistencyCheckJobItemInfo.java
@@ -35,13 +35,13 @@ public final class ConsistencyCheckJobItemInfo {
     
     private int finishedPercentage;
     
-    private Long remainingSeconds;
+    private long remainingSeconds;
     
     private String checkBeginTime;
     
     private String checkEndTime;
     
-    private Long durationSeconds;
+    private long durationSeconds;
     
     private String errorMessage;
 }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sqlbuilder/PipelineSQLBuilder.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sqlbuilder/PipelineSQLBuilder.java
@@ -151,6 +151,14 @@ public interface PipelineSQLBuilder extends TypedSPI {
     String buildSplitByPrimaryKeyRangeSQL(String schemaName, String tableName, String primaryKey);
     
     /**
+     * Build select offset SQL.
+     * @param schemaName schema name
+     * @param tableName tableName
+     * @return select offset SQL
+     */
+    String buildSelectOffsetSQL(String schemaName, String tableName);
+    
+    /**
      * Build CRC32 SQL.
      *
      * @param schemaName schema name

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sqlbuilder/PipelineSQLBuilder.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/spi/sqlbuilder/PipelineSQLBuilder.java
@@ -65,6 +65,15 @@ public interface PipelineSQLBuilder extends TypedSPI {
     String buildIndivisibleInventoryDumpSQL(String schemaName, String tableName, String uniqueKey, int uniqueKeyDataType, boolean firstQuery);
     
     /**
+     * Build inventory dump all SQL.
+     *
+     * @param schemaName schema name
+     * @param tableName tableName
+     * @return inventory dump all SQL
+     */
+    String buildInventoryDumpAllSQL(String schemaName, String tableName);
+    
+    /**
      * Build insert SQL.
      *
      * @param schemaName schema name
@@ -149,14 +158,6 @@ public interface PipelineSQLBuilder extends TypedSPI {
      * @return split SQL
      */
     String buildSplitByPrimaryKeyRangeSQL(String schemaName, String tableName, String primaryKey);
-    
-    /**
-     * Build select offset SQL.
-     * @param schemaName schema name
-     * @param tableName tableName
-     * @return select offset SQL
-     */
-    String buildSelectOffsetSQL(String schemaName, String tableName);
     
     /**
      * Build CRC32 SQL.

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/ConsistencyCheckJobItemProgressContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/ConsistencyCheckJobItemProgressContext.java
@@ -44,6 +44,8 @@ public final class ConsistencyCheckJobItemProgressContext implements PipelineJob
     
     private final Collection<String> tableNames = new CopyOnWriteArraySet<>();
     
+    private final Collection<String> ignoredTableNames = new CopyOnWriteArraySet<>();
+    
     private volatile long recordsCount;
     
     private final AtomicLong checkedRecordsCount = new AtomicLong(0);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataRecordMerger.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataRecordMerger.java
@@ -76,8 +76,8 @@ public final class DataRecordMerger {
      * @return grouped data records
      */
     public List<GroupedDataRecord> group(final List<DataRecord> dataRecords) {
-        List<DataRecord> mergedDataRecords = merge(dataRecords);
         List<GroupedDataRecord> result = new ArrayList<>(100);
+        List<DataRecord> mergedDataRecords = dataRecords.get(0).getUniqueKeyValue().isEmpty() ? dataRecords : merge(dataRecords);
         Map<String, List<DataRecord>> tableGroup = mergedDataRecords.stream().collect(Collectors.groupingBy(DataRecord::getTableName));
         for (Entry<String, List<DataRecord>> entry : tableGroup.entrySet()) {
             Map<String, List<DataRecord>> typeGroup = entry.getValue().stream().collect(Collectors.groupingBy(DataRecord::getType));

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataSourceImporter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataSourceImporter.java
@@ -109,6 +109,9 @@ public final class DataSourceImporter extends AbstractLifecycleExecutor implemen
     private PipelineJobProgressUpdatedParameter flush(final DataSource dataSource, final List<Record> buffer) {
         List<DataRecord> dataRecords = buffer.stream().filter(each -> each instanceof DataRecord).map(each -> (DataRecord) each).collect(Collectors.toList());
         int insertRecordNumber = 0;
+        if (dataRecords.isEmpty()) {
+            return new PipelineJobProgressUpdatedParameter(insertRecordNumber);
+        }
         for (DataRecord each : dataRecords) {
             if (IngestDataChangeType.INSERT.equals(each.getType())) {
                 insertRecordNumber++;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataSourceImporter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/importer/DataSourceImporter.java
@@ -110,7 +110,7 @@ public final class DataSourceImporter extends AbstractLifecycleExecutor implemen
         List<DataRecord> dataRecords = buffer.stream().filter(each -> each instanceof DataRecord).map(each -> (DataRecord) each).collect(Collectors.toList());
         int insertRecordNumber = 0;
         if (dataRecords.isEmpty()) {
-            return new PipelineJobProgressUpdatedParameter(insertRecordNumber);
+            return new PipelineJobProgressUpdatedParameter(0);
         }
         for (DataRecord each : dataRecords) {
             if (IngestDataChangeType.INSERT.equals(each.getType())) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/InventoryDumper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/ingest/dumper/InventoryDumper.java
@@ -119,6 +119,9 @@ public final class InventoryDumper extends AbstractLifecycleExecutor implements 
     
     private String buildInventoryDumpSQL(final boolean firstQuery) {
         String schemaName = dumperConfig.getSchemaName(new LogicTableName(dumperConfig.getLogicTableName()));
+        if (null == dumperConfig.getUniqueKey()) {
+            return sqlBuilder.buildSelectOffsetSQL(schemaName, dumperConfig.getActualTableName());
+        }
         if (PipelineJdbcUtils.isIntegerColumn(dumperConfig.getUniqueKeyDataType())) {
             return sqlBuilder.buildDivisibleInventoryDumpSQL(schemaName, dumperConfig.getActualTableName(), dumperConfig.getUniqueKey(), dumperConfig.getUniqueKeyDataType(), firstQuery);
         }
@@ -142,8 +145,12 @@ public final class InventoryDumper extends AbstractLifecycleExecutor implements 
                 Object maxUniqueKeyValue = null;
                 while (resultSet.next()) {
                     channel.pushRecord(loadDataRecord(resultSet, resultSetMetaData, tableMetaData));
-                    maxUniqueKeyValue = columnValueReader.readValue(resultSet, resultSetMetaData, tableMetaData.getColumnMetaData(dumperConfig.getUniqueKey()).getOrdinalPosition());
                     rowCount++;
+                    if (null == dumperConfig.getUniqueKey()) {
+                        maxUniqueKeyValue = rowCount + (int) beginUniqueKeyValue;
+                    } else {
+                        maxUniqueKeyValue = columnValueReader.readValue(resultSet, resultSetMetaData, tableMetaData.getColumnMetaData(dumperConfig.getUniqueKey()).getOrdinalPosition());
+                    }
                     if (!isRunning()) {
                         log.info("Broke because of inventory dump is not running.");
                         break;
@@ -160,6 +167,11 @@ public final class InventoryDumper extends AbstractLifecycleExecutor implements 
     
     private void setParameters(final PreparedStatement preparedStatement, final int batchSize, final Object beginUniqueKeyValue) throws SQLException {
         preparedStatement.setFetchSize(batchSize);
+        if (null == dumperConfig.getUniqueKey()) {
+            preparedStatement.setInt(1, batchSize);
+            preparedStatement.setObject(2, beginUniqueKeyValue);
+            return;
+        }
         if (PipelineJdbcUtils.isIntegerColumn(dumperConfig.getUniqueKeyDataType())) {
             preparedStatement.setObject(1, beginUniqueKeyValue);
             preparedStatement.setObject(2, ((PrimaryKeyPosition<?>) dumperConfig.getPosition()).getEndValue());

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlConsistencyCheckJobItemProgress.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlConsistencyCheckJobItemProgress.java
@@ -34,6 +34,8 @@ public final class YamlConsistencyCheckJobItemProgress implements YamlConfigurat
     
     private String tableNames;
     
+    private String ignoredTableNames;
+    
     private Long checkedRecordsCount;
     
     private Long recordsCount;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlConsistencyCheckJobItemProgressSwapper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/progress/yaml/YamlConsistencyCheckJobItemProgressSwapper.java
@@ -34,6 +34,7 @@ public final class YamlConsistencyCheckJobItemProgressSwapper implements YamlCon
         YamlConsistencyCheckJobItemProgress result = new YamlConsistencyCheckJobItemProgress();
         result.setStatus(data.getStatus().name());
         result.setTableNames(data.getTableNames());
+        result.setIgnoredTableNames(data.getIgnoredTableNames());
         result.setCheckedRecordsCount(data.getCheckedRecordsCount());
         result.setRecordsCount(data.getRecordsCount());
         result.setCheckBeginTimeMillis(data.getCheckBeginTimeMillis());
@@ -48,7 +49,7 @@ public final class YamlConsistencyCheckJobItemProgressSwapper implements YamlCon
         if (null != yamlConfig.getTableCheckPositions()) {
             tableCheckPositions.putAll(yamlConfig.getTableCheckPositions());
         }
-        ConsistencyCheckJobItemProgress result = new ConsistencyCheckJobItemProgress(yamlConfig.getTableNames(), yamlConfig.getCheckedRecordsCount(),
+        ConsistencyCheckJobItemProgress result = new ConsistencyCheckJobItemProgress(yamlConfig.getTableNames(), yamlConfig.getIgnoredTableNames(), yamlConfig.getCheckedRecordsCount(),
                 yamlConfig.getRecordsCount(), yamlConfig.getCheckBeginTimeMillis(), yamlConfig.getCheckEndTimeMillis(), tableCheckPositions);
         result.setStatus(JobStatus.valueOf(yamlConfig.getStatus()));
         return result;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/PipelineTableMetaDataUtil.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/PipelineTableMetaDataUtil.java
@@ -46,10 +46,10 @@ public final class PipelineTableMetaDataUtil {
      */
     public static Optional<PipelineColumnMetaData> getUniqueKeyColumn(final String schemaName, final String tableName, final PipelineTableMetaDataLoader metaDataLoader) {
         PipelineTableMetaData pipelineTableMetaData = metaDataLoader.getTableMetaData(schemaName, tableName);
-        return Optional.ofNullable(mustGetAnAppropriateUniqueKeyColumn(pipelineTableMetaData, tableName));
+        return Optional.ofNullable(getAnAppropriateUniqueKeyColumn(pipelineTableMetaData, tableName));
     }
     
-    private static PipelineColumnMetaData mustGetAnAppropriateUniqueKeyColumn(final PipelineTableMetaData tableMetaData, final String tableName) {
+    private static PipelineColumnMetaData getAnAppropriateUniqueKeyColumn(final PipelineTableMetaData tableMetaData, final String tableName) {
         ShardingSpherePreconditions.checkNotNull(tableMetaData, () -> new SplitPipelineJobByRangeException(tableName, "Can not get table meta data"));
         List<String> primaryKeys = tableMetaData.getPrimaryKeyColumns();
         if (1 == primaryKeys.size()) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/PipelineTableMetaDataUtil.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/loader/PipelineTableMetaDataUtil.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.infra.util.exception.ShardingSpherePrecondition
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Pipeline table meta data util.
@@ -43,9 +44,9 @@ public final class PipelineTableMetaDataUtil {
      * @param metaDataLoader meta data loader
      * @return pipeline column meta data
      */
-    public static PipelineColumnMetaData getUniqueKeyColumn(final String schemaName, final String tableName, final PipelineTableMetaDataLoader metaDataLoader) {
+    public static Optional<PipelineColumnMetaData> getUniqueKeyColumn(final String schemaName, final String tableName, final PipelineTableMetaDataLoader metaDataLoader) {
         PipelineTableMetaData pipelineTableMetaData = metaDataLoader.getTableMetaData(schemaName, tableName);
-        return mustGetAnAppropriateUniqueKeyColumn(pipelineTableMetaData, tableName);
+        return Optional.ofNullable(mustGetAnAppropriateUniqueKeyColumn(pipelineTableMetaData, tableName));
     }
     
     private static PipelineColumnMetaData mustGetAnAppropriateUniqueKeyColumn(final PipelineTableMetaData tableMetaData, final String tableName) {
@@ -54,7 +55,9 @@ public final class PipelineTableMetaDataUtil {
         if (1 == primaryKeys.size()) {
             return tableMetaData.getColumnMetaData(tableMetaData.getPrimaryKeyColumns().get(0));
         }
-        ShardingSpherePreconditions.checkState(primaryKeys.isEmpty(), () -> new SplitPipelineJobByRangeException(tableName, "primary key is union primary"));
+        if (primaryKeys.isEmpty()) {
+            return null;
+        }
         Collection<PipelineIndexMetaData> uniqueIndexes = tableMetaData.getUniqueIndexes();
         ShardingSpherePreconditions.checkState(!uniqueIndexes.isEmpty(), () -> new SplitPipelineJobByRangeException(tableName, "no primary key or unique index"));
         if (1 == uniqueIndexes.size() && 1 == uniqueIndexes.iterator().next().getColumns().size()) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
@@ -166,15 +166,16 @@ public final class InventoryTaskSplitter {
     
     private Collection<IngestPosition<?>> getPositionByNonePrimaryKey(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
                                                                       final InventoryDumperConfiguration dumperConfig) {
-        long tableCount = getTableCount(jobItemContext, dataSource, dumperConfig);
-        jobItemContext.updateInventoryRecordsCount(tableCount);
+        long tableRecordsCount = getTableRecordsCount(jobItemContext, dataSource, dumperConfig);
+        jobItemContext.updateInventoryRecordsCount(tableRecordsCount);
         return Collections.singletonList(new NonePrimaryKeyPosition(0));
     }
     
-    private long getTableCount(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource, final InventoryDumperConfiguration dumperConfig) {
+    private long getTableRecordsCount(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource, final InventoryDumperConfiguration dumperConfig) {
         PipelineJobConfiguration jobConfig = jobItemContext.getJobConfig();
         String schemaName = dumperConfig.getSchemaName(new LogicTableName(dumperConfig.getLogicTableName()));
         String actualTableName = dumperConfig.getActualTableName();
+        // TODO with a large amount of data, count the full table will have performance problem
         String sql = TypedSPILoader.getService(PipelineSQLBuilder.class, jobConfig.getSourceDatabaseType()).buildCountSQL(schemaName, actualTableName);
         try (
                 Connection connection = dataSource.getConnection();
@@ -230,8 +231,8 @@ public final class InventoryTaskSplitter {
     
     private Collection<IngestPosition<?>> getPositionByStringPrimaryKeyRange(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
                                                                              final InventoryDumperConfiguration dumperConfig) {
-        long tableCount = getTableCount(jobItemContext, dataSource, dumperConfig);
-        jobItemContext.updateInventoryRecordsCount(tableCount);
+        long tableRecordsCount = getTableRecordsCount(jobItemContext, dataSource, dumperConfig);
+        jobItemContext.updateInventoryRecordsCount(tableRecordsCount);
         Collection<IngestPosition<?>> result = new LinkedList<>();
         result.add(new StringPrimaryKeyPosition("!", "~"));
         return result;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.data.pipeline.api.config.process.PipelineReadCo
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceWrapper;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IngestPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IntegerPrimaryKeyPosition;
-import org.apache.shardingsphere.data.pipeline.api.ingest.position.NonePrimaryKeyPosition;
+import org.apache.shardingsphere.data.pipeline.api.ingest.position.NoUniqueKeyPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.PlaceholderPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.StringPrimaryKeyPosition;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
@@ -168,7 +168,7 @@ public final class InventoryTaskSplitter {
                                                                       final InventoryDumperConfiguration dumperConfig) {
         long tableRecordsCount = getTableRecordsCount(jobItemContext, dataSource, dumperConfig);
         jobItemContext.updateInventoryRecordsCount(tableRecordsCount);
-        return Collections.singletonList(new NonePrimaryKeyPosition(0));
+        return Collections.singletonList(new NoUniqueKeyPosition());
     }
     
     private long getTableRecordsCount(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource, final InventoryDumperConfiguration dumperConfig) {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.core.prepare;
 
+import com.google.common.base.Strings;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.config.ImporterConfiguration;
@@ -26,6 +27,7 @@ import org.apache.shardingsphere.data.pipeline.api.config.process.PipelineReadCo
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceWrapper;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IngestPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.IntegerPrimaryKeyPosition;
+import org.apache.shardingsphere.data.pipeline.api.ingest.position.NonePrimaryKeyPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.PlaceholderPosition;
 import org.apache.shardingsphere.data.pipeline.api.ingest.position.StringPrimaryKeyPosition;
 import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
@@ -50,8 +52,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Inventory data task splitter.
@@ -112,9 +116,11 @@ public final class InventoryTaskSplitter {
         if (null == dumperConfig.getUniqueKey()) {
             String schemaName = dumperConfig.getSchemaName(new LogicTableName(dumperConfig.getLogicTableName()));
             String actualTableName = dumperConfig.getActualTableName();
-            PipelineColumnMetaData uniqueKeyColumn = PipelineTableMetaDataUtil.getUniqueKeyColumn(schemaName, actualTableName, jobItemContext.getSourceMetaDataLoader());
-            dumperConfig.setUniqueKey(uniqueKeyColumn.getName());
-            dumperConfig.setUniqueKeyDataType(uniqueKeyColumn.getDataType());
+            Optional<PipelineColumnMetaData> uniqueKeyColumn = PipelineTableMetaDataUtil.getUniqueKeyColumn(schemaName, actualTableName, jobItemContext.getSourceMetaDataLoader());
+            uniqueKeyColumn.ifPresent(column -> {
+                dumperConfig.setUniqueKey(column.getName());
+                dumperConfig.setUniqueKeyDataType(column.getDataType());
+            });
         }
         Collection<InventoryDumperConfiguration> result = new LinkedList<>();
         InventoryIncrementalProcessContext jobProcessContext = jobItemContext.getJobProcessContext();
@@ -123,9 +129,9 @@ public final class InventoryTaskSplitter {
         JobRateLimitAlgorithm rateLimitAlgorithm = jobProcessContext.getReadRateLimitAlgorithm();
         Collection<IngestPosition<?>> inventoryPositions = getInventoryPositions(jobItemContext, dumperConfig, dataSource);
         int i = 0;
-        for (IngestPosition<?> inventoryPosition : inventoryPositions) {
+        for (IngestPosition<?> each : inventoryPositions) {
             InventoryDumperConfiguration splitDumperConfig = new InventoryDumperConfiguration(dumperConfig);
-            splitDumperConfig.setPosition(inventoryPosition);
+            splitDumperConfig.setPosition(each);
             splitDumperConfig.setShardingItem(i++);
             splitDumperConfig.setActualTableName(dumperConfig.getActualTableName());
             splitDumperConfig.setLogicTableName(dumperConfig.getLogicTableName());
@@ -145,6 +151,9 @@ public final class InventoryTaskSplitter {
             // Do NOT filter FinishedPosition here, since whole inventory tasks are required in job progress when persisting to register center.
             return initProgress.getInventory().getInventoryPosition(dumperConfig.getActualTableName()).values();
         }
+        if (Strings.isNullOrEmpty(dumperConfig.getUniqueKey())) {
+            return getPositionByNonePrimaryKey(jobItemContext, dataSource, dumperConfig);
+        }
         int uniqueKeyDataType = dumperConfig.getUniqueKeyDataType();
         if (PipelineJdbcUtils.isIntegerColumn(uniqueKeyDataType)) {
             return getPositionByIntegerPrimaryKeyRange(jobItemContext, dataSource, dumperConfig);
@@ -153,6 +162,30 @@ public final class InventoryTaskSplitter {
             return getPositionByStringPrimaryKeyRange(jobItemContext, dataSource, dumperConfig);
         }
         throw new SplitPipelineJobByRangeException(dumperConfig.getActualTableName(), "primary key is not integer or string type");
+    }
+    
+    private Collection<IngestPosition<?>> getPositionByNonePrimaryKey(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
+                                                                      final InventoryDumperConfiguration dumperConfig) {
+        long tableCount = getTableCount(jobItemContext, dataSource, dumperConfig);
+        jobItemContext.updateInventoryRecordsCount(tableCount);
+        return Collections.singletonList(new NonePrimaryKeyPosition(0));
+    }
+    
+    private long getTableCount(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource, final InventoryDumperConfiguration dumperConfig) {
+        PipelineJobConfiguration jobConfig = jobItemContext.getJobConfig();
+        String schemaName = dumperConfig.getSchemaName(new LogicTableName(dumperConfig.getLogicTableName()));
+        String actualTableName = dumperConfig.getActualTableName();
+        String sql = TypedSPILoader.getService(PipelineSQLBuilder.class, jobConfig.getSourceDatabaseType()).buildCountSQL(schemaName, actualTableName);
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+            try (ResultSet resultSet = preparedStatement.executeQuery()) {
+                resultSet.next();
+                return resultSet.getLong(1);
+            }
+        } catch (final SQLException ex) {
+            throw new SplitPipelineJobByUniqueKeyException(dumperConfig.getActualTableName(), dumperConfig.getUniqueKey(), ex);
+        }
     }
     
     private Collection<IngestPosition<?>> getPositionByIntegerPrimaryKeyRange(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
@@ -197,20 +230,8 @@ public final class InventoryTaskSplitter {
     
     private Collection<IngestPosition<?>> getPositionByStringPrimaryKeyRange(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
                                                                              final InventoryDumperConfiguration dumperConfig) {
-        PipelineJobConfiguration jobConfig = jobItemContext.getJobConfig();
-        String schemaName = dumperConfig.getSchemaName(new LogicTableName(dumperConfig.getLogicTableName()));
-        String actualTableName = dumperConfig.getActualTableName();
-        String sql = TypedSPILoader.getService(PipelineSQLBuilder.class, jobConfig.getSourceDatabaseType()).buildCountSQL(schemaName, actualTableName);
-        try (
-                Connection connection = dataSource.getConnection();
-                PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-            try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                resultSet.next();
-                jobItemContext.updateInventoryRecordsCount(resultSet.getLong(1));
-            }
-        } catch (final SQLException ex) {
-            throw new SplitPipelineJobByUniqueKeyException(dumperConfig.getActualTableName(), dumperConfig.getUniqueKey(), ex);
-        }
+        long tableCount = getTableCount(jobItemContext, dataSource, dumperConfig);
+        jobItemContext.updateInventoryRecordsCount(tableCount);
         Collection<IngestPosition<?>> result = new LinkedList<>();
         result.add(new StringPrimaryKeyPosition("!", "~"));
         return result;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/InventoryTaskSplitter.java
@@ -152,7 +152,7 @@ public final class InventoryTaskSplitter {
             return initProgress.getInventory().getInventoryPosition(dumperConfig.getActualTableName()).values();
         }
         if (Strings.isNullOrEmpty(dumperConfig.getUniqueKey())) {
-            return getPositionByNonePrimaryKey(jobItemContext, dataSource, dumperConfig);
+            return getPositionWithoutUniqueKey(jobItemContext, dataSource, dumperConfig);
         }
         int uniqueKeyDataType = dumperConfig.getUniqueKeyDataType();
         if (PipelineJdbcUtils.isIntegerColumn(uniqueKeyDataType)) {
@@ -164,7 +164,7 @@ public final class InventoryTaskSplitter {
         throw new SplitPipelineJobByRangeException(dumperConfig.getActualTableName(), "primary key is not integer or string type");
     }
     
-    private Collection<IngestPosition<?>> getPositionByNonePrimaryKey(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
+    private Collection<IngestPosition<?>> getPositionWithoutUniqueKey(final InventoryIncrementalJobItemContext jobItemContext, final DataSource dataSource,
                                                                       final InventoryDumperConfiguration dumperConfig) {
         long tableRecordsCount = getTableRecordsCount(jobItemContext, dataSource, dumperConfig);
         jobItemContext.updateInventoryRecordsCount(tableRecordsCount);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/AbstractPipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/AbstractPipelineSQLBuilder.java
@@ -190,4 +190,10 @@ public abstract class AbstractPipelineSQLBuilder implements PipelineSQLBuilder {
         return String.format("SELECT MAX(%s),COUNT(*) FROM (SELECT %s FROM %s WHERE %s>=? ORDER BY %s LIMIT ?) t",
                 quotedUniqueKey, quotedUniqueKey, getQualifiedTableName(schemaName, tableName), quotedUniqueKey, quotedUniqueKey);
     }
+    
+    @Override
+    public String buildSelectOffsetSQL(final String schemaName, final String tableName) {
+        String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
+        return String.format("SELECT * FROM %s LIMIT ? OFFSET ?", qualifiedTableName);
+    }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/AbstractPipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sqlbuilder/AbstractPipelineSQLBuilder.java
@@ -192,8 +192,8 @@ public abstract class AbstractPipelineSQLBuilder implements PipelineSQLBuilder {
     }
     
     @Override
-    public String buildSelectOffsetSQL(final String schemaName, final String tableName) {
+    public String buildInventoryDumpAllSQL(final String schemaName, final String tableName) {
         String qualifiedTableName = getQualifiedTableName(schemaName, tableName);
-        return String.format("SELECT * FROM %s LIMIT ? OFFSET ?", qualifiedTableName);
+        return String.format("SELECT * FROM %s", qualifiedTableName);
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResult.java
@@ -32,6 +32,10 @@ public final class YamlDataConsistencyCheckResult implements YamlConfiguration {
     
     private YamlDataConsistencyContentCheckResult contentCheckResult;
     
+    private String checkIgnoredType;
+    
+    private boolean ignored;
+    
     /**
      * YAML data consistency count result.
      */

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResult.java
@@ -32,9 +32,7 @@ public final class YamlDataConsistencyCheckResult implements YamlConfiguration {
     
     private YamlDataConsistencyContentCheckResult contentCheckResult;
     
-    private String checkIgnoredType;
-    
-    private boolean ignored;
+    private String ignoredType;
     
     /**
      * YAML data consistency count result.

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResultSwapper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResultSwapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.yaml.consistency;
 
+import com.google.common.base.Strings;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckIgnoredType;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyContentCheckResult;
@@ -35,8 +36,7 @@ public final class YamlDataConsistencyCheckResultSwapper implements YamlConfigur
     public YamlDataConsistencyCheckResult swapToYamlConfiguration(final DataConsistencyCheckResult data) {
         YamlDataConsistencyCheckResult result = new YamlDataConsistencyCheckResult();
         if (data.isIgnored()) {
-            result.setIgnored(true);
-            result.setCheckIgnoredType(data.getCheckIgnoredType().name());
+            result.setIgnoredType(data.getIgnoredType().name());
             return result;
         }
         YamlDataConsistencyCountCheckResult countCheckResult = new YamlDataConsistencyCountCheckResult();
@@ -55,8 +55,8 @@ public final class YamlDataConsistencyCheckResultSwapper implements YamlConfigur
         if (null == yamlConfig) {
             return null;
         }
-        if (yamlConfig.isIgnored()) {
-            return new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.valueOf(yamlConfig.getCheckIgnoredType()));
+        if (!Strings.isNullOrEmpty(yamlConfig.getIgnoredType())) {
+            return new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.valueOf(yamlConfig.getIgnoredType()));
         }
         YamlDataConsistencyCountCheckResult yamlCountCheck = yamlConfig.getCountCheckResult();
         DataConsistencyCountCheckResult countCheckResult = new DataConsistencyCountCheckResult(yamlCountCheck.getSourceRecordsCount(), yamlCountCheck.getTargetRecordsCount());

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResultSwapper.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/yaml/consistency/YamlDataConsistencyCheckResultSwapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.data.pipeline.yaml.consistency;
 
+import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckIgnoredType;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyContentCheckResult;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCountCheckResult;
@@ -32,11 +33,16 @@ public final class YamlDataConsistencyCheckResultSwapper implements YamlConfigur
     
     @Override
     public YamlDataConsistencyCheckResult swapToYamlConfiguration(final DataConsistencyCheckResult data) {
+        YamlDataConsistencyCheckResult result = new YamlDataConsistencyCheckResult();
+        if (data.isIgnored()) {
+            result.setIgnored(true);
+            result.setCheckIgnoredType(data.getCheckIgnoredType().name());
+            return result;
+        }
         YamlDataConsistencyCountCheckResult countCheckResult = new YamlDataConsistencyCountCheckResult();
         countCheckResult.setSourceRecordsCount(data.getCountCheckResult().getSourceRecordsCount());
         countCheckResult.setTargetRecordsCount(data.getCountCheckResult().getTargetRecordsCount());
         countCheckResult.setMatched(data.getContentCheckResult().isMatched());
-        YamlDataConsistencyCheckResult result = new YamlDataConsistencyCheckResult();
         result.setCountCheckResult(countCheckResult);
         YamlDataConsistencyContentCheckResult contentCheckResult = new YamlDataConsistencyContentCheckResult();
         contentCheckResult.setMatched(data.getContentCheckResult().isMatched());
@@ -48,6 +54,9 @@ public final class YamlDataConsistencyCheckResultSwapper implements YamlConfigur
     public DataConsistencyCheckResult swapToObject(final YamlDataConsistencyCheckResult yamlConfig) {
         if (null == yamlConfig) {
             return null;
+        }
+        if (yamlConfig.isIgnored()) {
+            return new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.valueOf(yamlConfig.getCheckIgnoredType()));
         }
         YamlDataConsistencyCountCheckResult yamlCountCheck = yamlConfig.getCountCheckResult();
         DataConsistencyCountCheckResult countCheckResult = new DataConsistencyCountCheckResult(yamlCountCheck.getSourceRecordsCount(), yamlCountCheck.getTargetRecordsCount());

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/fixture/FixturePipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/fixture/FixturePipelineSQLBuilder.java
@@ -89,6 +89,11 @@ public final class FixturePipelineSQLBuilder implements PipelineSQLBuilder {
     }
     
     @Override
+    public String buildSelectOffsetSQL(final String schemaName, final String tableName) {
+        return "";
+    }
+    
+    @Override
     public String getType() {
         return "FIXTURE";
     }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/fixture/FixturePipelineSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/fixture/FixturePipelineSQLBuilder.java
@@ -89,7 +89,7 @@ public final class FixturePipelineSQLBuilder implements PipelineSQLBuilder {
     }
     
     @Override
-    public String buildSelectOffsetSQL(final String schemaName, final String tableName) {
+    public String buildInventoryDumpAllSQL(final String schemaName, final String tableName) {
         return "";
     }
     

--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusResultSet.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusResultSet.java
@@ -26,8 +26,9 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -42,13 +43,17 @@ public final class ShowMigrationCheckStatusResultSet implements DatabaseDistSQLR
     @Override
     public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
         ShowMigrationCheckStatusStatement checkMigrationStatement = (ShowMigrationCheckStatusStatement) sqlStatement;
-        ConsistencyCheckJobItemInfo info = jobAPI.getJobItemInfo(checkMigrationStatement.getJobId());
-        String checkResult = null == info.getCheckSuccess() ? "" : info.getCheckSuccess().toString();
-        Collection<Object> result = Arrays.asList(Optional.ofNullable(info.getTableNames()).orElse(""), checkResult,
-                String.valueOf(info.getFinishedPercentage()), info.getRemainingSeconds(),
-                Optional.ofNullable(info.getCheckBeginTime()).orElse(""), Optional.ofNullable(info.getCheckEndTime()).orElse(""),
-                info.getDurationSeconds(), Optional.ofNullable(info.getErrorMessage()).orElse(""));
-        data = Collections.singletonList(result).iterator();
+        List<ConsistencyCheckJobItemInfo> infos = jobAPI.getJobItemInfos(checkMigrationStatement.getJobId());
+        Collection<Collection<Object>> result = new LinkedList<>();
+        for (ConsistencyCheckJobItemInfo each : infos) {
+            String checkResult = null == each.getCheckSuccess() ? "" : each.getCheckSuccess().toString();
+            Collection<Object> item = Arrays.asList(Optional.ofNullable(each.getTableNames()).orElse(""), checkResult,
+                    String.valueOf(each.getFinishedPercentage()), each.getRemainingSeconds(),
+                    Optional.ofNullable(each.getCheckBeginTime()).orElse(""), Optional.ofNullable(each.getCheckEndTime()).orElse(""),
+                    each.getDurationSeconds(), Optional.ofNullable(each.getErrorMessage()).orElse(""));
+            result.add(item);
+        }
+        data = result.iterator();
     }
     
     @Override

--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusResultSet.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusResultSet.java
@@ -46,14 +46,17 @@ public final class ShowMigrationCheckStatusResultSet implements DatabaseDistSQLR
         List<ConsistencyCheckJobItemInfo> infos = jobAPI.getJobItemInfos(checkMigrationStatement.getJobId());
         Collection<Collection<Object>> result = new LinkedList<>();
         for (ConsistencyCheckJobItemInfo each : infos) {
-            String checkResult = null == each.getCheckSuccess() ? "" : each.getCheckSuccess().toString();
-            Collection<Object> item = Arrays.asList(Optional.ofNullable(each.getTableNames()).orElse(""), checkResult,
-                    String.valueOf(each.getFinishedPercentage()), each.getRemainingSeconds(),
-                    Optional.ofNullable(each.getCheckBeginTime()).orElse(""), Optional.ofNullable(each.getCheckEndTime()).orElse(""),
-                    each.getDurationSeconds(), Optional.ofNullable(each.getErrorMessage()).orElse(""));
-            result.add(item);
+            result.add(convert(each));
         }
         data = result.iterator();
+    }
+    
+    private Collection<Object> convert(final ConsistencyCheckJobItemInfo info) {
+        String checkResult = null == info.getCheckSuccess() ? "" : info.getCheckSuccess().toString();
+        return Arrays.asList(Optional.ofNullable(info.getTableNames()).orElse(""), checkResult,
+                String.valueOf(info.getFinishedPercentage()), info.getRemainingSeconds(),
+                Optional.ofNullable(info.getCheckBeginTime()).orElse(""), Optional.ofNullable(info.getCheckEndTime()).orElse(""),
+                info.getDurationSeconds(), Optional.ofNullable(info.getErrorMessage()).orElse(""));
     }
     
     @Override

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/impl/ConsistencyCheckJobAPI.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/impl/ConsistencyCheckJobAPI.java
@@ -256,7 +256,7 @@ public final class ConsistencyCheckJobAPI extends AbstractPipelineJobAPIImpl {
             info.setCheckSuccess(false);
             DataConsistencyCheckResult checkResult = checkJobResult.get(each);
             if (null != checkResult && checkResult.isIgnored()) {
-                info.setErrorMessage(checkResult.getCheckIgnoredType().getMessage());
+                info.setErrorMessage(checkResult.getIgnoredType().getMessage());
             }
             result.add(info);
         }

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/impl/ConsistencyCheckJobAPI.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/api/impl/ConsistencyCheckJobAPI.java
@@ -245,6 +245,24 @@ public final class ConsistencyCheckJobAPI extends AbstractPipelineJobAPIImpl {
         return result;
     }
     
+    private List<ConsistencyCheckJobItemInfo> buildIgnoredTableInfo(final String[] ignoredTables, final Map<String, DataConsistencyCheckResult> checkJobResult) {
+        if (null == ignoredTables) {
+            return Collections.emptyList();
+        }
+        List<ConsistencyCheckJobItemInfo> result = new LinkedList<>();
+        for (String each : ignoredTables) {
+            ConsistencyCheckJobItemInfo info = new ConsistencyCheckJobItemInfo();
+            info.setTableNames(each);
+            info.setCheckSuccess(false);
+            DataConsistencyCheckResult checkResult = checkJobResult.get(each);
+            if (null != checkResult && checkResult.isIgnored()) {
+                info.setErrorMessage(checkResult.getCheckIgnoredType().getMessage());
+            }
+            result.add(info);
+        }
+        return result;
+    }
+    
     private ConsistencyCheckJobItemInfo getJobItemInfo(final String parentJobId) {
         Optional<String> latestCheckJobId = PipelineAPIFactory.getGovernanceRepositoryAPI().getLatestCheckJobId(parentJobId);
         ShardingSpherePreconditions.checkState(latestCheckJobId.isPresent(), () -> new ConsistencyCheckJobNotFoundException(parentJobId));
@@ -290,24 +308,6 @@ public final class ConsistencyCheckJobAPI extends AbstractPipelineJobAPIImpl {
         InventoryIncrementalJobAPI inventoryIncrementalJobAPI = (InventoryIncrementalJobAPI) TypedSPILoader.getService(
                 PipelineJobAPI.class, PipelineJobIdUtils.parseJobType(parentJobId).getTypeName());
         result.setCheckSuccess(inventoryIncrementalJobAPI.aggregateDataConsistencyCheckResults(parentJobId, checkJobResult));
-        return result;
-    }
-    
-    private List<ConsistencyCheckJobItemInfo> buildIgnoredTableInfo(final String[] ignoredTables, final Map<String, DataConsistencyCheckResult> checkJobResult) {
-        if (null == ignoredTables) {
-            return Collections.emptyList();
-        }
-        List<ConsistencyCheckJobItemInfo> result = new LinkedList<>();
-        for (String each : ignoredTables) {
-            ConsistencyCheckJobItemInfo info = new ConsistencyCheckJobItemInfo();
-            info.setTableNames(each);
-            info.setCheckSuccess(false);
-            DataConsistencyCheckResult checkResult = checkJobResult.get(each);
-            if (null != checkResult && checkResult.isIgnored()) {
-                info.setErrorMessage(checkResult.getCheckIgnoredType().getMessage());
-            }
-            result.add(info);
-        }
         return result;
     }
     

--- a/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/api/impl/MigrationJobAPI.java
+++ b/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/api/impl/MigrationJobAPI.java
@@ -74,7 +74,6 @@ import org.apache.shardingsphere.data.pipeline.spi.job.JobTypeFactory;
 import org.apache.shardingsphere.data.pipeline.spi.sqlbuilder.PipelineSQLBuilder;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.yaml.job.YamlMigrationJobConfigurationSwapper;
-import org.apache.shardingsphere.data.pipeline.yaml.metadata.YamlPipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.yaml.metadata.YamlPipelineColumnMetaDataSwapper;
 import org.apache.shardingsphere.elasticjob.infra.pojo.JobConfigurationPOJO;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
@@ -446,9 +445,8 @@ public final class MigrationJobAPI extends AbstractInventoryIncrementalJobAPIImp
         result.setTargetTableName(param.getTargetTableName());
         try (PipelineDataSourceWrapper dataSource = PipelineDataSourceFactory.newInstance(sourceDataSourceConfig)) {
             StandardPipelineTableMetaDataLoader metaDataLoader = new StandardPipelineTableMetaDataLoader(dataSource);
-            YamlPipelineColumnMetaData uniqueKeyColumn = new YamlPipelineColumnMetaDataSwapper().swapToYamlConfiguration(
-                    PipelineTableMetaDataUtil.getUniqueKeyColumn(sourceSchemaName, param.getSourceTableName(), metaDataLoader));
-            result.setUniqueKeyColumn(uniqueKeyColumn);
+            PipelineTableMetaDataUtil.getUniqueKeyColumn(sourceSchemaName, param.getSourceTableName(), metaDataLoader)
+                    .ifPresent(optional -> result.setUniqueKeyColumn(new YamlPipelineColumnMetaDataSwapper().swapToYamlConfiguration(optional)));
         } catch (final SQLException ex) {
             throw new RuntimeException(ex);
         }

--- a/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/check/consistency/MigrationDataConsistencyChecker.java
+++ b/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/check/consistency/MigrationDataConsistencyChecker.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.scenario.migration.check.consistency;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckIgnoredType;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.DataConsistencyCheckResult;
 import org.apache.shardingsphere.data.pipeline.api.check.consistency.PipelineDataConsistencyChecker;
 import org.apache.shardingsphere.data.pipeline.api.config.TableNameSchemaNameMapping;
@@ -77,12 +78,17 @@ public final class MigrationDataConsistencyChecker implements PipelineDataConsis
         verifyPipelineDatabaseType(calculateAlgorithm, jobConfig.getTarget());
         SchemaTableName sourceTable = new SchemaTableName(new SchemaName(tableNameSchemaNameMapping.getSchemaName(jobConfig.getSourceTableName())), new TableName(jobConfig.getSourceTableName()));
         SchemaTableName targetTable = new SchemaTableName(new SchemaName(tableNameSchemaNameMapping.getSchemaName(jobConfig.getTargetTableName())), new TableName(jobConfig.getTargetTableName()));
+        progressContext.getTableNames().add(jobConfig.getSourceTableName());
         Map<String, DataConsistencyCheckResult> result = new LinkedHashMap<>();
+        if (null == jobConfig.getUniqueKeyColumn()) {
+            progressContext.getIgnoredTableNames().add(sourceTable.getTableName().getOriginal());
+            result.put(sourceTable.getTableName().getOriginal(), new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.NONE_PRIMARY_KEY));
+            return result;
+        }
         try (
                 PipelineDataSourceWrapper sourceDataSource = PipelineDataSourceFactory.newInstance(jobConfig.getSource());
                 PipelineDataSourceWrapper targetDataSource = PipelineDataSourceFactory.newInstance(jobConfig.getTarget())) {
             progressContext.setRecordsCount(getRecordsCount());
-            progressContext.getTableNames().add(jobConfig.getSourceTableName());
             PipelineTableMetaDataLoader metaDataLoader = new StandardPipelineTableMetaDataLoader(sourceDataSource);
             SingleTableInventoryDataConsistencyChecker singleTableInventoryChecker = new SingleTableInventoryDataConsistencyChecker(
                     jobConfig.getJobId(), sourceDataSource, targetDataSource, sourceTable, targetTable, jobConfig.getUniqueKeyColumn(), metaDataLoader, readRateLimitAlgorithm, progressContext);

--- a/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/check/consistency/MigrationDataConsistencyChecker.java
+++ b/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/check/consistency/MigrationDataConsistencyChecker.java
@@ -82,7 +82,7 @@ public final class MigrationDataConsistencyChecker implements PipelineDataConsis
         Map<String, DataConsistencyCheckResult> result = new LinkedHashMap<>();
         if (null == jobConfig.getUniqueKeyColumn()) {
             progressContext.getIgnoredTableNames().add(sourceTable.getTableName().getOriginal());
-            result.put(sourceTable.getTableName().getOriginal(), new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.NONE_PRIMARY_KEY));
+            result.put(sourceTable.getTableName().getOriginal(), new DataConsistencyCheckResult(DataConsistencyCheckIgnoredType.NO_UNIQUE_KEY));
             return result;
         }
         try (

--- a/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/prepare/MigrationJobPreparer.java
+++ b/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/prepare/MigrationJobPreparer.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.data.pipeline.api.job.JobStatus;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncrementalJobItemProgress;
 import org.apache.shardingsphere.data.pipeline.api.job.progress.JobItemIncrementalTasksProgress;
 import org.apache.shardingsphere.data.pipeline.api.metadata.loader.PipelineTableMetaDataLoader;
-import org.apache.shardingsphere.data.pipeline.api.metadata.model.PipelineColumnMetaData;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PrepareJobWithGetBinlogPositionException;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
@@ -148,9 +147,10 @@ public final class MigrationJobPreparer {
     
     private void initInventoryTasks(final MigrationJobItemContext jobItemContext) {
         InventoryDumperConfiguration inventoryDumperConfig = new InventoryDumperConfiguration(jobItemContext.getTaskConfig().getDumperConfig());
-        PipelineColumnMetaData uniqueKeyColumn = jobItemContext.getJobConfig().getUniqueKeyColumn();
-        inventoryDumperConfig.setUniqueKey(uniqueKeyColumn.getName());
-        inventoryDumperConfig.setUniqueKeyDataType(uniqueKeyColumn.getDataType());
+        Optional.ofNullable(jobItemContext.getJobConfig().getUniqueKeyColumn()).ifPresent(uniqueKeyColumn -> {
+            inventoryDumperConfig.setUniqueKey(uniqueKeyColumn.getName());
+            inventoryDumperConfig.setUniqueKeyDataType(uniqueKeyColumn.getDataType());
+        });
         InventoryTaskSplitter inventoryTaskSplitter = new InventoryTaskSplitter(jobItemContext.getSourceDataSource(), inventoryDumperConfig, jobItemContext.getTaskConfig().getImporterConfig());
         jobItemContext.getInventoryTasks().addAll(inventoryTaskSplitter.splitInventoryData(jobItemContext));
     }

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.general
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.shardingsphere.data.pipeline.core.util.ThreadUtil;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.sharding.algorithm.keygen.SnowflakeKeyGenerateAlgorithm;
 import org.apache.shardingsphere.test.e2e.data.pipeline.cases.base.PipelineBaseE2EIT;
@@ -39,6 +40,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -97,6 +99,7 @@ public final class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
         assertMigrationSuccessById(orderJobId, "DATA_MATCH");
         String orderItemJobId = getJobIdByTableName("t_order_item");
         assertMigrationSuccessById(orderItemJobId, "DATA_MATCH");
+        ThreadUtil.sleep(2, TimeUnit.SECONDS);
         assertMigrationSuccessById(orderItemJobId, "CRC32_MATCH");
         for (String each : listJobId()) {
             commitMigrationByJobId(each);

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NoUniqueKeyMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NoUniqueKeyMigrationE2EIT.java
@@ -43,11 +43,11 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 @Slf4j
-public final class NonePrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
+public final class NoUniqueKeyMigrationE2EIT extends AbstractMigrationE2EIT {
     
     private final PipelineTestParameter testParam;
     
-    public NonePrimaryKeyMigrationE2EIT(final PipelineTestParameter testParam) {
+    public NoUniqueKeyMigrationE2EIT(final PipelineTestParameter testParam) {
         super(testParam);
         this.testParam = testParam;
     }

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NonePrimaryKeyMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NonePrimaryKeyMigrationE2EIT.java
@@ -86,11 +86,9 @@ public final class NonePrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
         waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
         proxyExecuteWithLog("REFRESH TABLE METADATA", 1);
         assertTargetAndSourceCountAreSame();
-        if (PipelineBaseE2EIT.ENV.getItEnvType() == PipelineEnvTypeEnum.DOCKER) {
-            commitMigrationByJobId(jobId);
-            List<String> lastJobIds = listJobId();
-            assertThat(lastJobIds.size(), is(0));
-        }
+        commitMigrationByJobId(jobId);
+        List<String> lastJobIds = listJobId();
+        assertThat(lastJobIds.size(), is(0));
         log.info("{} E2E IT finished, database type={}, docker image={}", this.getClass().getName(), testParam.getDatabaseType(), testParam.getStorageContainerImage());
     }
     

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NonePrimaryKeyMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/NonePrimaryKeyMigrationE2EIT.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.primarykey;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.base.PipelineBaseE2EIT;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.AbstractMigrationE2EIT;
+import org.apache.shardingsphere.test.e2e.data.pipeline.env.enums.PipelineEnvTypeEnum;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.helper.PipelineCaseHelper;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineTestParameter;
+import org.apache.shardingsphere.test.e2e.data.pipeline.util.AutoIncrementKeyGenerateAlgorithm;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(Parameterized.class)
+@Slf4j
+public final class NonePrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
+    
+    private final PipelineTestParameter testParam;
+    
+    public NonePrimaryKeyMigrationE2EIT(final PipelineTestParameter testParam) {
+        super(testParam);
+        this.testParam = testParam;
+    }
+    
+    @Parameters(name = "{0}")
+    public static Collection<PipelineTestParameter> getTestParameters() {
+        Collection<PipelineTestParameter> result = new LinkedList<>();
+        if (PipelineBaseE2EIT.ENV.getItEnvType() == PipelineEnvTypeEnum.NONE) {
+            return result;
+        }
+        for (String version : PipelineBaseE2EIT.ENV.listStorageContainerImages(new MySQLDatabaseType())) {
+            result.add(new PipelineTestParameter(new MySQLDatabaseType(), version, "env/scenario/primary_key/none_primary_key/mysql.xml"));
+        }
+        return result;
+    }
+    
+    @Override
+    protected String getSourceTableOrderName() {
+        return "t_order";
+    }
+    
+    @Test
+    public void assertTextPrimaryMigrationSuccess() throws SQLException, InterruptedException {
+        log.info("assertTextPrimaryMigrationSuccess testParam:{}", testParam);
+        createSourceOrderTable();
+        try (Connection connection = getSourceDataSource().getConnection()) {
+            AutoIncrementKeyGenerateAlgorithm generateAlgorithm = new AutoIncrementKeyGenerateAlgorithm();
+            PipelineCaseHelper.batchInsertOrderRecordsWithGeneralColumns(connection, generateAlgorithm, getSourceTableOrderName(), PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT);
+        }
+        addMigrationProcessConfig();
+        addMigrationSourceResource();
+        addMigrationTargetResource();
+        createTargetOrderTableRule();
+        startMigration(getSourceTableOrderName(), getTargetTableOrderName());
+        String jobId = listJobId().get(0);
+        waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
+        proxyExecuteWithLog("REFRESH TABLE METADATA", 1);
+        assertTargetAndSourceCountAreSame();
+        if (PipelineBaseE2EIT.ENV.getItEnvType() == PipelineEnvTypeEnum.DOCKER) {
+            commitMigrationByJobId(jobId);
+            List<String> lastJobIds = listJobId();
+            assertThat(lastJobIds.size(), is(0));
+        }
+        log.info("{} E2E IT finished, database type={}, docker image={}", this.getClass().getName(), testParam.getDatabaseType(), testParam.getStorageContainerImage());
+    }
+    
+    private void assertTargetAndSourceCountAreSame() {
+        List<Map<String, Object>> targetList = queryForListWithLog("SELECT COUNT(*) AS count FROM t_order");
+        assertFalse(targetList.isEmpty());
+        assertThat(Integer.parseInt(targetList.get(0).get("count").toString()), is(PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT));
+    }
+}

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/TextPrimaryKeyMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/TextPrimaryKeyMigrationE2EIT.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sharding.algorithm.keygen.UUIDKeyGenerateAlgori
 import org.apache.shardingsphere.test.e2e.data.pipeline.cases.base.PipelineBaseE2EIT;
 import org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.AbstractMigrationE2EIT;
 import org.apache.shardingsphere.test.e2e.data.pipeline.env.enums.PipelineEnvTypeEnum;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.helper.PipelineCaseHelper;
 import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineTestParameter;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.util.DatabaseTypeUtil;
 import org.junit.Test;
@@ -33,13 +34,10 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -86,7 +84,10 @@ public class TextPrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
     public void assertTextPrimaryMigrationSuccess() throws SQLException, InterruptedException {
         log.info("assertTextPrimaryMigrationSuccess testParam:{}", testParam);
         createSourceOrderTable();
-        batchInsertOrder();
+        try (Connection connection = getSourceDataSource().getConnection()) {
+            UUIDKeyGenerateAlgorithm keyGenerateAlgorithm = new UUIDKeyGenerateAlgorithm();
+            PipelineCaseHelper.batchInsertOrderRecordsWithGeneralColumns(connection, keyGenerateAlgorithm, getSourceTableOrderName(), PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT);
+        }
         addMigrationProcessConfig();
         addMigrationSourceResource();
         addMigrationTargetResource();
@@ -102,21 +103,5 @@ public class TextPrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
             assertThat(lastJobIds.size(), is(0));
         }
         log.info("{} E2E IT finished, database type={}, docker image={}", this.getClass().getName(), testParam.getDatabaseType(), testParam.getStorageContainerImage());
-    }
-    
-    private void batchInsertOrder() throws SQLException {
-        log.info("init data begin: {}", LocalDateTime.now());
-        UUIDKeyGenerateAlgorithm keyGenerateAlgorithm = new UUIDKeyGenerateAlgorithm();
-        try (Connection connection = getSourceDataSource().getConnection()) {
-            PreparedStatement preparedStatement = connection.prepareStatement(String.format("INSERT INTO %s (order_id,user_id,status) VALUES (?,?,?)", getSourceTableOrderName()));
-            for (int i = 0; i < PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT * 2; i++) {
-                preparedStatement.setObject(1, keyGenerateAlgorithm.generateKey());
-                preparedStatement.setObject(2, ThreadLocalRandom.current().nextInt(0, 6));
-                preparedStatement.setObject(3, "OK");
-                preparedStatement.addBatch();
-            }
-            preparedStatement.executeBatch();
-        }
-        log.info("init data end: {}", LocalDateTime.now());
     }
 }

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/TextPrimaryKeyMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/TextPrimaryKeyMigrationE2EIT.java
@@ -97,11 +97,9 @@ public class TextPrimaryKeyMigrationE2EIT extends AbstractMigrationE2EIT {
         sourceExecuteWithLog(String.format("INSERT INTO %s (order_id,user_id,status) VALUES (%s, %s, '%s')", getSourceTableOrderName(), "1000000000", 1, "afterStop"));
         waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
         assertCheckMigrationSuccess(jobId, "DATA_MATCH");
-        if (PipelineBaseE2EIT.ENV.getItEnvType() == PipelineEnvTypeEnum.DOCKER) {
-            commitMigrationByJobId(jobId);
-            List<String> lastJobIds = listJobId();
-            assertThat(lastJobIds.size(), is(0));
-        }
+        commitMigrationByJobId(jobId);
+        List<String> lastJobIds = listJobId();
+        assertThat(lastJobIds.size(), is(0));
         log.info("{} E2E IT finished, database type={}, docker image={}", this.getClass().getName(), testParam.getDatabaseType(), testParam.getStorageContainerImage());
     }
 }

--- a/test/e2e/pipeline/src/test/resources/env/scenario/primary_key/none_primary_key/mysql.xml
+++ b/test/e2e/pipeline/src/test/resources/env/scenario/primary_key/none_primary_key/mysql.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<command>
+    <create-table-order>
+        CREATE TABLE `%s` (
+        `order_id` INT NOT NULL,
+        `user_id` INT NOT NULL,
+        `status` varchar(255) NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    </create-table-order>
+</command>


### PR DESCRIPTION

Changes proposed in this pull request:
  - Migration support for tables without primary key
  - Add E2E IT test

Tables without primary keys currently do not support data consistency checks, it's will be ignored.

eg.
```
mysql> show  MIGRATION check status 'j01018f00c0a95509ff8e7066269c23bb165e';
+--------------+--------+---------------------+-------------------+------------------+----------------+------------------+---------------------------------------------------------------------------+
| tables       | result | finished_percentage | remaining_seconds | check_begin_time | check_end_time | duration_seconds | error_message                                                             |
+--------------+--------+---------------------+-------------------+------------------+----------------+------------------+---------------------------------------------------------------------------+
| t_order_item | false  | 0                   | 0                 |                  |                | 0                | Data consistency check are not supported for tables without primary keys |
+--------------+--------+---------------------+-------------------+------------------+----------------+------------------+---------------------------------------------------------------------------+
1 row in set (7.31 sec)
```


---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
