### PR TITLE
Fix `hint` sharding strategy in DistSQL

### DIFF
--- a/features/sharding/distsql/parser/src/main/antlr4/imports/sharding/RDLStatement.g4
+++ b/features/sharding/distsql/parser/src/main/antlr4/imports/sharding/RDLStatement.g4
@@ -136,7 +136,7 @@ shardingAlgorithm
     ;
 
 shardingStrategy
-    : TYPE EQ_ strategyType (COMMA_ shardingColumnDefinition COMMA_ shardingAlgorithm)?
+    : TYPE EQ_ strategyType ((COMMA_ shardingColumnDefinition)? COMMA_ shardingAlgorithm)?
     ;
 
 databaseStrategy

--- a/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
+++ b/features/sharding/distsql/parser/src/main/java/org/apache/shardingsphere/sharding/distsql/parser/core/ShardingDistSQLStatementVisitor.java
@@ -191,14 +191,14 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
     public ASTNode visitCreateDefaultShardingStrategy(final CreateDefaultShardingStrategyContext ctx) {
         ShardingStrategyContext shardingStrategyContext = ctx.shardingStrategy();
         String strategyType = getIdentifierValue(shardingStrategyContext.strategyType());
+        String defaultType = new IdentifierValue(ctx.type.getText()).getValue();
         if ("none".equalsIgnoreCase(strategyType)) {
-            return new CreateDefaultShardingStrategyStatement(null != ctx.ifNotExists(), new IdentifierValue(ctx.type.getText()).getValue(), "none", null, null);
+            return new CreateDefaultShardingStrategyStatement(null != ctx.ifNotExists(), defaultType, "none", null, null);
         }
         AlgorithmSegment algorithmSegment = null != shardingStrategyContext.shardingAlgorithm().algorithmDefinition()
                 ? (AlgorithmSegment) visitAlgorithmDefinition(shardingStrategyContext.shardingAlgorithm().algorithmDefinition())
                 : null;
-        String defaultType = new IdentifierValue(ctx.type.getText()).getValue();
-        String shardingColumn = buildShardingColumn(ctx.shardingStrategy().shardingColumnDefinition());
+        String shardingColumn = null != ctx.shardingStrategy().shardingColumnDefinition() ? buildShardingColumn(ctx.shardingStrategy().shardingColumnDefinition()) : null;
         return new CreateDefaultShardingStrategyStatement(null != ctx.ifNotExists(), defaultType, strategyType, shardingColumn, algorithmSegment);
     }
     
@@ -332,7 +332,8 @@ public final class ShardingDistSQLStatementVisitor extends ShardingDistSQLStatem
             return new ShardingStrategySegment(strategyType, null, null);
         }
         AlgorithmSegment algorithmSegment = null != ctx.shardingAlgorithm().algorithmDefinition() ? (AlgorithmSegment) visitAlgorithmDefinition(ctx.shardingAlgorithm().algorithmDefinition()) : null;
-        return new ShardingStrategySegment(strategyType, buildShardingColumn(ctx.shardingColumnDefinition()), algorithmSegment);
+        String shardingColumn = null != ctx.shardingColumnDefinition() ? buildShardingColumn(ctx.shardingColumnDefinition()) : null;
+        return new ShardingStrategySegment(strategyType, shardingColumn, algorithmSegment);
     }
     
     private Collection<String> getResources(final StorageUnitsContext ctx) {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
@@ -343,7 +343,7 @@ public final class ConvertYamlConfigurationExecutor implements QueryableRALExecu
                 result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_COMPLEX, strategyType, type, complexShardingStrategyConfig.getShardingColumns(), algorithmDefinition));
                 break;
             case DistSQLScriptConstants.HINT:
-                result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_HINT, type, algorithmDefinition));
+                result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_HINT, strategyType, type, algorithmDefinition));
                 break;
             case DistSQLScriptConstants.NONE:
                 result.append(String.format(DistSQLScriptConstants.SHARDING_STRATEGY_NONE, strategyType, "none"));

--- a/proxy/backend/core/src/test/resources/conf/convert/config-sharding.yaml
+++ b/proxy/backend/core/src/test/resources/conf/convert/config-sharding.yaml
@@ -61,6 +61,9 @@ rules:
        complex:
          shardingColumns: order_id, user_id
          shardingAlgorithmName: t_order_item_inline
+     databaseStrategy:
+       hint:
+         shardingAlgorithmName: t_order_item_hint_inline
      keyGenerateStrategy:
        column: order_item_id
        keyGeneratorName: snowflake
@@ -93,6 +96,10 @@ rules:
      props:
        algorithm-expression: t_order_item_${order_id % 2}
        datetime-lower: "2022-01-01 00:00:00"
+   t_order_item_hint_inline:
+     type: HINT_INLINE
+     props:
+       algorithm-expression: t_order_item_${order_id % 2}
 
  keyGenerators:
    snowflake:

--- a/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
+++ b/proxy/backend/core/src/test/resources/expected/convert-sharding.yaml
@@ -37,6 +37,7 @@ KEY_GENERATE_STRATEGY(COLUMN=order_id, TYPE(NAME='snowflake')),
 AUDIT_STRATEGY(TYPE(NAME='dml_sharding_conditions'), ALLOW_HINT_DISABLE=true)
 ), t_order_item (
 DATANODES('ds_${0..1}.t_order_item_${0..1}'),
+DATABASE_STRATEGY(TYPE='hint', SHARDING_ALGORITHM(TYPE(NAME='hint_inline', PROPERTIES('algorithm-expression'='t_order_item_${order_id % 2}')))),
 TABLE_STRATEGY(TYPE='complex', SHARDING_COLUMNS=order_id, user_id, SHARDING_ALGORITHM(TYPE(NAME='inline', PROPERTIES('algorithm-expression'='t_order_item_${order_id % 2}', 'datetime-lower'='2022-01-01 00:00:00')))),
 KEY_GENERATE_STRATEGY(COLUMN=order_item_id, TYPE(NAME='snowflake')),
 AUDIT_STRATEGY(TYPE(NAME='dml_sharding_conditions'), ALLOW_HINT_DISABLE=true)


### PR DESCRIPTION
related to #23823.

Changes proposed in this pull request:
  - Fix `hint` sharding strategy in DistSQL
  - Fix `hint` sharding strategy for `ConvertYamlConfigurationExecutor`

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
