### PR TITLE
Add visitorType in sql parse it for more visit type test

### DIFF
--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserTestParameter.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/InternalSQLParserTestParameter.java
@@ -34,6 +34,8 @@ public final class InternalSQLParserTestParameter {
     
     private final String databaseType;
     
+    private final String visitorType;
+    
     @Override
     public String toString() {
         return String.format("%s (%s) -> %s", sqlCaseId, sqlCaseType, databaseType);

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/SQLCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/SQLCases.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.it.sql.parser.internal.cases.sql;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.sql.jaxb.SQLCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.sql.type.CaseTypedSQLBuilderFactory;
@@ -65,10 +66,14 @@ public final class SQLCases {
         Collection<InternalSQLParserTestParameter> result = new LinkedList<>();
         for (String each : getDatabaseTypes(sqlCase.getDatabaseTypes())) {
             if (databaseTypes.contains(each) && containsSQLCaseType(sqlCase, caseType)) {
-                result.add(new InternalSQLParserTestParameter(sqlCase.getId(), caseType, each));
+                result.add(new InternalSQLParserTestParameter(sqlCase.getId(), caseType, each, getVisitorType(sqlCase)));
             }
         }
         return result;
+    }
+    
+    private String getVisitorType(final SQLCase sqlCase) {
+        return Strings.isNullOrEmpty(sqlCase.getVisitorType()) ? "STATEMENT" : sqlCase.getVisitorType();
     }
     
     private Collection<String> getDatabaseTypes(final String databaseTypes) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/jaxb/SQLCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/jaxb/SQLCase.java
@@ -43,4 +43,7 @@ public final class SQLCase {
     
     @XmlAttribute(name = "case-types")
     private String caseTypes;
+    
+    @XmlAttribute(name = "visitor-type")
+    private String visitorType;
 }


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add visitorType in sql parse it for more visit type test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
