### PR TITLE
Fix grammar for mysql begin statement

### DIFF
--- a/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/TCLStatement.g4
+++ b/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/TCLStatement.g4
@@ -28,7 +28,7 @@ setAutoCommit
     ;
 
 beginTransaction
-    : BEGIN | START TRANSACTION (transactionCharacteristic (COMMA_ transactionCharacteristic)*)?
+    : BEGIN WORK? | START TRANSACTION (transactionCharacteristic (COMMA_ transactionCharacteristic)*)?
     ;
 
 transactionCharacteristic

--- a/test/it/parser/src/main/resources/case/tcl/begin-transaction.xml
+++ b/test/it/parser/src/main/resources/case/tcl/begin-transaction.xml
@@ -18,6 +18,7 @@
 
 <sql-parser-test-cases>
     <begin-transaction sql-case-id="begin" />
+    <begin-transaction sql-case-id="begin_work" />
     <begin-transaction sql-case-id="begin_transaction" />
     <begin-transaction sql-case-id="begin_with_name" />
     <begin-transaction sql-case-id="begin_with_variable_name" />

--- a/test/it/parser/src/main/resources/sql/supported/tcl/begin-transcation.xml
+++ b/test/it/parser/src/main/resources/sql/supported/tcl/begin-transcation.xml
@@ -18,6 +18,7 @@
 
 <sql-cases>
     <sql-case id="begin" value="BEGIN" db-types="MySQL,PostgreSQL,openGauss" />
+    <sql-case id="begin_work" value="BEGIN WORK" db-types="MySQL" />
     <sql-case id="begin_transaction" value="BEGIN TRANSACTION" db-types="SQLServer,PostgreSQL,openGauss" />
     <sql-case id="begin_with_name" value="BEGIN TRANSACTION transaction1" db-types="SQLServer" />
     <sql-case id="begin_with_variable_name" value="BEGIN TRANSACTION @TranName" db-types="SQLServer" />


### PR DESCRIPTION
according to official documentation, **BEGIN** statement has an optional keyword '**WORK**'

syntax:
```
BEGIN [WORK]
```
