### PR TITLE
Revise #24223, optimize exception message

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/state/exception/UnavailableDataSourceException.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/state/exception/UnavailableDataSourceException.java
@@ -32,11 +32,7 @@ public final class UnavailableDataSourceException extends ShardingSphereServerEx
     
     private static final int ERROR_CODE = 1;
     
-    public UnavailableDataSourceException(final SQLException cause) {
-        super(ERROR_CATEGORY, ERROR_CODE, "Data source unavailable.", cause);
-    }
-    
-    public UnavailableDataSourceException(final SQLException cause, final String databaseName) {
-        super(ERROR_CATEGORY, ERROR_CODE, String.format("Data source unavailable from `%s`.", databaseName), cause);
+    public UnavailableDataSourceException(final SQLException cause, final String dataSourceName) {
+        super(ERROR_CATEGORY, ERROR_CODE, String.format("Data source `%s` is unavailable.", dataSourceName), cause);
     }
 }


### PR DESCRIPTION
Revise #24223.

Changes proposed in this pull request:
  - Remove unused constructor
  - Optimize exception message

```
Exception in thread "main" org.apache.shardingsphere.infra.datasource.state.exception.UnavailableDataSourceException: DATA-SOURCE-00001: Data source `ds_0` is unavailable.
	at org.apache.shardingsphere.infra.datasource.state.DataSourceStateManager.lambda$checkState$1(DataSourceStateManager.java:87)
	at org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions.checkState(ShardingSpherePreconditions.java:41)
	at org.apache.shardingsphere.infra.datasource.state.DataSourceStateManager.checkState(DataSourceStateManager.java:87)
	at org.apache.shardingsphere.infra.datasource.state.DataSourceStateManager.initState(DataSourceStateManager.java:79)
	at org.apache.shardingsphere.infra.datasource.state.DataSourceStateManager.lambda$initStates$0(DataSourceStateManager.java:70)
	at java.base/java.util.LinkedHashMap.forEach(LinkedHashMap.java:721)
	at org.apache.shardingsphere.infra.datasource.state.DataSourceStateManager.initStates(DataSourceStateManager.java:70)
	at org.apache.shardingsphere.mode.metadata.MetaDataContextsFactory.lambda$checkDataSourceStates$4(MetaDataContextsFactory.java:113)
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
