### PR TITLE
Correct the Shadow Algorithm Chinese document

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/algorithm.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/algorithm.cn.md
@@ -42,7 +42,7 @@ loadBalancers:
 ## 影子算法
 
 ```yaml
-loadBalancers:
+shadowAlgorithms:
   # shadowAlgorithmName 由用户指定，需要和影子库规则中的 shadowAlgorithmNames 属性一致
   <shadowAlgorithmName>:
     # type 和 props，请参考影子库内置算法：https://shardingsphere.apache.org/document/current/cn/user-manual/common-config/builtin-algorithm/shadow/


### PR DESCRIPTION
The configuration of shadow algorithms is wrong, loadBalancers should be changed to shadowAlgorithms.

Fixes #24191.

Changes proposed in this pull request:
  -
- In the Chinese document of YAML algorithm configuration, the shadow algorithm configuration item changes `loadBalancers` to `shadowAlgorithms`.
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
