### PR TITLE
Support proxy sharding rule absent for migration job

### DIFF
--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -104,7 +104,7 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 
 | SQL State | Vendor Code | 错误信息 |
 | --------- | ----------- | ------ |
-| 44000     | 18002       | Altered process configuration does not exist. |
+| 42S02     | 18002       | There is no rule in database \`%s\`. |
 | 44000     | 18003       | Mode configuration does not exist. |
 | 44000     | 18004       | Target database name is null. You could define it in DistSQL or select a database. |
 | HY000     | 18020       | Failed to get DDL for table \`%s\`. |

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -104,7 +104,7 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 
 | SQL State | Vendor Code | Reason |
 | --------- | ----------- | ------ |
-| 44000     | 18002       | Altered process configuration does not exist. |
+| 42S02     | 18002       | There is no rule in database \`%s\`. |
 | 44000     | 18003       | Mode configuration does not exist. |
 | 44000     | 18004       | Target database name is null. You could define it in DistSQL or select a database. |
 | HY000     | 18020       | Failed to get DDL for table \`%s\`. |

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverter.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverter.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 /**
  * Sharding rule configuration converter.
  */
+// TODO Move to pipeline module
 public final class ShardingRuleConfigurationConverter {
     
     /**
@@ -38,8 +39,8 @@ public final class ShardingRuleConfigurationConverter {
      * @return sharding rule configuration
      * @throws IllegalStateException if there is no available sharding rule
      */
-    public static ShardingRuleConfiguration findAndConvertShardingRuleConfiguration(final Collection<YamlRuleConfiguration> yamlRuleConfigs) {
-        return new YamlShardingRuleConfigurationSwapper().swapToObject(findYamlShardingRuleConfiguration(yamlRuleConfigs));
+    public static Optional<ShardingRuleConfiguration> findAndConvertShardingRuleConfiguration(final Collection<YamlRuleConfiguration> yamlRuleConfigs) {
+        return Optional.of(new YamlShardingRuleConfigurationSwapper().swapToObject(findYamlShardingRuleConfiguration(yamlRuleConfigs)));
     }
     
     /**

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverter.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverter.java
@@ -17,10 +17,8 @@
 
 package org.apache.shardingsphere.sharding.yaml.swapper;
 
-import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.exception.metadata.ShardingRuleNotFoundException;
 import org.apache.shardingsphere.sharding.yaml.config.YamlShardingRuleConfiguration;
 
 import java.util.Collection;
@@ -40,7 +38,7 @@ public final class ShardingRuleConfigurationConverter {
      * @throws IllegalStateException if there is no available sharding rule
      */
     public static Optional<ShardingRuleConfiguration> findAndConvertShardingRuleConfiguration(final Collection<YamlRuleConfiguration> yamlRuleConfigs) {
-        return Optional.of(new YamlShardingRuleConfigurationSwapper().swapToObject(findYamlShardingRuleConfiguration(yamlRuleConfigs)));
+        return findYamlShardingRuleConfiguration(yamlRuleConfigs).map(each -> new YamlShardingRuleConfigurationSwapper().swapToObject(each));
     }
     
     /**
@@ -50,9 +48,7 @@ public final class ShardingRuleConfigurationConverter {
      * @return YAML sharding rule configuration
      * @throws IllegalStateException if there is no available sharding rule
      */
-    public static YamlShardingRuleConfiguration findYamlShardingRuleConfiguration(final Collection<YamlRuleConfiguration> yamlRuleConfigs) {
-        Optional<YamlRuleConfiguration> ruleConfig = yamlRuleConfigs.stream().filter(each -> each instanceof YamlShardingRuleConfiguration).findFirst();
-        ShardingSpherePreconditions.checkState(ruleConfig.isPresent(), ShardingRuleNotFoundException::new);
-        return (YamlShardingRuleConfiguration) ruleConfig.get();
+    public static Optional<YamlShardingRuleConfiguration> findYamlShardingRuleConfiguration(final Collection<YamlRuleConfiguration> yamlRuleConfigs) {
+        return yamlRuleConfigs.stream().filter(each -> each instanceof YamlShardingRuleConfiguration).findFirst().map(each -> (YamlShardingRuleConfiguration) each);
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverterTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverterTest.java
@@ -22,13 +22,15 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public final class ShardingRuleConfigurationConverterTest {
     
     @Test
     public void assertFindAndConvertShardingRuleConfiguration() {
-        assertNotNull(ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(Collections.singletonList(mock(YamlShardingRuleConfiguration.class))));
+        assertTrue("Sharding rule should be present", ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(
+                Collections.singletonList(mock(YamlShardingRuleConfiguration.class))).isPresent());
+        assertTrue("Sharding rule should be not present", ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(Collections.emptyList()).isPresent());
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverterTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/ShardingRuleConfigurationConverterTest.java
@@ -22,6 +22,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
@@ -31,6 +32,6 @@ public final class ShardingRuleConfigurationConverterTest {
     public void assertFindAndConvertShardingRuleConfiguration() {
         assertTrue("Sharding rule should be present", ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(
                 Collections.singletonList(mock(YamlShardingRuleConfiguration.class))).isPresent());
-        assertTrue("Sharding rule should be not present", ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(Collections.emptyList()).isPresent());
+        assertFalse("Sharding rule should be not present", ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(Collections.emptyList()).isPresent());
     }
 }

--- a/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableNodesExecutorTest.java
+++ b/features/sharding/distsql/handler/src/test/java/org/apache/shardingsphere/sharding/distsql/query/ShowShardingTableNodesExecutorTest.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
 import org.apache.shardingsphere.sharding.distsql.handler.query.ShowShardingTableNodesExecutor;
 import org.apache.shardingsphere.sharding.distsql.parser.statement.ShowShardingTableNodesStatement;
+import org.apache.shardingsphere.sharding.exception.metadata.ShardingRuleNotFoundException;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.yaml.swapper.ShardingRuleConfigurationConverter;
 import org.junit.Test;
@@ -63,7 +64,8 @@ public final class ShowShardingTableNodesExecutorTest {
         URL url = getClass().getClassLoader().getResource("yaml/config_sharding_for_table_nodes.yaml");
         assertNotNull(url);
         YamlRootConfiguration yamlRootConfig = YamlEngine.unmarshal(new File(url.getFile()), YamlRootConfiguration.class);
-        ShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(yamlRootConfig.getRules());
+        ShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(yamlRootConfig.getRules())
+                .orElseThrow(ShardingRuleNotFoundException::new);
         return new ShardingRule(shardingRuleConfig, Arrays.asList("ds_1", "ds_2", "ds_3"), null);
     }
     

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -39,8 +39,7 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
     public DataSource createPipelineDataSource(final Object dataSourceConfig) throws SQLException {
         YamlRootConfiguration rootConfig = YamlEngine.unmarshal(YamlEngine.marshal(dataSourceConfig), YamlRootConfiguration.class);
         enableStreamingQuery(rootConfig);
-        YamlShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findYamlShardingRuleConfiguration(rootConfig.getRules());
-        enableRangeQueryForInline(shardingRuleConfig);
+        ShardingRuleConfigurationConverter.findYamlShardingRuleConfiguration(rootConfig.getRules()).ifPresent(this::enableRangeQueryForInline);
         rootConfig.setDatabaseName(null);
         rootConfig.setSchemaName(null);
         return YamlShardingSphereDataSourceFactory.createDataSourceWithoutCache(rootConfig);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/metadata/NoAnyRuleExistsException.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/exception/metadata/NoAnyRuleExistsException.java
@@ -21,13 +21,13 @@ import org.apache.shardingsphere.data.pipeline.core.exception.PipelineSQLExcepti
 import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
 
 /**
- * Alter not exist process configuration exception.
+ * No any rule exists exception.
  */
-public final class AlterNotExistProcessConfigurationException extends PipelineSQLException {
+public final class NoAnyRuleExistsException extends PipelineSQLException {
     
     private static final long serialVersionUID = 8799641580689564088L;
     
-    public AlterNotExistProcessConfigurationException() {
-        super(XOpenSQLState.CHECK_OPTION_VIOLATION, 2, "Altered process configuration does not exist.");
+    public NoAnyRuleExistsException(final String databaseName) {
+        super(XOpenSQLState.NOT_FOUND, 2, String.format("There is no rule in database `%s`.", databaseName));
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sharding/ShardingColumnsExtractor.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/sharding/ShardingColumnsExtractor.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -48,7 +49,11 @@ public final class ShardingColumnsExtractor {
      * @return sharding columns map
      */
     public Map<LogicTableName, Set<String>> getShardingColumnsMap(final Collection<YamlRuleConfiguration> yamlRuleConfigs, final Set<LogicTableName> logicTableNames) {
-        ShardingRuleConfiguration shardingRuleConfig = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(yamlRuleConfigs);
+        Optional<ShardingRuleConfiguration> shardingRuleConfigOptional = ShardingRuleConfigurationConverter.findAndConvertShardingRuleConfiguration(yamlRuleConfigs);
+        if (!shardingRuleConfigOptional.isPresent()) {
+            return Collections.emptyMap();
+        }
+        ShardingRuleConfiguration shardingRuleConfig = shardingRuleConfigOptional.get();
         Set<String> defaultDatabaseShardingColumns = extractShardingColumns(shardingRuleConfig.getDefaultDatabaseShardingStrategy());
         Set<String> defaultTableShardingColumns = extractShardingColumns(shardingRuleConfig.getDefaultTableShardingStrategy());
         Map<LogicTableName, Set<String>> result = new ConcurrentHashMap<>();

--- a/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/api/impl/MigrationJobAPI.java
+++ b/kernel/data-pipeline/scenario/migration/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/migration/api/impl/MigrationJobAPI.java
@@ -59,6 +59,7 @@ import org.apache.shardingsphere.data.pipeline.core.context.PipelineContext;
 import org.apache.shardingsphere.data.pipeline.core.datasource.PipelineDataSourceFactory;
 import org.apache.shardingsphere.data.pipeline.core.exception.connection.RegisterMigrationSourceStorageUnitException;
 import org.apache.shardingsphere.data.pipeline.core.exception.connection.UnregisterMigrationSourceStorageUnitException;
+import org.apache.shardingsphere.data.pipeline.core.exception.metadata.NoAnyRuleExistsException;
 import org.apache.shardingsphere.data.pipeline.core.metadata.loader.PipelineSchemaUtil;
 import org.apache.shardingsphere.data.pipeline.core.sharding.ShardingColumnsExtractor;
 import org.apache.shardingsphere.data.pipeline.scenario.migration.MigrationJob;
@@ -88,8 +89,6 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.resource.YamlDataSourceConfigurationSwapper;
 import org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapperEngine;
-import org.apache.shardingsphere.sharding.api.config.ShardingRuleConfiguration;
-import org.apache.shardingsphere.sharding.exception.metadata.ShardingRuleNotFoundException;
 
 import javax.sql.DataSource;
 import java.nio.charset.StandardCharsets;
@@ -453,9 +452,8 @@ public final class MigrationJobAPI extends AbstractInventoryIncrementalJobAPIImp
     }
     
     private YamlRootConfiguration getYamlRootConfiguration(final String databaseName, final Map<String, Map<String, Object>> yamlDataSources, final Collection<RuleConfiguration> rules) {
-        // TODO Check rules empty. Sharding rule could be empty
-        if (rules.stream().noneMatch(each -> each instanceof ShardingRuleConfiguration)) {
-            throw new ShardingRuleNotFoundException();
+        if (rules.isEmpty()) {
+            throw new NoAnyRuleExistsException(databaseName);
         }
         YamlRootConfiguration result = new YamlRootConfiguration();
         result.setDatabaseName(databaseName);

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -88,7 +88,7 @@ public final class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
         createTargetOrderTableRule();
         createTargetOrderTableEncryptRule();
         createTargetOrderItemTableRule();
-        Pair<List<Object[]>, List<Object[]>> dataPair = PipelineCaseHelper.generateFullInsertData(testParam.getDatabaseType(), 3000);
+        Pair<List<Object[]>, List<Object[]>> dataPair = PipelineCaseHelper.generateFullInsertData(testParam.getDatabaseType(), PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT);
         log.info("init data begin: {}", LocalDateTime.now());
         DataSourceExecuteUtil.execute(getSourceDataSource(), getExtraSQLCommand().getFullInsertOrder(getSourceTableOrderName()), dataPair.getLeft());
         DataSourceExecuteUtil.execute(getSourceDataSource(), getExtraSQLCommand().getFullInsertOrderItem(), dataPair.getRight());

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/RulesMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/RulesMigrationE2EIT.java
@@ -72,7 +72,7 @@ public final class RulesMigrationE2EIT extends AbstractMigrationE2EIT {
         return "t_order";
     }
     
-    //    @Test
+    @Test
     public void assertNoRuleMigrationSuccess() throws Exception {
         assertMigrationSuccess(null);
     }

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/RulesMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/RulesMigrationE2EIT.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.general;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.data.pipeline.scenario.migration.MigrationJobType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.sharding.algorithm.keygen.UUIDKeyGenerateAlgorithm;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.base.PipelineBaseE2EIT;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.AbstractMigrationE2EIT;
+import org.apache.shardingsphere.test.e2e.data.pipeline.env.enums.PipelineEnvTypeEnum;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.helper.PipelineCaseHelper;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineTestParameter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.sql.Connection;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * E2E IT for different types of rules, includes:
+ * 1) no any rule.
+ * 2) only encrypt rule.
+ */
+@RunWith(Parameterized.class)
+@Slf4j
+public final class RulesMigrationE2EIT extends AbstractMigrationE2EIT {
+    
+    public RulesMigrationE2EIT(final PipelineTestParameter testParam) {
+        super(testParam);
+    }
+    
+    @Parameters(name = "{0}")
+    public static Collection<PipelineTestParameter> getTestParameters() {
+        Collection<PipelineTestParameter> result = new LinkedList<>();
+        if (PipelineBaseE2EIT.ENV.getItEnvType() == PipelineEnvTypeEnum.NONE) {
+            return result;
+        }
+        List<String> versions = PipelineBaseE2EIT.ENV.listStorageContainerImages(new MySQLDatabaseType());
+        if (versions.isEmpty()) {
+            return result;
+        }
+        result.add(new PipelineTestParameter(new MySQLDatabaseType(), versions.get(0), "env/scenario/primary_key/text_primary_key/mysql.xml"));
+        return result;
+    }
+    
+    @Override
+    protected String getSourceTableOrderName() {
+        return "t_order";
+    }
+    
+    //    @Test
+    public void assertNoRuleMigrationSuccess() throws Exception {
+        assertMigrationSuccess(null);
+    }
+    
+    @Test
+    public void assertOnlyEncryptRuleMigrationSuccess() throws Exception {
+        assertMigrationSuccess(() -> {
+            createTargetOrderTableEncryptRule();
+            return null;
+        });
+    }
+    
+    private void assertMigrationSuccess(final Callable<Void> addRuleFn) throws Exception {
+        initEnvironment(getDatabaseType(), new MigrationJobType());
+        createSourceOrderTable();
+        try (Connection connection = getSourceDataSource().getConnection()) {
+            PipelineCaseHelper.batchInsertOrderRecordsWithGeneralColumns(connection, new UUIDKeyGenerateAlgorithm(), getSourceTableOrderName(), PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT);
+        }
+        addMigrationSourceResource();
+        addMigrationTargetResource();
+        if (null != addRuleFn) {
+            addRuleFn.call();
+        }
+        startMigration(getSourceTableOrderName(), getTargetTableOrderName());
+        String jobId = listJobId().get(0);
+        waitJobPrepareSuccess(String.format("SHOW MIGRATION STATUS '%s'", jobId));
+        waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
+        assertCheckMigrationSuccess(jobId, "DATA_MATCH");
+        commitMigrationByJobId(jobId);
+        proxyExecuteWithLog("REFRESH TABLE METADATA", 1);
+        assertThat(getTargetTableRecordsCount(getSourceTableOrderName()), is(PipelineBaseE2EIT.TABLE_INIT_ROW_COUNT));
+    }
+}

--- a/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/IndexesMigrationE2EIT.java
+++ b/test/e2e/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/primarykey/IndexesMigrationE2EIT.java
@@ -46,7 +46,9 @@ import static org.hamcrest.Matchers.is;
 /**
  * E2E IT for different types of indexes, includes:
  * 1) no unique key.
- * 2) special type single column unique key.
+ * 2) special type single column unique key, e.g. VARBINARY.
+ * 3) multiple columns primary key, first column type is VARCHAR.
+ * 4) multiple columns unique key, first column type is BIGINT.
  */
 @RunWith(Parameterized.class)
 @Slf4j


### PR DESCRIPTION

Changes proposed in this pull request:
  - ShardingRuleConfigurationConverter.java is refactored, return Optional
  - ShardingColumnsExtractor.getShardingColumnsMap return empty map if sharding rule doesn't exist
  - ShardingSpherePipelineDataSourceCreator.createPipelineDataSource support sharding rule absent
  - In MigrationJobAPI.createJobConfigAndStart, check rules empty or not, sharding rule could be absent
  - Add RulesMigrationE2EIT, includes: 1) no any rule, 2) only encrypt rule.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
