### PR TITLE
Add `none` sharding strategy type for `ConvertYamlConfigurationExecutor`

### DIFF
--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/rule/ReadwriteSplittingRule.java
@@ -195,8 +195,8 @@ public final class ReadwriteSplittingRule implements DatabaseRule, DataSourceCon
         if (rule.getReadwriteSplittingStrategy() instanceof DynamicReadwriteSplittingStrategy) {
             return;
         }
-        rule.getReadwriteSplittingStrategy().getReadDataSources().forEach(each ->
-                instanceContext.getEventBusContext().post(new StorageNodeDataSourceDeletedEvent(new QualifiedDatabase(databaseName, rule.getName(), each))));
+        rule.getReadwriteSplittingStrategy().getReadDataSources()
+                .forEach(each -> instanceContext.getEventBusContext().post(new StorageNodeDataSourceDeletedEvent(new QualifiedDatabase(databaseName, rule.getName(), each))));
     }
     
     @Override

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
@@ -32,6 +32,8 @@ public final class DistSQLScriptConstants {
     
     public static final String HINT = "hint";
     
+    public static final String NONE = "";
+    
     public static final String COMMA = ",";
     
     public static final String SEMI = ";";
@@ -101,11 +103,15 @@ public final class DistSQLScriptConstants {
     
     public static final String STRATEGY_HINT = "TYPE='%s', SHARDING_ALGORITHM(%s)";
     
+    public static final String STRATEGY_NONE = "TYPE='%s'";
+    
     public static final String SHARDING_STRATEGY_STANDARD = "%s(" + STRATEGY_STANDARD + ")";
     
     public static final String SHARDING_STRATEGY_COMPLEX = "%s(" + STRATEGY_COMPLEX + ")";
     
     public static final String SHARDING_STRATEGY_HINT = "%s(" + STRATEGY_HINT + ")";
+    
+    public static final String SHARDING_STRATEGY_NONE = "%s(" + STRATEGY_NONE + ")";
     
     public static final String KEY_GENERATOR_STRATEGY = "KEY_GENERATE_STRATEGY(COLUMN=%s, %s)";
     

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
@@ -342,6 +342,9 @@ public final class ConvertYamlConfigurationExecutor implements QueryableRALExecu
             case DistSQLScriptConstants.HINT:
                 result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_HINT, type, algorithmDefinition));
                 break;
+            case DistSQLScriptConstants.NONE:
+                result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_NONE, strategyType, "none"));
+                break;
             default:
                 break;
         }

--- a/proxy/backend/core/src/test/resources/conf/convert/config-sharding.yaml
+++ b/proxy/backend/core/src/test/resources/conf/convert/config-sharding.yaml
@@ -46,6 +46,8 @@ rules:
        complex:
          shardingColumns: order_id, user_id
          shardingAlgorithmName: t_order_inline
+     databaseStrategy:
+       none:
      keyGenerateStrategy:
        column: order_id
        keyGeneratorName: snowflake

--- a/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
+++ b/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
@@ -31,6 +31,7 @@ PROPERTIES('minPoolSize'='1', 'connectionTimeoutMilliseconds'='30000', 'maxLifet
 
 CREATE SHARDING TABLE RULE t_order (
 DATANODES('ds_${0..1}.t_order_${0..1}'),
+DATABASE_STRATEGY(TYPE='none'),
 TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=order_id, user_id, SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}', 'datetime-lower'='2022-01-01 00:00:00')))),
 KEY_GENERATE_STRATEGY(COLUMN=order_id, TYPE(NAME='snowflake')),
 AUDIT_STRATEGY(TYPE(NAME='dml_sharding_conditions'), ALLOW_HINT_DISABLE=true)


### PR DESCRIPTION
For #23823.

Changes proposed in this pull request:
  - Add `none` sharding strategy type for `ConvertYamlConfigurationExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
