### PR TITLE
pg, set valueformat of row description in bind command

### DIFF
--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query;
 
-import lombok.Getter;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLArrayColumnType;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLValueFormat;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLColumnType;
@@ -27,7 +26,6 @@ import java.sql.Types;
 /**
  * Column description for PostgreSQL.
  */
-@Getter
 public final class PostgreSQLColumnDescription {
     
     private final String columnName;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query;
 
+import lombok.Getter;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLArrayColumnType;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLValueFormat;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLColumnType;
@@ -26,6 +27,7 @@ import java.sql.Types;
 /**
  * Column description for PostgreSQL.
  */
+@Getter
 public final class PostgreSQLColumnDescription {
     
     private final String columnName;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query;
 
 import lombok.Getter;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLArrayColumnType;
+import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLValueFormat;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLColumnType;
 
 import java.sql.Types;
@@ -41,12 +42,20 @@ public final class PostgreSQLColumnDescription {
     
     private final int typeModifier = -1;
     
-    private final int dataFormat = 0;
+    private int dataFormat = PostgreSQLValueFormat.TEXT.getCode();
     
     public PostgreSQLColumnDescription(final String columnName, final int columnIndex, final int columnType, final int columnLength, final String columnTypeName) {
         this.columnName = columnName;
         this.columnIndex = columnIndex;
         this.columnLength = columnLength;
+        typeOID = Types.ARRAY == columnType ? PostgreSQLArrayColumnType.getTypeOid(columnTypeName) : PostgreSQLColumnType.valueOfJDBCType(columnType).getValue();
+    }
+
+    public PostgreSQLColumnDescription(final String columnName, final int columnIndex, final int columnType, final int columnLength, final String columnTypeName, final int dataFormat) {
+        this.columnName = columnName;
+        this.columnIndex = columnIndex;
+        this.columnLength = columnLength;
+        this.dataFormat = dataFormat;
         typeOID = Types.ARRAY == columnType ? PostgreSQLArrayColumnType.getTypeOid(columnTypeName) : PostgreSQLColumnType.valueOfJDBCType(columnType).getValue();
     }
 }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLColumnDescription.java
@@ -42,13 +42,10 @@ public final class PostgreSQLColumnDescription {
     
     private final int typeModifier = -1;
     
-    private int dataFormat = PostgreSQLValueFormat.TEXT.getCode();
+    private final int dataFormat;
     
     public PostgreSQLColumnDescription(final String columnName, final int columnIndex, final int columnType, final int columnLength, final String columnTypeName) {
-        this.columnName = columnName;
-        this.columnIndex = columnIndex;
-        this.columnLength = columnLength;
-        typeOID = Types.ARRAY == columnType ? PostgreSQLArrayColumnType.getTypeOid(columnTypeName) : PostgreSQLColumnType.valueOfJDBCType(columnType).getValue();
+        this(columnName, columnIndex, columnType, columnLength, columnTypeName, PostgreSQLValueFormat.TEXT.getCode());
     }
 
     public PostgreSQLColumnDescription(final String columnName, final int columnIndex, final int columnType, final int columnLength, final String columnTypeName, final int dataFormat) {

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacket.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -29,6 +30,7 @@ import java.util.Collection;
  * Row description packet for PostgreSQL.
  */
 @RequiredArgsConstructor
+@Getter
 public final class PostgreSQLRowDescriptionPacket implements PostgreSQLIdentifierPacket {
     
     private final Collection<PostgreSQLColumnDescription> columnDescriptions;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/PostgreSQLRowDescriptionPacket.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -30,7 +29,6 @@ import java.util.Collection;
  * Row description packet for PostgreSQL.
  */
 @RequiredArgsConstructor
-@Getter
 public final class PostgreSQLRowDescriptionPacket implements PostgreSQLIdentifierPacket {
     
     private final Collection<PostgreSQLColumnDescription> columnDescriptions;

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/Portal.java
@@ -127,7 +127,8 @@ public final class Portal {
         Collection<PostgreSQLColumnDescription> result = new LinkedList<>();
         int columnIndex = 0;
         for (QueryHeader each : queryResponseHeader.getQueryHeaders()) {
-            result.add(new PostgreSQLColumnDescription(each.getColumnLabel(), ++columnIndex, each.getColumnType(), each.getColumnLength(), each.getColumnTypeName()));
+            PostgreSQLValueFormat valueFormat = determineValueFormat(columnIndex);
+            result.add(new PostgreSQLColumnDescription(each.getColumnLabel(), ++columnIndex, each.getColumnType(), each.getColumnLength(), each.getColumnTypeName(), valueFormat.getCode()));
         }
         return result;
     }

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -78,7 +78,6 @@ import java.util.Optional;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -141,7 +140,6 @@ class PortalTest {
         QueryHeader queryHeader = new QueryHeader("schema", "table", "columnLabel", "columnName", Types.VARCHAR, "columnTypeName", 0, 0, false, false, false, false);
         QueryHeader intColumnQueryHeader = new QueryHeader("schema", "table", "columnLabel", "columnName", Types.INTEGER, "columnTypeName", 0, 0, false, false, false, false);
         when(responseHeader.getQueryHeaders()).thenReturn(Arrays.asList(queryHeader, intColumnQueryHeader));
-
         when(proxyBackendHandler.execute()).thenReturn(responseHeader);
         when(proxyBackendHandler.next()).thenReturn(true, true, false);
         when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.INTEGER, 0))),
@@ -153,7 +151,6 @@ class PortalTest {
         List<PostgreSQLValueFormat> resultFormats = new ArrayList<>(Arrays.asList(PostgreSQLValueFormat.TEXT, PostgreSQLValueFormat.BINARY));
         Portal portal = new Portal("", preparedStatement, Collections.emptyList(), resultFormats, backendConnection);
         portal.bind();
-
         PostgreSQLPacket portalDescription = portal.describe();
         assertThat(portalDescription, instanceOf(PostgreSQLRowDescriptionPacket.class));
         Optional<Collection<PostgreSQLColumnDescription>> columnDescriptions = ReflectionUtils.getFieldValue(portalDescription, "columnDescriptions");
@@ -161,9 +158,8 @@ class PortalTest {
         Iterator<PostgreSQLColumnDescription> columnDescriptionIterator = columnDescriptions.get().iterator();
         PostgreSQLColumnDescription textColumnDescription = columnDescriptionIterator.next();
         PostgreSQLColumnDescription intColumnDescription = columnDescriptionIterator.next();
-        assertEquals(textColumnDescription.getDataFormat(), PostgreSQLValueFormat.TEXT.getCode());
-        assertEquals(intColumnDescription.getDataFormat(), PostgreSQLValueFormat.BINARY.getCode());
-
+        assertThat(textColumnDescription.getDataFormat(), is(PostgreSQLValueFormat.TEXT.getCode()));
+        assertThat(intColumnDescription.getDataFormat(), is(PostgreSQLValueFormat.BINARY.getCode()));
         List<PostgreSQLPacket> actualPackets = portal.execute(0);
         assertThat(actualPackets.size(), is(3));
         Iterator<PostgreSQLPacket> actualPacketsIterator = actualPackets.iterator();

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.database.type.dialect.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.util.reflection.ReflectionUtils;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.proxy.backend.connector.BackendConnection;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
@@ -155,8 +156,10 @@ class PortalTest {
         assertThat(portalDescription, instanceOf(PostgreSQLRowDescriptionPacket.class));
         Collection<PostgreSQLColumnDescription> postgreSQLColumnDescriptions = ((PostgreSQLRowDescriptionPacket) portalDescription).getColumnDescriptions();
         Iterator<PostgreSQLColumnDescription> columnDescriptionIterator = postgreSQLColumnDescriptions.iterator();
-        assertEquals(columnDescriptionIterator.next().getDataFormat(), PostgreSQLValueFormat.TEXT.getCode());
-        assertEquals(columnDescriptionIterator.next().getDataFormat(), PostgreSQLValueFormat.BINARY.getCode());
+        PostgreSQLColumnDescription textColumnDescription = columnDescriptionIterator.next();
+        PostgreSQLColumnDescription intColumnDescription = columnDescriptionIterator.next();
+        assertEquals(ReflectionUtils.getFieldValue(textColumnDescription, "dataFormat").get(), PostgreSQLValueFormat.TEXT.getCode());
+        assertEquals(ReflectionUtils.getFieldValue(intColumnDescription, "dataFormat").get(), PostgreSQLValueFormat.BINARY.getCode());
 
         List<PostgreSQLPacket> actualPackets = portal.execute(0);
         assertThat(actualPackets.size(), is(3));

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -135,8 +135,10 @@ class PortalTest {
     @Test
     void assertExecuteSelectStatementAndReturnAllRows() throws SQLException {
         QueryResponseHeader responseHeader = mock(QueryResponseHeader.class);
-        QueryHeader queryHeader = new QueryHeader("schema", "table", "columnLabel", "columnName", Types.INTEGER, "columnTypeName", 0, 0, false, false, false, false);
-        when(responseHeader.getQueryHeaders()).thenReturn(Collections.singletonList(queryHeader));
+        QueryHeader queryHeader = new QueryHeader("schema", "table", "columnLabel", "columnName", Types.VARCHAR, "columnTypeName", 0, 0, false, false, false, false);
+        QueryHeader intColumnQueryHeader = new QueryHeader("schema", "table", "columnLabel", "columnName", Types.INTEGER, "columnTypeName", 0, 0, false, false, false, false);
+        when(responseHeader.getQueryHeaders()).thenReturn(Arrays.asList(queryHeader, intColumnQueryHeader));
+
         when(proxyBackendHandler.execute()).thenReturn(responseHeader);
         when(proxyBackendHandler.next()).thenReturn(true, true, false);
         when(proxyBackendHandler.getRowData()).thenReturn(new QueryResponseRow(Collections.singletonList(new QueryResponseCell(Types.INTEGER, 0))),

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.proxy.frontend.postgresql.command.query.extend
 
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLValueFormat;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.PostgreSQLPacket;
+import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLColumnDescription;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLDataRowPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLEmptyQueryResponsePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.PostgreSQLNoDataPacket;
@@ -67,6 +68,7 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -74,6 +76,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -145,7 +148,14 @@ class PortalTest {
         List<PostgreSQLValueFormat> resultFormats = new ArrayList<>(Arrays.asList(PostgreSQLValueFormat.TEXT, PostgreSQLValueFormat.BINARY));
         Portal portal = new Portal("", preparedStatement, Collections.emptyList(), resultFormats, backendConnection);
         portal.bind();
-        assertThat(portal.describe(), instanceOf(PostgreSQLRowDescriptionPacket.class));
+
+        PostgreSQLPacket portalDescription = portal.describe();
+        assertThat(portalDescription, instanceOf(PostgreSQLRowDescriptionPacket.class));
+        Collection<PostgreSQLColumnDescription> postgreSQLColumnDescriptions = ((PostgreSQLRowDescriptionPacket) portalDescription).getColumnDescriptions();
+        Iterator<PostgreSQLColumnDescription> columnDescriptionIterator = postgreSQLColumnDescriptions.iterator();
+        assertEquals(columnDescriptionIterator.next().getDataFormat(), PostgreSQLValueFormat.TEXT.getCode());
+        assertEquals(columnDescriptionIterator.next().getDataFormat(), PostgreSQLValueFormat.BINARY.getCode());
+
         List<PostgreSQLPacket> actualPackets = portal.execute(0);
         assertThat(actualPackets.size(), is(3));
         Iterator<PostgreSQLPacket> actualPacketsIterator = actualPackets.iterator();

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PortalTest.java
@@ -73,12 +73,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -154,12 +156,13 @@ class PortalTest {
 
         PostgreSQLPacket portalDescription = portal.describe();
         assertThat(portalDescription, instanceOf(PostgreSQLRowDescriptionPacket.class));
-        Collection<PostgreSQLColumnDescription> postgreSQLColumnDescriptions = ((PostgreSQLRowDescriptionPacket) portalDescription).getColumnDescriptions();
-        Iterator<PostgreSQLColumnDescription> columnDescriptionIterator = postgreSQLColumnDescriptions.iterator();
+        Optional<Collection<PostgreSQLColumnDescription>> columnDescriptions = ReflectionUtils.getFieldValue(portalDescription, "columnDescriptions");
+        assertTrue(columnDescriptions.isPresent());
+        Iterator<PostgreSQLColumnDescription> columnDescriptionIterator = columnDescriptions.get().iterator();
         PostgreSQLColumnDescription textColumnDescription = columnDescriptionIterator.next();
         PostgreSQLColumnDescription intColumnDescription = columnDescriptionIterator.next();
-        assertEquals(ReflectionUtils.getFieldValue(textColumnDescription, "dataFormat").get(), PostgreSQLValueFormat.TEXT.getCode());
-        assertEquals(ReflectionUtils.getFieldValue(intColumnDescription, "dataFormat").get(), PostgreSQLValueFormat.BINARY.getCode());
+        assertEquals(textColumnDescription.getDataFormat(), PostgreSQLValueFormat.TEXT.getCode());
+        assertEquals(intColumnDescription.getDataFormat(), PostgreSQLValueFormat.BINARY.getCode());
 
         List<PostgreSQLPacket> actualPackets = portal.execute(0);
         assertThat(actualPackets.size(), is(3));


### PR DESCRIPTION
when using with gorm ,   select int column,     gorm  will check  valueFormat in the row description  to decide how to deal with the column value , but  the format is always  0(text),  then gorm treat  int8 array as string, then it failed to convert 

<img width="661" alt="image" src="https://user-images.githubusercontent.com/17156143/230534852-3779a3b2-8e1a-47c2-ac8a-2fde80eaeceb.png">

<img width="274" alt="image" src="https://user-images.githubusercontent.com/17156143/230534458-5243cbc2-d027-4117-870e-fb93c26d53bd.png">

cuz format = 0, then `strconv.ParseUint(string(src), 10, 64)`
error message as follows:

convert field 0 failed: strconv.ParseInt: parsing "\x00\x00\x00\x00\x00\x00\x00\x16": invalid syntax [437.417ms] [rows:0] INSERT INTO "t_student_info_copy" ("student_name","id") VALUES ('go name',22) RETURNING "id" &{0xc0000ee510 convert field 0 failed: strconv.ParseInt: parsing "\x00\x00\x00\x00\x00\x00\x00\x16": invalid syntax 0 0xc000242380 0}

