### PR TITLE
Make `ShowShardingTableReferenceRule`support query specified rule

### DIFF
--- a/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShowShardingTableReferenceRuleExecutor.java
+++ b/features/sharding/distsql/handler/src/main/java/org/apache/shardingsphere/sharding/distsql/handler/query/ShowShardingTableReferenceRuleExecutor.java
@@ -44,13 +44,11 @@ public final class ShowShardingTableReferenceRuleExecutor implements RQLExecutor
         }
         Collection<LocalDataQueryResultRow> result = new LinkedList<>();
         for (final ShardingTableReferenceRuleConfiguration referenceRule : ((ShardingRuleConfiguration) rule.get().getConfiguration()).getBindingTableGroups()) {
-            result.add(new LocalDataQueryResultRow(referenceRule.getName(), referenceRule.getReference()));
+            if (null == sqlStatement.getRuleName() || referenceRule.getName().equalsIgnoreCase(sqlStatement.getRuleName())) {
+                result.add(new LocalDataQueryResultRow(referenceRule.getName(), referenceRule.getReference()));
+            }
         }
         return result;
-    }
-    
-    private Collection<ShardingTableReferenceRuleConfiguration> buildData(final ShardingRuleConfiguration ruleConfig) {
-        return ruleConfig.getBindingTableGroups();
     }
     
     @Override

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableReferenceRuleExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableReferenceRuleExecutorTest.java
@@ -54,6 +54,17 @@ public final class ShowShardingTableReferenceRuleExecutorTest {
     }
     
     @Test
+    public void assertGetRowDataWithSpecifiedRuleName() {
+        RQLExecutor<ShowShardingTableReferenceRulesStatement> executor = new ShowShardingTableReferenceRuleExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(mockDatabase(), new ShowShardingTableReferenceRulesStatement("foo", null));
+        assertThat(actual.size(), is(1));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        LocalDataQueryResultRow row = iterator.next();
+        assertThat(row.getCell(1), is("foo"));
+        assertThat(row.getCell(2), is("t_order,t_order_item"));
+    }
+    
+    @Test
     public void assertGetColumnNames() {
         RQLExecutor<ShowShardingTableReferenceRulesStatement> executor = new ShowShardingTableReferenceRuleExecutor();
         Collection<String> columns = executor.getColumnNames();

--- a/features/sharding/distsql/parser/src/main/antlr4/imports/sharding/RQLStatement.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/imports/sharding/RQLStatement.g4
@@ -24,7 +24,7 @@ showShardingTableRules
     ;
 
 showShardingTableReferenceRules
-    : SHOW SHARDING TABLE REFERENCE RULES (FROM databaseName)?
+    : SHOW SHARDING TABLE REFERENCE (RULE ruleName | RULES) (FROM databaseName)?
     ;
 
 showBroadcastTableRules

--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -378,7 +378,8 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     
     @Override
     public ASTNode visitShowShardingTableReferenceRules(final ShowShardingTableReferenceRulesContext ctx) {
-        return new ShowShardingTableReferenceRulesStatement(null == ctx.databaseName() ? null : (DatabaseSegment) visit(ctx.databaseName()));
+        return new ShowShardingTableReferenceRulesStatement(null == ctx.ruleName() ? null : getIdentifierValue(ctx.ruleName()),
+                null == ctx.databaseName() ? null : (DatabaseSegment) visit(ctx.databaseName()));
     }
     
     @Override

--- a/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/ShowShardingTableReferenceRulesStatement.java
+++ b/features/sharding/distsql/statement/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/statement/ShowShardingTableReferenceRulesStatement.java
@@ -17,15 +17,20 @@
 
 package org.apache.shardingsphere.sharding.distsql.parser.statement;
 
+import lombok.Getter;
 import org.apache.shardingsphere.distsql.parser.statement.rql.show.ShowRulesStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DatabaseSegment;
 
 /**
  * Show sharding table reference rules statement.
  */
+@Getter
 public final class ShowShardingTableReferenceRulesStatement extends ShowRulesStatement {
     
-    public ShowShardingTableReferenceRulesStatement(final DatabaseSegment database) {
+    private final String ruleName;
+    
+    public ShowShardingTableReferenceRulesStatement(final String ruleName, final DatabaseSegment database) {
         super(database);
+        this.ruleName = ruleName;
     }
 }

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
@@ -175,12 +175,12 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
     public BigDecimal getBigDecimal(final String columnLabel) throws SQLException {
         return getBigDecimal(findColumn(columnLabel));
     }
-
+    
     @Override
     public Statement getStatement() throws SQLException {
         return resultSet.getStatement();
     }
-
+    
     @Override
     public String getString(final int columnIndex) throws SQLException {
         checkClosed();
@@ -209,7 +209,7 @@ public final class DatabaseMetaDataResultSet extends AbstractUnsupportedDatabase
         checkColumnIndex(columnIndex);
         return (boolean) ResultSetUtil.convertValue(currentDatabaseMetaDataObject.getObject(columnIndex), boolean.class);
     }
-
+    
     @Override
     public boolean getBoolean(final String columnLabel) throws SQLException {
         return getBoolean(findColumn(columnLabel));


### PR DESCRIPTION
For #24158.

Changes proposed in this pull request:
  - Make `ShowShardingTableReferenceRule`support query specified rule with rule name

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
