### PR TITLE
Initialize the generateStandardMetadata Maven Profile of all module

### DIFF
--- a/.github/workflows/nightly-build-artifact.yml
+++ b/.github/workflows/nightly-build-artifact.yml
@@ -125,4 +125,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push docker image
-        run: ./mvnw -am -pl distribution/proxy-native -Pnative,docker.buildx.push.native -B -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip=true -Dproxy.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.image.tag=${{ github.sha }} clean package
+        run: |
+          ./mvnw -PgenerateStandardMetadata -DskipNativeTests -B -T1C clean test
+          ./mvnw -am -pl distribution/proxy-native -Prelease.native,docker.buildx.push.native -B -T1C -DskipTests -Dproxy.image.repository=${{ env.PROXY_NATIVE }} -Dproxy.image.tag=${{ github.sha }} clean package

--- a/distribution/proxy-native/access-filter.json
+++ b/distribution/proxy-native/access-filter.json
@@ -1,0 +1,14 @@
+{
+  "rules": [
+    {"includeClasses": "**"},
+    {"excludeClasses": "org.junit.platform.launcher.**"},
+    {"excludeClasses": "org.mariadb.jdbc.**"},
+    {"excludeClasses": "com.mysql.jdbc.**"},
+    {"excludeClasses": "org.apache.commons.dbcp2.**"},
+    {"excludeClasses": "org.apache.shardingsphere.test.fixture.jdbc.**"},
+    {"excludeClasses": "org.apache.shardingsphere.data.pipeline.core.sqlbuilder.H2PipelineSQLBuilder"}
+  ],
+  "regexRules": [
+    {"excludeClasses": ".*Fixture*.*"}
+  ]
+}

--- a/distribution/proxy-native/caller-filter.json
+++ b/distribution/proxy-native/caller-filter.json
@@ -1,0 +1,6 @@
+{
+  "rules": [
+    {"excludeClasses": "**"},
+    {"includeClasses": "org.apache.shardingsphere.**"}
+  ]
+}

--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -28,8 +28,6 @@
     <artifactId>shardingsphere-proxy-native-distribution</artifactId>
     
     <properties>
-        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
-        <native.maven.plugin.version>0.9.19</native.maven.plugin.version>
         <imageName>apache-shardingsphere-proxy-native</imageName>
         <mainClass>org.apache.shardingsphere.proxy.Bootstrap</mainClass>
         <native.image.repository>apache/shardingsphere-proxy-native</native.image.repository>
@@ -69,11 +67,14 @@
     
     <profiles>
         <profile>
-            <id>native</id>
+            <id>release.native</id>
             <properties>
-                <hikari-cp.version>5.0.1</hikari-cp.version>
                 <truffle-api.version>22.3.1</truffle-api.version>
-                <caffeine.version>3.1.2</caffeine.version>
+                <jacoco.skip>true</jacoco.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+                <rat.skip>true</rat.skip>
+                <spotless.apply.skip>true</spotless.apply.skip>
             </properties>
             <build>
                 <finalName>apache-shardingsphere-${project.version}</finalName>
@@ -91,7 +92,7 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
-                        <version>${native.maven.plugin.version}</version>
+                        <version>${native-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <fallback>false</fallback>
@@ -105,7 +106,6 @@
                             </jvmArgs>
                             <metadataRepository>
                                 <enabled>true</enabled>
-                                <version>0.2.6</version>
                             </metadataRepository>
                         </configuration>
                         <executions>

--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -222,7 +222,7 @@ The text of each license is the standard Apache 2.0 license.
     avatica-core 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     avatica-metrics 1.22.0: https://calcite.apache.org/avatica, Apache 2.0
     auto-service-annotations 1.0: https://github.com/google/auto/tree/master/service, Apache 2.0
-    caffeine 3.1.2: https://github.com/ben-manes/caffeine, Apache 2.0
+    caffeine 2.9.3: https://github.com/ben-manes/caffeine, Apache 2.0
     calcite-core 1.32.0: https://calcite.apache.org, Apache 2.0
     calcite-linq4j 1.32.0: https://calcite.apache.org, Apache 2.0
     commons-codec 1.15: https://github.com/apache/commons-codec, Apache 2.0
@@ -251,7 +251,7 @@ The text of each license is the standard Apache 2.0 license.
     grpc-stub 1.48.0: https://github.com/grpc/grpc-java, Apache 2.0
     gson 2.9.1: https://github.com/google/gson, Apache 2.0
     guava 30.0-jre: https://github.com/google/guava, Apache 2.0
-    HikariCP 5.0.1: https://github.com/brettwooldridge/HikariCP, Apache 2.0
+    HikariCP 4.0.3: https://github.com/brettwooldridge/HikariCP, Apache 2.0
     httpclient5 5.1.3: https://hc.apache.org/httpcomponents-client-5.1.x, Apache 2.0
     httpcore5-h2 5.1.3: https://hc.apache.org/httpcomponents-core-5.1.x, Apache 2.0
     httpcore5 5.1.3: https://hc.apache.org/httpcomponents-core-5.1.x, Apache 2.0

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.cn.md
@@ -60,6 +60,12 @@ services:
 
 4. 如果需要构建 Docker Image， 确保 `docker-ce` 已安装。
 
+5. 首先需要在项目的根目录下，执行如下命令以为所有子模块采集 Standard 形态的 GraalVM 可达性元数据。
+
+```shell
+./mvnw -PgenerateStandardMetadata -DskipNativeTests -B -T1C clean test
+```
+
 ## 操作步骤
 
 1. 获取 Apache ShardingSphere Git Source
@@ -74,7 +80,7 @@ services:
 - 在 Git Source 同级目录下执行如下命令, 直接完成 Native Image 的构建。
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```
 
 - 情形二：需要使用存在 SPI 实现的 JAR 或 GPL V2 等 LICENSE 的第三方依赖的 JAR。
@@ -101,7 +107,7 @@ services:
 - 通过命令行构建 GraalVM Native Image。
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```
 
 3. 通过命令行启动 Native Image, 需要带上 4 个参数。
@@ -116,7 +122,7 @@ services:
 4. 如果需要构建 Docker Image, 在添加存在 SPI 实现的依赖或第三方依赖后, 在命令行执行如下命令。
 
 ```shell
-./mvnw -am -pl distribution/proxy-native -B -Pnative,docker.native -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native,docker.native -DskipTests clean package
 ```
 
 - 假设存在包含`server.yaml` 的 `conf` 文件夹为 `./custom/conf`，可通过如下的 `docker-compose.yml` 文件启动 GraalVM Native
@@ -178,5 +184,5 @@ services:
 3. 通过命令行构建 GraalVM Native Image。
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/graalvm-native-image.en.md
@@ -67,6 +67,13 @@ services:
 
 4. If you need to build a Docker Image, make sure `docker-ce` is installed.
 
+5. First, you need to execute the following command in the root directory of the project to collect the GraalVM
+   Reachability Metadata of the Standard form for all submodules.
+
+```shell
+./mvnw -PgenerateStandardMetadata -DskipNativeTests -B -T1C clean test
+```
+
 ## Steps
 
 1. Get Apache ShardingSphere Git Source
@@ -82,7 +89,7 @@ services:
   Image.
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```
 
 - Scenario 2: It is necessary to use a JAR that has an SPI implementation or a third-party dependent JAR of a LICENSE
@@ -110,7 +117,7 @@ services:
 - Build GraalVM Native Image via command line.
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```
 
 3. To start Native Image through the command line, you need to bring 4 parameters.
@@ -128,7 +135,7 @@ services:
    exist for SPI implementation or third-party dependencies.
 
 ```shell
-./mvnw -am -pl distribution/proxy-native -B -Pnative,docker.native -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat .skip=true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native,docker.native -DskipTests clean package
 ```
 
 - Assuming that there is a `conf` folder containing `server.yaml` as `./custom/conf`, you can start the Docker Image
@@ -195,5 +202,5 @@ services:
 3. Build the GraalVM Native Image from the command line.
 
 ```bash
-./mvnw -am -pl distribution/proxy-native -B -Pnative -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true -Dspotless.apply.skip=true -Drat.skip =true clean package
+./mvnw -am -pl distribution/proxy-native -B -T1C -Prelease.native -DskipTests clean package
 ```

--- a/infra/util/pom.xml
+++ b/infra/util/pom.xml
@@ -53,6 +53,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>copy</id>

--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/EspressoInlineExpressionParser.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/EspressoInlineExpressionParser.java
@@ -36,12 +36,12 @@ public final class EspressoInlineExpressionParser {
     private final Value espressoInlineExpressionParser;
     
     static {
-        // https://github.com/oracle/graal/issues/4555 not yet closed
+        // TODO https://github.com/oracle/graal/issues/4555 not yet closed
         String javaHome = System.getenv("JAVA_HOME");
         if (null == javaHome) {
             throw new RuntimeException("Failed to determine the system's environment variable JAVA_HOME!");
         }
-        URL resource = Thread.currentThread().getContextClassLoader().getResource("espresso-need-libs");
+        URL resource = EspressoInlineExpressionParser.class.getClassLoader().getResource("espresso-need-libs");
         assert null != resource;
         String dir = resource.getPath();
         String javaClasspath = String.join(":", dir + "/groovy.jar", dir + "/guava.jar", dir + "/shardingsphere-infra-util-groovy.jar");

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <docker-compose-maven-plugin.version>4.0.0</docker-compose-maven-plugin.version>
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
+        <native-maven-plugin.version>0.9.21</native-maven-plugin.version>
         
         <!-- Compile plugin versions -->
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>
@@ -134,6 +135,7 @@
         <jandex-maven-plugin.version>3.0.5</jandex-maven-plugin.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
         <maven-dependency-plugin.version>3.5.0</maven-dependency-plugin.version>
+        <exec-maven-plugin.version>3.1.0</exec-maven-plugin.version>
         
         <!-- Release plugin versions -->
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
@@ -757,10 +759,6 @@
                     <version>${maven-jar-plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-dependency-plugin</artifactId>
-                    <version>${maven-dependency-plugin.version}</version>
-                </plugin>
-                <plugin>
                     <groupId>io.smallrye</groupId>
                     <artifactId>jandex-maven-plugin</artifactId>
                     <version>${jandex-maven-plugin.version}</version>
@@ -1223,6 +1221,80 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>generateStandardMetadata</id>
+            <properties>
+                <truffle-api.version>22.3.1</truffle-api.version>
+                <jacoco.skip>true</jacoco.skip>
+                <maven.javadoc.skip>true</maven.javadoc.skip>
+                <checkstyle.skip>true</checkstyle.skip>
+                <rat.skip>true</rat.skip>
+                <spotless.apply.skip>true</spotless.apply.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>${maven-compiler-plugin.version}</version>
+                        <configuration>
+                            <source>17</source>
+                            <target>17</target>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven-surefire-plugin.version}</version>
+                        <configuration>
+                            <excludes>
+                                <exclude>org.apache.shardingsphere.agent.core.**</exclude>
+                            </excludes>
+                            <argLine>--add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.graalvm.buildtools</groupId>
+                        <artifactId>native-maven-plugin</artifactId>
+                        <version>${native-maven-plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <agent>
+                                <enabled>true</enabled>
+                                <defaultMode>Direct</defaultMode>
+                                <modes>
+                                    <direct>config-output-dir=${project.basedir}/src/main/resources/META-INF/native-image/${project.groupId}/${project.artifactId}</direct>
+                                </modes>
+                                <options>
+                                    <callerFilterFiles>
+                                        <filterFile>${user.dir}/distribution/proxy-native/caller-filter.json</filterFile>
+                                    </callerFilterFiles>
+                                    <accessFilterFiles>
+                                        <filterFile>${user.dir}/distribution/proxy-native/access-filter.json</filterFile>
+                                    </accessFilterFiles>
+                                </options>
+                            </agent>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>test-native</id>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <phase>test</phase>
+                            </execution>
+                            <execution>
+                                <id>build-native</id>
+                                <goals>
+                                    <goal>compile-no-fork</goal>
+                                </goals>
+                                <phase>package</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Initialize the collectReachabilityMetadata Maven Task of all module. Since https://github.com/graalvm/native-build-tools/issues/403 is not closed, it is inconvenient to collect GraalVM Reachability Metadata in Conditional form.
  - Modify the name of the `native` profile to `release.native`, and simplify the command line parameters used in the document.
  - Update GraalVM Native Build Tools to 0.9.21.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
