### PR TITLE
Add useServerPrepStmts=false for pipeline job on MySQL

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtension.java
@@ -35,6 +35,7 @@ public final class MySQLJdbcQueryPropertiesExtension implements JdbcQueryPropert
     
     public MySQLJdbcQueryPropertiesExtension() {
         queryProps.setProperty("useSSL", Boolean.FALSE.toString());
+        queryProps.setProperty("useServerPrepStmts", Boolean.FALSE.toString());
         queryProps.setProperty("rewriteBatchedStatements", Boolean.TRUE.toString());
         queryProps.setProperty("yearIsDateType", Boolean.FALSE.toString());
         queryProps.setProperty("zeroDateTimeBehavior", getZeroDateTimeBehavior());

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/datasource/MySQLJdbcQueryPropertiesExtensionTest.java
@@ -45,8 +45,9 @@ public final class MySQLJdbcQueryPropertiesExtensionTest {
     }
     
     private void assertQueryProperties(final Properties actual) {
-        assertThat(actual.size(), equalTo(7));
+        assertThat(actual.size(), equalTo(8));
         assertThat(actual.getProperty("useSSL"), equalTo(Boolean.FALSE.toString()));
+        assertThat(actual.getProperty("useServerPrepStmts"), equalTo(Boolean.FALSE.toString()));
         assertThat(actual.getProperty("rewriteBatchedStatements"), equalTo(Boolean.TRUE.toString()));
         assertThat(actual.getProperty("yearIsDateType"), equalTo(Boolean.FALSE.toString()));
         assertThat(actual.getProperty("zeroDateTimeBehavior"), equalTo("convertToNull"));


### PR DESCRIPTION
Currently, `useServerPrepStmts` is set to `true` in `MySQLDataSourceMetaData`, and it's `false` by default in MySQL JDBC driver.

Set `useServerPrepStmts=true` will cause too many prepared statements in MySQL server. It could be verified by SQLs:
```
SHOW GLOBAL STATUS LIKE '%prepared_stmt_count%';

SELECT * FROM performance_schema.prepared_statements_instances;
```

By default, `max_prepared_stmt_count` in MySQL is `16382`.
If there're thousands of sharding tables, then it might cause error: `Error 1461: Can't create more than max_prepared_stmt_count statements (current value: 16382)`.

And set `useServerPrepStmts=true` might hurt batch insert performance.

So `useServerPrepStmts` will be set to `false` in pipeline job.

Ref [MySQL Connector/J]( https://dev.mysql.com/doc/connectors/en/connector-j-reference-configuration-properties.html )

Changes proposed in this pull request:
  - Add useServerPrepStmts=false for pipeline job on MySQL

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
