### PR TITLE
Change the lib directory of the agent package to log-lib

### DIFF
--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/log/AgentLoggerClassLoaderFactory.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/log/AgentLoggerClassLoaderFactory.java
@@ -54,7 +54,7 @@ public final class AgentLoggerClassLoaderFactory {
     @SneakyThrows(IOException.class)
     private static Collection<JarFile> getLoggingJars() {
         Collection<JarFile> result = new LinkedList<>();
-        Files.walkFileTree(new File(String.join(File.separator, AgentPath.getRootPath().getPath(), "lib")).toPath(), new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(new File(String.join(File.separator, AgentPath.getRootPath().getPath(), "log-lib")).toPath(), new SimpleFileVisitor<Path>() {
             
             @Override
             public FileVisitResult visitFile(final Path path, final BasicFileAttributes attributes) {

--- a/distribution/agent/src/main/assembly/shardingsphere-agent-binary-distribution.xml
+++ b/distribution/agent/src/main/assembly/shardingsphere-agent-binary-distribution.xml
@@ -95,7 +95,7 @@
     
     <dependencySets>
         <dependencySet>
-            <outputDirectory>./lib</outputDirectory>
+            <outputDirectory>./log-lib</outputDirectory>
             <includes>
                 <include>org.slf4j:slf4j-api</include>
                 <include>ch.qos.logback:*</include>


### PR DESCRIPTION
Fixes #23868.

Changes proposed in this pull request:
  - Change the lib directory of the agent package to log-lib

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
