### PR TITLE
Update seata-all to handle cglib breaking unit test execution with GraalVM Tracing Agent

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,7 +60,7 @@
         <jboss-logging.version>3.2.1.Final</jboss-logging.version>
         <btm.version>2.1.3</btm.version>
         
-        <seata.version>1.4.2</seata.version>
+        <seata.version>1.6.1</seata.version>
         
         <junit4.version>4.13.2</junit4.version>
         <hamcrest.version>1.3</hamcrest.version>

--- a/kernel/transaction/type/base/seata-at/pom.xml
+++ b/kernel/transaction/type/base/seata-at/pom.xml
@@ -28,7 +28,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <seata.version>1.4.2</seata.version>
+        <seata.version>1.6.1</seata.version>
     </properties>
     
     <dependencies>
@@ -50,6 +50,12 @@
             <artifactId>seata-all</artifactId>
             <version>${seata.version}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/fixture/MockMessageHandler.java
+++ b/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/fixture/MockMessageHandler.java
@@ -88,6 +88,21 @@ public final class MockMessageHandler extends ChannelDuplexHandler {
             response.setBody(HeartbeatMessage.PONG);
         } else if (requestBody instanceof MergedWarpMessage) {
             setMergeResultMessage(request, response);
+        } else if (requestBody instanceof GlobalBeginRequest) {
+            GlobalBeginResponse globalBeginResponse = new GlobalBeginResponse();
+            globalBeginResponse.setXid(XID.generateXID(id.incrementAndGet()));
+            globalBeginResponse.setResultCode(ResultCode.Success);
+            response.setBody(globalBeginResponse);
+        } else if (requestBody instanceof GlobalCommitRequest) {
+            GlobalCommitResponse globalCommitResponse = new GlobalCommitResponse();
+            globalCommitResponse.setResultCode(ResultCode.Success);
+            globalCommitResponse.setGlobalStatus(GlobalStatus.Committing);
+            response.setBody(globalCommitResponse);
+        } else if (requestBody instanceof GlobalRollbackRequest) {
+            GlobalRollbackResponse globalRollbackResponse = new GlobalRollbackResponse();
+            globalRollbackResponse.setResultCode(ResultCode.Success);
+            globalRollbackResponse.setGlobalStatus(GlobalStatus.Rollbacked);
+            response.setBody(globalRollbackResponse);
         }
         if (requestBody != HeartbeatMessage.PING) {
             requestQueue.offer(requestBody);


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Update seata-all to handle cglib breaking unit test execution with GraalVM Tracing Agent.
  - Adapt to the changes made by Seata 1.6.x. Refer to https://github.com/seata/seata/issues/5343#issuecomment-1431053066 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
