### PR TITLE
Remove useless resourceDefinition in `encrypt/RDLStatement.g4`

### DIFF
--- a/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/RDLStatement.g4
+++ b/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/RDLStatement.g4
@@ -32,11 +32,7 @@ dropEncryptRule
     ;
 
 encryptRuleDefinition
-    : tableName LP_ (resourceDefinition COMMA_)? COLUMNS LP_ encryptColumnDefinition (COMMA_ encryptColumnDefinition)* RP_ (COMMA_ QUERY_WITH_CIPHER_COLUMN EQ_ queryWithCipherColumn)? RP_
-    ;
-
-resourceDefinition
-    : RESOURCE EQ_ resourceName
+    : tableName LP_ COLUMNS LP_ encryptColumnDefinition (COMMA_ encryptColumnDefinition)* RP_ (COMMA_ QUERY_WITH_CIPHER_COLUMN EQ_ queryWithCipherColumn)? RP_
     ;
 
 resourceName

--- a/kernel/time-service/type/database/pom.xml
+++ b/kernel/time-service/type/database/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test-util</artifactId>
-            <version>5.3.2-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/RALBackendHandlerFactory.java
@@ -44,7 +44,7 @@ public final class RALBackendHandlerFactory {
             return new QueryableRALBackendHandler<>((QueryableRALStatement) sqlStatement, connectionSession);
         }
         if (sqlStatement instanceof UpdatableGlobalRuleRALStatement) {
-            new UpdatableGlobalRuleRALBackendHandler((UpdatableGlobalRuleRALStatement) sqlStatement);
+            return new UpdatableGlobalRuleRALBackendHandler((UpdatableGlobalRuleRALStatement) sqlStatement);
         }
         return new UpdatableRALBackendHandler<>((UpdatableRALStatement) sqlStatement, connectionSession);
     }


### PR DESCRIPTION
- Remove useless resourceDefinition in `encrypt/RDLStatement.g4`
- Fix a dependency version in pom.xml

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
