### PR TITLE
Refactor `ShowShardingTableRulesUsedKeyGeneratorResultSet` 

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -21,3 +21,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingKeyGenerato
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowDefaultShardingStrategyExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAuditorsExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedAlgorithmExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedKeyGeneratorExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -21,6 +21,5 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableNodesResul
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAuditorsResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedAuditorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorResultSetTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorResultSetTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.sharding.distsql.query;
 
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
@@ -27,16 +28,16 @@ import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableRuleConfi
 import org.apache.shardingsphere.sharding.api.config.strategy.keygen.KeyGenerateStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
-import org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedKeyGeneratorResultSet;
+import org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedKeyGeneratorExecutor;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.ShowShardingTableRulesUsedKeyGeneratorStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -54,18 +55,28 @@ public final class ShowShardingTableRulesUsedKeyGeneratorResultSetTest {
         ShardingRule rule = mock(ShardingRule.class);
         when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
         when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
-        DatabaseDistSQLResultSet resultSet = new ShardingTableRulesUsedKeyGeneratorResultSet();
+        RQLExecutor<ShowShardingTableRulesUsedKeyGeneratorStatement> executor = new ShowShardingTableRulesUsedKeyGeneratorExecutor();
         ShowShardingTableRulesUsedKeyGeneratorStatement statement = mock(ShowShardingTableRulesUsedKeyGeneratorStatement.class);
         when(statement.getKeyGeneratorName()).thenReturn(Optional.of("snowflake"));
-        resultSet.init(database, statement);
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(database, statement);
         assertThat(actual.size(), is(2));
-        assertThat(actual.get(0), is("table"));
-        assertThat(actual.get(1), is("t_order"));
-        actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(2));
-        assertThat(actual.get(0), is("auto_table"));
-        assertThat(actual.get(1), is("t_order_auto"));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("table"));
+        assertThat(row.getCell(2), is("t_order"));
+        row = iterator.next();
+        assertThat(row.getCell(1), is("auto_table"));
+        assertThat(row.getCell(2), is("t_order_auto"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowShardingTableRulesUsedKeyGeneratorStatement> executor = new ShowShardingTableRulesUsedKeyGeneratorExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(2));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("type"));
+        assertThat(iterator.next(), is("name"));
     }
     
     private ShardingRuleConfiguration createRuleConfiguration() {


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `ShowShardingTableRulesUsedKeyGeneratorResultSet` with `ShowShardingTableRulesUsedKeyGeneratorExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
