### PR TITLE
Make CREATE DEFAULT SHARDING STRATEGY support `None`ShardingStrategy TYPE

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateDefaultShardingStrategyStatementUpdater.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/update/CreateDefaultShardingStrategyStatementUpdater.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.ShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.distsql.handler.converter.ShardingTableRuleStatementConverter;
 import org.apache.shardingsphere.sharding.distsql.handler.enums.ShardingStrategyLevelType;
@@ -44,7 +45,9 @@ public final class CreateDefaultShardingStrategyStatementUpdater implements Rule
     public void checkSQLStatement(final ShardingSphereDatabase database, final CreateDefaultShardingStrategyStatement sqlStatement, final ShardingRuleConfiguration currentRuleConfig) {
         String databaseName = database.getName();
         checkCurrentRuleConfiguration(databaseName, currentRuleConfig);
-        checkAlgorithm(databaseName, currentRuleConfig, sqlStatement);
+        if (!"none".equalsIgnoreCase(sqlStatement.getStrategyType())) {
+            checkAlgorithm(sqlStatement);
+        }
         if (!sqlStatement.isIfNotExists()) {
             checkExist(databaseName, sqlStatement, currentRuleConfig);
         }
@@ -54,7 +57,7 @@ public final class CreateDefaultShardingStrategyStatementUpdater implements Rule
         ShardingSpherePreconditions.checkNotNull(currentRuleConfig, () -> new MissingRequiredRuleException("Sharding", databaseName));
     }
     
-    private void checkAlgorithm(final String databaseName, final ShardingRuleConfiguration currentRuleConfig, final CreateDefaultShardingStrategyStatement sqlStatement) {
+    private void checkAlgorithm(final CreateDefaultShardingStrategyStatement sqlStatement) {
         ShardingSpherePreconditions.checkState(ShardingStrategyType.contains(sqlStatement.getStrategyType()), () -> new InvalidAlgorithmConfigurationException(sqlStatement.getStrategyType()));
         ShardingSpherePreconditions.checkState(ShardingStrategyType.getValueOf(sqlStatement.getStrategyType())
                 .isValid(sqlStatement.getShardingColumn()), () -> new InvalidAlgorithmConfigurationException(sqlStatement.getStrategyType()));
@@ -81,10 +84,14 @@ public final class CreateDefaultShardingStrategyStatementUpdater implements Rule
     @Override
     public ShardingRuleConfiguration buildToBeCreatedRuleConfiguration(final ShardingRuleConfiguration currentRuleConfig, final CreateDefaultShardingStrategyStatement sqlStatement) {
         ShardingRuleConfiguration result = new ShardingRuleConfiguration();
-        String shardingAlgorithmName = getShardingAlgorithmName(sqlStatement, result);
-        ShardingStrategyConfiguration strategyConfig = ShardingTableRuleStatementConverter.createStrategyConfiguration(
-                sqlStatement.getStrategyType(), sqlStatement.getShardingColumn(), shardingAlgorithmName);
-        setStrategyConfiguration(result, sqlStatement.getDefaultType(), strategyConfig);
+        if ("none".equalsIgnoreCase(sqlStatement.getStrategyType())) {
+            setStrategyConfiguration(result, sqlStatement.getDefaultType(), new NoneShardingStrategyConfiguration());
+        } else {
+            String shardingAlgorithmName = getShardingAlgorithmName(sqlStatement, result);
+            ShardingStrategyConfiguration strategyConfig = ShardingTableRuleStatementConverter.createStrategyConfiguration(
+                    sqlStatement.getStrategyType(), sqlStatement.getShardingColumn(), shardingAlgorithmName);
+            setStrategyConfiguration(result, sqlStatement.getDefaultType(), strategyConfig);
+        }
         return result;
     }
     

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateDefaultShardingStrategyStatementUpdaterTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/update/CreateDefaultShardingStrategyStatementUpdaterTest.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.distsql.handler.exception.rule.MissingRequiredR
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
+import org.apache.shardingsphere.sharding.api.config.strategy.sharding.NoneShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.api.config.strategy.sharding.StandardShardingStrategyConfiguration;
 import org.apache.shardingsphere.sharding.distsql.handler.update.CreateDefaultShardingStrategyStatementUpdater;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.CreateDefaultShardingStrategyStatement;
@@ -148,6 +149,32 @@ public final class CreateDefaultShardingStrategyStatementUpdaterTest {
         StandardShardingStrategyConfiguration defaultDatabaseShardingStrategy = (StandardShardingStrategyConfiguration) currentRuleConfig.getDefaultDatabaseShardingStrategy();
         assertThat(defaultDatabaseShardingStrategy.getShardingAlgorithmName(), is("default_database_inline"));
         assertThat(defaultDatabaseShardingStrategy.getShardingColumn(), is("user_id"));
+    }
+    
+    @Test
+    public void assertCreateDefaultTableShardingStrategyWithNoneShardingStrategyType() {
+        CreateDefaultShardingStrategyStatement statement = new CreateDefaultShardingStrategyStatement(false, "TABLE", "none", null, null);
+        ShardingRuleConfiguration currentRuleConfig = new ShardingRuleConfiguration();
+        currentRuleConfig.setDefaultDatabaseShardingStrategy(new StandardShardingStrategyConfiguration("order_id", "orderAlgorithm"));
+        currentRuleConfig.getShardingAlgorithms().put("order_id_algorithm", null);
+        updater.checkSQLStatement(database, statement, currentRuleConfig);
+        ShardingRuleConfiguration toBeCreatedRuleConfig = updater.buildToBeCreatedRuleConfiguration(currentRuleConfig, statement);
+        updater.updateCurrentRuleConfiguration(currentRuleConfig, toBeCreatedRuleConfig);
+        NoneShardingStrategyConfiguration defaultTableShardingStrategy = (NoneShardingStrategyConfiguration) currentRuleConfig.getDefaultTableShardingStrategy();
+        assertThat(defaultTableShardingStrategy.getType(), is(""));
+        assertThat(defaultTableShardingStrategy.getShardingAlgorithmName(), is(""));
+    }
+    
+    @Test
+    public void assertCreateDefaultDatabaseShardingStrategyWithNoneShardingStrategyType() {
+        CreateDefaultShardingStrategyStatement statement = new CreateDefaultShardingStrategyStatement(false, "DATABASE", "none", null, null);
+        ShardingRuleConfiguration currentRuleConfig = new ShardingRuleConfiguration();
+        updater.checkSQLStatement(database, statement, currentRuleConfig);
+        ShardingRuleConfiguration toBeCreatedRuleConfig = updater.buildToBeCreatedRuleConfiguration(currentRuleConfig, statement);
+        updater.updateCurrentRuleConfiguration(currentRuleConfig, toBeCreatedRuleConfig);
+        NoneShardingStrategyConfiguration defaultDatabaseShardingStrategy = (NoneShardingStrategyConfiguration) currentRuleConfig.getDefaultDatabaseShardingStrategy();
+        assertThat(defaultDatabaseShardingStrategy.getType(), is(""));
+        assertThat(defaultDatabaseShardingStrategy.getShardingAlgorithmName(), is(""));
     }
     
     private AlgorithmSegment getAutoCreativeAlgorithmSegment(final String name, final Properties props) {

--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -190,11 +190,14 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     @Override
     public ASTNode visitCreateDefaultShardingStrategy(final CreateDefaultShardingStrategyContext ctx) {
         ShardingStrategyContext shardingStrategyContext = ctx.shardingStrategy();
+        String strategyType = getIdentifierValue(shardingStrategyContext.strategyType());
+        if ("none".equalsIgnoreCase(strategyType)) {
+            return new CreateDefaultShardingStrategyStatement(null != ctx.ifNotExists(), new IdentifierValue(ctx.type.getText()).getValue(), "none", null, null);
+        }
         AlgorithmSegment algorithmSegment = null != shardingStrategyContext.shardingAlgorithm().algorithmDefinition()
                 ? (AlgorithmSegment) visitAlgorithmDefinition(shardingStrategyContext.shardingAlgorithm().algorithmDefinition())
                 : null;
         String defaultType = new IdentifierValue(ctx.type.getText()).getValue();
-        String strategyType = getIdentifierValue(shardingStrategyContext.strategyType());
         String shardingColumn = buildShardingColumn(ctx.shardingStrategy().shardingColumnDefinition());
         return new CreateDefaultShardingStrategyStatement(null != ctx.ifNotExists(), defaultType, strategyType, shardingColumn, algorithmSegment);
     }
@@ -321,14 +324,12 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     
     @Override
     public ASTNode visitShardingStrategy(final ShardingStrategyContext ctx) {
-        if (null == ctx) {
-            return null;
-        }
-        if ("none".equalsIgnoreCase(getIdentifierValue(ctx.strategyType()))) {
-            return new ShardingStrategySegment(getIdentifierValue(ctx.strategyType()), null, null);
+        String strategyType = getIdentifierValue(ctx.strategyType());
+        if ("none".equalsIgnoreCase(strategyType)) {
+            return new ShardingStrategySegment(strategyType, null, null);
         }
         AlgorithmSegment algorithmSegment = null != ctx.shardingAlgorithm().algorithmDefinition() ? (AlgorithmSegment) visitAlgorithmDefinition(ctx.shardingAlgorithm().algorithmDefinition()) : null;
-        return new ShardingStrategySegment(getIdentifierValue(ctx.strategyType()), buildShardingColumn(ctx.shardingColumnDefinition()), algorithmSegment);
+        return new ShardingStrategySegment(strategyType, buildShardingColumn(ctx.shardingColumnDefinition()), algorithmSegment);
     }
     
     private Collection<String> getResources(final StorageUnitsContext ctx) {

--- a/proxy/frontend/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
+++ b/proxy/frontend/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngineTest.java
@@ -153,9 +153,8 @@ public final class MySQLAuthenticationEngineTest extends ProxyContextRestorer {
         ChannelHandlerContext context = mockChannelHandlerContext();
         try (
                 MockedConstruction<AuthenticatorFactory> mockedAuthenticatorFactory = mockConstruction(AuthenticatorFactory.class,
-                        (mock, mockContext) -> when(mock.newInstance(user)).thenReturn(mock(Authenticator.class))); 
-                MockedConstruction<MySQLErrPacket> mockedErrPacket = mockConstruction(MySQLErrPacket.class, (mock, mockContext) -> assertAuthenticationErrorPacket(mockContext.arguments()))
-        ) {
+                        (mock, mockContext) -> when(mock.newInstance(user)).thenReturn(mock(Authenticator.class)));
+                MockedConstruction<MySQLErrPacket> mockedErrPacket = mockConstruction(MySQLErrPacket.class, (mock, mockContext) -> assertAuthenticationErrorPacket(mockContext.arguments()))) {
             authenticationEngine.authenticate(context, getPayload("root", "sharding_db", authResponse));
             verify(context).writeAndFlush(any(MySQLErrPacket.class));
             verify(context).close();
@@ -164,7 +163,7 @@ public final class MySQLAuthenticationEngineTest extends ProxyContextRestorer {
     
     private void assertAuthenticationErrorPacket(final List<?> arguments) {
         assertThat(arguments.get(0), is(MySQLVendorError.ER_ACCESS_DENIED_ERROR));
-        assertThat(arguments.get(1), is(new String[] {"root", "127.0.0.1", "YES"}));
+        assertThat(arguments.get(1), is(new String[]{"root", "127.0.0.1", "YES"}));
     }
     
     @Test
@@ -185,7 +184,7 @@ public final class MySQLAuthenticationEngineTest extends ProxyContextRestorer {
     
     private void assertDatabaseAccessDeniedErrorPacket(final List<?> arguments) {
         assertThat(arguments.get(0), is(MySQLVendorError.ER_DBACCESS_DENIED_ERROR));
-        assertThat(arguments.get(1), is(new String[] {"root", "127.0.0.1", "sharding_db"}));
+        assertThat(arguments.get(1), is(new String[]{"root", "127.0.0.1", "sharding_db"}));
     }
     
     @Test
@@ -204,7 +203,7 @@ public final class MySQLAuthenticationEngineTest extends ProxyContextRestorer {
     
     private void assertInvalidDatabaseErrorPacket(final List<?> arguments) {
         assertThat(arguments.get(0), is(MySQLVendorError.ER_BAD_DB_ERROR));
-        assertThat(arguments.get(1), is(new String[] {"invalid_db"}));
+        assertThat(arguments.get(1), is(new String[]{"invalid_db"}));
     }
     
     @Test


### PR DESCRIPTION
For #23835.

Changes proposed in this pull request:
  - Make CREATE DEFAULT SHARDING STRATEGY support `None`ShardingStrategy TYPE

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
