### PR TITLE
support for CAST Function

### DIFF
--- a/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -1002,8 +1002,9 @@ repairType
     
 castFunction
     : CAST LP_ expr AS dataType RP_
+    | CAST LP_ expr AT TIME ZONE expr AS DATETIME typeDatetimePrecision? RP_
     ;
-    
+
 convertFunction
     : CONVERT LP_ expr COMMA_ castType RP_
     | CONVERT LP_ expr USING charsetName RP_

--- a/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
+++ b/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/MySQLKeyword.g4
@@ -2958,3 +2958,7 @@ JSON_VALID
     : J S O N UL_ V A L I D
     ;
 
+ZONE
+    : Z O N E
+    ;
+

--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -887,13 +887,15 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
     
     @Override
     public final ASTNode visitCastFunction(final CastFunctionContext ctx) {
-        calculateParameterCount(Collections.singleton(ctx.expr()));
+        calculateParameterCount(ctx.expr());
         FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.CAST().getText(), getOriginalText(ctx));
-        ASTNode exprSegment = visit(ctx.expr());
-        if (exprSegment instanceof ColumnSegment) {
-            result.getParameters().add((ColumnSegment) exprSegment);
-        } else if (exprSegment instanceof LiteralExpressionSegment) {
-            result.getParameters().add((LiteralExpressionSegment) exprSegment);
+        for (ExprContext each : ctx.expr()) {
+            ASTNode expr = visit(each);
+            if (expr instanceof ColumnSegment) {
+                result.getParameters().add((ColumnSegment) expr);
+            } else if (expr instanceof LiteralExpressionSegment) {
+                result.getParameters().add((LiteralExpressionSegment) expr);
+            }
         }
         result.getParameters().add((DataTypeSegment) visit(ctx.dataType()));
         return result;

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -62,6 +62,25 @@
             </expression-projection>
         </projections>
     </select>
+    <select sql-case-id="select_cast">
+        <projections start-index="7" stop-index="42">
+            <expression-projection text="CAST(c AT TIME ZONE 'UTC' AS DATETIME)" start-index="7" stop-index="42">
+                <expr>
+                    <function function-name="CAST" start-index="7" stop-index="42" text="CAST(c AT TIME ZONE 'UTC' AS DATETIME)">
+                        <parameter>
+                            <literal-expression value="c" start-index="12" stop-index="12" />
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="UTC" start-index="24" stop-index="29" />
+                        </parameter>
+                        <parameter>
+                            <data-type value="DATETIME" start-index="34" stop-index="41" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+    </select>
     <select sql-case-id="select_convert_function">
         <projections start-index="7" stop-index="33">
             <expression-projection text="CONVERT('2020-10-01', DATE)" start-index="7" stop-index="33">

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -20,6 +20,7 @@
     <sql-case id="select_group_concat" value="SELECT GROUP_CONCAT(status) FROM t_order" db-types="MySQL" />
     <sql-case id="select_window_function" value="SELECT order_id, ROW_NUMBER() OVER() FROM t_order" db-types="MySQL" />
     <sql-case id="select_cast_function" value="SELECT CAST('1' AS UNSIGNED)" db-types="MySQL" />
+    <sql-case id="select_cast" value="SELECT CAST(c AT TIME ZONE 'UTC' AS DATETIME)" db-types="MySQL" />
     <sql-case id="select_convert_function" value="SELECT CONVERT('2020-10-01', DATE)" db-types="MySQL" />
     <sql-case id="select_position" value="SELECT POSITION('bar' IN 'foobarbar')" db-types="MySQL" />
     <sql-case id="select_substring" value="SELECT SUBSTRING('foobarbar' from 4)" db-types="MySQL" />

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -24,7 +24,6 @@
     <sql-case id="assert_dist_SQL_show_rule_parse_conflict" value="SHOW REPLICA_QUERY RULE FROM schema_name" />
     <sql-case id="with_select" value="WITH cte AS (SELECT 0 /*! ) */ SELECT * FROM cte a, cte b;" db-types="MySQL" />
     <sql-case id="with_select_comment" value="WITH cte AS /*! ( */ SELECT 0) SELECT * FROM cte a, cte b;" db-types="MySQL" />
-    <sql-case id="select_cast" value="SELECT cast( NULL AT TIME ZONE 'UTC' AS DATETIME );" db-types="MySQL" />
     <sql-case id="create_table_as_select" value="create table agg_data_2k as select g from generate_series(0, 1999) g;" db-types="PostgreSQL" />
     <sql-case id="create_temp_table" value="create temp table old_oids as select relname, oid as oldoid, relfilenode as oldfilenode from pg_class where relname like 'at_partitioned%'" db-types="PostgreSQL" />
     <sql-case id="select_case_when" value="select relname,c.oid = oldoid as orig_oid,case relfilenode when 0 then 'none' when c.oid then 'own' when oldfilenode then 'orig' else 'OTHER' end as storage, obj_description(c.oid, 'pg_class') as desc from pg_class c left join old_oids using (relname) where relname like 'at_partitioned%' order by relname" db-types="PostgreSQL" />


### PR DESCRIPTION
Fixes #24398 .

Changes proposed in this pull request:
1.  Added support for this in ANTLR :
[CAST(timestamp_value AT TIME ZONE timezone_specifier AS DATETIME[(precision)])]
(https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast)

2. Optimised MySQLStatementSQLVisitor#visitCastFunction

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
