### PR TITLE
Replace `CountShardingRuleResultSet` with `CountShardingRuleExecutor`

### DIFF
--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.query.RQLExecutor
@@ -27,3 +27,4 @@ org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableNodesE
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowUnusedShardingAlgorithmsExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowUnusedShardingKeyGeneratorExecutor
 org.apache.shardingsphere.sharding.distsql.handler.query.ShowUnusedShardingAuditorsExecutor
+org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleExecutor

--- a/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/features/sharding/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -17,4 +17,3 @@
 
 org.apache.shardingsphere.sharding.distsql.handler.query.ShardingTableReferenceRuleResultSet
 org.apache.shardingsphere.sharding.distsql.handler.query.BroadcastTableRuleResultSet
-org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/CountShardingRuleExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/CountShardingRuleExecutorTest.java
@@ -17,56 +17,62 @@
 
 package org.apache.shardingsphere.sharding.distsql.query;
 
+import org.apache.shardingsphere.distsql.handler.query.RQLExecutor;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.rule.ShardingTableReferenceRuleConfiguration;
-import org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleResultSet;
+import org.apache.shardingsphere.sharding.distsql.handler.query.CountShardingRuleExecutor;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.CountShardingRuleStatement;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class CountShardingRuleResultSetTest {
+public final class CountShardingRuleExecutorTest {
     
     @Test
     public void assertGetRowData() {
-        CountShardingRuleResultSet resultSet = new CountShardingRuleResultSet();
-        resultSet.init(mockDatabase(), mock(CountShardingRuleStatement.class));
-        assertTrue(resultSet.next());
-        List<Object> actual = new ArrayList<>(resultSet.getRowData());
+        RQLExecutor<CountShardingRuleStatement> executor = new CountShardingRuleExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), mock(CountShardingRuleStatement.class));
         assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_table"));
-        assertThat(actual.get(1), is("db_1"));
-        assertThat(actual.get(2), is(2));
-        assertTrue(resultSet.next());
-        actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("sharding_table_reference"));
-        assertThat(actual.get(1), is("db_1"));
-        assertThat(actual.get(2), is(1));
-        assertTrue(resultSet.next());
-        actual = new ArrayList<>(resultSet.getRowData());
-        assertThat(actual.size(), is(3));
-        assertThat(actual.get(0), is("broadcast_table"));
-        assertThat(actual.get(1), is("db_1"));
-        assertThat(actual.get(2), is(2));
-        assertFalse(resultSet.next());
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("sharding_table"));
+        assertThat(row.getCell(2), is("db_1"));
+        assertThat(row.getCell(3), is(2));
+        row = iterator.next();
+        assertThat(row.getCell(1), is("sharding_table_reference"));
+        assertThat(row.getCell(2), is("db_1"));
+        assertThat(row.getCell(3), is(1));
+        row = iterator.next();
+        assertThat(row.getCell(1), is("broadcast_table"));
+        assertThat(row.getCell(2), is("db_1"));
+        assertThat(row.getCell(3), is(2));
+    }
+    
+    @Test
+    public void assertGetColumns() {
+        RQLExecutor<CountShardingRuleStatement> executor = new CountShardingRuleExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(3));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("rule_name"));
+        assertThat(iterator.next(), is("database"));
+        assertThat(iterator.next(), is("count"));
     }
     
     private ShardingSphereDatabase mockDatabase() {

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableRulesUsedKeyGeneratorExecutorTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class ShowShardingTableRulesUsedKeyGeneratorResultSetTest {
+public final class ShowShardingTableRulesUsedKeyGeneratorExecutorTest {
     
     @Test
     public void assertGetRowData() {


### PR DESCRIPTION
Fixes #23772.

Changes proposed in this pull request:
  - Replace `CountShardingRuleResultSet` with `CountShardingRuleExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
