### PR TITLE
Refactor `ShowMigrationCheckStatusResultSet`

### DIFF
--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -17,3 +17,4 @@
 
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationListExecutor
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusExecutor
+org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStatusExecutor

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -15,6 +15,5 @@
 # limitations under the License.
 #
 
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStatusResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckAlgorithmsResultSet
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsResultSet

--- a/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusExecutorTest.java
+++ b/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationCheckStatusExecutorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.migration.distsql.handler.query;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class ShowMigrationCheckStatusExecutorTest {
+    
+    @Test
+    public void assertGetColumnNames() {
+        ShowMigrationCheckStatusExecutor executor = new ShowMigrationCheckStatusExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(8));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("tables"));
+        assertThat(iterator.next(), is("result"));
+        assertThat(iterator.next(), is("finished_percentage"));
+        assertThat(iterator.next(), is("remaining_seconds"));
+        assertThat(iterator.next(), is("check_begin_time"));
+        assertThat(iterator.next(), is("check_end_time"));
+        assertThat(iterator.next(), is("duration_seconds"));
+        assertThat(iterator.next(), is("error_message"));
+    }
+}


### PR DESCRIPTION

For #23854.

Changes proposed in this pull request:
  - Replace `ShowMigrationCheckStatusResultSet` with `ShowMigrationCheckStatusExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
