### PR TITLE
Fixes #24424, support mysql member of grammar

### DIFF
--- a/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/sql-parser/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -831,6 +831,7 @@ notOperator
 booleanPrimary
     : booleanPrimary IS NOT? (TRUE | FALSE | UNKNOWN | NULL)
     | booleanPrimary SAFE_EQ_ predicate
+    | booleanPrimary MEMBER OF LP_ (expr) RP_
     | booleanPrimary comparisonOperator predicate
     | booleanPrimary comparisonOperator (ALL | ANY) subquery
     | booleanPrimary assignmentOperator predicate

--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -448,6 +448,16 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
         if (null != ctx.comparisonOperator() || null != ctx.SAFE_EQ_()) {
             return createCompareSegment(ctx);
         }
+        if (null != ctx.MEMBER()) {
+            int startIndex = ctx.MEMBER().getSymbol().getStopIndex() + 5;
+            int endIndex = ctx.stop.getStopIndex() - 1;
+            String rightText = ctx.start.getInputStream().getText(new Interval(startIndex, endIndex));
+            ExpressionSegment right = new ExpressionProjectionSegment(startIndex, endIndex, rightText);
+            String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+            ExpressionSegment left = (ExpressionSegment) visit(ctx.booleanPrimary());
+            String operator = "MEMBER OF";
+            return new BinaryOperationExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), left, right, operator, text);
+        }
         if (null != ctx.assignmentOperator()) {
             return createAssignmentSegment(ctx);
         }

--- a/test/it/parser/src/main/resources/case/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-expression.xml
@@ -1697,6 +1697,28 @@
         </where>
     </select>
 
+    <select sql-case-id="select_where_with_simple_expr_with_json_member_of">
+        <from start-index="14" stop-index="20">
+            <simple-table name="t_order" start-index="14" stop-index="20" />
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <where start-index="22" stop-index="56">
+            <expr>
+                <binary-operation-expression start-index="28" stop-index="56">
+                    <left>
+                        <column name="order_id" start-index="28" stop-index="35"/>
+                    </left>
+                    <operator>MEMBER OF</operator>
+                    <right>
+                        <expression-projection text="&quot;[1,2,3]&quot;" start-index="47" stop-index="55" />
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
     <select sql-case-id="select_where_with_simple_expr_with_json_unquote_extract_sign">
         <from start-index="14" stop-index="20">
             <simple-table name="t_order" start-index="14" stop-index="20" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-expression.xml
@@ -74,6 +74,7 @@
     <sql-case id="select_where_with_simple_expr_with_exists_subquery" value="SELECT * FROM t_order WHERE EXISTS (SELECT order_id FROM t_order_item WHERE status &gt; ? )" db-types="MySQL" />
     <sql-case id="select_where_with_simple_expr_with_odbc_escape_syntax" value="SELECT * FROM t_order WHERE {ts ?}" db-types="MySQL" />
     <sql-case id="select_where_with_simple_expr_with_json_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&quot;$[1]&quot;" db-types="MySQL" />
+    <sql-case id="select_where_with_simple_expr_with_json_member_of" value="SELECT * FROM t_order WHERE order_id member of(&quot;[1,2,3]&quot;)" db-types="MySQL" />
     <sql-case id="select_where_with_simple_expr_with_json_unquote_extract_sign" value="SELECT * FROM t_order WHERE order_id -&gt;&gt; &quot;$[1]&quot;" db-types="MySQL" />
     <sql-case id="select_where_with_simple_expr_with_json_contains" value="SELECT * FROM t_order WHERE JSON_CONTAINS(order_msg -> '$[*].code', 'x', '$') " db-types="MySQL" />
     <sql-case id="select_where_with_simple_expr_with_json_contains_and_limit" value="SELECT id, order_info->'$.id' FROM t_order where json_contains(order_info, ?, '$.id') limit ?, ?" db-types="MySQL" />


### PR DESCRIPTION
Fixes #24424.

Changes proposed in this pull request:
  - support mysql [member of](https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_member-of) grammar, 

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
