### PR TITLE
Rename subscription to streaming at pipeline CDC and simplification CDC protocol

### DIFF
--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
@@ -29,8 +29,8 @@ import io.netty.handler.codec.protobuf.ProtobufEncoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import io.netty.handler.codec.protobuf.ProtobufVarint32LengthFieldPrepender;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.cdc.client.handler.CDCRequestHandler;
 import org.apache.shardingsphere.data.pipeline.cdc.client.handler.LoginRequestHandler;
-import org.apache.shardingsphere.data.pipeline.cdc.client.handler.SubscriptionRequestHandler;
 import org.apache.shardingsphere.data.pipeline.cdc.client.parameter.StartCDCClientParameter;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 
@@ -88,7 +88,7 @@ public final class CDCClient {
                         channel.pipeline().addLast(new ProtobufVarint32LengthFieldPrepender());
                         channel.pipeline().addLast(new ProtobufEncoder());
                         channel.pipeline().addLast(new LoginRequestHandler(parameter.getUsername(), parameter.getPassword()));
-                        channel.pipeline().addLast(new SubscriptionRequestHandler(parameter));
+                        channel.pipeline().addLast(new CDCRequestHandler(parameter));
                     }
                 });
         try {

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/CDCClient.java
@@ -57,11 +57,8 @@ public final class CDCClient {
         if (null == parameter.getAddress() || parameter.getAddress().isEmpty()) {
             throw new IllegalArgumentException("The address parameter can't be null");
         }
-        if (null == parameter.getSubscriptionMode()) {
-            throw new IllegalArgumentException("The subscriptionMode parameter can't be null");
-        }
-        if (null == parameter.getSubscribeTables() || parameter.getSubscribeTables().isEmpty()) {
-            throw new IllegalArgumentException("The subscribeTables parameter can't be null");
+        if (null == parameter.getSchemaTables() || parameter.getSchemaTables().isEmpty()) {
+            throw new IllegalArgumentException("The schema tables parameter can't be null");
         }
     }
     

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/constant/ClientConnectionStatus.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/constant/ClientConnectionStatus.java
@@ -28,8 +28,5 @@ public enum ClientConnectionStatus {
     
     LOGGING_IN,
     
-    // TODO this state is not required and needs to be removed
-    CREATING_SUBSCRIPTION,
-    
-    SUBSCRIBING
+    STREAMING
 }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/constant/ClientConnectionStatus.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/constant/ClientConnectionStatus.java
@@ -28,6 +28,7 @@ public enum ClientConnectionStatus {
     
     LOGGING_IN,
     
+    // TODO this state is not required and needs to be removed
     CREATING_SUBSCRIPTION,
     
     SUBSCRIBING

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/context/ClientConnectionContext.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/context/ClientConnectionContext.java
@@ -26,10 +26,12 @@ import org.apache.shardingsphere.data.pipeline.cdc.client.constant.ClientConnect
  * Client connection context.
  */
 @Getter
+@Setter
 public final class ClientConnectionContext {
     
     public static final AttributeKey<ClientConnectionContext> CONTEXT_KEY = AttributeKey.valueOf("client.context");
     
-    @Setter
     private volatile ClientConnectionStatus status;
+    
+    private volatile String streamingId;
 }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/event/StreamDataEvent.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/event/StreamDataEvent.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.data.pipeline.cdc.client.event;
 
 /**
- * Create subscription event.
+ * Stream data event.
  */
-public final class CreateSubscriptionEvent {
+public final class StreamDataEvent {
 }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/handler/LoginRequestHandler.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/handler/LoginRequestHandler.java
@@ -24,7 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.cdc.client.constant.ClientConnectionStatus;
 import org.apache.shardingsphere.data.pipeline.cdc.client.context.ClientConnectionContext;
-import org.apache.shardingsphere.data.pipeline.cdc.client.event.CreateSubscriptionEvent;
+import org.apache.shardingsphere.data.pipeline.cdc.client.event.StreamDataEvent;
 import org.apache.shardingsphere.data.pipeline.cdc.client.util.RequestIdUtil;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Type;
@@ -68,7 +68,7 @@ public final class LoginRequestHandler extends ChannelInboundHandlerAdapter {
                 setLoginRequest(ctx, response, connectionContext);
                 break;
             case NOT_LOGGED_IN:
-                sendSubscriptionEvent(ctx, response, connectionContext);
+                sendStreamDataEvent(ctx, response, connectionContext);
                 break;
             default:
                 ctx.fireChannelRead(msg);
@@ -87,11 +87,11 @@ public final class LoginRequestHandler extends ChannelInboundHandlerAdapter {
         connectionContext.setStatus(ClientConnectionStatus.NOT_LOGGED_IN);
     }
     
-    private void sendSubscriptionEvent(final ChannelHandlerContext ctx, final CDCResponse response, final ClientConnectionContext connectionContext) {
+    private void sendStreamDataEvent(final ChannelHandlerContext ctx, final CDCResponse response, final ClientConnectionContext connectionContext) {
         if (response.getStatus() == Status.SUCCEED) {
             log.info("login success, username {}", username);
             connectionContext.setStatus(ClientConnectionStatus.LOGGING_IN);
-            ctx.fireUserEventTriggered(new CreateSubscriptionEvent());
+            ctx.fireUserEventTriggered(new StreamDataEvent());
         } else {
             log.error("login failed, username {}", username);
         }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/handler/LoginRequestHandler.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/handler/LoginRequestHandler.java
@@ -28,9 +28,9 @@ import org.apache.shardingsphere.data.pipeline.cdc.client.event.CreateSubscripti
 import org.apache.shardingsphere.data.pipeline.cdc.client.util.RequestIdUtil;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Type;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest.BasicBody;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest.LoginType;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.BasicBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.LoginType;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse.Status;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.ServerGreetingResult;
@@ -79,9 +79,10 @@ public final class LoginRequestHandler extends ChannelInboundHandlerAdapter {
         ServerGreetingResult serverGreetingResult = response.getServerGreetingResult();
         log.info("Server greeting result, server version: {}, protocol version: {}", serverGreetingResult.getServerVersion(), serverGreetingResult.getProtocolVersion());
         String encryptPassword = Hashing.sha256().hashBytes(password.getBytes()).toString().toUpperCase();
-        LoginRequest loginRequest = LoginRequest.newBuilder().setType(LoginType.BASIC).setBasicBody(BasicBody.newBuilder().setUsername(username).setPassword(encryptPassword).build()).build();
+        LoginRequestBody loginRequestBody = LoginRequestBody.newBuilder().setType(LoginType.BASIC).setBasicBody(BasicBody.newBuilder().setUsername(username).setPassword(encryptPassword).build())
+                .build();
         String loginRequestId = RequestIdUtil.generateRequestId();
-        CDCRequest data = CDCRequest.newBuilder().setType(Type.LOGIN).setVersion(1).setRequestId(loginRequestId).setLogin(loginRequest).build();
+        CDCRequest data = CDCRequest.newBuilder().setType(Type.LOGIN).setVersion(1).setRequestId(loginRequestId).setLoginRequestBody(loginRequestBody).build();
         ctx.writeAndFlush(data);
         connectionContext.setStatus(ClientConnectionStatus.NOT_LOGGED_IN);
     }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
@@ -51,7 +51,5 @@ public final class StartCDCClientParameter {
     
     private SubscriptionMode subscriptionMode = SubscriptionMode.INCREMENTAL;
     
-    private boolean incrementalGlobalOrderly;
-    
     private final ImportDataSourceParameter importDataSourceParameter;
 }

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.data.pipeline.cdc.client.parameter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.SubscriptionMode;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.TableName;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.TableName;
 
 import java.util.List;
 

--- a/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
+++ b/kernel/data-pipeline/cdc/client/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/client/parameter/StartCDCClientParameter.java
@@ -20,8 +20,7 @@ package org.apache.shardingsphere.data.pipeline.cdc.client.parameter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.TableName;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SchemaTable;
 
 import java.util.List;
 
@@ -45,11 +44,9 @@ public final class StartCDCClientParameter {
     
     private String database;
     
-    private List<TableName> subscribeTables;
+    private List<SchemaTable> schemaTables;
     
-    private String subscriptionName;
-    
-    private SubscriptionMode subscriptionMode = SubscriptionMode.INCREMENTAL;
+    private boolean full;
     
     private final ImportDataSourceParameter importDataSourceParameter;
 }

--- a/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
+++ b/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
@@ -42,7 +42,6 @@ public final class Bootstrap {
         parameter.setDatabase("sharding_db");
         parameter.setSubscriptionMode(SubscriptionMode.FULL);
         parameter.setSubscriptionName("subscribe_sharding_db");
-        parameter.setIncrementalGlobalOrderly(true);
         parameter.setSubscribeTables(Collections.singletonList(TableName.newBuilder().setName("t_order").build()));
         parameter.setDatabaseType("openGauss");
         CDCClient cdcClient = new CDCClient(parameter);

--- a/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
+++ b/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.data.pipeline.cdc.client.example.opengauss;
 import org.apache.shardingsphere.data.pipeline.cdc.client.CDCClient;
 import org.apache.shardingsphere.data.pipeline.cdc.client.parameter.ImportDataSourceParameter;
 import org.apache.shardingsphere.data.pipeline.cdc.client.parameter.StartCDCClientParameter;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.SubscriptionMode;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.TableName;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.TableName;
 
 import java.util.Collections;
 

--- a/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
+++ b/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/example/opengauss/Bootstrap.java
@@ -20,8 +20,7 @@ package org.apache.shardingsphere.data.pipeline.cdc.client.example.opengauss;
 import org.apache.shardingsphere.data.pipeline.cdc.client.CDCClient;
 import org.apache.shardingsphere.data.pipeline.cdc.client.parameter.ImportDataSourceParameter;
 import org.apache.shardingsphere.data.pipeline.cdc.client.parameter.StartCDCClientParameter;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.TableName;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SchemaTable;
 
 import java.util.Collections;
 
@@ -40,9 +39,8 @@ public final class Bootstrap {
         parameter.setUsername("root");
         parameter.setPassword("root");
         parameter.setDatabase("sharding_db");
-        parameter.setSubscriptionMode(SubscriptionMode.FULL);
-        parameter.setSubscriptionName("subscribe_sharding_db");
-        parameter.setSubscribeTables(Collections.singletonList(TableName.newBuilder().setName("t_order").build()));
+        parameter.setFull(true);
+        parameter.setSchemaTables(Collections.singletonList(SchemaTable.newBuilder().setTable("t_order").build()));
         parameter.setDatabaseType("openGauss");
         CDCClient cdcClient = new CDCClient(parameter);
         cdcClient.start();

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
@@ -45,7 +45,7 @@ import org.apache.shardingsphere.data.pipeline.api.metadata.LogicTableName;
 import org.apache.shardingsphere.data.pipeline.api.pojo.PipelineJobInfo;
 import org.apache.shardingsphere.data.pipeline.api.task.progress.IncrementalTaskProgress;
 import org.apache.shardingsphere.data.pipeline.cdc.api.job.type.CDCJobType;
-import org.apache.shardingsphere.data.pipeline.cdc.api.pojo.CreateStreamingJobParameter;
+import org.apache.shardingsphere.data.pipeline.cdc.api.pojo.CreateStreamDataParameter;
 import org.apache.shardingsphere.data.pipeline.cdc.config.job.CDCJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.config.task.CDCTaskConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.context.CDCProcessContext;
@@ -108,10 +108,10 @@ public final class CDCJobAPI extends AbstractInventoryIncrementalJobAPIImpl {
      * @param param create CDC job param
      * @return job id
      */
-    public String createJob(final CreateStreamingJobParameter param) {
+    public String createJob(final CreateStreamDataParameter param) {
         YamlCDCJobConfiguration yamlJobConfig = new YamlCDCJobConfiguration();
         yamlJobConfig.setDatabase(param.getDatabase());
-        yamlJobConfig.setTableNames(param.getSubscribeTableNames());
+        yamlJobConfig.setTableNames(param.getTableNames());
         yamlJobConfig.setFull(param.isFull());
         yamlJobConfig.setDecodeWithTX(param.isDecodeWithTX());
         ShardingSphereDatabase database = PipelineContext.getContextManager().getMetaDataContexts().getMetaData().getDatabase(param.getDatabase());

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
@@ -51,7 +51,7 @@ import org.apache.shardingsphere.data.pipeline.cdc.config.task.CDCTaskConfigurat
 import org.apache.shardingsphere.data.pipeline.cdc.context.CDCProcessContext;
 import org.apache.shardingsphere.data.pipeline.cdc.core.job.CDCJob;
 import org.apache.shardingsphere.data.pipeline.cdc.core.job.CDCJobId;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.SubscriptionMode;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
 import org.apache.shardingsphere.data.pipeline.cdc.yaml.job.YamlCDCJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.yaml.job.YamlCDCJobConfigurationSwapper;
 import org.apache.shardingsphere.data.pipeline.core.api.GovernanceRepositoryAPI;

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/impl/CDCJobAPI.java
@@ -107,9 +107,9 @@ public final class CDCJobAPI extends AbstractInventoryIncrementalJobAPIImpl {
      * Create CDC job config.
      *
      * @param param create CDC job param
-     * @return true if job is not exist, otherwise false
+     * @return job id
      */
-    public boolean createJob(final CreateSubscriptionJobParameter param) {
+    public String createJob(final CreateSubscriptionJobParameter param) {
         YamlCDCJobConfiguration yamlJobConfig = new YamlCDCJobConfiguration();
         yamlJobConfig.setDatabase(param.getDatabase());
         yamlJobConfig.setTableNames(param.getSubscribeTableNames());
@@ -130,7 +130,7 @@ public final class CDCJobAPI extends AbstractInventoryIncrementalJobAPIImpl {
         String jobConfigKey = PipelineMetaDataNode.getJobConfigPath(jobConfig.getJobId());
         if (repositoryAPI.isExisted(jobConfigKey)) {
             log.warn("cdc job already exists in registry center, ignore, jobConfigKey={}", jobConfigKey);
-            return false;
+            return jobConfig.getJobId();
         }
         repositoryAPI.persist(PipelineMetaDataNode.getJobRootPath(jobConfig.getJobId()), getJobClassName());
         JobConfigurationPOJO jobConfigPOJO = convertJobConfiguration(jobConfig);
@@ -139,7 +139,7 @@ public final class CDCJobAPI extends AbstractInventoryIncrementalJobAPIImpl {
         if (SubscriptionMode.INCREMENTAL.name().equals(param.getSubscriptionMode())) {
             initIncrementalPosition(jobConfig);
         }
-        return true;
+        return jobConfig.getJobId();
     }
     
     private void initIncrementalPosition(final CDCJobConfiguration jobConfig) {

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/pojo/CreateStreamDataParameter.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/pojo/CreateStreamDataParameter.java
@@ -25,15 +25,15 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Create subscription job parameter.
+ * Create stream data parameter.
  */
 @RequiredArgsConstructor
 @Getter
-public final class CreateStreamingJobParameter {
+public final class CreateStreamDataParameter {
     
     private final String database;
     
-    private final List<String> subscribeTableNames;
+    private final List<String> tableNames;
     
     private final boolean full;
     

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/pojo/CreateStreamingJobParameter.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/api/pojo/CreateStreamingJobParameter.java
@@ -29,15 +29,13 @@ import java.util.Map;
  */
 @RequiredArgsConstructor
 @Getter
-public final class CreateSubscriptionJobParameter {
+public final class CreateStreamingJobParameter {
     
     private final String database;
     
     private final List<String> subscribeTableNames;
     
-    private final String subscriptionName;
-    
-    private final String subscriptionMode;
+    private final boolean full;
     
     private final Map<String, List<DataNode>> dataNodesMap;
     

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/config/job/CDCJobConfiguration.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/config/job/CDCJobConfiguration.java
@@ -38,9 +38,7 @@ public final class CDCJobConfiguration implements PipelineJobConfiguration {
     
     private final List<String> tableNames;
     
-    private final String subscriptionName;
-    
-    private final String subscriptionMode;
+    private final boolean full;
     
     private final String sourceDatabaseType;
     

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/constant/CDCConnectionStatus.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/constant/CDCConnectionStatus.java
@@ -26,5 +26,5 @@ public enum CDCConnectionStatus {
     
     LOGGED_IN,
     
-    SUBSCRIBED
+    DATA_STREAMING
 }

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/context/CDCConnectionContext.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/context/CDCConnectionContext.java
@@ -31,6 +31,8 @@ public final class CDCConnectionContext {
     
     private volatile CDCConnectionStatus status;
     
+    private volatile String database;
+    
     private volatile String jobId;
     
     private volatile ShardingSphereUser currentUser;

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJobId.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJobId.java
@@ -22,6 +22,8 @@ import lombok.ToString;
 import org.apache.shardingsphere.data.pipeline.cdc.api.job.type.CDCJobType;
 import org.apache.shardingsphere.data.pipeline.core.job.AbstractPipelineJobId;
 
+import java.util.List;
+
 /**
  * CDC job id.
  */
@@ -33,11 +35,14 @@ public final class CDCJobId extends AbstractPipelineJobId {
     
     private final String databaseName;
     
-    private final String subscriptionName;
+    private final List<String> tableNames;
     
-    public CDCJobId(final String databaseName, final String subscriptionName) {
+    private final boolean full;
+    
+    public CDCJobId(final String databaseName, final List<String> tableNames, final boolean full) {
         super(new CDCJobType(), CURRENT_VERSION);
         this.databaseName = databaseName;
-        this.subscriptionName = subscriptionName;
+        this.tableNames = tableNames;
+        this.full = full;
     }
 }

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/prepare/CDCJobPreparer.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/prepare/CDCJobPreparer.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.data.pipeline.cdc.api.impl.CDCJobAPI;
 import org.apache.shardingsphere.data.pipeline.cdc.config.job.CDCJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.config.task.CDCTaskConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.context.job.CDCJobItemContext;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PrepareJobWithGetBinlogPositionException;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobCenter;
@@ -70,7 +69,7 @@ public final class CDCJobPreparer {
         }
         initIncrementalTasks(jobItemContext);
         CDCJobConfiguration jobConfig = jobItemContext.getJobConfig();
-        if (SubscriptionMode.FULL.name().equals(jobConfig.getSubscriptionMode())) {
+        if (jobConfig.isFull()) {
             initInventoryTasks(jobItemContext);
         }
         if (needUpdateJobStatus) {

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/prepare/CDCJobPreparer.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/prepare/CDCJobPreparer.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.data.pipeline.cdc.api.impl.CDCJobAPI;
 import org.apache.shardingsphere.data.pipeline.cdc.config.job.CDCJobConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.config.task.CDCTaskConfiguration;
 import org.apache.shardingsphere.data.pipeline.cdc.context.job.CDCJobItemContext;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.SubscriptionMode;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
 import org.apache.shardingsphere.data.pipeline.core.exception.job.PrepareJobWithGetBinlogPositionException;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobCenter;

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfiguration.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfiguration.java
@@ -37,9 +37,7 @@ public final class YamlCDCJobConfiguration implements YamlPipelineJobConfigurati
     
     private List<String> tableNames;
     
-    private String subscriptionName;
-    
-    private String subscriptionMode;
+    private boolean full;
     
     private String sourceDatabaseType;
     

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfigurationSwapper.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfigurationSwapper.java
@@ -41,8 +41,7 @@ public final class YamlCDCJobConfigurationSwapper implements YamlConfigurationSw
         result.setJobId(data.getJobId());
         result.setDatabase(data.getDatabase());
         result.setTableNames(data.getTableNames());
-        result.setSubscriptionName(data.getSubscriptionName());
-        result.setSubscriptionMode(data.getSubscriptionMode());
+        result.setFull(data.isFull());
         result.setSourceDatabaseType(data.getSourceDatabaseType());
         result.setDataSourceConfiguration(dataSourceConfigSwapper.swapToYamlConfiguration(data.getDataSourceConfig()));
         result.setTablesFirstDataNodes(null == data.getTablesFirstDataNodes() ? null : data.getTablesFirstDataNodes().marshal());
@@ -60,8 +59,8 @@ public final class YamlCDCJobConfigurationSwapper implements YamlConfigurationSw
                 ? Collections.emptyList()
                 : yamlConfig.getJobShardingDataNodes().stream().map(JobDataNodeLine::unmarshal).collect(Collectors.toList());
         JobDataNodeLine tablesFirstDataNodes = null == yamlConfig.getTablesFirstDataNodes() ? null : JobDataNodeLine.unmarshal(yamlConfig.getTablesFirstDataNodes());
-        return new CDCJobConfiguration(yamlConfig.getJobId(), yamlConfig.getDatabase(), yamlConfig.getTableNames(), yamlConfig.getSubscriptionName(), yamlConfig.getSubscriptionMode(),
-                yamlConfig.getSourceDatabaseType(), (ShardingSpherePipelineDataSourceConfiguration) dataSourceConfigSwapper.swapToObject(yamlConfig.getDataSourceConfiguration()), tablesFirstDataNodes,
+        return new CDCJobConfiguration(yamlConfig.getJobId(), yamlConfig.getDatabase(), yamlConfig.getTableNames(), yamlConfig.isFull(), yamlConfig.getSourceDatabaseType(),
+                (ShardingSpherePipelineDataSourceConfiguration) dataSourceConfigSwapper.swapToObject(yamlConfig.getDataSourceConfiguration()), tablesFirstDataNodes,
                 jobShardingDataNodes, yamlConfig.isDecodeWithTX(), yamlConfig.getConcurrency(), yamlConfig.getRetryTimes());
     }
     

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJobIdTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJobIdTest.java
@@ -22,6 +22,8 @@ import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.spi.job.JobType;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -29,7 +31,7 @@ public final class CDCJobIdTest {
     
     @Test
     public void parseJobType() {
-        CDCJobId pipelineJobId = new CDCJobId("sharding_db", "test");
+        CDCJobId pipelineJobId = new CDCJobId("sharding_db", Arrays.asList("test", "t_order"), false);
         String jobId = PipelineJobIdUtils.marshalJobIdCommonPrefix(pipelineJobId) + "abcd";
         JobType actualJobType = PipelineJobIdUtils.parseJobType(jobId);
         assertThat(actualJobType, instanceOf(CDCJobType.class));

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfigurationSwapperTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/yaml/job/YamlCDCJobConfigurationSwapperTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public final class YamlCDCJobConfigurationSwapperTest {
     
@@ -33,13 +34,11 @@ public final class YamlCDCJobConfigurationSwapperTest {
         yamlJobConfig.setJobId("j51017f973ac82cb1edea4f5238a258c25e89");
         yamlJobConfig.setDatabase("test_db");
         yamlJobConfig.setTableNames(Arrays.asList("t_order", "t_order_item"));
-        yamlJobConfig.setSubscriptionName("test_name");
-        yamlJobConfig.setSubscriptionMode("FULL");
+        yamlJobConfig.setFull(true);
         CDCJobConfiguration actual = new YamlCDCJobConfigurationSwapper().swapToObject(yamlJobConfig);
         assertThat(actual.getJobId(), is("j51017f973ac82cb1edea4f5238a258c25e89"));
         assertThat(actual.getDatabase(), is("test_db"));
         assertThat(actual.getTableNames(), is(Arrays.asList("t_order", "t_order_item")));
-        assertThat(actual.getSubscriptionName(), is("test_name"));
-        assertThat(actual.getSubscriptionMode(), is("FULL"));
+        assertTrue(actual.isFull());
     }
 }

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
@@ -74,21 +74,17 @@ message StreamDataRequestBody {
     FULL = 2;
   }
   SubscriptionMode subscription_mode = 4;
-  bool incremental_global_orderly = 5;
 }
 
 message StartStreamingRequestBody {
-  string database = 1;
   string subscription_name = 2;
 }
 
 message StopStreamingRequestBody {
-  string database = 1;
   string subscription_name = 2;
 }
 
 message DropStreamingRequestBody {
-  string database = 1;
   string subscription_name = 2;
 }
 

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
@@ -62,30 +62,25 @@ message LoginRequestBody {
 
 message StreamDataRequestBody {
   string database = 1;
-  message TableName {
+  message SchemaTable {
     string schema = 1;
-    string name = 2;
+    string table = 2;
   }
-  repeated TableName table_names = 2;
-  string subscription_name = 3;
-  enum SubscriptionMode {
-    UNKNOWN = 0;
-    INCREMENTAL = 1;
-    FULL = 2;
-  }
-  SubscriptionMode subscription_mode = 4;
+  repeated string source_schemas = 2;
+  repeated SchemaTable source_schema_tables = 3;
+  bool full = 4;
 }
 
 message StartStreamingRequestBody {
-  string subscription_name = 2;
+  string streaming_id = 2;
 }
 
 message StopStreamingRequestBody {
-  string subscription_name = 2;
+  string streaming_id = 2;
 }
 
 message DropStreamingRequestBody {
-  string subscription_name = 2;
+  string streaming_id = 2;
 }
 
 message AckStreamingRequestBody {

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCRequestProtocol.proto
@@ -27,24 +27,24 @@ message CDCRequest {
   enum Type {
     UNKNOWN = 0;
     LOGIN = 1;
-    CREATE_SUBSCRIPTION = 2;
-    START_SUBSCRIPTION = 3;
-    ACK = 4;
-    STOP_SUBSCRIPTION = 5;
-    DROP_SUBSCRIPTION = 6;
+    STREAM_DATA = 2;
+    START_STREAMING = 3;
+    ACK_STREAMING = 4;
+    STOP_STREAMING = 5;
+    DROP_STREAMING = 6;
   }
   Type type = 3;
-  oneof request {
-    LoginRequest login = 4;
-    CreateSubscriptionRequest create_subscription = 5;
-    StartSubscriptionRequest start_subscription = 6;
-    AckRequest ack_request = 7;
-    StopSubscriptionRequest stop_subscription = 8;
-    DropSubscriptionRequest drop_subscription = 9;
+  oneof request_body {
+    LoginRequestBody login_request_body = 4;
+    StreamDataRequestBody stream_data_request_body = 5;
+    StartStreamingRequestBody start_streaming_request_body =6;
+    AckStreamingRequestBody ack_streaming_request_body = 7;
+    StopStreamingRequestBody stop_streaming_request_body = 8;
+    DropStreamingRequestBody drop_streaming_request_body = 9;
   }
 }
 
-message LoginRequest {
+message LoginRequestBody {
   enum LoginType {
     UNKNOWN = 0;
     BASIC = 1;
@@ -60,7 +60,7 @@ message LoginRequest {
   }
 }
 
-message CreateSubscriptionRequest {
+message StreamDataRequestBody {
   string database = 1;
   message TableName {
     string schema = 1;
@@ -77,21 +77,21 @@ message CreateSubscriptionRequest {
   bool incremental_global_orderly = 5;
 }
 
-message StartSubscriptionRequest {
+message StartStreamingRequestBody {
   string database = 1;
   string subscription_name = 2;
 }
 
-message StopSubscriptionRequest {
+message StopStreamingRequestBody {
   string database = 1;
   string subscription_name = 2;
 }
 
-message DropSubscriptionRequest {
+message DropStreamingRequestBody {
   string database = 1;
   string subscription_name = 2;
 }
 
-message AckRequest {
+message AckStreamingRequestBody {
   string ack_id = 3;
 }

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
@@ -33,7 +33,7 @@ message CDCResponse {
   Status status = 2;
   oneof response {
     ServerGreetingResult server_greeting_result = 3;
-    CreateSubscriptionResult create_subscription_result = 4;
+    CreateCDCResult create_CDC_result = 4;
     DataRecordResult data_record_result = 5;
   }
 
@@ -46,7 +46,7 @@ message ServerGreetingResult {
   string protocol_version = 2;
 }
 
-message CreateSubscriptionResult {
+message CreateCDCResult {
   string subscription_name = 1;
   bool existing = 2;
 }

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
@@ -48,7 +48,6 @@ message ServerGreetingResult {
 
 message CreateCDCResult {
   string subscription_name = 1;
-  bool existing = 2;
 }
 
 message NullValue {

--- a/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
+++ b/kernel/data-pipeline/cdc/protocol/src/main/proto/CDCResponseProtocol.proto
@@ -33,10 +33,9 @@ message CDCResponse {
   Status status = 2;
   oneof response {
     ServerGreetingResult server_greeting_result = 3;
-    CreateCDCResult create_CDC_result = 4;
+    StreamDataResult stream_data_result = 4;
     DataRecordResult data_record_result = 5;
   }
-
   optional string error_code = 14;
   optional string error_message = 15;
 }
@@ -46,8 +45,8 @@ message ServerGreetingResult {
   string protocol_version = 2;
 }
 
-message CreateCDCResult {
-  string subscription_name = 1;
+message StreamDataResult {
+  string streaming_id = 1;
 }
 
 message NullValue {

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.cdc;
 
+import org.apache.shardingsphere.data.pipeline.cdc.context.CDCConnectionContext;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
@@ -86,7 +87,7 @@ public final class CDCBackendHandlerTest {
     @Test
     public void assertCreateSubscriptionFailed() {
         CDCRequest request = CDCRequest.newBuilder().setRequestId("1").setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("none")).build();
-        CDCResponse actualResponse = handler.createSubscription(request);
+        CDCResponse actualResponse = handler.streamData(request, mock(CDCConnectionContext.class));
         assertThat(actualResponse.getStatus(), is(Status.FAILED));
     }
     
@@ -96,7 +97,7 @@ public final class CDCBackendHandlerTest {
     public void assertCreateSubscriptionSucceed() {
         String requestId = "1";
         CDCRequest request = CDCRequest.newBuilder().setRequestId(requestId).setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("sharding_db")).build();
-        CDCResponse actualResponse = handler.createSubscription(request);
+        CDCResponse actualResponse = handler.streamData(request, mock(CDCConnectionContext.class));
         assertThat(actualResponse.getStatus(), is(Status.SUCCEED));
         assertThat(actualResponse.getRequestId(), is(requestId));
     }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
@@ -17,8 +17,10 @@
 
 package org.apache.shardingsphere.proxy.backend.handler.cdc;
 
+import io.netty.channel.Channel;
 import org.apache.shardingsphere.data.pipeline.cdc.context.CDCConnectionContext;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Type;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse.Status;
@@ -36,7 +38,6 @@ import org.apache.shardingsphere.mode.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
@@ -85,20 +86,9 @@ public final class CDCBackendHandlerTest {
     }
     
     @Test
-    public void assertCreateSubscriptionFailed() {
-        CDCRequest request = CDCRequest.newBuilder().setRequestId("1").setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("none")).build();
-        CDCResponse actualResponse = handler.streamData(request, mock(CDCConnectionContext.class));
+    public void assertStreamDataRequestFailed() {
+        CDCRequest request = CDCRequest.newBuilder().setRequestId("1").setType(Type.STREAM_DATA).setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("none")).build();
+        CDCResponse actualResponse = handler.streamData(request.getRequestId(), request.getStreamDataRequestBody(), mock(CDCConnectionContext.class), mock(Channel.class));
         assertThat(actualResponse.getStatus(), is(Status.FAILED));
-    }
-    
-    // TODO ignore for now, it need more mock, since SPI is removed. It's better to put it in E2E test
-    @Ignore
-    @Test
-    public void assertCreateSubscriptionSucceed() {
-        String requestId = "1";
-        CDCRequest request = CDCRequest.newBuilder().setRequestId(requestId).setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("sharding_db")).build();
-        CDCResponse actualResponse = handler.streamData(request, mock(CDCConnectionContext.class));
-        assertThat(actualResponse.getStatus(), is(Status.SUCCEED));
-        assertThat(actualResponse.getRequestId(), is(requestId));
     }
 }

--- a/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
+++ b/proxy/backend/src/test/java/org/apache/shardingsphere/proxy/backend/handler/cdc/CDCBackendHandlerTest.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.proxy.backend.handler.cdc;
 
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse.Status;
 import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
@@ -85,7 +85,7 @@ public final class CDCBackendHandlerTest {
     
     @Test
     public void assertCreateSubscriptionFailed() {
-        CDCRequest request = CDCRequest.newBuilder().setRequestId("1").setCreateSubscription(CreateSubscriptionRequest.newBuilder().setDatabase("none")).build();
+        CDCRequest request = CDCRequest.newBuilder().setRequestId("1").setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("none")).build();
         CDCResponse actualResponse = handler.createSubscription(request);
         assertThat(actualResponse.getStatus(), is(Status.FAILED));
     }
@@ -95,7 +95,7 @@ public final class CDCBackendHandlerTest {
     @Test
     public void assertCreateSubscriptionSucceed() {
         String requestId = "1";
-        CDCRequest request = CDCRequest.newBuilder().setRequestId(requestId).setCreateSubscription(CreateSubscriptionRequest.newBuilder().setDatabase("sharding_db")).build();
+        CDCRequest request = CDCRequest.newBuilder().setRequestId(requestId).setStreamDataRequestBody(StreamDataRequestBody.newBuilder().setDatabase("sharding_db")).build();
         CDCResponse actualResponse = handler.createSubscription(request);
         assertThat(actualResponse.getStatus(), is(Status.SUCCEED));
         assertThat(actualResponse.getRequestId(), is(requestId));

--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandler.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandler.java
@@ -30,14 +30,14 @@ import org.apache.shardingsphere.data.pipeline.cdc.common.CDCResponseErrorCode;
 import org.apache.shardingsphere.data.pipeline.cdc.constant.CDCConnectionStatus;
 import org.apache.shardingsphere.data.pipeline.cdc.context.CDCConnectionContext;
 import org.apache.shardingsphere.data.pipeline.cdc.generator.CDCResponseGenerator;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.AckRequest;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.AckStreamingRequestBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CreateSubscriptionRequest.SubscriptionMode;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.DropSubscriptionRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest.BasicBody;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StartSubscriptionRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StopSubscriptionRequest;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.DropStreamingRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.BasicBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StartStreamingRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StopStreamingRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.StreamDataRequestBody.SubscriptionMode;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.ServerGreetingResult;
 import org.apache.shardingsphere.distsql.handler.exception.rule.MissingRequiredRuleException;
@@ -112,33 +112,34 @@ public final class CDCChannelInboundHandler extends ChannelInboundHandlerAdapter
             processLogin(ctx, request, connectionContext);
             return;
         }
-        switch (request.getRequestCase()) {
-            case CREATE_SUBSCRIPTION:
-                processCreateSubscription(ctx, request, connectionContext);
+        switch (request.getType()) {
+            case STREAM_DATA:
+                // TODO stream data right now, need improve
+                processStreamDataRequest(ctx, request, connectionContext);
                 break;
-            case START_SUBSCRIPTION:
-                processStartSubscription(ctx, request, connectionContext);
+            case START_STREAMING:
+                processStartStreamingRequest(ctx, request, connectionContext);
                 break;
-            case STOP_SUBSCRIPTION:
-                processStopSubscription(ctx, request, connectionContext);
+            case STOP_STREAMING:
+                processStopStreamingRequest(ctx, request, connectionContext);
                 break;
-            case DROP_SUBSCRIPTION:
-                processDropSubscription(ctx, request, connectionContext);
+            case DROP_STREAMING:
+                processDropStreamingRequest(ctx, request, connectionContext);
                 break;
-            case ACK_REQUEST:
-                processAckRequest(ctx, request);
+            case ACK_STREAMING:
+                processAckStreamingRequest(ctx, request);
                 break;
             default:
-                log.warn("Cannot handle this type of request {}", request);
+                log.warn("can't handle this type of request {}", request);
         }
     }
     
     private void processLogin(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
-        if (!request.hasLogin() || !request.getLogin().hasBasicBody()) {
+        if (!request.hasLoginRequestBody() || !request.getLoginRequestBody().hasBasicBody()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Miss login request body")).addListener(ChannelFutureListener.CLOSE);
             return;
         }
-        BasicBody body = request.getLogin().getBasicBody();
+        BasicBody body = request.getLoginRequestBody().getBasicBody();
         AuthorityRule authorityRule = ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData().getSingleRule(AuthorityRule.class);
         Optional<ShardingSphereUser> user = authorityRule.findUser(new Grantee(body.getUsername(), getHostAddress(ctx)));
         if (user.isPresent() && Objects.equals(Hashing.sha256().hashBytes(user.get().getPassword().getBytes()).toString().toUpperCase(), body.getPassword())) {
@@ -164,51 +165,51 @@ public final class CDCChannelInboundHandler extends ChannelInboundHandlerAdapter
         return socketAddress instanceof InetSocketAddress ? ((InetSocketAddress) socketAddress).getAddress().getHostAddress() : socketAddress.toString();
     }
     
-    private void processCreateSubscription(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
-        if (!request.hasCreateSubscription()) {
+    private void processStreamDataRequest(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
+        if (!request.hasStreamDataRequestBody()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Miss create subscription request body"))
                     .addListener(ChannelFutureListener.CLOSE);
             return;
         }
-        CreateSubscriptionRequest createSubscriptionRequest = request.getCreateSubscription();
-        if (createSubscriptionRequest.getTableNamesList().isEmpty() || createSubscriptionRequest.getDatabase().isEmpty() || createSubscriptionRequest.getSubscriptionName().isEmpty()
-                || createSubscriptionRequest.getSubscriptionMode() == SubscriptionMode.UNKNOWN) {
+        StreamDataRequestBody streamDataRequestBody = request.getStreamDataRequestBody();
+        if (streamDataRequestBody.getTableNamesList().isEmpty() || streamDataRequestBody.getDatabase().isEmpty() || streamDataRequestBody.getSubscriptionName().isEmpty()
+                || streamDataRequestBody.getSubscriptionMode() == SubscriptionMode.UNKNOWN) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Illegal create subscription request parameter"));
             return;
         }
-        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), createSubscriptionRequest.getDatabase());
+        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), streamDataRequestBody.getDatabase());
         CDCResponse response = backendHandler.createSubscription(request);
         ctx.writeAndFlush(response);
     }
     
-    private void processStartSubscription(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
-        if (!request.hasStartSubscription()) {
+    private void processStartStreamingRequest(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
+        if (!request.hasStartStreamingRequestBody()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Miss start subscription request body"))
                     .addListener(ChannelFutureListener.CLOSE);
             return;
         }
-        StartSubscriptionRequest startSubscriptionRequest = request.getStartSubscription();
-        if (startSubscriptionRequest.getDatabase().isEmpty() || startSubscriptionRequest.getSubscriptionName().isEmpty()) {
+        StartStreamingRequestBody startStreamingRequestBody = request.getStartStreamingRequestBody();
+        if (startStreamingRequestBody.getDatabase().isEmpty() || startStreamingRequestBody.getSubscriptionName().isEmpty()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Illegal start subscription request parameter"))
                     .addListener(ChannelFutureListener.CLOSE);
             return;
         }
-        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), startSubscriptionRequest.getDatabase());
-        CDCResponse response = backendHandler.startSubscription(request, ctx.channel(), connectionContext);
+        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), startStreamingRequestBody.getDatabase());
+        CDCResponse response = backendHandler.startStreaming(request, ctx.channel(), connectionContext);
         ctx.writeAndFlush(response);
     }
     
-    private void processStopSubscription(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
-        StopSubscriptionRequest stopSubscriptionRequest = request.getStopSubscription();
-        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), stopSubscriptionRequest.getDatabase());
+    private void processStopStreamingRequest(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
+        StopStreamingRequestBody stopStreamingRequestBody = request.getStopStreamingRequestBody();
+        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), stopStreamingRequestBody.getDatabase());
         backendHandler.stopSubscription(connectionContext.getJobId());
         connectionContext.setStatus(CDCConnectionStatus.LOGGED_IN);
         ctx.writeAndFlush(CDCResponseGenerator.succeedBuilder(request.getRequestId()).build());
     }
     
-    private void processDropSubscription(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
-        DropSubscriptionRequest dropSubscriptionRequest = request.getDropSubscription();
-        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), dropSubscriptionRequest.getDatabase());
+    private void processDropStreamingRequest(final ChannelHandlerContext ctx, final CDCRequest request, final CDCConnectionContext connectionContext) {
+        DropStreamingRequestBody dropStreamingRequestBody = request.getDropStreamingRequestBody();
+        checkPrivileges(connectionContext.getCurrentUser().getGrantee(), dropStreamingRequestBody.getDatabase());
         try {
             backendHandler.dropSubscription(connectionContext.getJobId());
             ctx.writeAndFlush(CDCResponseGenerator.succeedBuilder(request.getRequestId()).build());
@@ -217,16 +218,16 @@ public final class CDCChannelInboundHandler extends ChannelInboundHandlerAdapter
         }
     }
     
-    private void processAckRequest(final ChannelHandlerContext ctx, final CDCRequest request) {
-        if (!request.hasAckRequest()) {
+    private void processAckStreamingRequest(final ChannelHandlerContext ctx, final CDCRequest request) {
+        if (!request.hasAckStreamingRequestBody()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Miss ack request body")).addListener(ChannelFutureListener.CLOSE);
             return;
         }
-        AckRequest ackRequest = request.getAckRequest();
-        if (ackRequest.getAckId().isEmpty()) {
+        AckStreamingRequestBody ackStreamingRequestBody = request.getAckStreamingRequestBody();
+        if (ackStreamingRequestBody.getAckId().isEmpty()) {
             ctx.writeAndFlush(CDCResponseGenerator.failed(request.getRequestId(), CDCResponseErrorCode.ILLEGAL_REQUEST_ERROR, "Illegal ack request parameter"));
             return;
         }
-        backendHandler.processAck(ackRequest);
+        backendHandler.processAck(ackStreamingRequestBody);
     }
 }

--- a/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandlerTest.java
+++ b/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandlerTest.java
@@ -83,7 +83,8 @@ public final class CDCChannelInboundHandlerTest {
     
     @Test
     public void assertLoginRequestFailed() {
-        CDCRequest actualRequest = CDCRequest.newBuilder().setLoginRequestBody(LoginRequestBody.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root2").build()).build()).build();
+        CDCRequest actualRequest = CDCRequest.newBuilder().setType(Type.LOGIN).setLoginRequestBody(LoginRequestBody.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root2").build())
+                .build()).build();
         channel.writeInbound(actualRequest);
         CDCResponse expectedGreetingResult = channel.readOutbound();
         assertTrue(expectedGreetingResult.hasServerGreetingResult());

--- a/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandlerTest.java
+++ b/proxy/frontend/core/src/test/java/org/apache/shardingsphere/proxy/frontend/netty/CDCChannelInboundHandlerTest.java
@@ -24,8 +24,9 @@ import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.data.pipeline.cdc.common.CDCResponseErrorCode;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Builder;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest;
-import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequest.BasicBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.CDCRequest.Type;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody;
+import org.apache.shardingsphere.data.pipeline.cdc.protocol.request.LoginRequestBody.BasicBody;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse;
 import org.apache.shardingsphere.data.pipeline.cdc.protocol.response.CDCResponse.Status;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -82,7 +83,7 @@ public final class CDCChannelInboundHandlerTest {
     
     @Test
     public void assertLoginRequestFailed() {
-        CDCRequest actualRequest = CDCRequest.newBuilder().setLogin(LoginRequest.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root2").build()).build()).build();
+        CDCRequest actualRequest = CDCRequest.newBuilder().setLoginRequestBody(LoginRequestBody.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root2").build()).build()).build();
         channel.writeInbound(actualRequest);
         CDCResponse expectedGreetingResult = channel.readOutbound();
         assertTrue(expectedGreetingResult.hasServerGreetingResult());
@@ -94,7 +95,7 @@ public final class CDCChannelInboundHandlerTest {
     
     @Test
     public void assertIllegalLoginRequest() {
-        CDCRequest actualRequest = CDCRequest.newBuilder().setVersion(1).setRequestId("test").build();
+        CDCRequest actualRequest = CDCRequest.newBuilder().setType(Type.LOGIN).setVersion(1).setRequestId("test").build();
         channel.writeInbound(actualRequest);
         CDCResponse expectedGreetingResult = channel.readOutbound();
         assertTrue(expectedGreetingResult.hasServerGreetingResult());
@@ -107,7 +108,8 @@ public final class CDCChannelInboundHandlerTest {
     @Test
     public void assertLoginRequestSucceed() {
         String encryptPassword = Hashing.sha256().hashBytes("root".getBytes()).toString().toUpperCase();
-        Builder builder = CDCRequest.newBuilder().setLogin(LoginRequest.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root").setPassword(encryptPassword).build()).build());
+        Builder builder = CDCRequest.newBuilder().setType(Type.LOGIN).setLoginRequestBody(LoginRequestBody.newBuilder().setBasicBody(BasicBody.newBuilder().setUsername("root")
+                .setPassword(encryptPassword).build()).build());
         CDCRequest actualRequest = builder.build();
         channel.writeInbound(actualRequest);
         CDCResponse expectedGreetingResult = channel.readOutbound();


### PR DESCRIPTION


Changes proposed in this pull request:
  - Rename subscription to streaming in pipeline CDC
  - Remove database and incremental_global_orderly at CDC request protocol
  - Rename subscription_name to streaming_id and remove subscription_mode
  - Refactor stream data, start job immediately

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
