### PR TITLE
Refactor `ShardingTableRulesUsedAuditorResultSet`

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -22,3 +22,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowDefaultShardingStra
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingAuditorsExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedAlgorithmExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedKeyGeneratorExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedAuditorExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -21,5 +21,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableNodesResul
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAuditorsResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableRulesUsedAuditorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowDefaultSingleTableStorageUnitExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowDefaultSingleTableStorageUnitExecutorTest.java
@@ -41,7 +41,6 @@ public final class ShowDefaultSingleTableStorageUnitExecutorTest {
     @Test
     public void assertGetRowData() {
         RQLExecutor<ShowDefaultSingleTableStorageUnitStatement> executor = new ShowDefaultSingleTableStorageUnitExecutor();
-        executor.getRows(mockDatabase(), mock(ShowDefaultSingleTableStorageUnitStatement.class));
         Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(ShowDefaultSingleTableStorageUnitStatement.class));
         assertThat(actual.size(), is(1));
         Iterator<LocalDataQueryResultRow> rowData = actual.iterator();

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowSingleTableExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowSingleTableExecutorTest.java
@@ -65,7 +65,6 @@ public final class ShowSingleTableExecutorTest {
     @Test
     public void assertGetRowData() {
         RQLExecutor<ShowSingleTableStatement> executor = new ShowSingleTableExecutor();
-        executor.getRows(database, mock(ShowSingleTableStatement.class));
         Collection<LocalDataQueryResultRow> actual = executor.getRows(database, mock(ShowSingleTableStatement.class));
         assertThat(actual.size(), is(2));
         Iterator<LocalDataQueryResultRow> rowData = actual.iterator();

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowStorageUnitExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/ShowStorageUnitExecutorTest.java
@@ -136,7 +136,6 @@ public final class ShowStorageUnitExecutorTest {
     public void assertUnusedStorageUnit() {
         RQLExecutor<ShowStorageUnitsStatement> executor = new ShowStorageUnitExecutor();
         ShowStorageUnitsStatement showStorageUnitsStatement = new ShowStorageUnitsStatement(mock(DatabaseSegment.class), 0);
-        executor.getRows(database, showStorageUnitsStatement);
         Collection<LocalDataQueryResultRow> actual = executor.getRows(database, showStorageUnitsStatement);
         assertThat(actual.size(), is(1));
         Iterator<LocalDataQueryResultRow> rowData = actual.iterator();


### PR DESCRIPTION
For #23772.

Changes proposed in this pull request:
  - Replace `ShardingTableRulesUsedAuditorResultSet` with `ShowShardingTableRulesUsedAuditorExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
