### PR TITLE
Support inserting data into varbinary sharding column table with hash_mod sharding algorithm

### DIFF
--- a/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
+++ b/features/sharding/api/src/main/java/org/apache/shardingsphere/sharding/api/sharding/standard/PreciseShardingValue.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.sharding.api.sharding.standard;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
-import org.apache.shardingsphere.sharding.api.sharding.ShardingValue;
 import org.apache.shardingsphere.infra.datanode.DataNodeInfo;
+import org.apache.shardingsphere.sharding.api.sharding.ShardingValue;
 
 /**
  * Sharding value for precise.
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.infra.datanode.DataNodeInfo;
 @RequiredArgsConstructor
 @Getter
 @ToString
-public final class PreciseShardingValue<T extends Comparable<?>> implements ShardingValue {
+public final class PreciseShardingValue<T> implements ShardingValue {
     
     private final String logicTableName;
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithm.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/algorithm/sharding/mod/HashModShardingAlgorithm.java
@@ -58,7 +58,7 @@ public final class HashModShardingAlgorithm implements StandardShardingAlgorithm
         return availableTargetNames;
     }
     
-    private long hashShardingValue(final Comparable<?> shardingValue) {
+    private long hashShardingValue(final Object shardingValue) {
         return Math.abs((long) shardingValue.hashCode());
     }
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/engine/InsertClauseShardingConditionEngine.java
@@ -24,8 +24,6 @@ import org.apache.shardingsphere.infra.binder.segment.insert.values.InsertValueC
 import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
-import org.apache.shardingsphere.sharding.exception.data.NotImplementComparableValueException;
 import org.apache.shardingsphere.sharding.exception.data.NullShardingValueException;
 import org.apache.shardingsphere.sharding.route.engine.condition.ExpressionConditionUtils;
 import org.apache.shardingsphere.sharding.route.engine.condition.ShardingCondition;
@@ -134,13 +132,10 @@ public final class InsertClauseShardingConditionEngine {
         }
     }
     
-    @SuppressWarnings("rawtypes")
-    private Comparable<?> getShardingValue(final SimpleExpressionSegment expressionSegment, final List<Object> params) {
-        Object result = expressionSegment instanceof ParameterMarkerExpressionSegment
+    private Object getShardingValue(final SimpleExpressionSegment expressionSegment, final List<Object> params) {
+        return expressionSegment instanceof ParameterMarkerExpressionSegment
                 ? params.get(((ParameterMarkerExpressionSegment) expressionSegment).getParameterMarkerIndex())
                 : ((LiteralExpressionSegment) expressionSegment).getLiterals();
-        ShardingSpherePreconditions.checkState(result instanceof Comparable, () -> new NotImplementComparableValueException("Sharding", result));
-        return (Comparable) result;
     }
     
     private List<ShardingCondition> createShardingConditionsWithInsertSelect(final InsertStatementContext sqlStatementContext, final List<Object> params) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/value/ListShardingConditionValue.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/condition/value/ListShardingConditionValue.java
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
  */
 @RequiredArgsConstructor
 @Getter
-public final class ListShardingConditionValue<T extends Comparable<?>> implements ShardingConditionValue {
+public final class ListShardingConditionValue<T> implements ShardingConditionValue {
     
     private final String columnName;
     

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/strategy/type/standard/StandardShardingStrategy.java
@@ -71,7 +71,7 @@ public final class StandardShardingStrategy implements ShardingStrategy {
     @SuppressWarnings({"unchecked", "rawtypes"})
     private Collection<String> doSharding(final Collection<String> availableTargetNames, final ListShardingConditionValue<?> shardingValue, final DataNodeInfo dataNodeInfo) {
         Collection<String> result = new LinkedList<>();
-        for (Comparable<?> each : shardingValue.getValues()) {
+        for (Object each : shardingValue.getValues()) {
             String target = shardingAlgorithm.doSharding(availableTargetNames,
                     new PreciseShardingValue(shardingValue.getTableName(), shardingValue.getColumnName(), dataNodeInfo, each));
             if (null != target && availableTargetNames.contains(target)) {

--- a/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/checker/ShardingRouteCacheableChecker.java
+++ b/features/sharding/plugin/cache/src/main/java/org/apache/shardingsphere/sharding/cache/checker/ShardingRouteCacheableChecker.java
@@ -186,7 +186,7 @@ public final class ShardingRouteCacheableChecker {
     
     private static boolean isConditionTypeCacheable(final ShardingConditionValue conditionValue) {
         if (conditionValue instanceof ListShardingConditionValue<?>) {
-            for (Comparable<?> eachValue : ((ListShardingConditionValue<?>) conditionValue).getValues()) {
+            for (Object eachValue : ((ListShardingConditionValue<?>) conditionValue).getValues()) {
                 if (!(eachValue instanceof Number)) {
                     return false;
                 }

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/ShardingSphereDriverTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -50,6 +51,26 @@ public final class ShardingSphereDriverTest {
             try (ResultSet resultSet = statement.executeQuery("SELECT COUNT(1) FROM t_order")) {
                 assertTrue(resultSet.next());
                 assertThat(resultSet.getInt(1), is(2));
+            }
+        }
+    }
+    
+    @Test
+    public void assertVarbinaryColumnWorks() throws SQLException {
+        try (
+                Connection connection = DriverManager.getConnection("jdbc:shardingsphere:classpath:config/driver/foo-driver-fixture.yaml");
+                Statement statement = connection.createStatement()) {
+            assertThat(connection, instanceOf(ShardingSphereConnection.class));
+            statement.execute("DROP TABLE IF EXISTS t_order");
+            statement.execute("CREATE TABLE t_order (order_id VARBINARY(64) PRIMARY KEY, user_id INT)");
+            PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO t_order (order_id, user_id) VALUES (?, ?)");
+            preparedStatement.setBytes(1, new byte[]{-1, 0, 1});
+            preparedStatement.setInt(2, 101);
+            int updatedCount = preparedStatement.executeUpdate();
+            assertThat(updatedCount, is(1));
+            try (ResultSet resultSet = statement.executeQuery("SELECT COUNT(1) FROM t_order")) {
+                assertTrue(resultSet.next());
+                assertThat(resultSet.getInt(1), is(1));
             }
         }
     }

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURLManagerTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/core/driver/ShardingSphereDriverURLManagerTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class ShardingSphereDriverURLManagerTest {
     
-    private final int fooDriverConfigLength = 995;
+    private final int fooDriverConfigLength = 999;
     
     @Test(expected = DriverURLProviderNotFoundException.class)
     public void assertNewConstructorWithEmptyURL() {

--- a/jdbc/core/src/test/resources/config/driver/foo-driver-fixture.yaml
+++ b/jdbc/core/src/test/resources/config/driver/foo-driver-fixture.yaml
@@ -41,11 +41,11 @@ rules:
             shardingColumn: order_id
             shardingAlgorithmName: auto-mod
         keyGenerateStrategy:
-          column: order_id
+          column: user_id
           keyGeneratorName: snowflake
     shardingAlgorithms:
       auto-mod:
-        type: MOD
+        type: HASH_MOD
         props:
           sharding-count: 2
     


### PR DESCRIPTION
Fixes #24210.

Changes proposed in this pull request:
  - Add unit test: insert data into varbinary column table
  - Update IndexesMigrationE2EIT to test varbinary sharding column
  - Support inserting data into varbinary sharding column table. Remove or replace related `Comparable<?>` for sharding algorithm `hash_mod`

sharding algorithm `mod` is not supported for varbinary, since `ModShardingAlgorithm.cutShardingValue`:
```
    private BigInteger cutShardingValue(final Comparable<?> shardingValue) {
        ShardingSpherePreconditions.checkState(shardingValue.toString().length() - stopOffset > startOffset, () -> new ShardingValueOffsetException(shardingValue, startOffset, stopOffset));
        return 0 == startOffset && 0 == stopOffset ? getBigInteger(shardingValue) : new BigInteger(shardingValue.toString().substring(startOffset, shardingValue.toString().length() - stopOffset));
    }
```
byte[].toString() is not suitable for `cutShardingValue`.

And also other sharding algorithms are not supported for varbinary.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
