### PR TITLE
Update seata-all and netty to fix nativeTest in GraalVM Native Build Tools

### DIFF
--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -270,20 +270,20 @@ The text of each license is the standard Apache 2.0 license.
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
     log4j 1.2.17: http://logging.apache.org/log4j/1.2/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.87.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.87.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.90.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.90.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.90.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.23.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.0.1: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -268,20 +268,20 @@ The text of each license is the standard Apache 2.0 license.
     json-simple 1.1.1: https://code.google.com/archive/p/json-simple/, Apache 2.0 
     jsr305 3.0.2: http://findbugs.sourceforge.net/, Apache 2.0
     memory 0.9.0, Apache 2.0
-    netty-buffer 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-http2 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-codec-socks 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-common 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-handler 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-handler-proxy 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-resolver 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport-classes-epoll 4.1.87.Final: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.87.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-epoll 4.1.87.Final-linux-x86_64: https://github.com/netty, Apache 2.0
-    netty-transport-native-unix-common 4.1.87.Final: https://github.com/netty, Apache 2.0
+    netty-buffer 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-http2 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-codec-socks 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-common 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-handler 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-handler-proxy 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-resolver 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport-classes-epoll 4.1.90.Final: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.90.Final-linux-aarch_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-epoll 4.1.90.Final-linux-x86_64: https://github.com/netty, Apache 2.0
+    netty-transport-native-unix-common 4.1.90.Final: https://github.com/netty, Apache 2.0
     perfmark-api 0.25.0: https://github.com/perfmark/perfmark, Apache 2.0
     proto-google-common-protos 2.9.0: https://github.com/googleapis/common-protos-java, Apache 2.0
     proj4j 1.1.5: https://github.com/locationtech/proj4j, Apache 2.0

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,7 +60,7 @@
         <jboss-logging.version>3.2.1.Final</jboss-logging.version>
         <btm.version>2.1.3</btm.version>
         
-        <seata.version>1.4.2</seata.version>
+        <seata.version>1.6.1</seata.version>
         
         <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>

--- a/kernel/transaction/type/base/seata-at/pom.xml
+++ b/kernel/transaction/type/base/seata-at/pom.xml
@@ -28,7 +28,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <seata.version>1.4.2</seata.version>
+        <seata.version>1.6.1</seata.version>
     </properties>
     
     <dependencies>
@@ -60,6 +60,12 @@
                     <artifactId>dubbo</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManagerTest.java
+++ b/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/SeataATShardingSphereTransactionManagerTest.java
@@ -20,10 +20,10 @@ package org.apache.shardingsphere.transaction.base.seata.at;
 import io.seata.core.context.RootContext;
 import io.seata.core.protocol.MergeResultMessage;
 import io.seata.core.protocol.MergedWarpMessage;
-import io.seata.core.protocol.RegisterRMRequest;
 import io.seata.core.protocol.RegisterRMResponse;
 import io.seata.core.protocol.RegisterTMRequest;
 import io.seata.core.protocol.RegisterTMResponse;
+import io.seata.core.protocol.transaction.GlobalBeginRequest;
 import io.seata.core.rpc.netty.RmNettyRemotingClient;
 import io.seata.core.rpc.netty.TmNettyRemotingClient;
 import io.seata.rm.datasource.ConnectionProxy;
@@ -160,8 +160,8 @@ class SeataATShardingSphereTransactionManagerTest {
     private void assertResult() {
         int requestQueueSize = requestQueue.size();
         if (3 == requestQueueSize) {
-            assertThat(requestQueue.poll(), instanceOf(RegisterRMRequest.class));
             assertThat(requestQueue.poll(), instanceOf(RegisterTMRequest.class));
+            assertThat(requestQueue.poll(), instanceOf(GlobalBeginRequest.class));
             assertThat(requestQueue.poll(), instanceOf(MergedWarpMessage.class));
         }
         int responseQueueSize = responseQueue.size();

--- a/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/fixture/MockMessageHandler.java
+++ b/kernel/transaction/type/base/seata-at/src/test/java/org/apache/shardingsphere/transaction/base/seata/at/fixture/MockMessageHandler.java
@@ -88,6 +88,21 @@ public final class MockMessageHandler extends ChannelDuplexHandler {
             response.setBody(HeartbeatMessage.PONG);
         } else if (requestBody instanceof MergedWarpMessage) {
             setMergeResultMessage(request, response);
+        } else if (requestBody instanceof GlobalBeginRequest) {
+            GlobalBeginResponse globalBeginResponse = new GlobalBeginResponse();
+            globalBeginResponse.setXid(XID.generateXID(id.incrementAndGet()));
+            globalBeginResponse.setResultCode(ResultCode.Success);
+            response.setBody(globalBeginResponse);
+        } else if (requestBody instanceof GlobalCommitRequest) {
+            GlobalCommitResponse globalCommitResponse = new GlobalCommitResponse();
+            globalCommitResponse.setResultCode(ResultCode.Success);
+            globalCommitResponse.setGlobalStatus(GlobalStatus.Committing);
+            response.setBody(globalCommitResponse);
+        } else if (requestBody instanceof GlobalRollbackRequest) {
+            GlobalRollbackResponse globalRollbackResponse = new GlobalRollbackResponse();
+            globalRollbackResponse.setResultCode(ResultCode.Success);
+            globalRollbackResponse.setGlobalStatus(GlobalStatus.Rollbacked);
+            response.setBody(globalRollbackResponse);
         }
         if (requestBody != HeartbeatMessage.PING) {
             requestQueue.offer(requestBody);

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <truffle-api.version>21.2.0</truffle-api.version>
         
         <calcite.version>1.32.0</calcite.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.90.Final</netty.version>
         
         <javax.transaction.version>1.1</javax.transaction.version>
         


### PR DESCRIPTION
Fixes #24177 and #24382.

Changes proposed in this pull request:
  - Update seata-all to handle cglib breaking unit test execution with GraalVM Tracing Agent. Refer to https://github.com/apache/shardingsphere/pull/24177 .  
  - Update netty to get graalvm reachability metadata for `io.netty:netty-transport-classes-epoll`. Refer to https://github.com/netty/netty/pull/13242 and https://github.com/netty/netty/pull/13158 .
  - For https://github.com/apache/shardingsphere/issues/21347 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
