### PR TITLE
Fix sql federation e2e test error when logical datasource change

### DIFF
--- a/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/engine/E2EContainerComposer.java
+++ b/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/engine/E2EContainerComposer.java
@@ -75,11 +75,12 @@ public final class E2EContainerComposer {
         if (!logicDatabaseInitSQLFile.isPresent()) {
             return;
         }
-        if (!INITIALIZED_SUITES.contains(testParam.getKey())) {
+        String cacheKey = testParam.getKey() + "-" + System.identityHashCode(targetDataSource);
+        if (!INITIALIZED_SUITES.contains(cacheKey)) {
             synchronized (INITIALIZED_SUITES) {
-                if (!INITIALIZED_SUITES.contains(testParam.getKey())) {
+                if (!INITIALIZED_SUITES.contains(cacheKey)) {
                     executeInitSQL(targetDataSource, logicDatabaseInitSQLFile.get());
-                    INITIALIZED_SUITES.add(testParam.getKey());
+                    INITIALIZED_SUITES.add(cacheKey);
                 }
             }
         }

--- a/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/engine/dql/BaseDQLE2EIT.java
+++ b/test/e2e/suite/src/test/java/org/apache/shardingsphere/test/e2e/engine/dql/BaseDQLE2EIT.java
@@ -75,14 +75,15 @@ public abstract class BaseDQLE2EIT {
     }
     
     private void fillDataOnlyOnce(final AssertionTestParameter testParam, final SingleE2EITContainerComposer containerComposer) throws SQLException, ParseException, IOException, JAXBException {
-        if (!FILLED_SUITES.contains(testParam.getKey())) {
+        String cacheKey = testParam.getKey() + "-" + System.identityHashCode(containerComposer.getContainerComposer().getActualDataSourceMap());
+        if (!FILLED_SUITES.contains(cacheKey)) {
             synchronized (FILLED_SUITES) {
-                if (!FILLED_SUITES.contains(testParam.getKey())) {
+                if (!FILLED_SUITES.contains(cacheKey)) {
                     new DataSetEnvironmentManager(
                             new ScenarioDataPath(testParam.getScenario()).getDataSetFile(Type.ACTUAL), containerComposer.getContainerComposer().getActualDataSourceMap()).fillData();
                     new DataSetEnvironmentManager(
                             new ScenarioDataPath(testParam.getScenario()).getDataSetFile(Type.EXPECTED), containerComposer.getContainerComposer().getExpectedDataSourceMap()).fillData();
-                    FILLED_SUITES.add(testParam.getKey());
+                    FILLED_SUITES.add(cacheKey);
                 }
             }
         }


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix sql federation e2e test error when logical datasource change

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
