### PR TITLE
Fixes #24557

### DIFF
--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
@@ -99,7 +99,6 @@ public final class MySQLTimeBinaryProtocolValueTest {
     public void assertWriteWithTwelveBytes() {
         MySQLTimeBinaryProtocolValue actual = new MySQLTimeBinaryProtocolValue();
         actual.write(payload, new Time(1L));
-        verify(payload).writeInt1(12);
         verify(payload, times(5)).writeInt1(anyInt());
         verify(payload).writeInt4(0);
         verify(payload).writeInt4(1000000);

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLTimeBinaryProtocolValueTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -99,6 +100,7 @@ public final class MySQLTimeBinaryProtocolValueTest {
     public void assertWriteWithTwelveBytes() {
         MySQLTimeBinaryProtocolValue actual = new MySQLTimeBinaryProtocolValue();
         actual.write(payload, new Time(1L));
+        verify(payload, atLeastOnce()).writeInt1(12);
         verify(payload, times(5)).writeInt1(anyInt());
         verify(payload).writeInt4(0);
         verify(payload).writeInt4(1000000);


### PR DESCRIPTION
Fixes #24557.

### Cause Analysis:
When the time zone is New Zealand, `assertWriteWithTwelveBytes` will fail, because the time zone of New Zealand is `GMT+12`, and the `hourOfDay` corresponding to GMT 0 o'clock is `12`, which will cause `writeInt1(12)` to be called twice.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
