### PR TITLE
Replace `ShowMigrationListResultSet` with `ShowMigrationListExecutor`

### DIFF
--- a/distsql/statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/scaling/QueryableScalingRALStatement.java
+++ b/distsql/statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/scaling/QueryableScalingRALStatement.java
@@ -17,10 +17,10 @@
 
 package org.apache.shardingsphere.distsql.parser.statement.ral.scaling;
 
-import org.apache.shardingsphere.distsql.parser.statement.ral.ScalingRALStatement;
+import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
 
 /**
  * Queryable RAL statement.
  */
-public abstract class QueryableScalingRALStatement extends ScalingRALStatement {
+public abstract class QueryableScalingRALStatement extends QueryableRALStatement {
 }

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -15,7 +15,4 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStatusResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckAlgorithmsResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsResultSet
+org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationListExecutor

--- a/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationListExecutorTest.java
+++ b/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationListExecutorTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.migration.distsql.handler.query;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class ShowMigrationListExecutorTest {
+    
+    @Test
+    public void assertGetColumnNames() {
+        ShowMigrationListExecutor executor = new ShowMigrationListExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(6));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("id"));
+        assertThat(iterator.next(), is("tables"));
+        assertThat(iterator.next(), is("job_item_count"));
+        assertThat(iterator.next(), is("active"));
+        assertThat(iterator.next(), is("create_time"));
+        assertThat(iterator.next(), is("stop_time"));
+    }
+}


### PR DESCRIPTION
For #23854.

Changes proposed in this pull request:
  - Replace `ShowMigrationListResultSet` with `ShowMigrationListExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
