### PR TITLE
Fix nightly builds and release profile of ShardingSphere Proxy Native

### DIFF
--- a/.github/workflows/nightly-build-artifact.yml
+++ b/.github/workflows/nightly-build-artifact.yml
@@ -125,4 +125,4 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push docker image
-        run: ./mvnw -am -pl distribution/proxy-native -B -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Pnative,docker.buildx.push.native -Dproxy.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.image.tag=${{ github.sha }} clean package
+        run: ./mvnw -am -pl distribution/proxy-native -Pnative,docker.buildx.push.native -B -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dproxy.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.image.tag=${{ github.sha }} clean package

--- a/distribution/proxy-native/Dockerfile
+++ b/distribution/proxy-native/Dockerfile
@@ -14,23 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-FROM busybox AS prepare
-
-RUN mkdir -p /conf/
-
-FROM oraclelinux:9-slim
-
-MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
-
-ENV LOCAL_PATH /opt/shardingsphere-proxy-native
-
-bash <(curl -sL https://get.graalvm.org/jdk) -c espresso graalvm-ce-java17-22.3.1
-
-COPY --from=prepare /conf/ ${LOCAL_PATH}/conf
+FROM alpine AS prepare
 
 ARG APP_NAME
+ENV LOCAL_PATH /opt/shardingsphere-proxy-native
 
-ADD target/${APP_NAME} ${LOCAL_PATH}/
+ADD target/${APP_NAME}.tar.gz /opt
+RUN mv /opt/${APP_NAME} ${LOCAL_PATH}
 
-ENTRYPOINT ${LOCAL_PATH}/${APP_NAME} 3307 ${LOCAL_PATH}/conf
+FROM oraclelinux:9-slim
+MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"
+
+ARG NATIVE_IMAGE_NAME
+ENV LOCAL_PATH /opt/shardingsphere-proxy-native
+ENV JAVA_HOME "/opt/graalvm-ce-java17-22.3.1"
+ENV PATH "$JAVA_HOME/bin:$PATH"
+
+RUN microdnf install gzip -y && \
+    bash <(curl -sL https://get.graalvm.org/jdk) --to "/opt" -c espresso graalvm-ce-java17-22.3.1 && \
+    $JAVA_HOME/bin/gu remove native-image && \
+    microdnf clean all
+
+COPY --from=prepare ${LOCAL_PATH} ${LOCAL_PATH}
+ENTRYPOINT ${LOCAL_PATH}/${NATIVE_IMAGE_NAME} 3307 ${LOCAL_PATH}/conf "0.0.0.0" false

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -28,10 +28,11 @@
     <artifactId>shardingsphere-proxy-native-distribution</artifactId>
     
     <properties>
-        <native.image.name>apache-shardingsphere-proxy-native</native.image.name>
-        <native.image.repository>apache/shardingsphere-proxy-native</native.image.repository>
         <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         <native.maven.plugin.version>0.9.19</native.maven.plugin.version>
+        <imageName>apache-shardingsphere-proxy-native</imageName>
+        <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
+        <native.image.repository>apache/shardingsphere-proxy-native</native.image.repository>
     </properties>
     
     <dependencies>
@@ -68,41 +69,14 @@
     
     <profiles>
         <profile>
-            <id>release</id>
-            <build>
-                <finalName>apache-shardingsphere-${project.version}</finalName>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-assembly-plugin</artifactId>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml</descriptor>
-                            </descriptors>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>shardingsphere-proxy-native-bin</id>
-                                <goals>
-                                    <goal>single</goal>
-                                </goals>
-                                <phase>package</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>net.nicoulaj.maven.plugins</groupId>
-                        <artifactId>checksum-maven-plugin</artifactId>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>native</id>
             <properties>
                 <hikari-cp.version>5.0.1</hikari-cp.version>
                 <truffle-api.version>22.3.1</truffle-api.version>
+                <caffeine.version>3.1.2</caffeine.version>
             </properties>
             <build>
+                <finalName>apache-shardingsphere-${project.version}</finalName>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -120,8 +94,6 @@
                         <version>${native.maven.plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <imageName>${native.image.name}</imageName>
-                            <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
                             <fallback>false</fallback>
                             <verbose>true</verbose>
                             <buildArgs>
@@ -153,6 +125,27 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>shardingsphere-proxy-native-bin</id>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.nicoulaj.maven.plugins</groupId>
+                        <artifactId>checksum-maven-plugin</artifactId>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -181,7 +174,9 @@
                                         <argument>build</argument>
                                         <argument>--pull</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${native.image.name}</argument>
+                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.image.repository}:${proxy.image.tag}</argument>
@@ -245,7 +240,9 @@
                                         <argument>--platform</argument>
                                         <argument>${proxy.image.platform}</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${native.image.name}</argument>
+                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>
@@ -265,7 +262,9 @@
                                         <argument>--platform</argument>
                                         <argument>${proxy.image.platform}</argument>
                                         <argument>--build-arg</argument>
-                                        <argument>APP_NAME=${native.image.name}</argument>
+                                        <argument>APP_NAME=${project.build.finalName}-shardingsphere-proxy-native-bin</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>NATIVE_IMAGE_NAME=${imageName}</argument>
                                         <argument>.</argument>
                                         <argument>-t</argument>
                                         <argument>${proxy.image.repository}:${proxy.image.tag}</argument>

--- a/distribution/proxy-native/src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml
+++ b/distribution/proxy-native/src/main/assembly/shardingsphere-proxy-native-binary-distribution.xml
@@ -26,15 +26,15 @@
     
     <fileSets>
         <fileSet>
-            <directory>../../proxy/bootstrap/src/main/resources/conf</directory>
-            <outputDirectory>conf</outputDirectory>
-            <fileMode>0644</fileMode>
+            <directory>${project.build.directory}</directory>
+            <includes>
+                <include>${imageName}</include>
+            </includes>
+            <outputDirectory>/</outputDirectory>
+            <fileMode>0755</fileMode>
         </fileSet>
         <fileSet>
-            <directory>../../proxy/bootstrap/src/main/resources</directory>
-            <includes>
-                <include>logback.xml</include>
-            </includes>
+            <directory>../../proxy/bootstrap/src/main/resources/conf</directory>
             <outputDirectory>conf</outputDirectory>
             <fileMode>0644</fileMode>
         </fileSet>

--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -222,7 +222,7 @@ The text of each license is the standard Apache 2.0 license.
     avatica-core 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     avatica-metrics 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     auto-service-annotations 1.0: https://github.com/google/auto/tree/master/service, Apache 2.0
-    caffeine 2.9.3: https://github.com/ben-manes/caffeine, Apache 2.0
+    caffeine 3.1.2: https://github.com/ben-manes/caffeine, Apache 2.0
     calcite-core 1.32.0: https://calcite.apache.org, Apache 2.0
     calcite-linq4j 1.32.0: https://calcite.apache.org, Apache 2.0
     commons-codec 1.15: https://github.com/apache/commons-codec, Apache 2.0
@@ -260,28 +260,30 @@ The text of each license is the standard Apache 2.0 license.
     jackson-databind 2.13.4: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-dataformat-yaml 2.13.4: http://github.com/FasterXML/jackson, Apache 2.0
     jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
-    jetcd-common 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
-    jetcd-core 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-api 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-common 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-core 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-grpc 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
     json-path 2.7.0: https://github.com/jayway/JsonPath, Apache 2.0
     json-smart 2.4.7: https://www.minidev.net/, Apache 2.0
     json-simple 1.1.1: https://code.google.com/archive/p/json-simple/, Apache 2.0 
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.86.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.86.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.86.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.87.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.87.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.87.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.23.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.0.1: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0
@@ -290,8 +292,8 @@ The text of each license is the standard Apache 2.0 license.
     snakeyaml 1.33: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
     transmittable-thread-local 2.14.2: https://github.com/alibaba/transmittable-thread-local, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
-    zookeeper 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.8.1: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.8.1: https://github.com/apache/zookeeper, Apache 2.0
 
 ========================================================================
 Apache 2.0 licenses
@@ -319,8 +321,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     janino 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
     opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
     postgresql 42.4.1: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
-    protobuf-java 3.17.2: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
-    protobuf-java-util 3.17.2: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
+    protobuf-java 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
+    protobuf-java-util 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     jts-io-common 1.19.0: https://github.com/locationtech/jts, EDL 1.0
     jts-core 1.19.0: https://github.com/locationtech/jts, EDL 1.0
 

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -259,31 +259,31 @@ The text of each license is the standard Apache 2.0 license.
     jackson-databind 2.13.4: http://github.com/FasterXML/jackson, Apache 2.0
     jackson-dataformat-yaml 2.13.4: http://github.com/FasterXML/jackson, Apache 2.0
     jcl-over-slf4j 1.7.36: https://github.com/qos-ch/slf4j, Apache 2.0
-    jetcd-api 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
-    jetcd-common 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
-    jetcd-core 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
-    jetcd-grpc 0.7.3: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-api 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-common 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-core 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
+    jetcd-grpc 0.7.5: https://github.com/etcd-io/jetcd, Apache 2.0
     json-path 2.7.0: https://github.com/jayway/JsonPath, Apache 2.0
     json-smart 2.4.7: https://www.minidev.net/, Apache 2.0
     json-simple 1.1.1: https://code.google.com/archive/p/json-simple/, Apache 2.0 
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.86.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.87.Final: https://github.com/netty, Apache 2.0
     netty-tcnative 2.0.48.Final: https://github.com/netty/netty-tcnative, Apache 2.0
     netty-tcnative-classes 2.0.48.Final: https://github.com/netty/netty-tcnative, Apache 2.0
-    netty-transport 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.86.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.86.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.86.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.86.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.87.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.87.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.87.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.25.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.9.0: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0
@@ -292,8 +292,8 @@ The text of each license is the standard Apache 2.0 license.
     snakeyaml 1.33: https://bitbucket.org/snakeyaml/snakeyaml, Apache 2.0
     transmittable-thread-local 2.14.2: https://github.com/alibaba/transmittable-thread-local, Apache 2.0
     uzaygezen-core 0.2: https://code.google.com/p/uzaygezen, Apache 2.0
-    zookeeper 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
-    zookeeper-jute 3.8.0: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper 3.8.1: https://github.com/apache/zookeeper, Apache 2.0
+    zookeeper-jute 3.8.1: https://github.com/apache/zookeeper, Apache 2.0
 
 ========================================================================
 Apache 2.0 licenses
@@ -321,8 +321,8 @@ The text of each license is also included at licenses/LICENSE-[project].txt.
     janino 3.1.8: https://github.com/janino-compiler/janino, BSD-3-Clause
     opengauss-jdbc 3.1.0-og: https://gitee.com/opengauss/openGauss-connector-jdbc, BSD-2-Clause
     postgresql 42.4.1: https://github.com/pgjdbc/pgjdbc, BSD-2-Clause
-    protobuf-java 3.19.6: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
-    protobuf-java-util 3.19.6: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
+    protobuf-java 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
+    protobuf-java-util 3.21.12: https://github.com/protocolbuffers/protobuf/blob/master/java, BSD-3-Clause
     jts-io-common 1.19.0: https://github.com/locationtech/jts, EDL 1.0
     jts-core 1.19.0: https://github.com/locationtech/jts, EDL 1.0
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -43,8 +43,8 @@ services:
 - 当前阶段，GraalVM Native Image 形态的 ShardingSphere Proxy 处于混合 AOT ( GraalVM Native Image ) 和 JIT ( GraalVM
   Truffle Espresso ) 运行的阶段。由于 https://github.com/oracle/graal/issues/4555 尚未关闭，GraalVM Truffle Espresso
   运行需要的 `.so` 文件并不会进入 GraalVM Native Image 内。因此如果你需要在 Docker Image 外运行 ShardingSphere Proxy
-  Native 的二进制文件，你需要确保系统环境变量 `GRAALVM_HOME` 或 `JAVA_HOME` 指向 GraalVM 的 `bin` 目录，并且此 GraalVM
-  实例已经通过 `GraalVM Updater` 安装了 `espresso` 组件。目前，`GRAALVM_HOME` 优先级比 `JAVA_HOME` 高。
+  Native 的二进制文件，你需要确保系统环境变量 `JAVA_HOME` 指向 GraalVM 的 `bin` 目录，并且此 GraalVM
+  实例已经通过 `GraalVM Updater` 安装了 `espresso` 组件。
 
 - 本节假定处于 Linux（amd64，aarch64）， MacOS（amd64）或 Windows（amd64）环境。
   如果你位于 MacOS（aarch64/M1） 环境，你需要关注尚未关闭的 https://github.com/oracle/graal/issues/2666 。
@@ -58,7 +58,7 @@ services:
 
 3. 根据 https://www.graalvm.org/22.3/reference-manual/native-image/#prerequisites 的要求安装本地工具链。
 
-4. 如果需要构建 Docker Image， 确保 `docker-cli` 在系统环境变量内。
+4. 如果需要构建 Docker Image， 确保 `docker-ce` 已安装。
 
 ## 操作步骤
 
@@ -104,15 +104,16 @@ services:
 ./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
 ```
 
-3. 通过命令行启动 Native Image, 需要带上两个参数，
+3. 通过命令行启动 Native Image, 需要带上 4 个参数。
    第一个参数为 ShardingSphere Proxy 使用的端口，第二个参数为你编写的包含 `server.yaml` 的 `/conf` 文件夹，
+   第三个参数为绑定端口的 Address，第四个参数为 Force Start，如果为 true 则保证 ShardingSphere Proxy Native 无论能否连接都能正常启动。
    假设已存在文件夹`./custom/conf`，示例为
 
 ```bash
-./apache-shardingsphere-proxy-native 3307 ./custom/conf
+./apache-shardingsphere-proxy-native 3307 ./custom/conf "0.0.0.0" false
 ```
 
-4. 如果需要构建 Docker Image, 在添加后存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令。
+4. 如果需要构建 Docker Image, 在添加存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令。
 
 ```shell
 ./mvnw -am -pl distribution/proxy-native -B -Pnative,docker.native -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
@@ -149,13 +150,13 @@ services:
 
 - 你可以使用 https://www.graalvm.org/22.3/tools/ 提供的一系列命令行工具或可视化工具观察 GraalVM Native Image
   的内部行为，并根据其要求使用 VSCode 完成调试工作。
-  如果你正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native Image，
-  你可以关注 https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java
-  及其后继。
+  如果你正在使用 IntelliJ IDEA 并且希望调试生成的 GraalVM Native
+  Image，你可以关注 https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java
+  及其后继。如果你使用的不是 Linux，则无法对 GraalVM Native Image 进行
+  Debug，请关注尚未关闭的 https://github.com/oracle/graal/issues/5648 。
 
-- 对于使用 `ShardingSphere Agent` 等 APM Java Agent 的情形，
-  GraalVM 的 `native-image` 组件尚未完全支持在构建 Native Image 时使用
-  javaagent，你需要关注尚未关闭的 https://github.com/oracle/graal/issues/1065。
+- 对于使用 `ShardingSphere Agent` 等 APM Java Agent 的情形， GraalVM 的 `native-image` 组件尚未完全支持在构建 Native
+  Image 时使用 javaagent，你需要关注尚未关闭的 https://github.com/oracle/graal/issues/1065。
 
 - 以下部分采用 `Apache SkyWalking Java Agent` 作为示例，可用于跟踪 GraalVM 社区的对应 issue。
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -48,10 +48,9 @@ services:
 - At the current stage, ShardingSphere Proxy in GraalVM Native Image is in the stage of mixed AOT ( GraalVM
   Native Image ) and JIT ( GraalVM Truffle Espresso ) operation. Since https://github.com/oracle/graal/issues/4555 has
   not been closed, the `.so` file required for GraalVM Truffle Espresso to run does not enter the GraalVM Native Image.
-  So if you need to run the binary files of ShardingSphere Proxy Native outside the Docker Image, you need to ensure
-  that the system environment variable `GRAALVM_HOME` or `JAVA_HOME` points to the `bin` directory of GraalVM, and this
-  GraalVM instance has been installed `espresso` component by `GraalVM Updater`. Currently, `GRAALVM_HOME` has higher
-  priority than `JAVA_HOME`.
+  So if you need to run ShardingSphere Proxy Native binary files outside the Docker Image, you need to ensure
+  that the system environment variable `JAVA_HOME` points to the `bin` directory of GraalVM, and this
+  GraalVM instance already has the `espresso` component installed via the `GraalVM Updater`.
 
 - This section assumes a Linux (amd64, aarch64), MacOS (amd64) or Windows (amd64) environment.
   If you are on MacOS (aarch64/M1) environment, you need to follow https://github.com/oracle/graal/issues/2666 which is
@@ -66,7 +65,7 @@ services:
 
 3. Install the local toolchain as required by https://www.graalvm.org/22.3/reference-manual/native-image/#prerequisites.
 
-4. If you need to build a Docker Image, make sure `docker-cli` is in the system environment variables.
+4. If you need to build a Docker Image, make sure `docker-ce` is installed.
 
 ## Steps
 
@@ -114,17 +113,19 @@ services:
 ./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
 ```
 
-3. Start Native Image through the command line, you need to bring two parameters,
-   The first parameter is the port used by ShardingSphere Proxy, and the second parameter is the `/conf` folder that
-   contains `server.yaml` written by you,
+3. To start Native Image through the command line, you need to bring 4 parameters.
+   The first parameter is the port used by ShardingSphere Proxy, the second parameter is the `/conf` folder
+   containing `server.yaml` written by you, the third parameter is the Address of the bound port, and the fourth parameter is
+   Force Start, if it is true, it will ensure that ShardingSphere Proxy Native can start normally no matter whether it
+   is connected or not.
    Assuming the folder `./custom/conf` already exists, the example is
 
 ```bash
-./apache-shardingsphere-proxy-native 3307 ./custom/conf
+./apache-shardingsphere-proxy-native 3307 ./custom/conf "0.0.0.0" false
 ````
 
-4. If you need to build a Docker Image, after adding the dependencies of the SPI implementation or third-party
-   dependencies, execute the following commands on the command line.
+4. If you need to build a Docker Image, execute the following command on the command line after adding dependencies that
+   exist for SPI implementation or third-party dependencies.
 
 ```shell
 ./mvnw -am -pl distribution/proxy-native -B -Pnative,docker.native -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Drat .skip=true clean package
@@ -164,10 +165,10 @@ services:
 
 - You can observe GraalVM Native Image using a series of command line tools or visualization tools available
   at https://www.graalvm.org/22.3/tools/, and use VSCode to debug it according to its requirements.
-  If you are using IntelliJ IDEA and want to debug the generated GraalVM Native Image,
-  You can
+  If you are using IntelliJ IDEA and want to debug the generated GraalVM Native Image, You can
   follow https://blog.jetbrains.com/idea/2022/06/intellij-idea-2022-2-eap-5/#Experimental_GraalVM_Native_Debugger_for_Java
-  and its successors.
+  and its successors. If you are not using Linux, you cannot debug GraalVM Native Image, please pay attention
+  to https://github.com/oracle/graal/issues/5648 which has not been closed yet.
 
 - In the case of using APM Java Agent such as `ShardingSphere Agent`,
   GraalVM's `native-image` component is not yet fully supported when building Native Images

--- a/infra/util-groovy/pom.xml
+++ b/infra/util-groovy/pom.xml
@@ -32,9 +32,5 @@
             <groupId>org.apache.groovy</groupId>
             <artifactId>groovy</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/infra/util-groovy/src/main/java/org/apache/shardingsphere/infra/util/groovy/expr/HotspotInlineExpressionParser.java
+++ b/infra/util-groovy/src/main/java/org/apache/shardingsphere/infra/util/groovy/expr/HotspotInlineExpressionParser.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
- * Inline expression parser.
+ * Hotspot Inline expression parser.
  */
 @RequiredArgsConstructor
 public final class HotspotInlineExpressionParser {

--- a/pom.xml
+++ b/pom.xml
@@ -79,13 +79,13 @@
         <truffle-api.version>21.2.0</truffle-api.version>
         
         <calcite.version>1.32.0</calcite.version>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.87.Final</netty.version>
         
         <javax.transaction.version>1.1</javax.transaction.version>
         
-        <zookeeper.version>3.8.0</zookeeper.version>
+        <zookeeper.version>3.8.1</zookeeper.version>
         <curator.version>5.3.0</curator.version>
-        <jetcd.version>0.7.3</jetcd.version>
+        <jetcd.version>0.7.5</jetcd.version>
         
         <elasticjob.version>3.0.2</elasticjob.version>
         
@@ -109,7 +109,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>4.8.0</mockito.version>
         
-        <protobuf-java.version>3.19.6</protobuf-java.version>
+        <protobuf-java.version>3.21.12</protobuf-java.version>
         <awaitility.version>4.2.0</awaitility.version>
         
         <!-- Plugin versions -->


### PR DESCRIPTION
For #23873 and #21347.

Changes proposed in this pull request:
  - Fix nightly builds of ShardingSphere Proxy Native. Refer to https://github.com/apache/shardingsphere/actions/runs/4076339389/jobs/7023936873 .
  - Fix release profile of ShardingSphere Proxy Native. Previously this Profile did not contain GraalVM Native Image binaries. Since the Release Profile is always executed after the Native Profile for ShardingSphere Proxy Native, it is a more reasonable choice to merge the two profiles.
  - Update protobuf-java-util to match GraalVM reachability metadata. Reference https://github.com/oracle/graalvm-reachability-metadata/pull/167 .
  - Update zookeeper to resolve ZOOKEEPER-4460 that prevents GraalVM Native Image from compiling, see https://github.com/oracle/graalvm-reachability-metadata/issues/163 .
  - Update jetcd-core to match GraalVM reachability metadata, see https://github.com/oracle/graalvm-reachability-metadata/pull/170 .
  - Split caffeine version in native profile to match GraalVM reachability metadata. Reference https://github.com/oracle/graalvm-reachability-metadata/pull/193 .
  - Update LICENSE.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
