### PR TITLE
Use assertThat to instead of assertEquals

### DIFF
--- a/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/util/ProtobufAnyValueConverterTest.java
+++ b/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/util/ProtobufAnyValueConverterTest.java
@@ -69,6 +69,6 @@ class ProtobufAnyValueConverterTest {
                 .putFields("list", Value.newBuilder().setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(1)).build()).build()).build();
         Builder expected = Struct.newBuilder();
         JsonFormat.parser().merge((String) ProtobufAnyValueConverter.convertToObject(Any.pack((Struct) actual)), expected);
-        assertThat(actual.toString(),is(expected.toString()));
+        assertThat(actual.toString(), is(expected.toString()));
     }
 }

--- a/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/util/ProtobufAnyValueConverterTest.java
+++ b/kernel/data-pipeline/cdc/client/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/client/util/ProtobufAnyValueConverterTest.java
@@ -40,7 +40,6 @@ import java.time.OffsetDateTime;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtobufAnyValueConverterTest {
@@ -70,6 +69,6 @@ class ProtobufAnyValueConverterTest {
                 .putFields("list", Value.newBuilder().setListValue(ListValue.newBuilder().addValues(Value.newBuilder().setNumberValue(1)).build()).build()).build();
         Builder expected = Struct.newBuilder();
         JsonFormat.parser().merge((String) ProtobufAnyValueConverter.convertToObject(Any.pack((Struct) actual)), expected);
-        assertEquals(actual.toString(), expected.toString());
+        assertThat(actual.toString(),is(expected.toString()));
     }
 }

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/context/PipelineContextKeyTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/core/context/PipelineContextKeyTest.java
@@ -22,18 +22,17 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-final class PipelineContextKeyTest {
+class PipelineContextKeyTest {
     
     @Test
     void assertHashCodeEqualsForProxyMode() {
         PipelineContextKey contextKey1 = PipelineContextKey.build(InstanceType.PROXY, null);
         PipelineContextKey contextKey2 = PipelineContextKey.build(InstanceType.PROXY, "sharding_db");
         assertThat(contextKey1.hashCode(), is(contextKey2.hashCode()));
-        assertEquals(contextKey1, contextKey2);
+        assertThat(contextKey1, is(contextKey2));
     }
     
     @Test


### PR DESCRIPTION
Use assertThat to instead of assertEquals.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
