### PR TITLE
Add more mysql information schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -38,7 +38,9 @@ public enum SystemSchemaBuilderRule {
     MYSQL_INFORMATION_SCHEMA("MySQL", "information_schema", new HashSet<>(Arrays.asList("character_sets", "collation_character_set_applicability", "collations", "column_privileges", "columns",
             "engines", "events", "files", "global_status", "global_variables", "parameters", "routines", "schemata", "tables", "views",
             "innodb_buffer_page", "innodb_buffer_page_lru", "innodb_buffer_pool_stats", "innodb_cmp", "innodb_cmp_per_index", "innodb_cmp_per_index_reset", "innodb_cmp_reset",
-            "innodb_cmpmem", "innodb_cmpmem_reset", "innodb_ft_being_deleted"))),
+            "innodb_cmpmem", "innodb_cmpmem_reset", "innodb_ft_being_deleted",
+            "innodb_ft_config", "innodb_ft_default_stopword", "innodb_ft_deleted", "innodb_ft_index_cache", "innodb_ft_index_table", "innodb_lock_waits", "innodb_locks",
+            "innodb_metrics", "innodb_sys_columns", "innodb_sys_datafiles"))),
     
     MYSQL_MYSQL("MySQL", "mysql", new HashSet<>(Collections.singleton("db"))),
     

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_config.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_config.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_FT_CONFIG
+columns:
+  key:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: KEY
+    primaryKey: false
+    unsigned: false
+    visible: true
+  value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_default_stopword.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_default_stopword.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_FT_DEFAULT_STOPWORD
+columns:
+  value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: value
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_deleted.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_deleted.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_FT_DELETED
+columns:
+  doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_index_cache.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_index_cache.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_FT_INDEX_CACHE
+columns:
+  word:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: WORD
+    primaryKey: false
+    unsigned: false
+    visible: true
+  first_doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: FIRST_DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  last_doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LAST_DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  doc_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DOC_COUNT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  position:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: POSITION
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_index_table.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_ft_index_table.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_FT_INDEX_TABLE
+columns:
+  word:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: WORD
+    primaryKey: false
+    unsigned: false
+    visible: true
+  first_doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: FIRST_DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  last_doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LAST_DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  doc_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DOC_COUNT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  doc_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DOC_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  position:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: POSITION
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_lock_waits.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_lock_waits.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_LOCK_WAITS
+columns:
+  requesting_trx_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: requesting_trx_id
+    primaryKey: false
+    unsigned: false
+    visible: true
+  requested_lock_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: requested_lock_id
+    primaryKey: false
+    unsigned: false
+    visible: true
+  blocking_trx_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: blocking_trx_id
+    primaryKey: false
+    unsigned: false
+    visible: true
+  blocking_lock_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: blocking_lock_id
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_locks.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_locks.yaml
@@ -1,0 +1,99 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_LOCKS
+columns:
+  lock_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_id
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_trx_id:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_trx_id
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_mode:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_mode
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_type
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_table:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_table
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_index:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_index
+    primaryKey: false
+    unsigned: false
+    visible: true
+  lock_space:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: lock_space
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_page:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: lock_page
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_rec:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: lock_rec
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_data:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: lock_data
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_metrics.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_metrics.yaml
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_METRICS
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  subsystem:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SUBSYSTEM
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  max_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_COUNT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  min_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_COUNT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  avg_count:
+    caseSensitive: false
+    dataType: 8
+    generated: false
+    name: AVG_COUNT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_reset:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_RESET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  max_count_reset:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_COUNT_RESET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  min_count_reset:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_COUNT_RESET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  avg_count_reset:
+    caseSensitive: false
+    dataType: 8
+    generated: false
+    name: AVG_COUNT_RESET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  time_enabled:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: TIME_ENABLED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  time_disabled:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: TIME_DISABLED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  time_elapsed:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIME_ELAPSED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  time_reset:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: TIME_RESET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  status:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATUS
+    primaryKey: false
+    unsigned: false
+    visible: true
+  type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  comment:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: COMMENT
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_sys_columns.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_sys_columns.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_SYS_COLUMNS
+columns:
+  table_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TABLE_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  pos:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: POS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  mtype:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MTYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  prtype:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: PRTYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  len:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LEN
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/information_schema/innodb_sys_datafiles.yaml
+++ b/infra/common/src/main/resources/schema/mysql/information_schema/innodb_sys_datafiles.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: INNODB_SYS_DATAFILES
+columns:
+  space:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SPACE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  path:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: PATH
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -32,7 +32,7 @@ class SystemSchemaBuilderRuleTest {
     void assertValueOfSchemaPathSuccess() {
         SystemSchemaBuilderRule actual = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "information_schema");
         assertThat(actual, is(SystemSchemaBuilderRule.MYSQL_INFORMATION_SCHEMA));
-        assertThat(actual.getTables().size(), is(25));
+        assertThat(actual.getTables().size(), is(35));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -36,7 +36,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actual = SystemSchemaBuilder.build("information_schema", new MySQLDatabaseType());
         assertThat(actual.size(), is(1));
         assertTrue(actual.containsKey("information_schema"));
-        assertThat(actual.get("information_schema").getTables().size(), is(25));
+        assertThat(actual.get("information_schema").getTables().size(), is(35));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_config.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_config.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="key" />
+        <column name="value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_default_stopword.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_default_stopword.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_deleted.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_deleted.xml
@@ -1,0 +1,22 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="doc_id" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_index_cache.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_index_cache.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="word" />
+        <column name="first_doc_id" />
+        <column name="last_doc_id" />
+        <column name="doc_count" />
+        <column name="doc_id" />
+        <column name="position" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_index_table.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_ft_index_table.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="word" />
+        <column name="first_doc_id" />
+        <column name="last_doc_id" />
+        <column name="doc_count" />
+        <column name="doc_id" />
+        <column name="position" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_lock_waits.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_lock_waits.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="requesting_trx_id" />
+        <column name="requested_lock_id" />
+        <column name="blocking_trx_id" />
+        <column name="blocking_lock_id" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_locks.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_locks.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="lock_id" />
+        <column name="lock_trx_id" />
+        <column name="lock_mode" />
+        <column name="lock_type" />
+        <column name="lock_table" />
+        <column name="lock_index" />
+        <column name="lock_space" />
+        <column name="lock_page" />
+        <column name="lock_rec" />
+        <column name="lock_data" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_metrics.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_metrics.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="subsystem" />
+        <column name="count" />
+        <column name="max_count" />
+        <column name="min_count" />
+        <column name="avg_count" />
+        <column name="count_reset" />
+        <column name="max_count_reset" />
+        <column name="min_count_reset" />
+        <column name="avg_count_reset" />
+        <column name="time_enabled" />
+        <column name="time_disabled" />
+        <column name="time_elapsed" />
+        <column name="time_reset" />
+        <column name="status" />
+        <column name="type" />
+        <column name="comment" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_sys_columns.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_sys_columns.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="table_id" />
+        <column name="name" />
+        <column name="pos" />
+        <column name="mtype" />
+        <column name="prtype" />
+        <column name="len" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_sys_datafiles.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_information_schema_innodb_sys_datafiles.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="space" />
+        <column name="path" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -85,4 +85,44 @@
         <assertion expected-data-file="select_mysql_information_schema_innodb_ft_being_deleted.xml" />
     </test-case>
     
+    <test-case sql="select * from information_schema.innodb_ft_config;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_ft_config.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_ft_default_stopword;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_ft_default_stopword.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_ft_deleted;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_ft_deleted.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_ft_index_cache;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_ft_index_cache.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_ft_index_table;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_ft_index_table.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_lock_waits;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_lock_waits.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_locks;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_locks.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_metrics;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_metrics.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_sys_columns;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_sys_columns.xml" />
+    </test-case>
+    
+    <test-case sql="select * from information_schema.innodb_sys_datafiles;" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_information_schema_innodb_sys_datafiles.xml" />
+    </test-case>
+
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql information schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
