### PR TITLE
Refactor `ShowMigrationJobStatusResultSet`

### DIFF
--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutor.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutor.java
@@ -33,7 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * Result set for show migration job status.
+ * Show migration job status executor.
  */
 public final class ShowMigrationJobStatusExecutor implements QueryableRALExecutor<ShowMigrationStatusStatement> {
     

--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutor.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutor.java
@@ -21,16 +21,13 @@ import org.apache.shardingsphere.data.pipeline.api.job.progress.InventoryIncreme
 import org.apache.shardingsphere.data.pipeline.api.pojo.InventoryIncrementalJobItemInfo;
 import org.apache.shardingsphere.data.pipeline.core.api.InventoryIncrementalJobAPI;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineJobAPI;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationStatusStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -38,57 +35,36 @@ import java.util.stream.Collectors;
 /**
  * Result set for show migration job status.
  */
-public final class ShowMigrationJobStatusResultSet implements DatabaseDistSQLResultSet {
-    
-    private Iterator<Collection<Object>> data;
+public final class ShowMigrationJobStatusExecutor implements QueryableRALExecutor<ShowMigrationStatusStatement> {
     
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
+    public Collection<LocalDataQueryResultRow> getRows(final ShowMigrationStatusStatement sqlStatement) {
         InventoryIncrementalJobAPI jobAPI = (InventoryIncrementalJobAPI) TypedSPILoader.getService(PipelineJobAPI.class, "MIGRATION");
-        List<InventoryIncrementalJobItemInfo> jobItemInfos = jobAPI.getJobItemInfos(((ShowMigrationStatusStatement) sqlStatement).getJobId());
+        List<InventoryIncrementalJobItemInfo> jobItemInfos = jobAPI.getJobItemInfos(sqlStatement.getJobId());
         long currentTimeMillis = System.currentTimeMillis();
-        data = jobItemInfos.stream().map(each -> {
-            Collection<Object> result = new LinkedList<>();
-            result.add(each.getShardingItem());
+        Collection<LocalDataQueryResultRow> result = jobItemInfos.stream().map(each -> {
+            LocalDataQueryResultRow row;
             InventoryIncrementalJobItemProgress jobItemProgress = each.getJobItemProgress();
             if (null != jobItemProgress) {
-                result.add(jobItemProgress.getDataSourceName());
-                result.add(jobItemProgress.getStatus());
-                result.add(jobItemProgress.isActive() ? Boolean.TRUE.toString() : Boolean.FALSE.toString());
-                result.add(jobItemProgress.getProcessedRecordsCount());
-                result.add(each.getInventoryFinishedPercentage());
                 String incrementalIdleSeconds = "";
                 if (jobItemProgress.getIncremental().getIncrementalLatestActiveTimeMillis() > 0) {
                     long latestActiveTimeMillis = Math.max(each.getStartTimeMillis(), jobItemProgress.getIncremental().getIncrementalLatestActiveTimeMillis());
                     incrementalIdleSeconds = String.valueOf(TimeUnit.MILLISECONDS.toSeconds(currentTimeMillis - latestActiveTimeMillis));
                 }
-                result.add(incrementalIdleSeconds);
+                row = new LocalDataQueryResultRow(each.getShardingItem(), jobItemProgress.getDataSourceName(), jobItemProgress.getStatus(),
+                        jobItemProgress.isActive() ? Boolean.TRUE.toString() : Boolean.FALSE.toString(), jobItemProgress.getProcessedRecordsCount(), each.getInventoryFinishedPercentage(),
+                        incrementalIdleSeconds, each.getErrorMessage());
             } else {
-                result.add("");
-                result.add("");
-                result.add("");
-                result.add("");
-                result.add("");
-                result.add("");
+                row = new LocalDataQueryResultRow(each.getShardingItem(), "", "", "", "", "", "", each.getErrorMessage());
             }
-            result.add(each.getErrorMessage());
-            return result;
-        }).collect(Collectors.toList()).iterator();
+            return row;
+        }).collect(Collectors.toList());
+        return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
         return Arrays.asList("item", "data_source", "status", "active", "processed_records_count", "inventory_finished_percentage", "incremental_idle_seconds", "error_message");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        return data.next();
     }
     
     @Override

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationListExecutor
+org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusExecutor

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -16,6 +16,5 @@
 #
 
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStatusResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckAlgorithmsResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsResultSet

--- a/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutorTest.java
+++ b/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.migration.distsql.handler.query;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class ShowMigrationJobStatusExecutorTest {
+    
+    @Test
+    public void assertGetColumnNames() {
+        ShowMigrationJobStatusExecutor executor = new ShowMigrationJobStatusExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(8));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("item"));
+        assertThat(iterator.next(), is("data_source"));
+        assertThat(iterator.next(), is("status"));
+        assertThat(iterator.next(), is("active"));
+        assertThat(iterator.next(), is("processed_records_count"));
+        assertThat(iterator.next(), is("inventory_finished_percentage"));
+        assertThat(iterator.next(), is("incremental_idle_seconds"));
+        assertThat(iterator.next(), is("error_message"));
+    }
+    
+    @Test
+    public void assertGetRows() {
+        
+    }
+}

--- a/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutorTest.java
+++ b/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationJobStatusExecutorTest.java
@@ -42,9 +42,4 @@ public final class ShowMigrationJobStatusExecutorTest {
         assertThat(iterator.next(), is("incremental_idle_seconds"));
         assertThat(iterator.next(), is("error_message"));
     }
-    
-    @Test
-    public void assertGetRows() {
-        
-    }
 }


### PR DESCRIPTION

For #23854.

Changes proposed in this pull request:
  - Replace `ShowMigrationJobStatusResultSet` with `ShowMigrationJobStatusExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
