### PR TITLE
Refactor `ShowMigrationSourceStorageUnitsResultSet`

### DIFF
--- a/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsExecutor.java
+++ b/kernel/data-pipeline/distsql/handler/src/main/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsExecutor.java
@@ -18,43 +18,37 @@
 package org.apache.shardingsphere.migration.distsql.handler.query;
 
 import org.apache.shardingsphere.data.pipeline.scenario.migration.api.impl.MigrationJobAPI;
-import org.apache.shardingsphere.distsql.handler.resultset.DatabaseDistSQLResultSet;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor;
+import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.migration.distsql.statement.ShowMigrationSourceStorageUnitsStatement;
-import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
 
 /**
- * Result set for show migration source storage units.
+ * Show migration source storage units executor.
  */
-public final class ShowMigrationSourceStorageUnitsResultSet implements DatabaseDistSQLResultSet {
+public final class ShowMigrationSourceStorageUnitsExecutor implements QueryableRALExecutor<ShowMigrationSourceStorageUnitsStatement> {
     
     private final MigrationJobAPI jobAPI = new MigrationJobAPI();
     
-    private Iterator<Collection<Object>> data;
-    
     @Override
-    public void init(final ShardingSphereDatabase database, final SQLStatement sqlStatement) {
-        data = jobAPI.listMigrationSourceResources().iterator();
-    }
-    
-    @Override
-    public Collection<Object> getRowData() {
-        return data.next();
+    public Collection<LocalDataQueryResultRow> getRows(final ShowMigrationSourceStorageUnitsStatement sqlStatement) {
+        Iterator<Collection<Object>> data = jobAPI.listMigrationSourceResources().iterator();
+        Collection<LocalDataQueryResultRow> result = new LinkedList<>();
+        while (data.hasNext()) {
+            result.add(new LocalDataQueryResultRow((List<Object>) data.next()));
+        }
+        return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
         return Arrays.asList("name", "type", "host", "port", "db", "connection_timeout_milliseconds", "idle_timeout_milliseconds",
                 "max_lifetime_milliseconds", "max_pool_size", "min_pool_size", "read_only", "other_attributes");
-    }
-    
-    @Override
-    public boolean next() {
-        return data.hasNext();
     }
     
     @Override

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.ral.query.QueryableRALExecutor
@@ -18,3 +18,4 @@
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationListExecutor
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationJobStatusExecutor
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckStatusExecutor
+org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsExecutor

--- a/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
+++ b/kernel/data-pipeline/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.resultset.DistSQLResultSet
@@ -16,4 +16,3 @@
 #
 
 org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationCheckAlgorithmsResultSet
-org.apache.shardingsphere.migration.distsql.handler.query.ShowMigrationSourceStorageUnitsResultSet

--- a/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsExecutorTest.java
+++ b/kernel/data-pipeline/distsql/handler/src/test/java/org/apache/shardingsphere/migration/distsql/handler/query/ShowMigrationSourceStorageUnitsExecutorTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.migration.distsql.handler.query;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class ShowMigrationSourceStorageUnitsExecutorTest {
+    
+    @Test
+    public void assertGetColumnNames() {
+        ShowMigrationSourceStorageUnitsExecutor executor = new ShowMigrationSourceStorageUnitsExecutor();
+        Collection<String> columns = executor.getColumnNames();
+        assertThat(columns.size(), is(12));
+        Iterator<String> iterator = columns.iterator();
+        assertThat(iterator.next(), is("name"));
+        assertThat(iterator.next(), is("type"));
+        assertThat(iterator.next(), is("host"));
+        assertThat(iterator.next(), is("port"));
+        assertThat(iterator.next(), is("db"));
+        assertThat(iterator.next(), is("connection_timeout_milliseconds"));
+        assertThat(iterator.next(), is("idle_timeout_milliseconds"));
+        assertThat(iterator.next(), is("max_lifetime_milliseconds"));
+        assertThat(iterator.next(), is("max_pool_size"));
+        assertThat(iterator.next(), is("min_pool_size"));
+        assertThat(iterator.next(), is("read_only"));
+        assertThat(iterator.next(), is("other_attributes"));
+    }
+}


### PR DESCRIPTION

For #23854.

Changes proposed in this pull request:
  - Replace `ShowMigrationSourceStorageUnitsResultSet` with `ShowMigrationSourceStorageUnitsExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
