### PR TITLE
Remove non-essential extensions at CDC protocol module

### DIFF
--- a/kernel/data-pipeline/cdc/protocol/pom.xml
+++ b/kernel/data-pipeline/cdc/protocol/pom.xml
@@ -59,12 +59,5 @@
                 </executions>
             </plugin>
         </plugins>
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-            </extension>
-        </extensions>
     </build>
 </project>


### PR DESCRIPTION
refer https://github.com/trustin/os-maven-plugin#issues-with-eclipse-m2e-or-other-ides

because the extensions already exists at root pom

Changes proposed in this pull request:
  - Remove non-essential extensions

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
