### PR TITLE
support for select substring

### DIFF
--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -942,7 +942,14 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
     @Override
     public final ASTNode visitSubstringFunction(final SubstringFunctionContext ctx) {
         calculateParameterCount(Collections.singleton(ctx.expr()));
-        return new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null == ctx.SUBSTR() ? ctx.SUBSTRING().getText() : ctx.SUBSTR().getText(), getOriginalText(ctx));
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
+                null == ctx.SUBSTR() ? ctx.SUBSTRING().getText() : ctx.SUBSTR().getText(), getOriginalText(ctx));
+        result.getParameters().add((LiteralExpressionSegment) visit(ctx.expr()));
+        for (int i = 0; i < ctx.NUMBER_().size(); i++) {
+            result.getParameters().add(new LiteralExpressionSegment(ctx.NUMBER_(i).getSymbol().getStartIndex(), ctx.NUMBER_(i).getSymbol().getStopIndex(),
+                    new NumberLiteralValue(ctx.NUMBER_(i).getText())));
+        }
+        return result;
     }
     
     @Override

--- a/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
+++ b/sql-parser/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/impl/MySQLStatementSQLVisitor.java
@@ -955,7 +955,11 @@ public abstract class MySQLStatementSQLVisitor extends MySQLStatementBaseVisitor
     @Override
     public final ASTNode visitExtractFunction(final ExtractFunctionContext ctx) {
         calculateParameterCount(Collections.singleton(ctx.expr()));
-        return new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.EXTRACT().getText(), getOriginalText(ctx));
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.EXTRACT().getText(), getOriginalText(ctx));
+        result.getParameters().add(new FunctionSegment(
+                ctx.identifier().getStart().getStartIndex(),ctx.identifier().getStop().getStopIndex(),ctx.identifier().getText(),getOriginalText(ctx.identifier())));
+        result.getParameters().add((ExpressionSegment) visit(ctx.expr()));
+        return result;
     }
     
     @Override

--- a/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
+++ b/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
@@ -191,6 +191,7 @@ class SQLNodeConverterEngineIT {
             result.add("select_natural_full_join");
             result.add("select_order_by_for_nulls_first");
             result.add("select_order_by_for_nulls_last");
+            result.add("select_substring");
             return result;
         }
         // CHECKSTYLE:ON

--- a/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
+++ b/test/it/optimizer/src/test/java/org/apache/shardingsphere/test/it/optimize/SQLNodeConverterEngineIT.java
@@ -192,6 +192,7 @@ class SQLNodeConverterEngineIT {
             result.add("select_order_by_for_nulls_first");
             result.add("select_order_by_for_nulls_last");
             result.add("select_substring");
+            result.add("select_extract");
             return result;
         }
         // CHECKSTYLE:ON

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -110,7 +110,11 @@
         <projections start-index="7" stop-index="35">
             <expression-projection text="SUBSTRING('foobarbar' from 4)" start-index="7" stop-index="35">
                 <expr>
-                    <function function-name="SUBSTRING" start-index="7" stop-index="35" text="SUBSTRING('foobarbar' from 4)" />
+                    <function function-name="SUBSTRING" start-index="7" stop-index="35" text="SUBSTRING('foobarbar' from 4)" >
+                        <parameter>
+                            <literal-expression value="foobarbar" start-index="17" stop-index="27" />
+                        </parameter>
+                    </function>
                 </expr>
             </expression-projection>
         </projections>


### PR DESCRIPTION
@strongduanmu Hello, while adding support for SQL's having identifiers, Numbers & Symbols I have came across a problem.
In the following code, I have debugged MySQLStatementSQLVisitor.java & the result of method VisitSubstringFunction have the required Parameters/OperandList. But the same do not shows up in SQLNodeConverterEngineIT.java ACTUAL parsing while running.
Can you please guide me regarding what I am doing wrong in parsing these type of queries ?
Thank you 
