### PR TITLE
Enforce Postgres standard_conforming_strings to "on"

### DIFF
--- a/proxy/frontend/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
+++ b/proxy/frontend/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/authentication/PostgreSQLAuthenticationEngine.java
@@ -106,6 +106,7 @@ public final class PostgreSQLAuthenticationEngine implements AuthenticationEngin
         context.write(new PostgreSQLParameterStatusPacket("client_encoding", clientEncoding));
         context.write(new PostgreSQLParameterStatusPacket("server_encoding", "UTF8"));
         context.write(new PostgreSQLParameterStatusPacket("integer_datetimes", "on"));
+        context.write(new PostgreSQLParameterStatusPacket("standard_conforming_strings", "on"));
         context.writeAndFlush(PostgreSQLReadyForQueryPacket.NOT_IN_TRANSACTION);
         return AuthenticationResultBuilder.finished(currentAuthResult.getUsername(), "", currentAuthResult.getDatabase());
     }


### PR DESCRIPTION
Fixes #23964.

Changes proposed in this pull request:
  * Enforcing Postgres standard_conforming_strings to "on" to handle issues associated to `gorm` while handling boolean values.

---

Before committing this PR, I'm sure that I have checked the following options:
- [X ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ X] I have self-reviewed the commit code.
- [ X] I have (or in comment I request) added corresponding labels for the pull request.
- [X ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ X] I have made corresponding changes to the documentation.
- [ X] I have added corresponding unit tests for my changes.
