### PR TITLE
PostgreSQL protocol support UUID binary data format

### DIFF
--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
@@ -148,6 +148,8 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
      */
     public List<PostgreSQLValueFormat> readResultFormats() {
         int resultFormatsLength = payload.readInt2();
+        System.out.println("payload" + payload);
+        System.out.println("Length of payload" + resultFormatsLength);
         if (0 == resultFormatsLength) {
             return Collections.emptyList();
         }
@@ -156,8 +158,10 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
         }
         List<PostgreSQLValueFormat> result = new ArrayList<>(resultFormatsLength);
         for (int i = 0; i < resultFormatsLength; i++) {
+            System.out.println("Test" + i);
             result.add(PostgreSQLValueFormat.valueOf(payload.readInt2()));
         }
+        System.out.println("outside readresult");
         return result;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
@@ -148,8 +148,6 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
      */
     public List<PostgreSQLValueFormat> readResultFormats() {
         int resultFormatsLength = payload.readInt2();
-        System.out.println("payload" + payload);
-        System.out.println("Length of payload" + resultFormatsLength);
         if (0 == resultFormatsLength) {
             return Collections.emptyList();
         }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
@@ -156,10 +156,8 @@ public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
         }
         List<PostgreSQLValueFormat> result = new ArrayList<>(resultFormatsLength);
         for (int i = 0; i < resultFormatsLength; i++) {
-            System.out.println("Test" + i);
             result.add(PostgreSQLValueFormat.valueOf(payload.readInt2()));
         }
-        System.out.println("outside readresult");
         return result;
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLBinaryProtocolValueFactory.java
@@ -53,6 +53,7 @@ public final class PostgreSQLBinaryProtocolValueFactory {
         setBoolArrayBinaryProtocolValue();
         setStringArrayBinaryProtocolValue();
         setByteaBinaryProtocolValue();
+        setUUIDBinaryProtocolValue();
     }
     
     private static void setUnspecifiedBinaryProtocolValue() {
@@ -138,6 +139,11 @@ public final class PostgreSQLBinaryProtocolValueFactory {
     
     private static void setByteaBinaryProtocolValue() {
         BINARY_PROTOCOL_VALUES.put(PostgreSQLColumnType.POSTGRESQL_TYPE_BYTEA, new PostgreSQLByteaBinaryProtocolValue());
+    }
+    
+    private static void setUUIDBinaryProtocolValue() {
+        PostgreSQLUUIDBinaryProtocolValue binaryProtocolValue = new PostgreSQLUUIDBinaryProtocolValue();
+        BINARY_PROTOCOL_VALUES.put(PostgreSQLColumnType.POSTGRESQL_TYPE_UUID, binaryProtocolValue);
     }
     
     /**

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.protocol;
+
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+
+/**
+ * Binary protocol value for UUID for PostgreSQL.
+ */
+public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinaryProtocolValue {
+    
+    @Override
+    public int getColumnLength(final Object value) {
+        return (value.toString()).length();
+    }
+    
+    @Override
+    public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
+        byte[] result = new byte[parameterValueLength];
+        UUID uuidFromBytes = UUID.nameUUIDFromBytes(result);
+        System.out.println("UUID low" + uuidFromBytes);
+        return uuidFromBytes;
+    }
+    
+    @Override
+    public void write(final PostgreSQLPacketPayload payload, final Object value) {
+        System.out.println("write object" + value);
+        payload.writeUUID((UUID) value);
+    }
+}

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.protocol;
 
-import java.nio.ByteBuffer;
 import java.util.UUID;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 
@@ -41,6 +40,6 @@ public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinary
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        payload.writeUUID((UUID) value);
+        payload.writeBytes((byte[]) value);
     }
 }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -27,7 +27,7 @@ public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinary
     
     @Override
     public int getColumnLength(final Object value) {
-        return (value.toString()).length();
+        return value.toString().length();
     }
     
     @Override

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -32,10 +32,10 @@ public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinary
     
     @Override
     public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
-        byte[] result = new byte[parameterValueLength];
-        UUID uuidFromBytes = UUID.nameUUIDFromBytes(result);
-        payload.getByteBuf().readBytes(result);
-        return uuidFromBytes;
+        byte[] uuidFromBytes = new byte[parameterValueLength];
+        UUID result = UUID.nameUUIDFromBytes(uuidFromBytes);
+        payload.getByteBuf().readBytes(uuidFromBytes);
+        return result;
     }
     
     @Override

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValue.java
@@ -35,13 +35,12 @@ public final class PostgreSQLUUIDBinaryProtocolValue implements PostgreSQLBinary
     public Object read(final PostgreSQLPacketPayload payload, final int parameterValueLength) {
         byte[] result = new byte[parameterValueLength];
         UUID uuidFromBytes = UUID.nameUUIDFromBytes(result);
-        System.out.println("UUID low" + uuidFromBytes);
+        payload.getByteBuf().readBytes(result);
         return uuidFromBytes;
     }
     
     @Override
     public void write(final PostgreSQLPacketPayload payload, final Object value) {
-        System.out.println("write object" + value);
         payload.writeUUID((UUID) value);
     }
 }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
@@ -18,8 +18,10 @@
 package org.apache.shardingsphere.db.protocol.postgresql.payload;
 
 import io.netty.buffer.ByteBuf;
+import java.nio.ByteBuffer;
 import io.netty.buffer.CompositeByteBuf;
 import lombok.Getter;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
 
@@ -56,12 +58,19 @@ public final class PostgreSQLPacketPayload implements PacketPayload {
         byteBuf.writeByte(value);
     }
     
+    public void writeUUID(final UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+    }
+    
     /**
      * Read 2 byte fixed length integer from byte buffers.
      *
      * @return 2 byte fixed length integer
      */
     public int readInt2() {
+        System.out.println("byteBuf" + byteBuf);
         return byteBuf.readUnsignedShort();
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
@@ -18,10 +18,8 @@
 package org.apache.shardingsphere.db.protocol.postgresql.payload;
 
 import io.netty.buffer.ByteBuf;
-import java.nio.ByteBuffer;
 import io.netty.buffer.CompositeByteBuf;
 import lombok.Getter;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
 
@@ -56,12 +54,6 @@ public final class PostgreSQLPacketPayload implements PacketPayload {
      */
     public void writeInt1(final int value) {
         byteBuf.writeByte(value);
-    }
-    
-    public void writeUUID(final UUID uuid) {
-        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-        bb.putLong(uuid.getMostSignificantBits());
-        bb.putLong(uuid.getLeastSignificantBits());
     }
     
     /**

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
@@ -70,7 +70,6 @@ public final class PostgreSQLPacketPayload implements PacketPayload {
      * @return 2 byte fixed length integer
      */
     public int readInt2() {
-        System.out.println("byteBuf" + byteBuf);
         return byteBuf.readUnsignedShort();
     }
     

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/payload/PostgreSQLPacketPayload.java
@@ -22,7 +22,6 @@ import io.netty.buffer.CompositeByteBuf;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.payload.PacketPayload;
-
 import java.nio.charset.Charset;
 
 /**

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
@@ -22,7 +22,6 @@ import io.netty.buffer.Unpooled;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
 import org.junit.Test;
 import java.util.UUID;
-//import org.junit.runners.Parameterized.Parameters;
 
 import java.nio.charset.StandardCharsets;
 

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.protocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
+import org.junit.Test;
+import java.util.UUID;
+//import org.junit.runners.Parameterized.Parameters;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public final class PostgreSQLUUIDBinaryProtocolValueTest {
+    
+    private final byte[] expected = new byte[5];
+    
+    @Test
+    public void assertGetColumnLength() {
+        assertThat(new PostgreSQLUUIDBinaryProtocolValue().getColumnLength(expected), is(11));
+    }
+    
+    @Test
+    public void assertRead() {
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(expected);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        assertThat(new PostgreSQLUUIDBinaryProtocolValue().read(payload, 5), is(UUID.nameUUIDFromBytes(expected)));
+    }
+    
+    @Test
+    public void assertWrite() {
+        byte[] bytes = new byte[5];
+        ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes).writerIndex(0);
+        PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
+        new PostgreSQLUUIDBinaryProtocolValue().write(payload, expected);
+        assertThat(bytes, is(expected));
+    }
+}

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
@@ -30,23 +30,23 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public final class PostgreSQLUUIDBinaryProtocolValueTest {
     
-    private final byte[] expected = new byte[5];
+    private final byte[] expected = new byte[16];
     
     @Test
     public void assertGetColumnLength() {
-        assertThat(new PostgreSQLUUIDBinaryProtocolValue().getColumnLength(expected), is(11));
+        assertThat(new PostgreSQLUUIDBinaryProtocolValue().getColumnLength(UUID.nameUUIDFromBytes(expected)), is(36));
     }
     
     @Test
     public void assertRead() {
         ByteBuf byteBuf = Unpooled.wrappedBuffer(expected);
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
-        assertThat(new PostgreSQLUUIDBinaryProtocolValue().read(payload, 5), is(UUID.nameUUIDFromBytes(expected)));
+        assertThat(new PostgreSQLUUIDBinaryProtocolValue().read(payload, 16), is(UUID.nameUUIDFromBytes(expected)));
     }
     
     @Test
     public void assertWrite() {
-        byte[] bytes = new byte[5];
+        byte[] bytes = new byte[16];
         ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes).writerIndex(0);
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
         new PostgreSQLUUIDBinaryProtocolValue().write(payload, expected);

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/protocol/PostgreSQLUUIDBinaryProtocolValueTest.java
@@ -50,6 +50,6 @@ public final class PostgreSQLUUIDBinaryProtocolValueTest {
         ByteBuf byteBuf = Unpooled.wrappedBuffer(bytes).writerIndex(0);
         PostgreSQLPacketPayload payload = new PostgreSQLPacketPayload(byteBuf, StandardCharsets.UTF_8);
         new PostgreSQLUUIDBinaryProtocolValue().write(payload, expected);
-        assertThat(bytes, is(expected));
+        assertThat(bytes, is(expected)); 
     }
 }


### PR DESCRIPTION
Fixes #24043.

Changes proposed in this pull request:
  - Support for UUID Datatype in ShardingSphere

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [X] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
