### PR TITLE
Refactor `UnusedShardingAlgorithmsResultSet`

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -24,3 +24,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesU
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedKeyGeneratorExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableRulesUsedAuditorExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableNodesExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.ShowUnusedShardingAlgorithmsExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -17,7 +17,6 @@
 
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableReferenceRuleResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.BroadcastTableRuleResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingKeyGeneratorResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAuditorsResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowUnusedShardingAlgorithmsExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowUnusedShardingAlgorithmsExecutorTest.java
@@ -17,23 +17,25 @@
 
 package org.apache.shardingsphere.sharding.distsql.query;
 
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingAutoTableRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
-import org.apache.shardingsphere.sharding.distsql.handler.query.UnusedShardingAlgorithmsResultSet;
-import org.apache.shardingsphere.sharding.distsql.parser.statement.ShowShardingAlgorithmsStatement;
+import org.apache.shardingsphere.sharding.distsql.handler.query.ShowUnusedShardingAlgorithmsExecutor;
+import org.apache.shardingsphere.sharding.distsql.parser.statement.ShowUnusedShardingAlgorithmsStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.Iterator;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -41,17 +43,33 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class UnusedShardingAlgorithmsResultSetTest {
+public final class ShowUnusedShardingAlgorithmsExecutorTest {
     
     @Test
     public void assertGetRowData() {
-        UnusedShardingAlgorithmsResultSet resultSet = new UnusedShardingAlgorithmsResultSet();
-        resultSet.init(mockDatabase(), mock(ShowShardingAlgorithmsStatement.class));
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("database_inline"));
-        assertThat(actual.get(1), is("INLINE"));
-        assertThat(actual.get(2), is("algorithm-expression=ds_${user_id % 2}"));
+        RQLExecutor<ShowUnusedShardingAlgorithmsStatement> executor = new ShowUnusedShardingAlgorithmsExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(ShowUnusedShardingAlgorithmsStatement.class));
+        assertThat(actual.size(), is(2));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("database_inline"));
+        assertThat(row.getCell(2), is("INLINE"));
+        assertThat(row.getCell(3), is("algorithm-expression=ds_${user_id % 2}"));
+        row = iterator.next();
+        assertThat(row.getCell(1), is("t_order_hash_mod"));
+        assertThat(row.getCell(2), is("hash_mod"));
+        assertThat(row.getCell(3), is("sharding-count=4"));
+    }
+    
+    @Test
+    public void assertGetColumnNames() {
+        RQLExecutor<ShowUnusedShardingAlgorithmsStatement> executor = new ShowUnusedShardingAlgorithmsExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(3));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("name"));
+        assertThat(iterator.next(), is("type"));
+        assertThat(iterator.next(), is("props"));
     }
     
     private ShardingSphereDatabase mockDatabase() {

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowUnusedShardingAlgorithmsExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowUnusedShardingAlgorithmsExecutorTest.java
@@ -49,16 +49,12 @@ public final class ShowUnusedShardingAlgorithmsExecutorTest {
     public void assertGetRowData() {
         RQLExecutor<ShowUnusedShardingAlgorithmsStatement> executor = new ShowUnusedShardingAlgorithmsExecutor();
         Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(ShowUnusedShardingAlgorithmsStatement.class));
-        assertThat(actual.size(), is(2));
+        assertThat(actual.size(), is(1));
         Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
         LocalDataQueryResultRow row = iterator.next();
         assertThat(row.getCell(1), is("database_inline"));
         assertThat(row.getCell(2), is("INLINE"));
         assertThat(row.getCell(3), is("algorithm-expression=ds_${user_id % 2}"));
-        row = iterator.next();
-        assertThat(row.getCell(1), is("t_order_hash_mod"));
-        assertThat(row.getCell(2), is("hash_mod"));
-        assertThat(row.getCell(3), is("sharding-count=4"));
     }
     
     @Test
@@ -98,7 +94,7 @@ public final class ShowUnusedShardingAlgorithmsExecutorTest {
     
     private ShardingAutoTableRuleConfiguration createShardingAutoTableRuleConfiguration() {
         ShardingAutoTableRuleConfiguration result = new ShardingAutoTableRuleConfiguration("auto_table", null);
-        result.setShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "hash_mod"));
+        result.setShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "t_order_hash_mod"));
         return result;
     }
 }


### PR DESCRIPTION

For #23772.

Changes proposed in this pull request:
  - Replace `UnusedShardingAlgorithmsResultSet` with `ShowUnusedShardingAlgorithmsExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
