### PR TITLE
Replace `ShadowTableRuleResultSet` with `ShowShadowTableRuleExecutor`

### DIFF
--- a/features/shadow/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/shadow/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.shadow.distsql.handler.query.ShowShadowRuleExecutor
+org.apache.shardingsphere.shadow.distsql.handler.query.ShowShadowTableRuleExecutor

--- a/features/shadow/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/shadow/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -17,5 +17,4 @@
 
 org.apache.shardingsphere.shadow.distsql.handler.query.ShadowAlgorithmResultSet
 org.apache.shardingsphere.shadow.distsql.handler.query.DefaultShadowAlgorithmResultSet
-org.apache.shardingsphere.shadow.distsql.handler.query.ShadowTableRuleResultSet
 org.apache.shardingsphere.shadow.distsql.handler.query.CountShadowRuleResultSet

--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/ShowShadowTableRuleExecutorTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/ShowShadowTableRuleExecutorTest.java
@@ -17,24 +17,25 @@
 
 package org.apache.shardingsphere.shadow.distsql.query;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.shadow.api.config.ShadowRuleConfiguration;
 import org.apache.shardingsphere.shadow.api.config.table.ShadowTableConfiguration;
-import org.apache.shardingsphere.shadow.distsql.handler.query.ShadowTableRuleResultSet;
-import org.apache.shardingsphere.shadow.distsql.parser.statement.ShowShadowAlgorithmsStatement;
+import org.apache.shardingsphere.shadow.distsql.handler.query.ShowShadowTableRuleExecutor;
+import org.apache.shardingsphere.shadow.distsql.parser.statement.ShowShadowTableRulesStatement;
 import org.apache.shardingsphere.shadow.rule.ShadowRule;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,16 +43,27 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class ShadowTableRuleResultSetTest {
+public final class ShowShadowTableRuleExecutorTest {
     
     @Test
     public void assertGetRowData() {
-        DatabaseDistSQLResultSet resultSet = new ShadowTableRuleResultSet();
-        resultSet.init(mockDatabase(), mock(ShowShadowAlgorithmsStatement.class));
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(2));
-        assertThat(actual.get(0), is("t_order"));
-        assertThat(actual.get(1), is("shadowAlgorithmName_1,shadowAlgorithmName_2"));
+        RQLExecutor<ShowShadowTableRulesStatement> executor = new ShowShadowTableRuleExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(ShowShadowTableRulesStatement.class));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("t_order"));
+        assertThat(row.getCell(2), is("shadowAlgorithmName_1,shadowAlgorithmName_2"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowShadowTableRulesStatement> executor = new ShowShadowTableRuleExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(2));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("shadow_table"));
+        assertThat(iterator.next(), is("shadow_algorithm_name"));
     }
     
     private ShardingSphereDatabase mockDatabase() {


### PR DESCRIPTION
For #23772.

Changes proposed in this pull request:
  - Replace `ShadowTableRuleResultSet` with `ShowShadowTableRuleExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
