### PR TITLE
Add new sql hint document and move sharding, readwrite-splitting sql hint document to new document

### DIFF
--- a/docs/document/content/user-manual/common-config/sql-hint.cn.md
+++ b/docs/document/content/user-manual/common-config/sql-hint.cn.md
@@ -1,0 +1,103 @@
++++
+title = "SQL Hint"
+weight = 3
+chapter = true
++++
+
+## 背景信息
+
+目前，主流的关系型数据库基本都提供了 SQL Hint 作为 SQL 语法的补充，SQL Hint 允许用户通过数据库内置的 Hint 语法来干预 SQL 的执行过程，从而完成一些特殊的功能，或实现对 SQL 执行的优化。
+ShardingSphere 同样提供了丰富的 SQL Hint 语法，允许用户进行数据分片、读写分离的强制路由以及数据源透传等灵活控制。
+
+## 使用规范
+
+ShardingSphere 的 SQL Hint 语法需要以注释的形式编写在 SQL 中，SQL Hint 语法格式暂时只支持 `/* */`，Hint 内容需要以 `SHARDINGSPHERE_HINT:` 为起始，然后定义不同功能所对应的属性键值对，当存在多个属性时使用逗号分隔。
+ShardingSphere 的 SQL Hint 语法格式如下：
+
+```sql
+/* SHARDINGSPHERE_HINT: {key} = {value}, {key} = {value} */ SELECT * FROM t_order;
+```
+
+使用 SQL Hint 功能，需要将 ShardingSphere SQL Parser 规则中的 `sqlCommentParseEnabled` 设置为 true，开启 SQL 注释解析功能。此外，如果使用 MySQL 客户端连接，需要添加 `-c` 选项保留注释，客户端默认是 `--skip-comments` 过滤注释。
+
+## 参数解释
+
+ShardingSphere SQL Hint 中可以定义如下的属性，为了兼容低版本 SQL Hint 语法，也可以使用别名中定义的属性： 
+
+| *名称*                       | *别名*                | *数据类型*  | *说明*                                  | *默认值* |
+|-----------------------------|-----------------------|------------|---------------------------------------|-------|
+| SHARDING_DATABASE_VALUE (?) | shardingDatabaseValue | Comparable | 数据分片分库值，和 Hint 分片策略配合使用               | -     |
+| SHARDING_TABLE_VALUE (?)    | shardingTableValue    | Comparable | 数据分片分表值，和 Hint 分片策略配合使用               | -     |
+| WRITE_ROUTE_ONLY (?)        | writeRouteOnly        | boolean    | 读写分离强制路由到主库执行                         | false |
+| DATA_SOURCE_NAME (?)        | dataSourceName        | String     | 数据源透传，将 SQL 直接路由到指定数据源                | -     |
+| SKIP_SQL_REWRITE (?)        | skipSQLRewrite        | boolean    | 跳过 SQL 改写阶段                           | false |
+| DISABLE_AUDIT_NAMES (?)     | disableAuditNames     | String     | 禁用指定 SQL 审计算法                         | -     |
+| SHADOW (?)                  | shadow                | boolean    | 影子库强制路由到影子库数据源执行，和影子库 SQL_HINT 算法配合使用 | false |
+
+
+## SQL Hint
+
+### 数据分片
+
+数据分片 SQL Hint 功能的可选属性包括：
+
+- `{table}.SHARDING_DATABASE_VALUE`：用于添加 `{table}` 表对应的数据源分片键值，多个属性使用逗号分隔；
+- `{table}.SHARDING_TABLE_VALUE`：用于添加 `{table}` 表对应的表分片键值，多个属性使用逗号分隔。
+
+> 分库不分表情况下，强制路由至某一个分库时，可使用 `SHARDING_DATABASE_VALUE` 方式设置分片，无需指定 `{table}`。
+
+数据分片 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: t_order.SHARDING_DATABASE_VALUE=1, t_order.SHARDING_TABLE_VALUE=1 */ SELECT * FROM t_order;
+```
+
+### 读写分离
+
+读写分离 SQL Hint 功能的可选属性为 `WRITE_ROUTE_ONLY`，`true` 表示将当前 SQL 强制路由到主库执行。
+
+读写分离 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: WRITE_ROUTE_ONLY=true */ SELECT * FROM t_order;
+```
+
+### 数据源透传
+
+数据源透传 SQL Hint 功能可选属性为 `DATA_SOURCE_NAME`，需要指定注册在 ShardingSphere 逻辑库中的数据源名称。
+
+数据源透传 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: DATA_SOURCE_NAME=ds_0 */ SELECT * FROM t_order;
+```
+
+### 跳过 SQL 改写
+
+跳过 SQL 改写 SQL Hint 功能可选属性为 `SKIP_SQL_REWRITE`，`true` 表示跳过当前 SQL 的改写阶段。
+
+跳过 SQL 改写 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: SKIP_SQL_REWRITE=true */ SELECT * FROM t_order;
+```
+
+### 禁用 SQL 审计
+
+禁用 SQL 审计 SQL Hint 功能可选属性为 `DISABLE_AUDIT_NAMES`，需要指定需要禁用的 SQL 审计算法名称，多个 SQL 审计算法需要使用逗号分隔。
+
+禁用 SQL 审计 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: DISABLE_AUDIT_NAMES=sharding_key_required_auditor */ SELECT * FROM t_order;
+```
+
+### 影子库压测
+
+影子库压测 SQL Hint 功能可选属性为 `SHADOW`，`true` 表示将当前 SQL 路由至影子库数据源执行。
+
+影子库压测 SQL Hint 功能的使用示例：
+
+```sql
+/* SHARDINGSPHERE_HINT: SHADOW=true */ SELECT * FROM t_order;
+```

--- a/docs/document/content/user-manual/common-config/sql-hint.en.md
+++ b/docs/document/content/user-manual/common-config/sql-hint.en.md
@@ -1,0 +1,103 @@
++++
+title = "SQL Hint"
+weight = 3
+chapter = true
++++
+
+## Background
+
+At present, most relational databases basically provide SQL Hint as a supplement to SQL syntax. SQL Hint allows users to intervene in the execution process of SQL through the built-in Hint syntax of the database, to complete some special functions or realize optimization of SQL execution.
+ShardingSphere also provides SQL Hint syntax, allowing users to perform force route for sharding and read-write splitting, and data source pass through.
+
+## Use specification
+
+The SQL Hint syntax of ShardingSphere needs to be written in SQL in the form of comments. The SQL Hint syntax format only supports `/* */` temporarily, and the Hint content needs to start with `SHARDINGSPHERE_HINT:`, and then define the attribute key/value pairs corresponding to different features, separated by commas when there are multiple attributes.
+The SQL Hint syntax format of ShardingSphere is as follows:
+
+```sql
+/* SHARDINGSPHERE_HINT: {key} = {value}, {key} = {value} */ SELECT * FROM t_order;
+```
+
+To use the SQL Hint, you need to set `sqlCommentParseEnabled` in ShardingSphere SQL Parser rule to `true` to enable the SQL comment parsing. In addition, if you use the MySQL client to connect, you need to add the `-c` option to retain comments, and the client defaults to `--skip-comments` to filter comments.
+
+## Parameters
+
+The following attributes can be defined in ShardingSphere SQL Hint. In order to be compatible with the lower version SQL Hint syntax, the attributes defined in the alias can also be used:
+
+| *Name*                      | *Alias*               | *Data Type*  | *Description*                                                             | *Default Value* |
+|-----------------------------|-----------------------|------------|---------------------------------------------------------------------------|-------|
+| SHARDING_DATABASE_VALUE (?) | shardingDatabaseValue | Comparable | Database sharding value, used when config Hint sharding strategy          | -     |
+| SHARDING_TABLE_VALUE (?)    | shardingTableValue    | Comparable | Table sharding value, used when config Hint sharding strategy             | -     |
+| WRITE_ROUTE_ONLY (?)        | writeRouteOnly        | boolean    | Route to the write datasource when use readwrite-splitting                | false |
+| DATA_SOURCE_NAME (?)        | dataSourceName        | String     | Data source pass through, route SQL directly to the specified data source | -     |
+| SKIP_SQL_REWRITE (?)        | skipSQLRewrite        | boolean    | Skip the SQL rewrite phase                                                | false |
+| DISABLE_AUDIT_NAMES (?)     | disableAuditNames     | String     | Disable the specified SQL audit algorithm                                 | -     |
+| SHADOW (?)                  | shadow                | boolean    | Route to the shadow datasource when use shadow                            | false |
+
+
+## SQL Hint
+
+### Sharding
+
+The optional attributes of sharding SQL Hint include:
+
+- `{table}.SHARDING_DATABASE_VALUE`: used to add data source sharding value corresponding to the `{table}` table, multiple attributes are separated by commas;
+- `{table}.SHARDING_TABLE_VALUE`: used to add table sharding value corresponding to the `{table}` table, multiple attributes are separated by commas.
+
+> In the case of only database sharding, when forcing routing to a certain datasource, you can use the `SHARDING_DATABASE_VALUE` method to set the sharding value without specifying `{table}`.
+
+An example of using the SQL Hint of sharding:
+
+```sql
+/* SHARDINGSPHERE_HINT: t_order.SHARDING_DATABASE_VALUE=1, t_order.SHARDING_TABLE_VALUE=1 */ SELECT * FROM t_order;
+```
+
+### ReadwriteSplitting
+
+The optional attribute of read-write splitting SQL Hint is `WRITE_ROUTE_ONLY`, and `true` means that the current SQL is forced to be routed to write datasource for execution.
+
+An example of using the SQL Hint for read-write splitting:
+
+```sql
+/* SHARDINGSPHERE_HINT: WRITE_ROUTE_ONLY=true */ SELECT * FROM t_order;
+```
+
+### DataSource Pass Through
+
+The optional attribute of datasource pass through SQL Hint is `DATA_SOURCE_NAME`, which needs to specify the name of the data source registered in the ShardingSphere logic database.
+
+An example of using the SQL Hint of data source pass through:
+
+```sql
+/* SHARDINGSPHERE_HINT: DATA_SOURCE_NAME=ds_0 */ SELECT * FROM t_order;
+```
+
+### SKIP SQL REWRITE
+
+The optional attribute of skip SQL rewriting SQL Hint is `SKIP_SQL_REWRITE`, and `true` means skipping the current SQL rewriting stage.
+
+An example of skipping SQL rewrite SQL Hint:
+
+```sql
+/* SHARDINGSPHERE_HINT: SKIP_SQL_REWRITE=true */ SELECT * FROM t_order;
+```
+
+### DISABLE SQL AUDIT
+
+The optional attribute of disable SQL audit is `DISABLE_AUDIT_NAMES`, you need to specify names of SQL audit algorithm that needs to be disabled, and multiple SQL audit algorithms need to be separated by commas.
+
+An example of disable sql audit SQL Hint:
+
+```sql
+/* SHARDINGSPHERE_HINT: DISABLE_AUDIT_NAMES=sharding_key_required_auditor */ SELECT * FROM t_order;
+```
+
+### SHADOW
+
+The optional attribute of the shadow database pressure test SQL Hint is `SHADOW`, and `true` means that the current SQL will be routed to the shadow database data source for execution.
+
+An example of using shadow SQL Hint:
+
+```sql
+/* SHARDINGSPHERE_HINT: SHADOW=true */ SELECT * FROM t_order;
+```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/readwrite-splitting/hint.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/readwrite-splitting/hint.cn.md
@@ -6,7 +6,6 @@ weight = 1
 ## 背景信息
 
 Apache ShardingSphere 使用 ThreadLocal 管理主库路由标记进行强制路由。 可以通过编程的方式向 HintManager 中添加主库路由标记，该值仅在当前线程内生效。
-Apache ShardingSphere 还可以通过 SQL 中增加注释的方式进行主库路由。
 
 Hint 在读写分离场景下，主要用于强制在主库进行某些数据操作。
 
@@ -21,21 +20,19 @@ Hint 在读写分离场景下，主要用于强制在主库进行某些数据操
 
 ### 使用 Hint 强制主库路由
 
-#### 使用手动编程的方式
-
-##### 获取 HintManager
+#### 获取 HintManager
 
 与基于 Hint 的数据分片相同。
 
-##### 设置主库路由
+#### 设置主库路由
 
 使用 hintManager.setWriteRouteOnly 设置主库路由。
 
-##### 清除分片键值
+#### 清除分片键值
 
 与基于 Hint 的数据分片相同。
 
-##### 完整代码示例
+#### 完整代码示例
 
 ```java
 String sql = "SELECT * FROM t_order";
@@ -50,32 +47,17 @@ try (HintManager hintManager = HintManager.getInstance();
 }
 ```
 
-#### 使用 SQL 注释的方式
-
-##### 使用规范
-
-SQL Hint 功能的注释格式暂时只支持 `/* */`，内容需要以 `SHARDINGSPHERE_HINT:` 开始，属性名为 `WRITE_ROUTE_ONLY`。
-
-##### 完整示例
-
-```java
-/* SHARDINGSPHERE_HINT: WRITE_ROUTE_ONLY=true */
-SELECT * FROM t_order;
-```
-
 ### 使用 Hint 路由至指定数据库
 
-#### 使用手动编程的方式
-
-##### 获取 HintManager
+#### 获取 HintManager
 
 与基于 Hint 的数据分片相同。
 
-##### 设置路由至指定数据库
+#### 设置路由至指定数据库
 
 - 使用 `hintManager.setDataSourceName` 设置数据库名称。
 
-##### 完整代码示例
+#### 完整代码示例
 
 ```java
 String sql = "SELECT * FROM t_order";
@@ -89,19 +71,6 @@ try (HintManager hintManager = HintManager.getInstance();
         }
     }
 }
-```
-
-#### 使用 SQL 注释的方式
-
-##### 使用规范
-
-SQL Hint 功能目前只支持路由至一个数据源。 注释格式暂时只支持 `/* */`，内容需要以 `SHARDINGSPHERE_HINT:` 开始，属性名为 `DATA_SOURCE_NAME`。
-如果使用 `MySQL` 客户端连接需要添加 `-c` 选项保留注释，客户端默认是 `--skip-comments` 过滤注释。
-
-##### 完整示例
-```sql
-/* SHARDINGSPHERE_HINT: DATA_SOURCE_NAME=ds_0 */
-SELECT * FROM t_order;
 ```
 
 - [核心特性：读写分离](/cn/features/readwrite-splitting/)

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/readwrite-splitting/hint.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/readwrite-splitting/hint.en.md
@@ -6,7 +6,6 @@ weight = 1
 ## Background
 
 Apache ShardingSphere uses `ThreadLocal` to manage primary database routing marks for mandatory routing. A primary database routing mark can be added to `HintManager` through programming, and this value is valid only in the current thread.
-Apache ShardingSphere can also route the primary database by adding comments to SQL.
 
 `Hint` is mainly used to perform mandatory data operations in the primary database for read/write splitting scenarios.
 
@@ -21,21 +20,19 @@ Apache ShardingSphere can also route the primary database by adding comments to 
 
 ### Primary Route with Hint
 
-#### Use manual programming
-
-##### Get HintManager
+#### Get HintManager
 
 The same as sharding based on hint.
 
-##### Configure Primary Database Route
+#### Configure Primary Database Route
 
 - Use `hintManager.setWriteRouteOnly` to configure primary database route.
 
-##### Clean Hint Value
+#### Clean Hint Value
 
 The same as data sharding based on hint.
 
-##### Code:
+#### Code:
 
 ```java
 String sql = "SELECT * FROM t_order";
@@ -51,31 +48,17 @@ try (HintManager hintManager = HintManager.getInstance();
 }
 ```
 
-#### Use special SQL comments
-
-##### Terms of Use
-
-For the SQL Hint function, the comment format only supports `/* */` for now. The content needs to start with `SHARDINGSPHERE_HINT:`, and the attribute name needs to be `WRITE_ROUTE_ONLY`.
-
-##### Code:
-```sql
-/* SHARDINGSPHERE_HINT: WRITE_ROUTE_ONLY=true */
-SELECT * FROM t_order;
-```
-
 ### Route to the specified database with Hint
 
-#### Use manual programming
-
-##### Get HintManager
+#### Get HintManager
 
 The same as sharding based on hint.
 
-##### Configure Database Route
+#### Configure Database Route
 
 - Use `hintManager.setDataSourceName` to configure database route.
 
-##### Code:
+#### Code:
 
 ```java
 String sql = "SELECT * FROM t_order";
@@ -89,20 +72,6 @@ try (HintManager hintManager = HintManager.getInstance();
         }
     }
 }
-```
-
-#### Use special SQL comments
-
-##### Terms of Use:
-
-Currently, the SQL Hint function only supports routing to one data source.
-The comment format only supports `/* */` for now. The content needs to start with `SHARDINGSPHERE_HINT:`, and the attribute name needs to be `DATA_SOURCE_NAME`.
-Client connections using `MySQL` need to add the `-c` option to preserve comments, because the client defaults to `--skip-comments` to filter comments.
-
-##### Code:
-```sql
-/* SHARDINGSPHERE_HINT: DATA_SOURCE_NAME=ds_0 */
-SELECT * FROM t_order;
 ```
 
 ## Related References

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.cn.md
@@ -6,7 +6,6 @@ weight = 1
 ## 背景信息
 
 Apache ShardingSphere 使用 ThreadLocal 管理分片键值进行强制路由。 可以通过编程的方式向 HintManager 中添加分片值，该分片值仅在当前线程内生效。
-Apache ShardingSphere 还可以通过 SQL 中增加注释的方式进行强制路由。
 
 Hint 的主要使用场景：
 - 分片字段不存在 SQL 和数据库表结构中，而存在于外部业务逻辑。
@@ -21,9 +20,7 @@ Hint 的主要使用场景：
 
 ## 配置示例
 
-### 使用 Hint 分片
-
-#### 规则配置
+### 规则配置
 
 Hint 分片算法需要用户实现 `org.apache.shardingsphere.sharding.api.sharding.hint.HintShardingAlgorithm` 接口。
 Apache ShardingSphere 在进行路由时，将会从 HintManager 中获取分片值进行路由操作。
@@ -52,26 +49,26 @@ props:
     sql-show: true
 ```
 
-#### 获取 HintManager
+### 获取 HintManager
 
 ```java
 HintManager hintManager = HintManager.getInstance();
 ```
 
-#### 添加分片键值
+### 添加分片键值
 
 - 使用 `hintManager.addDatabaseShardingValue` 来添加数据源分片键值。
 - 使用 `hintManager.addTableShardingValue` 来添加表分片键值。
 
 > 分库不分表情况下，强制路由至某一个分库时，可使用 `hintManager.setDatabaseShardingValue` 方式设置分片值。
 
-#### 清除分片键值
+### 清除分片键值
 
 分片键值保存在 ThreadLocal 中，所以需要在操作结束时调用 `hintManager.close()` 来清除 ThreadLocal 中的内容。
 
 __hintManager 实现了 AutoCloseable 接口，可推荐使用 try with resource 自动关闭。__
 
-#### 完整代码示例
+### 完整代码示例
 
 ```java
 // Sharding database and table with using HintManager
@@ -100,24 +97,6 @@ try (HintManager hintManager = HintManager.getInstance();
         }
     }
 }
-```
-
-#### 使用 SQL 注释的方式
-
-##### 使用规范
-
-SQL Hint 功能的注释格式暂时只支持 `/* */`，内容需要以 `SHARDINGSPHERE_HINT:` 开始，可选的属性包括：
-
-- `{table}.SHARDING_DATABASE_VALUE`：用于添加 `{table}` 表对应的数据源分片键值，多个属性使用逗号分隔；
-- `{table}.SHARDING_TABLE_VALUE`：用于添加 `{table}` 表对应的表分片键值，多个属性使用逗号分隔。
-
-> 分库不分表情况下，强制路由至某一个分库时，可使用 `SHARDING_DATABASE_VALUE` 方式设置分片，无需指定 `{table}`。
-
-##### 完整示例
-
-```sql
-/* SHARDINGSPHERE_HINT: t_order.SHARDING_DATABASE_VALUE=1, t_order.SHARDING_TABLE_VALUE=1 */
-SELECT * FROM t_order;
 ```
 
 ## 相关参考

--- a/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/special-api/sharding/hint.en.md
@@ -6,7 +6,6 @@ weight = 1
 ## Background
 
 Apache ShardingSphere uses ThreadLocal to manage sharding key values for mandatory routing. A sharding value can be added by programming to the HintManager that takes effect only within the current thread.
-Apache ShardingSphere can also do mandatory routing by adding comments to SQL.
 
 Main application scenarios for Hint:
 - The sharding fields do not exist in the SQL and database table structure but in the external business logic.
@@ -21,9 +20,7 @@ Main application scenarios for Hint:
 
 ## Sample
 
-### Sharding with Hint
-
-#### Hint Configuration
+### Hint Configuration
 
 Hint algorithms require users to implement the interface of `org.apache.shardingsphere.api.sharding.hint.HintShardingAlgorithm`. 
 Apache ShardingSphere will acquire sharding values from HintManager to route.
@@ -52,26 +49,26 @@ props:
     sql-show: true
 ```
 
-#### Get HintManager
+### Get HintManager
 
 ```java
 HintManager hintManager = HintManager.getInstance();
 ```
 
-#### Add Sharding Value
+### Add Sharding Value
 
 - Use `hintManager.addDatabaseShardingValue` to add sharding key value of data source.
 - Use `hintManager.addTableShardingValue` to add sharding key value of table.
 
 > Users can use `hintManager.setDatabaseShardingValue` to set sharding value in hint route to some certain sharding database without sharding tables.
 
-#### Clean Hint Values
+### Clean Hint Values
 
 Sharding values are saved in `ThreadLocal`, so it is necessary to use `hintManager.close()` to clean `ThreadLocal`.
 
 **`HintManager` has implemented `AutoCloseable`. We recommend to close it automatically with `try with resource`.**
 
-#### Codes:
+### Codes:
 
 ```java
 // Sharding database and table with HintManager
@@ -100,24 +97,6 @@ try (HintManager hintManager = HintManager.getInstance();
         }
     }
 }
-```
-
-#### Use special SQL comments
-
-##### Terms of Use
-
-For the SQL Hint function, the comment format only supports `/* */` for now. The content needs to start with `SHARDINGSPHERE_HINT:`, and optional attributes include:
-
-- `{table}.SHARDING_DATABASE_VALUE`: used to add the data source sharding value corresponding to `{table}` table, multiple attributes are separated by commas;
-- `{table}.SHARDING_TABLE_VALUE`: used to add the table sharding value corresponding to `{table}` table, multiple attributes are separated by commas.
-
-> Users can use `SHARDING_DATABASE_VALUE` to set sharding value in hint route to some certain sharding database without sharding tables.
-
-##### Codes:
-
-```sql
-/* SHARDINGSPHERE_HINT: t_order.SHARDING_DATABASE_VALUE=1, t_order.SHARDING_TABLE_VALUE=1 */
-SELECT * FROM t_order;
 ```
 
 ## Related References


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add new sql hint document and move sharding, readwrite-splitting sql hint document to new document

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
