### PR TITLE
Fix mysql create procedure syntax error.

### DIFF
--- a/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -17,7 +17,7 @@
 
 grammar DDLStatement;
 
-import DMLStatement, DALStatement;
+import DMLStatement, DALStatement, TCLStatement;
 
 alterStatement
     : alterTable
@@ -665,7 +665,7 @@ compoundStatement
 validStatement
     : (createTable | alterTable | dropTable | truncateTable 
     | insert | replace | update | delete | select | call
-    | createView
+    | createView | prepare | executeStmt | commit | deallocate
     | setVariable | beginStatement | declareStatement | flowControlStatement | cursorStatement | conditionHandlingStatement) SEMI_?
     ;
 

--- a/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-procedure.xml
@@ -31,4 +31,5 @@
     <create-procedure sql-case-id="create_procedure_with_sqlexception_and_create_view" />
     <create-procedure sql-case-id="create_procedure_with_deterministic_create_view" />
     <create-procedure sql-case-id="create_procedure_with_update_statement_oracle" />
+    <create-procedure sql-case-id="create_procedure_with_prepare_commit" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-procedure.xml
@@ -43,4 +43,5 @@
     <sql-case id="create_procedure_with_sqlexception_and_create_view" value="create procedure p() begin declare continue handler for sqlexception begin end; create view a as select 1; end" db-types="MySQL" />
     <sql-case id="create_procedure_with_deterministic_create_view" value="create procedure p1 () deterministic begin create view v1 as select 1; end;" db-types="MySQL" />
     <sql-case id="create_procedure_with_update_statement_oracle" value="CREATE PROCEDURE update_order (order_id NUMBER,status NUMBER) AS BEGIN  UPDATE t_order SET status = status WHERE order_id = order_id;END;" db-types="Oracle" />
+    <sql-case id="create_procedure_with_prepare_commit" value="CREATE DEFINER=`sys_data`@`%` PROCEDURE `TEST1` (a VARCHAR(64),b VARCHAR(64),c VARCHAR(64),d VARCHAR(8),e INT) BEGIN DECLARE f VARCHAR(8); SET f=DATE_FORMAT(DATE_ADD((STR_TO_DATE(d,'%Y%m%d')),INTERVAL -(e) MONTH),'%Y%m%d'); SET @aaa=CONCAT('delete from ',a,'.',b,' where ',c,'&lt;=',f,' or ', c,'&lt;&gt; LAST_DAY(',c,')', 'or ',c,'=', d); PREPARE stmt FROM @aaa; EXECUTE stmt; COMMIT; DEALLOCATE PREPARE stmt; END" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix mysql create procedure syntax error.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
