### PR TITLE
Support unix domain socket

### DIFF
--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -103,6 +103,7 @@ unset -v PORT
 unset -v ADDRESSES
 unset -v CONF_PATH
 unset -v FORCE
+unset -v SOCKET_FILE
 
 print_usage() {
     echo "usage:"
@@ -119,6 +120,7 @@ print_usage() {
     echo "-c  Path to config directory of ShardingSphere-Proxy, default is 'conf'"
     echo "-f  Force start ShardingSphere-Proxy"
     echo "-g  Enable agent if shardingsphere-agent deployed in 'agent' directory"
+    echo "-s  The socket file to use for connection."
     exit 0
 }
 
@@ -170,8 +172,8 @@ if [ $# == 0 ]; then
     CLASS_PATH=${DEPLOY_DIR}/conf:${CLASS_PATH}
 fi
 
-if [[ $1 == -a ]] || [[ $1 == -p ]] || [[ $1 == -c ]] || [[ $1 == -f ]] ; then
-    while getopts ":a:p:c:f" opt
+if [[ $1 == -a ]] || [[ $1 == -p ]] || [[ $1 == -c ]] || [[ $1 == -f ]] || [[ $1 == -s ]]; then
+    while getopts ":a:p:c:f:s:" opt
     do
         case $opt in
         a)
@@ -186,6 +188,9 @@ if [[ $1 == -a ]] || [[ $1 == -p ]] || [[ $1 == -c ]] || [[ $1 == -f ]] ; then
         f)
           echo "The force param is true"
           FORCE=true;;
+        s)
+          echo "The socket file is $OPTARG"
+          SOCKET_FILE=$OPTARG;;
         ?)
           print_usage;;
         esac
@@ -216,6 +221,10 @@ fi
 
 if [ -z "$FORCE" ]; then
     FORCE=false
+fi
+
+if [ "$SOCKET_FILE" ]; then
+    ADDRESSES="${ADDRESSES},${SOCKET_FILE}"
 fi
 
 CLASS_PATH=${CONF_PATH}:${CLASS_PATH}

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
@@ -55,6 +55,6 @@ public final class Bootstrap {
         Optional.ofNullable((Integer) yamlConfig.getServerConfiguration().getProps().get(ConfigurationPropertyKey.CDC_SERVER_PORT.getKey()))
                 .ifPresent(cdcPort -> new CDCServer(addresses, cdcPort).start());
         bootstrapArgs.getSocketPath().ifPresent(socketPath -> new ShardingSphereProxy().start(socketPath));
-        new ShardingSphereProxy().start(port,addresses);
+        new ShardingSphereProxy().start(port, addresses);
     }
 }

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
@@ -54,6 +54,7 @@ public final class Bootstrap {
         new BootstrapInitializer().init(yamlConfig, port, bootstrapArgs.getForce());
         Optional.ofNullable((Integer) yamlConfig.getServerConfiguration().getProps().get(ConfigurationPropertyKey.CDC_SERVER_PORT.getKey()))
                 .ifPresent(cdcPort -> new CDCServer(addresses, cdcPort).start());
-        new ShardingSphereProxy().start("/tmp/shardingsphere.sock");
+        bootstrapArgs.getSocketPath().ifPresent(socketPath -> new ShardingSphereProxy().start(socketPath));
+        new ShardingSphereProxy().start(port,addresses);
     }
 }

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/Bootstrap.java
@@ -54,6 +54,6 @@ public final class Bootstrap {
         new BootstrapInitializer().init(yamlConfig, port, bootstrapArgs.getForce());
         Optional.ofNullable((Integer) yamlConfig.getServerConfiguration().getProps().get(ConfigurationPropertyKey.CDC_SERVER_PORT.getKey()))
                 .ifPresent(cdcPort -> new CDCServer(addresses, cdcPort).start());
-        new ShardingSphereProxy().start(port, addresses);
+        new ShardingSphereProxy().start("/tmp/shardingsphere.sock");
     }
 }

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/arguments/BootstrapArguments.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/arguments/BootstrapArguments.java
@@ -81,7 +81,7 @@ public final class BootstrapArguments {
         List<String> addresses = Arrays.asList(args[2].split(","));
         return addresses.stream().filter(InetAddresses::isInetAddress).collect(Collectors.toList());
     }
-
+    
     /**
      * Get unix domain socket path.
      *
@@ -118,8 +118,8 @@ public final class BootstrapArguments {
         }
         return result.toString();
     }
-
-    private boolean isValidPath(String path) {
+    
+    private boolean isValidPath(final String path) {
         try {
             Paths.get(path);
         } catch (InvalidPathException | NullPointerException ex) {

--- a/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/ServerHandlerInitializer.java
+++ b/proxy/frontend/core/src/main/java/org/apache/shardingsphere/proxy/frontend/netty/ServerHandlerInitializer.java
@@ -17,10 +17,11 @@
 
 package org.apache.shardingsphere.proxy.frontend.netty;
 
+import io.netty.channel.Channel;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.socket.SocketChannel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.db.protocol.codec.PacketCodec;
 import org.apache.shardingsphere.db.protocol.netty.ChannelAttrInitializer;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
@@ -31,12 +32,13 @@ import org.apache.shardingsphere.proxy.frontend.spi.DatabaseProtocolFrontendEngi
  * Server handler initializer.
  */
 @RequiredArgsConstructor
-public final class ServerHandlerInitializer extends ChannelInitializer<SocketChannel> {
+@Slf4j
+public final class ServerHandlerInitializer extends ChannelInitializer<Channel> {
     
     private final DatabaseType databaseType;
     
     @Override
-    protected void initChannel(final SocketChannel socketChannel) {
+    protected void initChannel(final Channel socketChannel) {
         DatabaseProtocolFrontendEngine databaseProtocolFrontendEngine = TypedSPILoader.getService(DatabaseProtocolFrontendEngine.class, databaseType.getType());
         databaseProtocolFrontendEngine.initChannel(socketChannel);
         ChannelPipeline pipeline = socketChannel.pipeline();

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/authentication/MySQLAuthenticationEngine.java
@@ -19,6 +19,8 @@ package org.apache.shardingsphere.proxy.frontend.mysql.authentication;
 
 import com.google.common.base.Strings;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.epoll.EpollDomainSocketChannel;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.authority.checker.AuthorityChecker;
 import org.apache.shardingsphere.authority.rule.AuthorityRule;
 import org.apache.shardingsphere.db.protocol.constant.CommonConstants;
@@ -56,6 +58,7 @@ import java.util.Optional;
 /**
  * Authentication engine for MySQL.
  */
+@Slf4j
 public final class MySQLAuthenticationEngine implements AuthenticationEngine {
     
     private final MySQLAuthenticationPluginData authPluginData = new MySQLAuthenticationPluginData();
@@ -147,6 +150,10 @@ public final class MySQLAuthenticationEngine implements AuthenticationEngine {
     }
     
     private String getHostAddress(final ChannelHandlerContext context) {
+        if (context.channel() instanceof EpollDomainSocketChannel) {
+            return context.channel().parent().localAddress().toString();
+        }
+        
         SocketAddress socketAddress = context.channel().remoteAddress();
         return socketAddress instanceof InetSocketAddress ? ((InetSocketAddress) socketAddress).getAddress().getHostAddress() : socketAddress.toString();
     }


### PR DESCRIPTION
Fixes #24095.

 ShardingSphere-Proxy supported UDS。

Changes proposed in this pull request:
  -  In  ShardingSphere-Proxy，add supported UDS by the `socket path` paramet.
  -  In  start.sh，add `-s` of paramet  to setting  `socket path`.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
