### PR TITLE
Specifying the agent argument in Docker env

### DIFF
--- a/distribution/proxy/src/main/resources/bin/start.sh
+++ b/distribution/proxy/src/main/resources/bin/start.sh
@@ -234,7 +234,7 @@ echo "The classpath is ${CLASS_PATH}"
 echo "main class ${MAIN_CLASS}"
 
 if [ -n "${IS_DOCKER}" ]; then
-  exec $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} ${MAIN_CLASS}
+  exec $JAVA ${JAVA_OPTS} ${JAVA_MEM_OPTS} -classpath ${CLASS_PATH} ${AGENT_PARAM} ${MAIN_CLASS}
   exit 0
 fi
 


### PR DESCRIPTION
Fixes #24892

Changes proposed in this pull request:
  -

as title.

Test steps:

1. use this script to build the image.

```docker
FROM alpine AS prepare

ARG APP_NAME="apache-shardingsphere-5.3.2-SNAPSHOT-shardingsphere-proxy-bin"
ENV LOCAL_PATH /opt/shardingsphere-proxy

ADD target/${APP_NAME}.tar.gz /opt
RUN mv /opt/${APP_NAME} ${LOCAL_PATH} && mkdir -p ${LOCAL_PATH}/ext-lib

FROM eclipse-temurin:17-jdk
MAINTAINER ShardingSphere "dev@shardingsphere.apache.org"

ENV LOCAL_PATH /opt/shardingsphere-proxy
ENV IS_DOCKER true

COPY --from=prepare ${LOCAL_PATH} ${LOCAL_PATH}
ENTRYPOINT ${LOCAL_PATH}/bin/start.sh ${PORT} -g
```

2. uncomment `/opt/shardingsphere-proxy/agent/conf/agent.yaml`

```
plugins:
  logging:
    File:
      props:
        level: "INFO"
  metrics:
    Prometheus:
      host:  "localhost"
      port: 9090
      props:
        jvm-information-collector-enabled: "true"
  tracing:
    OpenTelemetry:
      props:
        otel.service.name: "shardingsphere"
        otel.traces.exporter: "jaeger"
        otel.traces.sampler: "always_on"
        otel.exporter.otlp.traces.endpoint: "http://localhost:14250"
```

3. start the container:

```shell
2023-03-30 03:18:17 we find java version: java17, full_version=17.0.1, full_path=/opt/java/openjdk/bin/java
2023-03-30 03:18:17 The classpath is /opt/shardingsphere-proxy/conf:/opt/shardingsphere-proxy/conf:.:/opt/shardingsphere-proxy/lib/*:/opt/shardingsphere-proxy/ext-lib/*
2023-03-30 03:18:17 main class org.apache.shardingsphere.proxy.Bootstrap -1 /opt/shardingsphere-proxy/conf 0.0.0.0 false
2023-03-30 03:18:18 [INFO ] 2023-03-29 19:18:18.487 [main] o.a.s.p.frontend.ShardingSphereProxy - ShardingSphere-Proxy Standalone mode started successfully
```

4. after add `${AGENT_PARAM}`, restart the container

```shell
2023-03-30 03:20:10 we find java version: java17, full_version=17.0.1, full_path=/opt/java/openjdk/bin/java
2023-03-30 03:20:10 The classpath is /opt/shardingsphere-proxy/conf:/opt/shardingsphere-proxy/conf:.:/opt/shardingsphere-proxy/lib/*:/opt/shardingsphere-proxy/ext-lib/*
2023-03-30 03:20:10 main class org.apache.shardingsphere.proxy.Bootstrap -1 /opt/shardingsphere-proxy/conf 0.0.0.0 false
2023-03-30 03:20:12 [INFO ] 2023-03-29 19:20:12.298 [main] o.a.s.a.p.m.p.PrometheusPluginLifecycleService - Prometheus metrics HTTP server `localhost:9090` start success.
2023-03-30 03:20:12 [INFO ] 2023-03-29 19:20:12.861 [main] o.a.s.a.p.l.f.a.MetaDataContextsFactoryAdvice - Build meta data contexts finished, cost 165 milliseconds.
2023-03-30 03:20:12 [INFO ] 2023-03-29 19:20:12.995 [main] o.a.s.p.frontend.ShardingSphereProxy - ShardingSphere-Proxy Standalone mode started successfully
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [X] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
