### PR TITLE
Add netTimeoutForStreamingResults param at MySQLJdbcQueryPropertiesExtension

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
@@ -40,6 +40,7 @@ public final class MySQLJdbcQueryPropertiesExtension implements JdbcQueryPropert
         queryProps.setProperty("zeroDateTimeBehavior", getZeroDateTimeBehavior());
         queryProps.setProperty("noDatetimeStringSync", Boolean.TRUE.toString());
         queryProps.setProperty("jdbcCompliantTruncation", Boolean.FALSE.toString());
+        queryProps.setProperty("netTimeoutForStreamingResults", "600");
     }
     
     private String getZeroDateTimeBehavior() {

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
@@ -45,12 +45,13 @@ public final class MySQLJdbcQueryPropertiesExtensionTest {
     }
     
     private void assertQueryProperties(final Properties actual) {
-        assertThat(actual.size(), equalTo(6));
+        assertThat(actual.size(), equalTo(7));
         assertThat(actual.getProperty("useSSL"), equalTo(Boolean.FALSE.toString()));
         assertThat(actual.getProperty("rewriteBatchedStatements"), equalTo(Boolean.TRUE.toString()));
         assertThat(actual.getProperty("yearIsDateType"), equalTo(Boolean.FALSE.toString()));
         assertThat(actual.getProperty("zeroDateTimeBehavior"), equalTo("convertToNull"));
         assertThat(actual.getProperty("noDatetimeStringSync"), equalTo(Boolean.TRUE.toString()));
         assertThat(actual.getProperty("jdbcCompliantTruncation"), equalTo(Boolean.FALSE.toString()));
+        assertThat(actual.getProperty("netTimeoutForStreamingResults"), equalTo("600"));
     }
 }


### PR DESCRIPTION
refer: https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-connp-props-result-sets.html

Changes proposed in this pull request:
  - Add netTimeoutForStreamingResults param at MySQLJdbcQueryPropertiesExtension

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
