### PR TITLE
Add default sharding strategy for `ConvertYamlConfigurationExecutor`

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/constant/DistSQLScriptConstants.java
@@ -123,6 +123,10 @@ public final class DistSQLScriptConstants {
     
     public static final String BROADCAST_TABLE_RULE = "CREATE BROADCAST TABLE RULE %s";
     
+    public static final String DEFAULT_DATABASE_STRATEGY = "CREATE DEFAULT SHARDING DATABASE STRATEGY";
+    
+    public static final String DEFAULT_TABLE_STRATEGY = "CREATE DEFAULT SHARDING TABLE STRATEGY";
+    
     public static final String CREATE_READWRITE_SPLITTING_RULE = "CREATE READWRITE_SPLITTING RULE";
     
     public static final String READWRITE_SPLITTING_FOR_STATIC = " %s ("

--- a/proxy/backend/core/src/test/resources/expected/convert-mix.yaml
+++ b/proxy/backend/core/src/test/resources/expected/convert-mix.yaml
@@ -78,3 +78,5 @@ DATANODES('replica_ds_${0..1}.t_order_${0..1}'),
 TABLE_STRATEGY(TYPE='standard', SHARDING_COLUMN=order_id, SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_${order_id % 2}')))),
 KEY_GENERATE_STRATEGY(COLUMN=order_id, TYPE(NAME='snowflake'))
 );
+
+CREATE DEFAULT SHARDING DATABASE STRATEGY(TYPE='standard', SHARDING_COLUMN=user_id, SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='replica_ds_${user_id % 2}'))));

--- a/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
+++ b/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
@@ -43,3 +43,7 @@ AUDIT_STRATEGY(TYPE(NAME='dml_sharding_conditions'), ALLOW_HINT_DISABLE=true)
 );
 
 CREATE BROADCAST TABLE RULE t_address;
+
+CREATE DEFAULT SHARDING DATABASE STRATEGY(TYPE='standard', SHARDING_COLUMN=user_id, SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='ds_${user_id % 2}', 'datetime-lower'='2022-01-01 00:00:00'))));
+
+CREATE DEFAULT SHARDING TABLE STRATEGY(TYPE='none');


### PR DESCRIPTION
For #23823.

Changes proposed in this pull request:
  - Add default sharding strategy for `ConvertYamlConfigurationExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
