### PR TITLE
Replace `ShardingAuditorsResultSet` with `ShowShardingAuditorsExecutor`

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -19,3 +19,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRuleEx
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAlgorithmExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingKeyGeneratorExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowDefaultShardingStrategyExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAuditorsExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -17,7 +17,6 @@
 
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableReferenceRuleResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.BroadcastTableRuleResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.ShardingAuditorsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableNodesResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorResultSet


### PR DESCRIPTION
For #23772.

Changes proposed in this pull request:
  - Replace `ShardingAuditorsResultSet` with `ShowShardingAuditorsExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
