### PR TITLE
Replace ExecutorDataMap with SeataXIDContext in SeataTransactionalSQLExecutionHook

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
@@ -86,7 +86,7 @@ public abstract class JDBCExecutorCallback<T> implements ExecutorCallback<JDBCEx
         SQLExecutionHook sqlExecutionHook = new SPISQLExecutionHook();
         try {
             SQLUnit sqlUnit = jdbcExecutionUnit.getExecutionUnit().getSqlUnit();
-            sqlExecutionHook.start(jdbcExecutionUnit.getExecutionUnit().getDataSourceName(), sqlUnit.getSql(), sqlUnit.getParameters(), dataSourceMetaData, isTrunkThread, dataMap);
+            sqlExecutionHook.start(jdbcExecutionUnit.getExecutionUnit().getDataSourceName(), sqlUnit.getSql(), sqlUnit.getParameters(), dataSourceMetaData, isTrunkThread);
             T result = executeSQL(sqlUnit.getSql(), jdbcExecutionUnit.getStorageResource(), jdbcExecutionUnit.getConnectionMode(), storageType);
             sqlExecutionHook.finishSuccess();
             finishReport(dataMap, jdbcExecutionUnit);

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.infra.executor.sql.hook.SPISQLExecutionHook;
 import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 import org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
-import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.sql.DatabaseMetaData;
@@ -58,8 +57,6 @@ public abstract class JDBCExecutorCallback<T> implements ExecutorCallback<JDBCEx
     private final SQLStatement sqlStatement;
     
     private final boolean isExceptionThrown;
-    
-    private final EventBusContext eventBusContext;
     
     @Override
     public final Collection<T> execute(final Collection<JDBCExecutionUnit> executionUnits, final boolean isTrunkThread, final Map<String, Object> dataMap) throws SQLException {

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/driver/jdbc/JDBCExecutorCallback.java
@@ -29,6 +29,7 @@ import org.apache.shardingsphere.infra.executor.sql.hook.SPISQLExecutionHook;
 import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 import org.apache.shardingsphere.infra.executor.sql.process.ExecuteProcessEngine;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessConstants;
+import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.sql.DatabaseMetaData;
@@ -57,6 +58,8 @@ public abstract class JDBCExecutorCallback<T> implements ExecutorCallback<JDBCEx
     private final SQLStatement sqlStatement;
     
     private final boolean isExceptionThrown;
+    
+    private final EventBusContext eventBusContext;
     
     @Override
     public final Collection<T> execute(final Collection<JDBCExecutionUnit> executionUnits, final boolean isTrunkThread, final Map<String, Object> dataMap) throws SQLException {

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SPISQLExecutionHook.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SPISQLExecutionHook.java
@@ -22,7 +22,6 @@ import org.apache.shardingsphere.infra.util.spi.ShardingSphereServiceLoader;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 /**
  * SQL Execution hook for SPI.
@@ -32,10 +31,9 @@ public final class SPISQLExecutionHook implements SQLExecutionHook {
     private final Collection<SQLExecutionHook> sqlExecutionHooks = ShardingSphereServiceLoader.getServiceInstances(SQLExecutionHook.class);
     
     @Override
-    public void start(final String dataSourceName, final String sql, final List<Object> params,
-                      final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread, final Map<String, Object> shardingExecuteDataMap) {
+    public void start(final String dataSourceName, final String sql, final List<Object> params, final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread) {
         for (SQLExecutionHook each : sqlExecutionHooks) {
-            each.start(dataSourceName, sql, params, dataSourceMetaData, isTrunkThread, shardingExecuteDataMap);
+            each.start(dataSourceName, sql, params, dataSourceMetaData, isTrunkThread);
         }
     }
     

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SQLExecutionHook.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SQLExecutionHook.java
@@ -35,9 +35,8 @@ public interface SQLExecutionHook {
      * @param params SQL parameters
      * @param dataSourceMetaData data source meta data
      * @param isTrunkThread is execution in trunk thread
-     * @param shardingExecuteDataMap sharding execute data map
      */
-    void start(String dataSourceName, String sql, List<Object> params, DataSourceMetaData dataSourceMetaData, boolean isTrunkThread, Map<String, Object> shardingExecuteDataMap);
+    void start(String dataSourceName, String sql, List<Object> params, DataSourceMetaData dataSourceMetaData, boolean isTrunkThread);
     
     /**
      * Handle when SQL execution finished success.

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SQLExecutionHook.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/hook/SQLExecutionHook.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.infra.executor.sql.hook;
 import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * SQL Execution hook.

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/jdbc/JDBCExecutorCallbackTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/jdbc/JDBCExecutorCallbackTest.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMod
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutorExceptionHandler;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutorCallback;
-import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
@@ -79,8 +78,7 @@ public final class JDBCExecutorCallbackTest {
     @Test
     public void assertExecute() throws SQLException, NoSuchFieldException, IllegalAccessException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-        JDBCExecutorCallback<?> jdbcExecutorCallback = new JDBCExecutorCallback<Integer>(databaseType, Collections.singletonMap("ds", databaseType), mock(SelectStatement.class), true,
-                new EventBusContext()) {
+        JDBCExecutorCallback<?> jdbcExecutorCallback = new JDBCExecutorCallback<Integer>(databaseType, Collections.singletonMap("ds", databaseType), mock(SelectStatement.class), true) {
             
             @Override
             protected Integer executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
@@ -105,7 +103,7 @@ public final class JDBCExecutorCallbackTest {
         Object saneResult = new Object();
         JDBCExecutorCallback<Object> callback =
                 new JDBCExecutorCallback<Object>(TypedSPILoader.getService(DatabaseType.class, "MySQL"),
-                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true, new EventBusContext()) {
+                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true) {
                     
                     @Override
                     protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
@@ -125,7 +123,7 @@ public final class JDBCExecutorCallbackTest {
     public void assertExecuteSQLExceptionOccurredAndProtocolTypeSameAsDatabaseType() throws SQLException {
         JDBCExecutorCallback<Object> callback =
                 new JDBCExecutorCallback<Object>(TypedSPILoader.getService(DatabaseType.class, "MySQL"),
-                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true, new EventBusContext()) {
+                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true) {
                     
                     @Override
                     protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/jdbc/JDBCExecutorCallbackTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/execute/engine/jdbc/JDBCExecutorCallbackTest.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.infra.executor.sql.execute.engine.ConnectionMod
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutorExceptionHandler;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutorCallback;
+import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
@@ -78,7 +79,8 @@ public final class JDBCExecutorCallbackTest {
     @Test
     public void assertExecute() throws SQLException, NoSuchFieldException, IllegalAccessException {
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-        JDBCExecutorCallback<?> jdbcExecutorCallback = new JDBCExecutorCallback<Integer>(databaseType, Collections.singletonMap("ds", databaseType), mock(SelectStatement.class), true) {
+        JDBCExecutorCallback<?> jdbcExecutorCallback = new JDBCExecutorCallback<Integer>(databaseType, Collections.singletonMap("ds", databaseType), mock(SelectStatement.class), true,
+                new EventBusContext()) {
             
             @Override
             protected Integer executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
@@ -103,7 +105,7 @@ public final class JDBCExecutorCallbackTest {
         Object saneResult = new Object();
         JDBCExecutorCallback<Object> callback =
                 new JDBCExecutorCallback<Object>(TypedSPILoader.getService(DatabaseType.class, "MySQL"),
-                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true) {
+                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true, new EventBusContext()) {
                     
                     @Override
                     protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {
@@ -123,7 +125,7 @@ public final class JDBCExecutorCallbackTest {
     public void assertExecuteSQLExceptionOccurredAndProtocolTypeSameAsDatabaseType() throws SQLException {
         JDBCExecutorCallback<Object> callback =
                 new JDBCExecutorCallback<Object>(TypedSPILoader.getService(DatabaseType.class, "MySQL"),
-                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true) {
+                        Collections.singletonMap("ds", TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")), mock(SelectStatement.class), true, new EventBusContext()) {
                     
                     @Override
                     protected Object executeSQL(final String sql, final Statement statement, final ConnectionMode connectionMode, final DatabaseType storageType) throws SQLException {

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/hook/SPISQLExecutionHookTest.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/hook/SPISQLExecutionHookTest.java
@@ -37,7 +37,7 @@ public final class SPISQLExecutionHookTest {
     
     @Test
     public void assertStart() {
-        spiSQLExecutionHook.start("ds", "SELECT 1", Collections.emptyList(), null, true, null);
+        spiSQLExecutionHook.start("ds", "SELECT 1", Collections.emptyList(), null, true);
         assertTrue(SQLExecutionHookFixture.containsAction("start"));
     }
     

--- a/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/hook/fixture/SQLExecutionHookFixture.java
+++ b/infra/executor/src/test/java/org/apache/shardingsphere/infra/executor/sql/hook/fixture/SQLExecutionHookFixture.java
@@ -17,21 +17,19 @@
 
 package org.apache.shardingsphere.infra.executor.sql.hook.fixture;
 
-import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
+import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 public final class SQLExecutionHookFixture implements SQLExecutionHook {
     
     private static final Collection<String> ACTIONS = new LinkedList<>();
     
     @Override
-    public void start(final String dataSourceName, final String sql, final List<Object> params,
-                      final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread, final Map<String, Object> shardingExecuteDataMap) {
+    public void start(final String dataSourceName, final String sql, final List<Object> params, final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread) {
         ACTIONS.add("start");
     }
     

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManager.java
@@ -31,8 +31,8 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.transaction.api.TransactionType;
-import org.apache.shardingsphere.transaction.base.seata.at.exception.SeataATDisabledException;
 import org.apache.shardingsphere.transaction.base.seata.at.exception.SeataATConfigurationException;
+import org.apache.shardingsphere.transaction.base.seata.at.exception.SeataATDisabledException;
 import org.apache.shardingsphere.transaction.exception.TransactionTimeoutException;
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManager;
 
@@ -120,6 +120,7 @@ public final class SeataATShardingSphereTransactionManager implements ShardingSp
         } finally {
             SeataTransactionHolder.clear();
             RootContext.unbind();
+            SeataXIDContext.remove();
         }
     }
     
@@ -132,6 +133,7 @@ public final class SeataATShardingSphereTransactionManager implements ShardingSp
         } finally {
             SeataTransactionHolder.clear();
             RootContext.unbind();
+            SeataXIDContext.remove();
         }
     }
     

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataTransactionalSQLExecutionHook.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataTransactionalSQLExecutionHook.java
@@ -18,31 +18,26 @@
 package org.apache.shardingsphere.transaction.base.seata.at;
 
 import io.seata.core.context.RootContext;
-import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 import org.apache.shardingsphere.infra.database.metadata.DataSourceMetaData;
-import org.apache.shardingsphere.infra.executor.kernel.model.ExecutorDataMap;
+import org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Seata transactional SQL execution hook.
  */
-public final class TransactionalSQLExecutionHook implements SQLExecutionHook {
-    
-    private static final String SEATA_TX_XID = "SEATA_TX_XID";
+public final class SeataTransactionalSQLExecutionHook implements SQLExecutionHook {
     
     private boolean seataBranch;
     
     @Override
-    public void start(final String dataSourceName, final String sql, final List<Object> params,
-                      final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread, final Map<String, Object> shardingExecuteDataMap) {
+    public void start(final String dataSourceName, final String sql, final List<Object> params, final DataSourceMetaData dataSourceMetaData, final boolean isTrunkThread) {
         if (isTrunkThread) {
             if (RootContext.inGlobalTransaction()) {
-                ExecutorDataMap.getValue().put(SEATA_TX_XID, RootContext.getXID());
+                SeataXIDContext.set(RootContext.getXID());
             }
-        } else if (!RootContext.inGlobalTransaction() && shardingExecuteDataMap.containsKey(SEATA_TX_XID)) {
-            RootContext.bind((String) shardingExecuteDataMap.get(SEATA_TX_XID));
+        } else if (!RootContext.inGlobalTransaction()) {
+            RootContext.bind(SeataXIDContext.get());
             seataBranch = true;
         }
     }

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataTransactionalSQLExecutionHook.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataTransactionalSQLExecutionHook.java
@@ -36,7 +36,7 @@ public final class SeataTransactionalSQLExecutionHook implements SQLExecutionHoo
             if (RootContext.inGlobalTransaction()) {
                 SeataXIDContext.set(RootContext.getXID());
             }
-        } else if (!RootContext.inGlobalTransaction()) {
+        } else if (!RootContext.inGlobalTransaction() && !SeataXIDContext.isEmpty()) {
             RootContext.bind(SeataXIDContext.get());
             seataBranch = true;
         }

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
@@ -46,4 +46,11 @@ public final class SeataXIDContext {
     public static void set(final String xid) {
         XID.set(xid);
     }
+    
+    /**
+     * Remove xid.
+     */
+    public static void remove() {
+        XID.remove();
+    }
 }

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
@@ -15,38 +15,35 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.agent.plugin.tracing.core;
+package org.apache.shardingsphere.transaction.base.seata.at;
 
 import com.alibaba.ttl.TransmittableThreadLocal;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
 /**
- * Root span context.
+ * Seata xid context.
  */
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public final class RootSpanContext {
+public final class SeataXIDContext {
     
-    private static final TransmittableThreadLocal<Object> VALUE = new TransmittableThreadLocal<>();
+    private static final TransmittableThreadLocal<String> XID = new TransmittableThreadLocal<>();
     
     /**
-     * Get root span.
+     * Get xid.
      * 
-     * @param <T> type of span
-     * @return root span
+     * @return xid
      */
-    @SuppressWarnings("unchecked")
-    public static <T> T get() {
-        return (T) VALUE.get();
+    public static String get() {
+        return XID.get();
     }
     
     /**
-     * Set root span.
+     * Set xid.
      * 
-     * @param value root span
-     * @param <T> type of span
+     * @param xid xid
      */
-    public static <T> void set(final T value) {
-        VALUE.set(value);
+    public static void set(final String xid) {
+        XID.set(xid);
     }
 }

--- a/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
+++ b/kernel/transaction/type/base/seata-at/src/main/java/org/apache/shardingsphere/transaction/base/seata/at/SeataXIDContext.java
@@ -30,6 +30,15 @@ public final class SeataXIDContext {
     private static final TransmittableThreadLocal<String> XID = new TransmittableThreadLocal<>();
     
     /**
+     * Judge whether xid is empty or not.
+     *
+     * @return whether xid is empty or not
+     */
+    public static boolean isEmpty() {
+        return null == XID.get();
+    }
+    
+    /**
      * Get xid.
      * 
      * @return xid

--- a/kernel/transaction/type/base/seata-at/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook
+++ b/kernel/transaction/type/base/seata-at/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.executor.sql.hook.SQLExecutionHook
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.transaction.base.seata.at.TransactionalSQLExecutionHook
+org.apache.shardingsphere.transaction.base.seata.at.SeataTransactionalSQLExecutionHook

--- a/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataIDContextTest.java
+++ b/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataIDContextTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.base.seata.at;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public final class SeataIDContextTest {
+    
+    @After
+    public void tearDown() {
+        SeataXIDContext.remove();
+    }
+    
+    @Test
+    public void assertIsEmpty() {
+        assertTrue(SeataXIDContext.isEmpty());
+        SeataXIDContext.set("xid");
+        assertFalse(SeataXIDContext.isEmpty());
+    }
+    
+    @Test
+    public void assertGet() {
+        assertNull(SeataXIDContext.get());
+        SeataXIDContext.set("xid");
+        assertThat(SeataXIDContext.get(), is("xid"));
+    }
+    
+    @Test
+    public void assertSet() {
+        assertNull(SeataXIDContext.get());
+        SeataXIDContext.set("xid");
+        assertThat(SeataXIDContext.get(), is("xid"));
+        SeataXIDContext.set("xid-2");
+        assertThat(SeataXIDContext.get(), is("xid-2"));
+    }
+    
+    @Test
+    public void assertRemove() {
+        assertNull(SeataXIDContext.get());
+        SeataXIDContext.set("xid");
+        assertThat(SeataXIDContext.get(), is("xid"));
+        SeataXIDContext.remove();
+        assertNull(SeataXIDContext.get());
+    }
+}


### PR DESCRIPTION
Ref #23884.

Changes proposed in this pull request:
  - Replace ExecutorDataMap with SeataXIDContext in SeataTransactionalSQLExecutionHook
  - Rename TransactionalSQLExecutionHook to SeataTransactionalSQLExecutionHook

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
