### PR TITLE
Replace `ShowTableMetaDataHandler` with `ShowTableMetaDataExecutor`

### DIFF
--- a/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/CountShadowRuleExecutorTest.java
+++ b/features/shadow/distsql/handler/src/test/java/org/apache/shardingsphere/shadow/distsql/query/CountShadowRuleExecutorTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class CountShadowRuleResultSetTest {
+public final class CountShadowRuleExecutorTest {
     
     @Test
     public void assertGetRowData() {

--- a/kernel/authority/distsql/handler/src/main/java/org/apache/shardingsphere/authority/distsql/handler/ShowAuthorityRuleExecutor.java
+++ b/kernel/authority/distsql/handler/src/main/java/org/apache/shardingsphere/authority/distsql/handler/ShowAuthorityRuleExecutor.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 /**
  * Show authority rule executor.
  */
-public final class AuthorityRuleExecutor implements MetaDataRequiredQueryableRALExecutor<ShowAuthorityRuleStatement> {
+public final class ShowAuthorityRuleExecutor implements MetaDataRequiredQueryableRALExecutor<ShowAuthorityRuleStatement> {
     
     @Override
     public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereMetaData metaData, final ShowAuthorityRuleStatement sqlStatement) {

--- a/kernel/authority/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/kernel/authority/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.authority.distsql.handler.AuthorityRuleExecutor
+org.apache.shardingsphere.authority.distsql.handler.ShowAuthorityRuleExecutor

--- a/kernel/authority/distsql/handler/src/test/java/org/apache/shardingsphere/authority/distsql/handler/ShowAuthorityRuleExecutorTest.java
+++ b/kernel/authority/distsql/handler/src/test/java/org/apache/shardingsphere/authority/distsql/handler/ShowAuthorityRuleExecutorTest.java
@@ -39,12 +39,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public final class AuthorityRuleExecutorTest {
+public final class ShowAuthorityRuleExecutorTest {
     
     @Test
     public void assertExecute() {
         ShardingSphereMetaData metaData = mockMetaData();
-        AuthorityRuleExecutor executor = new AuthorityRuleExecutor();
+        ShowAuthorityRuleExecutor executor = new ShowAuthorityRuleExecutor();
         Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, mock(ShowAuthorityRuleStatement.class));
         assertThat(actual.size(), is(1));
         Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
@@ -56,7 +56,7 @@ public final class AuthorityRuleExecutorTest {
     
     @Test
     public void assertGetColumnNames() {
-        AuthorityRuleExecutor executor = new AuthorityRuleExecutor();
+        ShowAuthorityRuleExecutor executor = new ShowAuthorityRuleExecutor();
         Collection<String> columns = executor.getColumnNames();
         assertThat(columns.size(), is(3));
         Iterator<String> iterator = columns.iterator();

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
@@ -28,7 +28,6 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.HintRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableGlobalRuleRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.RALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.UpdatableGlobalRuleRALStatement;
-import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowTableMetaDataStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.QueryableScalingRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.scaling.UpdatableScalingRALStatement;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.ApplyDistSQLStatement;
@@ -49,7 +48,6 @@ import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.hint.HintRALB
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.query.QueryableScalingRALBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.migration.update.UpdatableScalingRALBackendHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowStatusFromReadwriteSplittingRulesHandler;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowTableMetaDataHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.AlterReadwriteSplittingStorageUnitStatusStatementHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.ApplyDistSQLHandler;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.DiscardDistSQLHandler;
@@ -89,7 +87,6 @@ public final class RALBackendHandlerFactory {
         HANDLERS.put(DiscardDistSQLStatement.class, DiscardDistSQLHandler.class);
         HANDLERS.put(ImportDatabaseConfigurationStatement.class, ImportDatabaseConfigurationHandler.class);
         HANDLERS.put(ShowStatusFromReadwriteSplittingRulesStatement.class, ShowStatusFromReadwriteSplittingRulesHandler.class);
-        HANDLERS.put(ShowTableMetaDataStatement.class, ShowTableMetaDataHandler.class);
     }
     
     /**

--- a/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/proxy/backend/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -22,3 +22,4 @@ org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ExportData
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ConvertYamlConfigurationExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowDistVariableExecutor
 org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowDistVariablesExecutor
+org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.ShowTableMetaDataExecutor


### PR DESCRIPTION
For #23854.

Changes proposed in this pull request:
  - Replace `ShowTableMetaDataHandler` with `ShowTableMetaDataExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
