### PR TITLE
Fix RAL CI failed.

### DIFF
--- a/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/show_status_from_readwrite_splitting_rules.xml
+++ b/test/e2e/suite/src/test/resources/cases/ral/dataset/empty_rules/show_status_from_readwrite_splitting_rules.xml
@@ -21,5 +21,5 @@
         <column name="status" />
         <column name="delay_time(ms)" />
     </metadata>
-    <row values="read_ds_0| enabled| 0" />
+    <row values="read_ds_0| ENABLED| 0" />
 </dataset>


### PR DESCRIPTION
Related to #23881, fix CI failed.

cause: `toLowerCase()` was removed.
