### PR TITLE
Make authentication method match the Authority rule configuration

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUserConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/user/yaml/config/YamlUserConfiguration.java
@@ -33,9 +33,4 @@ public final class YamlUserConfiguration implements YamlConfiguration {
     private String password;
     
     private String authenticationMethodName;
-    
-    @Override
-    public String toString() {
-        return user.contains("@") ? user + ":" + password : user + "@%:" + password;
-    }
 }

--- a/proxy/frontend/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
+++ b/proxy/frontend/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
@@ -113,7 +113,8 @@ public final class MySQLAuthenticationEngine implements AuthenticationEngine {
             writeErrorPacket(context, new MySQLErrPacket(MySQLVendorError.ER_BAD_DB_ERROR, packet.getDatabase()));
             return AuthenticationResultBuilder.continued();
         }
-        Authenticator authenticator = new AuthenticatorFactory<>(MySQLAuthenticatorType.class, rule).newInstance(new ShardingSphereUser(packet.getUsername(), "", getHostAddress(context)));
+        ShardingSphereUser user = rule.findUser(new Grantee(packet.getUsername(), getHostAddress(context))).orElseGet(() -> new ShardingSphereUser(packet.getUsername(), "", getHostAddress(context)));
+        Authenticator authenticator = new AuthenticatorFactory<>(MySQLAuthenticatorType.class, rule).newInstance(user);
         if (isClientPluginAuth(packet) && !authenticator.getAuthenticationMethodName().equals(packet.getAuthPluginName())) {
             connectionPhase = MySQLConnectionPhase.AUTHENTICATION_METHOD_MISMATCH;
             context.writeAndFlush(new MySQLAuthSwitchRequestPacket(authenticator.getAuthenticationMethodName(), authPluginData));

--- a/proxy/frontend/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/authenticator/MySQLClearPasswordAuthenticatorTest.java
+++ b/proxy/frontend/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/authenticator/MySQLClearPasswordAuthenticatorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.proxy.frontend.mysql.authentication.authenticator;
+
+import org.apache.shardingsphere.infra.metadata.user.ShardingSphereUser;
+import org.apache.shardingsphere.proxy.frontend.mysql.ProxyContextRestorer;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public final class MySQLClearPasswordAuthenticatorTest extends ProxyContextRestorer {
+    
+    @Test
+    public void assertAuthenticationMethodName() {
+        assertThat(new MySQLClearPasswordAuthenticator().getAuthenticationMethodName(), is("mysql_clear_password"));
+    }
+    
+    @Test
+    public void assertAuthenticate() {
+        ShardingSphereUser user = new ShardingSphereUser("foo", "password", "%");
+        byte[] password = "password".getBytes();
+        byte[] authInfo = new byte[password.length + 1];
+        System.arraycopy(password, 0, authInfo, 0, password.length);
+        assertTrue(new MySQLClearPasswordAuthenticator().authenticate(user, new Object[]{authInfo}));
+    }
+    
+    @Test
+    public void assertAuthenticateFailed() {
+        ShardingSphereUser user = new ShardingSphereUser("foo", "password", "%");
+        byte[] password = "wrong".getBytes();
+        assertFalse(new MySQLClearPasswordAuthenticator().authenticate(user, new Object[]{password}));
+    }
+}


### PR DESCRIPTION
Fixes #24155.

Changes proposed in this pull request:
  - Find user in rule to get authenticator
  - Add tese case for `MySQLClearPasswordAuthenticatorTest`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
