### PR TITLE
Make `ShowReadwriteSplittingRule`support query specified rule

### DIFF
--- a/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
+++ b/features/db-discovery/distsql/handler/src/main/java/org/apache/shardingsphere/dbdiscovery/distsql/handler/query/ShowDatabaseDiscoveryRuleExecutor.java
@@ -70,9 +70,7 @@ public final class ShowDatabaseDiscoveryRuleExecutor implements RQLExecutor<Show
             heartbeatMap.putAll(convertToMap(discoveryHeartbeats.get(dataSourceRuleConfig.getDiscoveryHeartbeatName())));
             String groupName = dataSourceRuleConfig.getGroupName();
             String primaryDataSourceName = null == primaryDataSources.get(groupName) ? "" : primaryDataSources.get(groupName);
-            if (null == sqlStatement.getRuleName()) {
-                result.add(new LocalDataQueryResultRow(groupName, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, typeMap, heartbeatMap));
-            } else if (sqlStatement.getRuleName().equalsIgnoreCase(groupName)) {
+            if (null == sqlStatement.getRuleName() || sqlStatement.getRuleName().equalsIgnoreCase(groupName)) {
                 result.add(new LocalDataQueryResultRow(groupName, String.join(",", dataSourceRuleConfig.getDataSourceNames()), primaryDataSourceName, typeMap, heartbeatMap));
             }
         }

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
@@ -52,7 +52,7 @@ public final class ShowReadwriteSplittingRuleExecutor implements RQLExecutor<Sho
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         if (rule.isPresent()) {
             buildExportableMap(rule.get());
-            result = buildData(rule.get());
+            result = buildData(rule.get(), sqlStatement);
         }
         return result;
     }
@@ -64,11 +64,15 @@ public final class ShowReadwriteSplittingRuleExecutor implements RQLExecutor<Sho
         exportableDataSourceMap = (Map<String, Map<String, String>>) exportedData.get(ExportableConstants.EXPORT_STATIC_READWRITE_SPLITTING_RULE);
     }
     
-    private Collection<LocalDataQueryResultRow> buildData(final ReadwriteSplittingRule rule) {
+    private Collection<LocalDataQueryResultRow> buildData(final ReadwriteSplittingRule rule, final ShowReadwriteSplittingRulesStatement sqlStatement) {
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         ((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()).getDataSources().forEach(each -> {
             LocalDataQueryResultRow dataItem = buildDataItem(each, getLoadBalancers((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()));
-            result.add(dataItem);
+            if (null == sqlStatement.getRuleName()) {
+                result.add(dataItem);
+            } else if (sqlStatement.getRuleName().equalsIgnoreCase(each.getName())) {
+                result.add(dataItem);
+            }
         });
         return result;
     }

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutor.java
@@ -68,9 +68,7 @@ public final class ShowReadwriteSplittingRuleExecutor implements RQLExecutor<Sho
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         ((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()).getDataSources().forEach(each -> {
             LocalDataQueryResultRow dataItem = buildDataItem(each, getLoadBalancers((ReadwriteSplittingRuleConfiguration) rule.getConfiguration()));
-            if (null == sqlStatement.getRuleName()) {
-                result.add(dataItem);
-            } else if (sqlStatement.getRuleName().equalsIgnoreCase(each.getName())) {
+            if (null == sqlStatement.getRuleName() || sqlStatement.getRuleName().equalsIgnoreCase(each.getName())) {
                 result.add(dataItem);
             }
         });

--- a/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutorTest.java
+++ b/features/readwrite-splitting/distsql/handler/src/test/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/query/ShowReadwriteSplittingRuleExecutorTest.java
@@ -82,6 +82,27 @@ public final class ShowReadwriteSplittingRuleExecutorTest {
         assertThat(row.getCell(7), is("read_weight=2:1"));
     }
     
+    @Test
+    public void assertGetRowDataWithSpecifiedRuleName() {
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
+        ReadwriteSplittingRule rule = mock(ReadwriteSplittingRule.class);
+        when(rule.getConfiguration()).thenReturn(createRuleConfiguration());
+        when(rule.getExportData()).thenReturn(createExportedData());
+        when(database.getRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(rule)));
+        RQLExecutor<ShowReadwriteSplittingRulesStatement> executor = new ShowReadwriteSplittingRuleExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(database, new ShowReadwriteSplittingRulesStatement("readwrite_ds", null));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("readwrite_ds"));
+        assertThat(row.getCell(2), is(""));
+        assertThat(row.getCell(3), is(""));
+        assertThat(row.getCell(4), is("ds_primary"));
+        assertThat(row.getCell(5), is("ds_slave_0,ds_slave_1"));
+        assertThat(row.getCell(6), is("random"));
+        assertThat(row.getCell(7), is("read_weight=2:1"));
+    }
+    
     private Map<String, Object> createExportedData() {
         Map<String, Object> result = new HashMap<>(2, 1);
         result.put(ExportableConstants.EXPORT_DYNAMIC_READWRITE_SPLITTING_RULE, Collections.emptyMap());

--- a/features/readwrite-splitting/distsql/parser/src/main/antlr4/imports/readwrite-splitting/RQLStatement.g4
+++ b/features/readwrite-splitting/distsql/parser/src/main/antlr4/imports/readwrite-splitting/RQLStatement.g4
@@ -20,9 +20,13 @@ grammar RQLStatement;
 import BaseRule;
 
 showReadwriteSplittingRules
-    : SHOW READWRITE_SPLITTING RULES (FROM databaseName)?
+    : SHOW READWRITE_SPLITTING (RULE ruleName | RULES) (FROM databaseName)?
     ;
 
 countReadwriteSplittingRule
     : COUNT READWRITE_SPLITTING RULE (FROM databaseName)?
+    ;
+
+ruleName
+    : IDENTIFIER_
     ;

--- a/features/readwrite-splitting/distsql/parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
+++ b/features/readwrite-splitting/distsql/parser/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/core/ReadwriteSplittingDistSQLStatementVisitor.java
@@ -88,7 +88,8 @@ public final class ReadwriteSplittingDistSQLStatementVisitor extends ReadwriteSp
     
     @Override
     public ASTNode visitShowReadwriteSplittingRules(final ShowReadwriteSplittingRulesContext ctx) {
-        return new ShowReadwriteSplittingRulesStatement(Objects.nonNull(ctx.databaseName()) ? (DatabaseSegment) visit(ctx.databaseName()) : null);
+        return new ShowReadwriteSplittingRulesStatement(null == ctx.ruleName() ? null : getIdentifierValue(ctx.ruleName()),
+                Objects.nonNull(ctx.databaseName()) ? (DatabaseSegment) visit(ctx.databaseName()) : null);
     }
     
     @Override

--- a/features/readwrite-splitting/distsql/statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/ShowReadwriteSplittingRulesStatement.java
+++ b/features/readwrite-splitting/distsql/statement/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/parser/statement/ShowReadwriteSplittingRulesStatement.java
@@ -17,15 +17,20 @@
 
 package org.apache.shardingsphere.readwritesplitting.distsql.parser.statement;
 
+import lombok.Getter;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowRulesStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DatabaseSegment;
 
 /**
  * Show readwrite splitting rules statement.
  */
+@Getter
 public final class ShowReadwriteSplittingRulesStatement extends ShowRulesStatement {
     
-    public ShowReadwriteSplittingRulesStatement(final DatabaseSegment database) {
+    private final String ruleName;
+    
+    public ShowReadwriteSplittingRulesStatement(final String ruleName, final DatabaseSegment database) {
         super(database);
+        this.ruleName = ruleName;
     }
 }


### PR DESCRIPTION
For #24158.

Changes proposed in this pull request:
  - Make `ShowReadwriteSplittingRule`support query specified rule with rule name

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
