### PR TITLE
Refactor PipelineWatcher to ease troubleshooting

### DIFF
--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/watcher/PipelineWatcher.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/watcher/PipelineWatcher.java
@@ -25,7 +25,6 @@ import org.apache.shardingsphere.mode.repository.cluster.ClusterPersistRepositor
 import org.apache.shardingsphere.mode.repository.cluster.zookeeper.ZookeeperRepository;
 import org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.compose.BaseContainerComposer;
 import org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.compose.DockerContainerComposer;
-import org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.compose.NativeContainerComposer;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
@@ -39,13 +38,6 @@ import java.util.Properties;
 public class PipelineWatcher extends TestWatcher {
     
     private final BaseContainerComposer containerComposer;
-    
-    @Override
-    protected void failed(final Throwable e, final Description description) {
-        if (containerComposer instanceof NativeContainerComposer) {
-            super.failed(e, description);
-        }
-    }
     
     // TODO now the meta data mistake is not reproduce, but keep this method, it may be used again
     private void outputZookeeperData() {
@@ -82,13 +74,22 @@ public class PipelineWatcher extends TestWatcher {
     
     @Override
     protected void starting(final Description description) {
-        log.info("starting: {}", description);
+        log.info("pipeline E2E starting: {}", description);
         containerComposer.start();
     }
     
     @Override
+    protected void succeeded(final Description description) {
+        log.info("pipeline E2E succeeded: {}", description);
+    }
+    
+    @Override
+    protected void failed(final Throwable ex, final Description description) {
+        log.info("pipeline E2E failed: {}", description, ex);
+    }
+    
+    @Override
     protected void finished(final Description description) {
-        log.info("finished: {}", description);
         containerComposer.close();
     }
 }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Refactor PipelineWatcher to ease troubleshooting. Print message on `succeeded/failed` just after unit test method finished, we could search `pipeline E2E failed` to locate it.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
