### PR TITLE
Revert broken checkstyle rule about Mockito Strictness

### DIFF
--- a/src/resources/checkstyle.xml
+++ b/src/resources/checkstyle.xml
@@ -119,9 +119,7 @@
         <module name="AvoidStaticImport">
             <property name="excludes" value="org.junit.jupiter.api.Assertions.*,org.junit.jupiter.api.Assumptions.*,org.junit.Assert.*,org.hamcrest.Matchers.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*" />
         </module>
-        <module name="IllegalImport">
-            <property name="illegalClasses" value="org.mockito.junit.MockitoJUnitRunner.Silent" />
-        </module>
+        <module name="IllegalImport" />
         <module name="RedundantImport" />
         <module name="UnusedImports" />
         <module name="CustomImportOrder" />
@@ -231,12 +229,6 @@
         <module name="TrailingComment" />
         <module name="UncommentedMain">
             <property name="excludedClasses" value="\.Bootstrap" />
-        </module>
-        
-        <module name="Regexp">
-            <property name="illegalPattern" value="true" />
-            <property name="format" value="MockitoJUnitRunner\.Silent" />
-            <property name="message" value="MockitoJUnitRunner.Silent is not allowed in tests" />
         </module>
         
         <!-- Javadoc Comments -->

--- a/src/resources/checkstyle_ci.xml
+++ b/src/resources/checkstyle_ci.xml
@@ -114,9 +114,7 @@
         <module name="AvoidStaticImport">
             <property name="excludes" value="org.junit.jupiter.api.Assertions.*,org.junit.jupiter.api.Assumptions.*,org.junit.Assert.*,org.hamcrest.Matchers.*,org.hamcrest.CoreMatchers.*,org.hamcrest.MatcherAssert.*,org.mockito.Mockito.*,org.mockito.ArgumentMatchers.*" />
         </module>
-        <module name="IllegalImport">
-            <property name="illegalClasses" value="org.mockito.junit.MockitoJUnitRunner.Silent" />
-        </module>
+        <module name="IllegalImport" />
         <module name="RedundantImport" />
         <module name="UnusedImports" />
         <module name="CustomImportOrder" />
@@ -216,12 +214,6 @@
         <module name="TrailingComment" />
         <module name="UncommentedMain">
             <property name="excludedClasses" value="\.Bootstrap" />
-        </module>
-        
-        <module name="Regexp">
-            <property name="illegalPattern" value="true" />
-            <property name="format" value="MockitoJUnitRunner\.Silent" />
-            <property name="message" value="MockitoJUnitRunner.Silent is not allowed in tests" />
         </module>
         
         <!-- Javadoc Comments -->


### PR DESCRIPTION
This reverts commit cd9737c0a8231b581b70cf9c4c3c8b8f56e558cd.

Related to #19708

Since the `org.mockito.quality.Strictness#LENIENT` which is an equivalent of `org.mockito.junit.MockitoJUnitRunner.Silent` was widely used recently, the checkstyle rules were broken.