### PR TITLE
Fix incorrect count under concurrency of CDC job

### DIFF
--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/context/job/CDCJobItemContext.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/context/job/CDCJobItemContext.java
@@ -101,9 +101,6 @@ public final class CDCJobItemContext implements InventoryIncrementalJobItemConte
         this.taskConfig = taskConfig;
         this.dataSourceManager = dataSourceManager;
         this.importerConnector = importerConnector;
-        if (null != initProgress) {
-            status = initProgress.getStatus();
-        }
     }
     
     @Override

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckPosition.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckPosition.java
@@ -17,27 +17,51 @@
 
 package org.apache.shardingsphere.data.pipeline.cdc.core.ack;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.data.pipeline.api.ingest.record.Record;
+
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * CDC ack position.
  */
 @Getter
-@AllArgsConstructor
 public final class CDCAckPosition {
     
     @Setter
     private Record lastRecord;
     
-    @Setter
-    private int dataRecordCount;
+    private final AtomicInteger dataRecordCount = new AtomicInteger();
     
     private final long createTimeMills;
     
     public CDCAckPosition(final Record lastRecord, final int dataRecordCount) {
-        this(lastRecord, dataRecordCount, System.currentTimeMillis());
+        this.lastRecord = lastRecord;
+        this.dataRecordCount.set(dataRecordCount);
+        createTimeMills = System.currentTimeMillis();
+    }
+    
+    public CDCAckPosition(final Record lastRecord, final long createTimeMills) {
+        this.lastRecord = lastRecord;
+        this.createTimeMills = createTimeMills;
+    }
+    
+    /**
+     * Add data record count.
+     *
+     * @param count count.
+     */
+    public void addDataRecordCount(final int count) {
+        dataRecordCount.addAndGet(count);
+    }
+    
+    /**
+     * Get data record count.
+     *
+     * @return data record count.
+     */
+    public int getDataRecordCount() {
+        return dataRecordCount.get();
     }
 }

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/CDCDataRecordUtil.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/CDCDataRecordUtil.java
@@ -69,7 +69,7 @@ public final class CDCDataRecordUtil {
             cdcAckPositionMap.put(socketSinkImporter, new CDCAckPosition(record, 1));
         } else {
             cdcAckPosition.setLastRecord(record);
-            cdcAckPosition.setDataRecordCount(cdcAckPosition.getDataRecordCount());
+            cdcAckPosition.addDataRecordCount(cdcAckPosition.getDataRecordCount());
         }
     }
     

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckHolderTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/core/ack/CDCAckHolderTest.java
@@ -54,7 +54,7 @@ public final class CDCAckHolderTest {
         CDCAckHolder cdcAckHolder = CDCAckHolder.getInstance();
         final Map<SocketSinkImporter, CDCAckPosition> importerDataRecordMap = new HashMap<>();
         SocketSinkImporter socketSinkImporter = mock(SocketSinkImporter.class);
-        importerDataRecordMap.put(socketSinkImporter, new CDCAckPosition(new FinishedRecord(new FinishedPosition()), 0, System.currentTimeMillis() - 60 * 1000 * 10));
+        importerDataRecordMap.put(socketSinkImporter, new CDCAckPosition(new FinishedRecord(new FinishedPosition()), System.currentTimeMillis() - 60 * 1000 * 10));
         cdcAckHolder.bindAckIdWithPosition(importerDataRecordMap);
         cdcAckHolder.cleanUp(socketSinkImporter);
         Optional<Map<String, Map<SocketSinkImporter, CDCAckPosition>>> ackIdPositionMap = ReflectionUtil.getFieldValue(cdcAckHolder, "ackIdPositionMap");


### PR DESCRIPTION


Changes proposed in this pull request:
  - Fix incorrect count under concurrency of CDC job 
  - Fix incremental task not starting correctly after job restart, the status will reset at InventoryIncrementalTasksRunner, so need remove at init

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
