### PR TITLE
Refactor `ShardingTableRulesUsedAlgorithmResultSet`

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -20,3 +20,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAlgorithmEx
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingKeyGeneratorExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowDefaultShardingStrategyExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAuditorsExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedAlgorithmExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -21,7 +21,6 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableNodesResul
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAuditorsResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedAlgorithmResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedAuditorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `ShardingTableRulesUsedAlgorithmResultSet` with `ShowShardingTableRulesUsedAlgorithmExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
