### PR TITLE
Print expected type of exception when debug is enabled in proxy

### DIFF
--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTask.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/command/CommandExecutorTask.java
@@ -131,6 +131,8 @@ public final class CommandExecutorTask implements Runnable {
     private void processException(final Exception cause) {
         if (!ExpectedExceptions.isExpected(cause.getClass())) {
             log.error("Exception occur: ", cause);
+        } else if (log.isDebugEnabled()) {
+            log.debug("Exception occur: ", cause);
         }
         context.write(databaseProtocolFrontendEngine.getCommandExecuteEngine().getErrorPacket(cause));
         Optional<DatabasePacket<?>> databasePacket = databaseProtocolFrontendEngine.getCommandExecuteEngine().getOtherPacket(connectionSession);


### PR DESCRIPTION

Changes proposed in this pull request:
  - Print expected type of exception when debug is enabled in proxy. For better troubleshooting, since exception might be thrown in unexpected scenario (e.g. bug), though the exception type is expected. Then we could run DistSQL `SET DIST VARIABLE system_log_level='DEBUG';` to get exception stack trace.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
