### PR TITLE
Make `ShowDatabaseDiscoveryRule`support query specified rule

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
@@ -44,17 +44,7 @@ import java.util.stream.Collectors;
  */
 public final class ShowDatabaseDiscoveryRuleExecutor implements RQLExecutor<ShowDatabaseDiscoveryRulesStatement> {
     
-    private static final String GROUP_NAME = "group_name";
-    
-    private static final String DATA_SOURCE_NAMES = "data_source_names";
-    
-    private static final String PRIMARY_DATA_SOURCE_NAME = "primary_data_source_name";
-    
     private static final String NAME = "name";
-    
-    private static final String DISCOVER_TYPE = "discovery_type";
-    
-    private static final String HEARTBEAT = "discovery_heartbeat";
     
     @Override
     public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereDatabase database, final ShowDatabaseDiscoveryRulesStatement sqlStatement) {
@@ -80,14 +70,18 @@ public final class ShowDatabaseDiscoveryRuleExecutor implements RQLExecutor<Show
             heartbeatMap.putAll(convertToMap(discoveryHeartbeats.get(dataSourceRuleConfig.getDiscoveryHeartbeatName())));
             String groupName = dataSourceRuleConfig.getGroupName();
             String primaryDataSourceName = null == primaryDataSources.get(groupName) ? "" : primaryDataSources.get(groupName);
-            result.add(new LocalDataQueryResultRow(groupName, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, typeMap, heartbeatMap));
+            if (null == sqlStatement.getRuleName()) {
+                result.add(new LocalDataQueryResultRow(groupName, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, typeMap, heartbeatMap));
+            } else if (sqlStatement.getRuleName().equalsIgnoreCase(groupName)) {
+                result.add(new LocalDataQueryResultRow(groupName, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, typeMap, heartbeatMap));
+            }
         }
         return result;
     }
     
     @Override
     public Collection<String> getColumnNames() {
-        return Arrays.asList(GROUP_NAME, DATA_SOURCE_NAMES, PRIMARY_DATA_SOURCE_NAME, DISCOVER_TYPE, HEARTBEAT);
+        return Arrays.asList("group_name", "data_source_names", "primary_data_source_name", "discovery_type", "discovery_heartbeat");
     }
     
     @SuppressWarnings("unchecked")

--- a/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
+++ b/features/db-discovery/distsql/handler/src/test/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutorTest.java
@@ -61,6 +61,20 @@ public final class ShowDatabaseDiscoveryRuleExecutorTest {
     }
     
     @Test
+    public void assertGetRowsWithSpecifiedRuleName() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        DatabaseDiscoveryRule rule = mock(DatabaseDiscoveryRule.class, RETURNS_DEEP_STUBS);
+        when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
+        DatabaseDiscoveryDataSourceRule dataSourceRule = mock(DatabaseDiscoveryDataSourceRule.class);
+        when(dataSourceRule.getPrimaryDataSourceName()).thenReturn("ds_0");
+        when(rule.getDataSourceRules()).thenReturn(Collections.singletonMap("ms_group", dataSourceRule));
+        when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
+        RQLExecutor<ShowDatabaseDiscoveryRulesStatement> executor = new ShowDatabaseDiscoveryRuleExecutor();
+        assertColumns(executor.getColumnNames());
+        assertRowData(new ArrayList<>(executor.getRows(database, new ShowDatabaseDiscoveryRulesStatement("ms_group", null))));
+    }
+    
+    @Test
     public void assertGetColumnNames() {
         RQLExecutor<ShowDatabaseDiscoveryRulesStatement> executor = new ShowDatabaseDiscoveryRuleExecutor();
         assertColumns(executor.getColumnNames());

--- a/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/RQLStatement.g4
+++ b/features/db-discovery/distsql/parser/src/main/antlr4/imports/db-discovery/RQLStatement.g4
@@ -20,7 +20,7 @@ grammar RQLStatement;
 import BaseRule;
 
 showDatabaseDiscoveryRules
-    : SHOW DB_DISCOVERY RULES (FROM databaseName)?
+    : SHOW DB_DISCOVERY (RULE ruleName | RULES) (FROM databaseName)?
     ;
 
 showDatabaseDiscoveryTypes
@@ -33,6 +33,10 @@ showDatabaseDiscoveryHeartbeats
 
 countDatabaseDiscoveryRule
     : COUNT DB_DISCOVERY RULE (FROM databaseName)?
+    ;
+
+ruleName
+    : IDENTIFIER_
     ;
 
 databaseName

--- a/features/db-discovery/distsql/parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
+++ b/features/db-discovery/distsql/parser/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/core/DatabaseDiscoveryDistSQLStatementVisitor.java
@@ -88,7 +88,8 @@ public final class DatabaseDiscoveryDistSQLStatementVisitor extends DatabaseDisc
     
     @Override
     public ASTNode visitShowDatabaseDiscoveryRules(final ShowDatabaseDiscoveryRulesContext ctx) {
-        return new ShowDatabaseDiscoveryRulesStatement(null == ctx.databaseName() ? null : (DatabaseSegment) visit(ctx.databaseName()));
+        return new ShowDatabaseDiscoveryRulesStatement(null == ctx.ruleName() ? null : getIdentifierValue(ctx.ruleName()),
+                null == ctx.databaseName() ? null : (DatabaseSegment) visit(ctx.databaseName()));
     }
     
     @Override

--- a/features/db-discovery/distsql/statement/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/statement/ShowDatabaseDiscoveryRulesStatement.java
+++ b/features/db-discovery/distsql/statement/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/parser/statement/ShowDatabaseDiscoveryRulesStatement.java
@@ -17,15 +17,20 @@
 
 package org.apache.shardingsphere.dbdiscovery.distsql.parser.statement;
 
+import lombok.Getter;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowRulesStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DatabaseSegment;
 
 /**
  * Show database discovery rules statement.
  */
+@Getter
 public final class ShowDatabaseDiscoveryRulesStatement extends ShowRulesStatement {
     
-    public ShowDatabaseDiscoveryRulesStatement(final DatabaseSegment database) {
+    private final String ruleName;
+    
+    public ShowDatabaseDiscoveryRulesStatement(final String ruleName, final DatabaseSegment database) {
         super(database);
+        this.ruleName = ruleName;
     }
 }


### PR DESCRIPTION
For #24158.

Changes proposed in this pull request:
  - Make `ShowDatabaseDiscoveryRule`support query specified rule with rule name

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
