### PR TITLE
Extract openGauss special impl from AbstractDataSourcePreparer to OpenGaussDataSourcePreparer

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/datasource/AbstractDataSourcePreparer.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/datasource/AbstractDataSourcePreparer.java
@@ -53,7 +53,7 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
     private static final String[] IGNORE_EXCEPTION_MESSAGE = {"multiple primary keys for table", "already exists"};
     
     @Override
-    public void prepareTargetSchemas(final PrepareTargetSchemasParameter param) {
+    public void prepareTargetSchemas(final PrepareTargetSchemasParameter param) throws SQLException {
         DatabaseType targetDatabaseType = param.getTargetDatabaseType();
         if (!targetDatabaseType.isSchemaAvailable()) {
             return;
@@ -75,14 +75,12 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
         }
     }
     
-    private void executeCreateSchema(final PipelineDataSourceManager dataSourceManager, final PipelineDataSourceConfiguration targetDataSourceConfig, final String sql) {
+    private void executeCreateSchema(final PipelineDataSourceManager dataSourceManager, final PipelineDataSourceConfiguration targetDataSourceConfig, final String sql) throws SQLException {
         log.info("prepareTargetSchemas, sql={}", sql);
         try (Connection connection = getCachedDataSource(dataSourceManager, targetDataSourceConfig).getConnection()) {
             try (Statement statement = connection.createStatement()) {
                 statement.execute(sql);
             }
-        } catch (final SQLException ex) {
-            log.warn("create schema failed, error: {}", ex.getMessage());
         }
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/datasource/AbstractDataSourcePreparer.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/prepare/datasource/AbstractDataSourcePreparer.java
@@ -49,9 +49,6 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
     
     private static final Pattern PATTERN_CREATE_TABLE = Pattern.compile("CREATE\\s+TABLE\\s+", Pattern.CASE_INSENSITIVE);
     
-    // TODO it's just used for openGauss
-    private static final String[] IGNORE_EXCEPTION_MESSAGE = {"multiple primary keys for table", "already exists"};
-    
     @Override
     public void prepareTargetSchemas(final PrepareTargetSchemasParameter param) throws SQLException {
         DatabaseType targetDatabaseType = param.getTargetDatabaseType();
@@ -95,18 +92,10 @@ public abstract class AbstractDataSourcePreparer implements DataSourcePreparer {
      * @param sql SQL
      * @throws SQLException SQL exception
      */
-    protected final void executeTargetTableSQL(final Connection targetConnection, final String sql) throws SQLException {
+    protected void executeTargetTableSQL(final Connection targetConnection, final String sql) throws SQLException {
         log.info("execute target table sql: {}", sql);
         try (Statement statement = targetConnection.createStatement()) {
             statement.execute(sql);
-        } catch (final SQLException ex) {
-            log.warn("execute target table sql failed", ex);
-            for (String ignoreMessage : IGNORE_EXCEPTION_MESSAGE) {
-                if (ex.getMessage().contains(ignoreMessage)) {
-                    return;
-                }
-            }
-            throw ex;
         }
     }
     

--- a/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/prepare/datasource/OpenGaussDataSourcePreparer.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/prepare/datasource/OpenGaussDataSourcePreparer.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 @Slf4j
 public final class OpenGaussDataSourcePreparer extends AbstractDataSourcePreparer {
     
+    private static final String[] IGNORE_EXCEPTION_MESSAGE = {"multiple primary keys for table", "already exists"};
+    
     @Override
     public void prepareTargetSchemas(final PrepareTargetSchemasParameter param) {
         try {
@@ -57,6 +59,20 @@ public final class OpenGaussDataSourcePreparer extends AbstractDataSourcePrepare
                     executeTargetTableSQL(targetConnection, addIfNotExistsForCreateTableSQL(sql));
                 }
             }
+        }
+    }
+    
+    @Override
+    protected void executeTargetTableSQL(final Connection targetConnection, final String sql) throws SQLException {
+        try {
+            super.executeTargetTableSQL(targetConnection, sql);
+        } catch (final SQLException ex) {
+            for (String ignoreMessage : IGNORE_EXCEPTION_MESSAGE) {
+                if (ex.getMessage().contains(ignoreMessage)) {
+                    return;
+                }
+            }
+            throw ex;
         }
     }
     

--- a/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/prepare/datasource/OpenGaussDataSourcePreparer.java
+++ b/kernel/data-pipeline/dialect/opengauss/src/main/java/org/apache/shardingsphere/data/pipeline/opengauss/prepare/datasource/OpenGaussDataSourcePreparer.java
@@ -18,10 +18,12 @@
 package org.apache.shardingsphere.data.pipeline.opengauss.prepare.datasource;
 
 import com.google.common.base.Splitter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.shaded.com.google.common.base.Strings;
 import org.apache.shardingsphere.data.pipeline.api.config.CreateTableConfiguration.CreateTableEntry;
 import org.apache.shardingsphere.data.pipeline.api.datasource.PipelineDataSourceManager;
 import org.apache.shardingsphere.data.pipeline.core.prepare.datasource.AbstractDataSourcePreparer;
+import org.apache.shardingsphere.data.pipeline.core.prepare.datasource.PrepareTargetSchemasParameter;
 import org.apache.shardingsphere.data.pipeline.core.prepare.datasource.PrepareTargetTablesParameter;
 
 import java.sql.Connection;
@@ -31,7 +33,19 @@ import java.util.stream.Collectors;
 /**
  * Data source preparer for openGauss.
  */
+@Slf4j
 public final class OpenGaussDataSourcePreparer extends AbstractDataSourcePreparer {
+    
+    @Override
+    public void prepareTargetSchemas(final PrepareTargetSchemasParameter param) {
+        try {
+            super.prepareTargetSchemas(param);
+        } catch (final SQLException ex) {
+            // openGauss CREATE SCHEMA doesn't support IF NOT EXISTS
+            // TODO Use actual data source to create schema, check whether schema exists or not
+            log.warn("create schema failed", ex);
+        }
+    }
     
     @Override
     public void prepareTargetTables(final PrepareTargetTablesParameter param) throws SQLException {


### PR DESCRIPTION

Changes proposed in this pull request:
  - Move special prepareTargetSchemas impl to OpenGaussDataSourcePreparer
  - Move special executeTargetTableSQL impl to OpenGaussDataSourcePreparer

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
