### PR TITLE
Fix wrong classpath in Espresso context

### DIFF
--- a/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/EspressoInlineExpressionParser.java
+++ b/infra/util/src/main/java/org/apache/shardingsphere/infra/util/expr/EspressoInlineExpressionParser.java
@@ -44,7 +44,7 @@ public final class EspressoInlineExpressionParser {
         URL resource = Thread.currentThread().getContextClassLoader().getResource("espresso-need-libs");
         assert null != resource;
         String dir = resource.getPath();
-        String javaClasspath = String.join(":", dir + "/groovy.jar", dir + "/guava.jar", dir + "/shardingsphere-infra-util.jar");
+        String javaClasspath = String.join(":", dir + "/groovy.jar", dir + "/guava.jar", dir + "/shardingsphere-infra-util-groovy.jar");
         POLYGLOT = Context.newBuilder().allowAllAccess(true)
                 .option("java.Properties.org.graalvm.home", javaHome)
                 .option("java.MultiThreaded", "true")

--- a/infra/util/src/test/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParserTest.java
+++ b/infra/util/src/test/java/org/apache/shardingsphere/infra/util/expr/InlineExpressionParserTest.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.infra.util.expr;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledInNativeImage;
 
 import java.util.Collections;
 import java.util.List;
@@ -120,9 +121,8 @@ class InlineExpressionParserTest {
      * Because `org.graalvm.polyglot.Value#as` does not allow this type to be returned from the guest JVM.
      */
     @Test
+    @DisabledInNativeImage
     void assertEvaluateClosure() {
-        if (!System.getProperty("java.vm.name").equals("Substrate VM")) {
-            assertThat(new InlineExpressionParser("${1+2}").evaluateClosure().call().toString(), is("3"));
-        }
+        assertThat(new InlineExpressionParser("${1+2}").evaluateClosure().call().toString(), is("3"));
     }
 }


### PR DESCRIPTION
For #24902.

Changes proposed in this pull request:
  - Fix wrong classpath in Espresso context. 
  - For #24902 and https://github.com/apache/shardingsphere/commit/7ee273dd209c6b93c6b8f3b1a18049e112c75202 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
