### PR TITLE
Fix storage type NPE causing the proxy to fail to start with -f(#24028)

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
@@ -55,10 +55,12 @@ public final class ShardingSphereResourceMetaData {
         dataSourceMetaDataMap = createDataSourceMetaDataMap(enabledDataSources, storageTypes);
     }
     
-    private Map<String, DatabaseType> createStorageTypes(final Map<String, DataSource> dataSources) {
+    private Map<String, DatabaseType> createStorageTypes(final Map<String, DataSource> enabledDataSources) {
         Map<String, DatabaseType> result = new LinkedHashMap<>(dataSources.size(), 1);
         for (Entry<String, DataSource> entry : dataSources.entrySet()) {
-            result.put(entry.getKey(), DatabaseTypeEngine.getStorageType(Collections.singletonList(entry.getValue())));
+            DatabaseType storageType = enabledDataSources.containsKey(entry.getKey()) ? DatabaseTypeEngine.getStorageType(Collections.singletonList(entry.getValue()))
+                    : DatabaseTypeEngine.getStorageType(Collections.emptyList());
+            result.put(entry.getKey(), storageType);
         }
         return result;
     }


### PR DESCRIPTION
Fix storage type NPE causing the proxy to fail to start with -f

Fixes #24028.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
