### PR TITLE
Unify usage of class.getCanonicalName() and class.getName()

### DIFF
--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/advisor/config/yaml/loader/YamlAdvisorsConfigurationLoaderTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/advisor/config/yaml/loader/YamlAdvisorsConfigurationLoaderTest.java
@@ -44,8 +44,8 @@ public final class YamlAdvisorsConfigurationLoaderTest {
     }
     
     private void assertYamlAdvisorConfiguration(final YamlAdvisorConfiguration actual) {
-        assertThat(actual.getTarget(), is(YamlTargetObjectFixture.class.getCanonicalName()));
-        assertThat(actual.getAdvice(), is(YamlAdviceFixture.class.getCanonicalName()));
+        assertThat(actual.getTarget(), is(YamlTargetObjectFixture.class.getName()));
+        assertThat(actual.getAdvice(), is(YamlAdviceFixture.class.getName()));
         assertThat(actual.getPointcuts().size(), is(8));
         List<YamlPointcutConfiguration> actualYamlPointcutConfigs = new ArrayList<>(actual.getPointcuts());
         assertYamlPointcutConfiguration(actualYamlPointcutConfigs.get(0), null, "constructor", Collections.emptyList());

--- a/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorder.java
+++ b/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorder.java
@@ -59,7 +59,7 @@ public final class MethodTimeRecorder {
     }
     
     private String getKey(final Method method) {
-        return String.format("%s@%s", adviceClass.getCanonicalName(), method.getName());
+        return String.format("%s@%s", adviceClass.getName(), method.getName());
     }
     
     private long getElapsedTime(final String key) {

--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/enums/ShardingStrategyType.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/enums/ShardingStrategyType.java
@@ -176,7 +176,7 @@ public enum ShardingStrategyType {
      */
     public static ShardingStrategyType getValueOf(final ShardingStrategyConfiguration shardingStrategyConfig) {
         Optional<ShardingStrategyType> type = Arrays.stream(values())
-                .filter(each -> shardingStrategyConfig.getClass().getCanonicalName().equals(each.getImplementedClass().getCanonicalName())).findFirst();
+                .filter(each -> shardingStrategyConfig.getClass().getName().equals(each.getImplementedClass().getName())).findFirst();
         type.orElseThrow(() -> new UnsupportedOperationException(String.format("unsupported strategy type %s", shardingStrategyConfig.getClass().getName())));
         return type.get();
     }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/database/DatabaseOperateBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/database/DatabaseOperateBackendHandlerFactory.java
@@ -50,6 +50,6 @@ public final class DatabaseOperateBackendHandlerFactory {
         if (sqlStatement instanceof DropDatabaseStatement) {
             return new DropDatabaseBackendHandler((DropDatabaseStatement) sqlStatement, connectionSession);
         }
-        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getCanonicalName());
+        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getName());
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/DistSQLBackendHandlerFactory.java
@@ -58,6 +58,6 @@ public final class DistSQLBackendHandlerFactory {
         if (sqlStatement instanceof RULStatement) {
             return RULBackendHandlerFactory.newInstance((RULStatement) sqlStatement, connectionSession);
         }
-        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getCanonicalName());
+        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getName());
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
@@ -120,17 +120,17 @@ public final class RALBackendHandlerFactory {
         }
         if (sqlStatement instanceof QueryableScalingRALStatement) {
             return new QueryableScalingRALBackendHandler((QueryableScalingRALStatement) sqlStatement,
-                    (DatabaseDistSQLResultSet) TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getCanonicalName()));
+                    (DatabaseDistSQLResultSet) TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getName()));
         }
         if (sqlStatement instanceof UpdatableScalingRALStatement) {
             return new UpdatableScalingRALBackendHandler((UpdatableScalingRALStatement) sqlStatement, connectionSession);
         }
         if (sqlStatement instanceof QueryableGlobalRuleRALStatement) {
             return new QueryableGlobalRuleRALBackendHandler(sqlStatement,
-                    (GlobalRuleDistSQLResultSet) TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getCanonicalName()));
+                    (GlobalRuleDistSQLResultSet) TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getName()));
         }
         if (sqlStatement instanceof UpdatableGlobalRuleRALStatement) {
-            return new UpdatableGlobalRuleRALBackendHandler(sqlStatement, TypedSPILoader.getService(GlobalRuleRALUpdater.class, sqlStatement.getClass().getCanonicalName()));
+            return new UpdatableGlobalRuleRALBackendHandler(sqlStatement, TypedSPILoader.getService(GlobalRuleRALUpdater.class, sqlStatement.getClass().getName()));
         }
         // TODO delete other if branches after replacing all query handlers with QueryableRALBackendHandler
         if (TypedSPILoader.contains(QueryableRALExecutor.class, sqlStatement.getClass().getName())) {
@@ -149,7 +149,7 @@ public final class RALBackendHandlerFactory {
     
     private static RALBackendHandler<?> createRALBackendHandler(final RALStatement sqlStatement, final ConnectionSession connectionSession) {
         Class<? extends RALBackendHandler<?>> clazz = HANDLERS.get(sqlStatement.getClass());
-        ShardingSpherePreconditions.checkState(null != clazz, () -> new UnsupportedSQLOperationException(String.format("Unsupported SQL statement : %s", sqlStatement.getClass().getCanonicalName())));
+        ShardingSpherePreconditions.checkState(null != clazz, () -> new UnsupportedSQLOperationException(String.format("Unsupported SQL statement : %s", sqlStatement.getClass().getName())));
         RALBackendHandler<?> result = newInstance(clazz);
         result.init(sqlStatement, connectionSession);
         return result;

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/hint/HintRALStatementExecutorFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/hint/HintRALStatementExecutorFactory.java
@@ -82,6 +82,6 @@ public final class HintRALStatementExecutorFactory {
         if (sqlStatement instanceof ClearShardingHintStatement) {
             return new ClearShardingHintExecutor((ClearShardingHintStatement) sqlStatement);
         }
-        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getCanonicalName());
+        throw new UnsupportedSQLOperationException(sqlStatement.getClass().getName());
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/migration/update/UpdatableScalingRALBackendHandler.java
@@ -44,7 +44,7 @@ public final class UpdatableScalingRALBackendHandler implements DistSQLBackendHa
     @Override
     public ResponseHeader execute() throws SQLException {
         String databaseName = getDatabaseName(connectionSession);
-        TypedSPILoader.getService(RALUpdater.class, sqlStatement.getClass().getCanonicalName()).executeUpdate(databaseName, sqlStatement);
+        TypedSPILoader.getService(RALUpdater.class, sqlStatement.getClass().getName()).executeUpdate(databaseName, sqlStatement);
         return new UpdateResponseHeader(sqlStatement);
     }
     

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/rule/RuleDefinitionBackendHandler.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/rule/RuleDefinitionBackendHandler.java
@@ -51,7 +51,7 @@ public final class RuleDefinitionBackendHandler<T extends RuleDefinitionStatemen
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
     protected ResponseHeader execute(final String databaseName, final T sqlStatement) {
-        RuleDefinitionUpdater ruleDefinitionUpdater = TypedSPILoader.getService(RuleDefinitionUpdater.class, sqlStatement.getClass().getCanonicalName());
+        RuleDefinitionUpdater ruleDefinitionUpdater = TypedSPILoader.getService(RuleDefinitionUpdater.class, sqlStatement.getClass().getName());
         Class<? extends RuleConfiguration> ruleConfigClass = ruleDefinitionUpdater.getRuleConfigurationClass();
         ShardingSphereDatabase database = ProxyContext.getInstance().getDatabase(databaseName);
         RuleConfiguration currentRuleConfig = findCurrentRuleConfiguration(database, ruleConfigClass).orElse(null);
@@ -87,7 +87,7 @@ public final class RuleDefinitionBackendHandler<T extends RuleDefinitionStatemen
         } else if (updater instanceof RuleDefinitionDropUpdater) {
             processDrop(result, sqlStatement, (RuleDefinitionDropUpdater) updater, currentRuleConfig);
         } else {
-            throw new UnsupportedSQLOperationException(String.format("Cannot support RDL updater type `%s`", updater.getClass().getCanonicalName()));
+            throw new UnsupportedSQLOperationException(String.format("Cannot support RDL updater type `%s`", updater.getClass().getName()));
         }
         return result;
     }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/RQLBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rql/RQLBackendHandlerFactory.java
@@ -41,14 +41,14 @@ public final class RQLBackendHandlerFactory {
      */
     public static ProxyBackendHandler newInstance(final RQLStatement sqlStatement, final ConnectionSession connectionSession) {
         // TODO remove this judgment after the refactoring of DistSQLResultSet is completed
-        if (TypedSPILoader.contains(DistSQLResultSet.class, sqlStatement.getClass().getCanonicalName())) {
+        if (TypedSPILoader.contains(DistSQLResultSet.class, sqlStatement.getClass().getName())) {
             return newInstanceByDistSQLResultSet(sqlStatement, connectionSession);
         }
         return new RQLBackendHandler<>(sqlStatement, connectionSession);
     }
     
     private static ProxyBackendHandler newInstanceByDistSQLResultSet(final RQLStatement sqlStatement, final ConnectionSession connectionSession) {
-        DistSQLResultSet resultSet = TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getCanonicalName());
+        DistSQLResultSet resultSet = TypedSPILoader.getService(DistSQLResultSet.class, sqlStatement.getClass().getName());
         return new RQLResultSetBackendHandler(sqlStatement, connectionSession, (DatabaseDistSQLResultSet) resultSet);
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/RULBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/RULBackendHandlerFactory.java
@@ -69,7 +69,7 @@ public final class RULBackendHandlerFactory {
     
     private static RULBackendHandler<?> createRULBackendHandler(final RULStatement sqlStatement, final ConnectionSession connectionSession) {
         Class<? extends RULBackendHandler<?>> clazz = HANDLERS.get(sqlStatement.getClass());
-        ShardingSpherePreconditions.checkState(null != clazz, () -> new UnsupportedSQLOperationException(String.format("Unsupported SQL statement : %s", sqlStatement.getClass().getCanonicalName())));
+        ShardingSpherePreconditions.checkState(null != clazz, () -> new UnsupportedSQLOperationException(String.format("Unsupported SQL statement : %s", sqlStatement.getClass().getName())));
         RULBackendHandler<?> result = newInstance(clazz);
         result.init(sqlStatement, connectionSession);
         return result;


### PR DESCRIPTION
Related to #15125.

Changes proposed in this pull request:
  - Change `class.getCanonicalName()` to `class.getName()`