### PR TITLE
Refactor : add JDK 8 CI in nightly CI (#24653)

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 8, 11, 17, 19 ]
+        java-version: [ 11, 17, 19 ]
     steps:
       - name: Support long paths in Windows
         if: matrix.os == 'windows-latest'
@@ -58,3 +58,39 @@ jobs:
         run: ./mvnw -T1C -B -ntp clean install
       - name: Build examples with Maven
         run: ./mvnw -T1C -B -f examples/pom.xml clean package
+  
+  ci-JDK8:
+    if: github.repository == 'apache/shardingsphere'
+    name: CI - JDK 8 on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - name: Support long paths in Windows
+        if: matrix.os == 'windows-latest'
+        run: git config --global core.longpaths true
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ env.REPOSITORY_NAME }}-maven-third-party-cache-${{ github.sha }}
+          restore-keys: |
+            ${{ env.REPOSITORY_NAME }}-maven-third-party-cache-
+            ${{ env.REPOSITORY_NAME }}-maven-third-party-
+      - name: Build prod with Maven
+        run: ./mvnw -T1C -B -ntp clean install
+      - name: Setup JDK 8 for Test
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 8
+      - name: Run tests with JDK 8
+        run: ./mvnw -T1C -B -ntp -fae test

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Build examples with Maven
         run: ./mvnw -T1C -B -f examples/pom.xml clean package
   
-  ci-JDK8:
+  ci-jdk8:
     if: github.repository == 'apache/shardingsphere'
     name: CI - JDK 8 on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #24653.

Changes proposed in this pull request:
  - refactor JDK 8 for nightly CI

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
