### PR TITLE
Unify ExecuteProcessStatusEnum variable name to processStatus

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessReporter.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/ExecuteProcessReporter.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.infra.executor.sql.process;
 import org.apache.shardingsphere.infra.binder.QueryContext;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.SQLExecutionUnit;
-import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessStatusEnum;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessContext;
+import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessStatusEnum;
 import org.apache.shardingsphere.infra.executor.sql.process.model.ExecuteProcessUnit;
 
 import java.util.Optional;
@@ -46,13 +46,13 @@ public final class ExecuteProcessReporter {
      *
      * @param queryContext query context
      * @param executionGroupContext execution group context
-     * @param constants constants
+     * @param processStatus process status
      */
     public void report(final QueryContext queryContext, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext,
-                       final ExecuteProcessStatusEnum constants) {
+                       final ExecuteProcessStatusEnum processStatus) {
         ExecuteProcessContext originExecuteProcessContext = ShowProcessListManager.getInstance().getProcessContext(executionGroupContext.getReportContext().getExecutionID());
         boolean isProxyContext = null != originExecuteProcessContext && originExecuteProcessContext.isProxyContext();
-        ExecuteProcessContext executeProcessContext = new ExecuteProcessContext(queryContext.getSql(), executionGroupContext, constants, isProxyContext);
+        ExecuteProcessContext executeProcessContext = new ExecuteProcessContext(queryContext.getSql(), executionGroupContext, processStatus, isProxyContext);
         ShowProcessListManager.getInstance().putProcessContext(executeProcessContext.getExecutionID(), executeProcessContext);
         ShowProcessListManager.getInstance().putProcessStatement(executeProcessContext.getExecutionID(), executeProcessContext.getProcessStatements());
     }
@@ -62,12 +62,12 @@ public final class ExecuteProcessReporter {
      *
      * @param executionID execution ID
      * @param executionUnit execution unit
-     * @param constants constants
+     * @param processStatus process status
      */
-    public void report(final String executionID, final SQLExecutionUnit executionUnit, final ExecuteProcessStatusEnum constants) {
-        ExecuteProcessUnit executeProcessUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), constants);
+    public void report(final String executionID, final SQLExecutionUnit executionUnit, final ExecuteProcessStatusEnum processStatus) {
+        ExecuteProcessUnit executeProcessUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), processStatus);
         ExecuteProcessContext executeProcessContext = ShowProcessListManager.getInstance().getProcessContext(executionID);
-        Optional.ofNullable(executeProcessContext.getProcessUnits().get(executeProcessUnit.getUnitID())).ifPresent(optional -> optional.setStatus(executeProcessUnit.getStatus()));
+        Optional.ofNullable(executeProcessContext.getProcessUnits().get(executeProcessUnit.getUnitID())).ifPresent(optional -> optional.setProcessStatus(executeProcessUnit.getProcessStatus()));
     }
     
     /**

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessContext.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessContext.java
@@ -52,11 +52,11 @@ public final class ExecuteProcessContext {
     
     private long startTimeMillis = System.currentTimeMillis();
     
-    private ExecuteProcessStatusEnum executeProcessConstants;
+    private ExecuteProcessStatusEnum processStatus;
     
     private final boolean proxyContext;
     
-    public ExecuteProcessContext(final String sql, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ExecuteProcessStatusEnum constants,
+    public ExecuteProcessContext(final String sql, final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ExecuteProcessStatusEnum processStatus,
                                  final boolean isProxyContext) {
         this.executionID = executionGroupContext.getReportContext().getExecutionID();
         this.sql = sql;
@@ -64,15 +64,15 @@ public final class ExecuteProcessContext {
         Grantee grantee = executionGroupContext.getReportContext().getGrantee();
         this.username = null != grantee ? grantee.getUsername() : null;
         this.hostname = null != grantee ? grantee.getHostname() : null;
-        executeProcessConstants = constants;
-        addProcessUnitsAndStatements(executionGroupContext, constants);
+        this.processStatus = processStatus;
+        addProcessUnitsAndStatements(executionGroupContext, processStatus);
         proxyContext = isProxyContext;
     }
     
-    private void addProcessUnitsAndStatements(final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ExecuteProcessStatusEnum constants) {
+    private void addProcessUnitsAndStatements(final ExecutionGroupContext<? extends SQLExecutionUnit> executionGroupContext, final ExecuteProcessStatusEnum processStatus) {
         for (ExecutionGroup<? extends SQLExecutionUnit> each : executionGroupContext.getInputGroups()) {
             for (SQLExecutionUnit executionUnit : each.getInputs()) {
-                ExecuteProcessUnit processUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), constants);
+                ExecuteProcessUnit processUnit = new ExecuteProcessUnit(executionUnit.getExecutionUnit(), processStatus);
                 processUnits.put(processUnit.getUnitID(), processUnit);
                 if (executionUnit instanceof JDBCExecutionUnit) {
                     processStatements.add(((JDBCExecutionUnit) executionUnit).getStorageResource());
@@ -87,7 +87,7 @@ public final class ExecuteProcessContext {
     public void resetExecuteProcessContextToSleep() {
         this.sql = "";
         this.startTimeMillis = System.currentTimeMillis();
-        this.executeProcessConstants = ExecuteProcessStatusEnum.SLEEP;
+        this.processStatus = ExecuteProcessStatusEnum.SLEEP;
     }
     
 }

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessUnit.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/ExecuteProcessUnit.java
@@ -30,10 +30,10 @@ public final class ExecuteProcessUnit {
     
     private final String unitID;
     
-    private volatile ExecuteProcessStatusEnum status;
+    private volatile ExecuteProcessStatusEnum processStatus;
     
-    public ExecuteProcessUnit(final ExecutionUnit executionUnit, final ExecuteProcessStatusEnum status) {
+    public ExecuteProcessUnit(final ExecutionUnit executionUnit, final ExecuteProcessStatusEnum processStatus) {
         this.unitID = String.valueOf(executionUnit.hashCode());
-        this.status = status;
+        this.processStatus = processStatus;
     }
 }

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessContext.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessContext.java
@@ -51,7 +51,7 @@ public final class YamlExecuteProcessContext {
     
     private Long startTimeMillis;
     
-    private ExecuteProcessStatusEnum executeProcessConstants;
+    private ExecuteProcessStatusEnum processStatus;
     
     public YamlExecuteProcessContext(final ExecuteProcessContext executeProcessContext) {
         executionID = executeProcessContext.getExecutionID();
@@ -64,6 +64,6 @@ public final class YamlExecuteProcessContext {
             unitStatuses.add(new YamlExecuteProcessUnit(each));
         }
         startTimeMillis = executeProcessContext.getStartTimeMillis();
-        executeProcessConstants = executeProcessContext.getExecuteProcessConstants();
+        processStatus = executeProcessContext.getProcessStatus();
     }
 }

--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/process/model/yaml/YamlExecuteProcessUnit.java
@@ -35,10 +35,10 @@ public final class YamlExecuteProcessUnit {
     
     private String unitID;
     
-    private volatile ExecuteProcessStatusEnum status;
+    private volatile ExecuteProcessStatusEnum processStatus;
     
     public YamlExecuteProcessUnit(final ExecuteProcessUnit executeProcessUnit) {
         unitID = executeProcessUnit.getUnitID();
-        status = executeProcessUnit.getStatus();
+        processStatus = executeProcessUnit.getProcessStatus();
     }
 }

--- a/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/mysql/executor/ShowProcessListExecutor.java
+++ b/proxy/backend/src/main/java/org/apache/shardingsphere/proxy/backend/handler/admin/mysql/executor/ShowProcessListExecutor.java
@@ -34,8 +34,8 @@ import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.mode.process.event.ShowProcessListRequestEvent;
 import org.apache.shardingsphere.mode.process.event.ShowProcessListResponseEvent;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
-import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.handler.admin.executor.DatabaseAdminQueryExecutor;
+import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 
 import java.sql.Types;
 import java.util.ArrayList;
@@ -95,12 +95,12 @@ public final class ShowProcessListExecutor implements DatabaseAdminQueryExecutor
             rowValues.add(processContext.getUsername());
             rowValues.add(processContext.getHostname());
             rowValues.add(processContext.getDatabaseName());
-            rowValues.add(processContext.getExecuteProcessConstants() == ExecuteProcessStatusEnum.SLEEP ? "Sleep" : "Execute");
+            rowValues.add(ExecuteProcessStatusEnum.SLEEP == processContext.getProcessStatus() ? "Sleep" : "Execute");
             rowValues.add(TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - processContext.getStartTimeMillis()));
             String sql = null;
-            if (processContext.getExecuteProcessConstants() != ExecuteProcessStatusEnum.SLEEP) {
+            if (ExecuteProcessStatusEnum.SLEEP != processContext.getProcessStatus()) {
                 int processDoneCount = processContext.getUnitStatuses().stream()
-                        .map(each -> ExecuteProcessStatusEnum.DONE == each.getStatus() ? 1 : 0)
+                        .map(each -> ExecuteProcessStatusEnum.DONE == each.getProcessStatus() ? 1 : 0)
                         .reduce(0, Integer::sum);
                 String statePrefix = "Executing ";
                 rowValues.add(statePrefix + processDoneCount + "/" + processContext.getUnitStatuses().size());

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/mysql/executor/ShowProcessListExecutorTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/admin/mysql/executor/ShowProcessListExecutorTest.java
@@ -57,9 +57,9 @@ public final class ShowProcessListExecutorTest extends ProxyContextRestorer {
                 + "  username: sharding\n"
                 + "  hostname: 127.0.0.1\n"
                 + "  unitStatuses:\n"
-                + "  - status: START\n"
+                + "  - processStatus: START\n"
                 + "    unitID: unitID1\n"
-                + "  - status: DONE\n"
+                + "  - processStatus: DONE\n"
                 + "    unitID: unitID2\n";
         Plugins.getMemberAccessor().set(showProcessListExecutor.getClass().getDeclaredField("batchProcessContexts"), showProcessListExecutor, Collections.singleton(executionNodeValue));
     }


### PR DESCRIPTION
Ref #23884.

Changes proposed in this pull request:
  - Unify ExecuteProcessStatusEnum variable name to processStatus

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
