### PR TITLE
Revert "Fix wrong logic table metadata when config same actual table name in different storage unit  (#25037)"

### DIFF
--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptMetaDataReviseEngineTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/EncryptMetaDataReviseEngineTest.java
@@ -74,6 +74,6 @@ class EncryptMetaDataReviseEngineTest {
                 new ColumnMetaData("pwd_cipher", Types.VARCHAR, false, false, true, true, false),
                 new ColumnMetaData("pwd_plain", Types.VARCHAR, false, false, true, true, false),
                 new ColumnMetaData("pwd_like", Types.VARCHAR, false, false, true, true, false));
-        return new TableMetaData(TABLE_NAME, "ds_0", columns, Collections.emptyList(), Collections.emptyList());
+        return new TableMetaData(TABLE_NAME, columns, Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/LogicTablesMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/LogicTablesMergedResult.java
@@ -52,7 +52,7 @@ public class LogicTablesMergedResult extends MemoryMergedResult<ShardingRule> {
             while (each.next()) {
                 MemoryQueryResultRow memoryResultSetRow = new MemoryQueryResultRow(each);
                 String actualTableName = memoryResultSetRow.getCell(1).toString();
-                Optional<TableRule> tableRule = findTableRule(shardingRule, sqlStatementContext);
+                Optional<TableRule> tableRule = shardingRule.findTableRuleByActualTable(actualTableName);
                 if (!tableRule.isPresent()) {
                     if (shardingRule.getTableRules().isEmpty() || tableNames.add(actualTableName)) {
                         setCellValue(memoryResultSetRow, actualTableName, actualTableName, schema.getTable(actualTableName), shardingRule);
@@ -67,13 +67,6 @@ public class LogicTablesMergedResult extends MemoryMergedResult<ShardingRule> {
             }
         }
         return result;
-    }
-    
-    private Optional<TableRule> findTableRule(final ShardingRule shardingRule, final SQLStatementContext<?> sqlStatementContext) {
-        if (sqlStatementContext.getTablesContext().getTableNames().isEmpty()) {
-            return Optional.empty();
-        }
-        return shardingRule.findTableRule(sqlStatementContext.getTablesContext().getTableNames().iterator().next());
     }
     
     protected void setCellValue(final MemoryQueryResultRow memoryResultSetRow,

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowIndexMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowIndexMergedResult.java
@@ -50,19 +50,12 @@ public final class ShowIndexMergedResult extends MemoryMergedResult<ShardingRule
                 MemoryQueryResultRow memoryResultSetRow = new MemoryQueryResultRow(each);
                 String actualTableName = memoryResultSetRow.getCell(1).toString();
                 String actualIndexName = memoryResultSetRow.getCell(3).toString();
-                Optional<TableRule> tableRule = findTableRule(shardingRule, sqlStatementContext);
+                Optional<TableRule> tableRule = shardingRule.findTableRuleByActualTable(actualTableName);
                 tableRule.ifPresent(optional -> memoryResultSetRow.setCell(1, optional.getLogicTable()));
                 memoryResultSetRow.setCell(3, IndexMetaDataUtils.getLogicIndexName(actualIndexName, actualTableName));
                 result.add(memoryResultSetRow);
             }
         }
         return result;
-    }
-    
-    private Optional<TableRule> findTableRule(final ShardingRule shardingRule, final SQLStatementContext<?> sqlStatementContext) {
-        if (sqlStatementContext.getTablesContext().getTableNames().isEmpty()) {
-            return Optional.empty();
-        }
-        return shardingRule.findTableRule(sqlStatementContext.getTablesContext().getTableNames().iterator().next());
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResult.java
@@ -50,7 +50,8 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
         for (QueryResult each : queryResults) {
             while (each.next()) {
                 MemoryQueryResultRow memoryResultSetRow = new MemoryQueryResultRow(each);
-                Optional<TableRule> tableRule = findTableRule(shardingRule, sqlStatementContext);
+                String actualTableName = memoryResultSetRow.getCell(1).toString();
+                Optional<TableRule> tableRule = shardingRule.findTableRuleByActualTable(actualTableName);
                 tableRule.ifPresent(optional -> memoryResultSetRow.setCell(1, optional.getLogicTable()));
                 String tableName = memoryResultSetRow.getCell(1).toString();
                 if (memoryQueryResultRows.containsKey(tableName)) {
@@ -61,13 +62,6 @@ public final class ShowTableStatusMergedResult extends MemoryMergedResult<Shardi
             }
         }
         return new LinkedList<>(memoryQueryResultRows.values());
-    }
-    
-    private Optional<TableRule> findTableRule(final ShardingRule shardingRule, final SQLStatementContext<?> sqlStatementContext) {
-        if (sqlStatementContext.getTablesContext().getTableNames().isEmpty()) {
-            return Optional.empty();
-        }
-        return shardingRule.findTableRule(sqlStatementContext.getTablesContext().getTableNames().iterator().next());
     }
     
     private void merge(final MemoryQueryResultRow row, final MemoryQueryResultRow newRow) {

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/ShardingMetaDataReviseEntry.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/ShardingMetaDataReviseEntry.java
@@ -47,18 +47,18 @@ public final class ShardingMetaDataReviseEntry implements MetaDataReviseEntry<Sh
     }
     
     @Override
-    public Optional<ShardingColumnGeneratedReviser> getColumnGeneratedReviser(final ShardingRule rule, final String dataSourceName, final String tableName) {
-        return rule.findTableRuleByDataSourceAndActualTable(dataSourceName, tableName).map(ShardingColumnGeneratedReviser::new);
+    public Optional<ShardingColumnGeneratedReviser> getColumnGeneratedReviser(final ShardingRule rule, final String tableName) {
+        return rule.findTableRuleByActualTable(tableName).map(ShardingColumnGeneratedReviser::new);
     }
     
     @Override
-    public Optional<ShardingIndexReviser> getIndexReviser(final ShardingRule rule, final String dataSourceName, final String tableName) {
-        return rule.findTableRuleByDataSourceAndActualTable(dataSourceName, tableName).map(ShardingIndexReviser::new);
+    public Optional<ShardingIndexReviser> getIndexReviser(final ShardingRule rule, final String tableName) {
+        return rule.findTableRuleByActualTable(tableName).map(ShardingIndexReviser::new);
     }
     
     @Override
-    public Optional<ShardingConstraintReviser> getConstraintReviser(final ShardingRule rule, final String dataSourceName, final String tableName) {
-        return rule.findTableRuleByDataSourceAndActualTable(dataSourceName, tableName).map(ShardingConstraintReviser::new);
+    public Optional<ShardingConstraintReviser> getConstraintReviser(final ShardingRule rule, final String tableName) {
+        return rule.findTableRuleByActualTable(tableName).map(ShardingConstraintReviser::new);
     }
     
     @Override

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/constraint/ShardingConstraintReviser.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/constraint/ShardingConstraintReviser.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.sharding.metadata.reviser.constraint;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.datanode.DataNode;
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.reviser.constraint.ConstraintReviser;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.sharding.rule.ShardingRule;
 import org.apache.shardingsphere.sharding.rule.TableRule;
 
@@ -35,13 +35,12 @@ public final class ShardingConstraintReviser implements ConstraintReviser<Shardi
     private final TableRule tableRule;
     
     @Override
-    public Optional<ConstraintMetaData> revise(final String dataSourceName, final String tableName, final ConstraintMetaData originalMetaData, final ShardingRule rule) {
+    public Optional<ConstraintMetaData> revise(final String tableName, final ConstraintMetaData originalMetaData, final ShardingRule rule) {
         for (DataNode each : tableRule.getActualDataNodes()) {
             String referencedTableName = originalMetaData.getReferencedTableName();
             Optional<String> logicIndexName = getLogicIndex(originalMetaData.getName(), each.getTableName());
             if (logicIndexName.isPresent()) {
-                return Optional.of(new ConstraintMetaData(logicIndexName.get(),
-                        rule.findTableRuleByDataSourceAndActualTable(dataSourceName, referencedTableName).map(TableRule::getLogicTable).orElse(referencedTableName)));
+                return Optional.of(new ConstraintMetaData(logicIndexName.get(), rule.findLogicTableByActualTable(referencedTableName).orElse(referencedTableName)));
             }
         }
         return Optional.empty();

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/table/ShardingTableNameReviser.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/reviser/table/ShardingTableNameReviser.java
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.sharding.rule.TableRule;
 public final class ShardingTableNameReviser implements TableNameReviser<ShardingRule> {
     
     @Override
-    public String revise(final String originalName, final String dataSourceName, final ShardingRule rule) {
-        return rule.findTableRuleByDataSourceAndActualTable(dataSourceName, originalName).map(TableRule::getLogicTable).orElse(originalName);
+    public String revise(final String originalName, final ShardingRule rule) {
+        return rule.findTableRuleByActualTable(originalName).map(TableRule::getLogicTable).orElse(originalName);
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rule/ShardingRule.java
@@ -334,25 +334,15 @@ public final class ShardingRule implements DatabaseRule, DataNodeContainedRule, 
         return Optional.of(tableRules.get(logicTableName.toLowerCase()));
     }
     
-    private Optional<TableRule> findTableRuleByActualTable(final String actualTableName) {
-        for (TableRule each : tableRules.values()) {
-            if (each.isExisted(actualTableName)) {
-                return Optional.of(each);
-            }
-        }
-        return Optional.empty();
-    }
-    
     /**
-     * Find table rule via data source name and actual table name.
+     * Find table rule via actual table name.
      *
-     * @param dataSourceName data source name
      * @param actualTableName actual table name
      * @return table rule
      */
-    public Optional<TableRule> findTableRuleByDataSourceAndActualTable(final String dataSourceName, final String actualTableName) {
+    public Optional<TableRule> findTableRuleByActualTable(final String actualTableName) {
         for (TableRule each : tableRules.values()) {
-            if (each.getActualDataSourceNames().contains(dataSourceName) && each.isExisted(actualTableName)) {
+            if (each.isExisted(actualTableName)) {
                 return Optional.of(each);
             }
         }
@@ -695,7 +685,6 @@ public final class ShardingRule implements DatabaseRule, DataNodeContainedRule, 
     
     @Override
     public Optional<String> findLogicTableByActualTable(final String actualTable) {
-        // TODO findLogicTableByActualTable according to actual table name and data source name to avoid getting wrong logic table in #24982
         return findTableRuleByActualTable(actualTable).map(TableRule::getLogicTable);
     }
     

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowCreateTableMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowCreateTableMergedResultTest.java
@@ -76,16 +76,12 @@ class ShowCreateTableMergedResultTest {
     
     @Test
     void assertNextForTableRulePresent() throws SQLException {
-        SQLStatementContext<?> sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
-        assertTrue(new ShowCreateTableMergedResult(shardingRule, sqlStatementContext, schema, Collections.singletonList(mockQueryResult())).next());
+        assertTrue(new ShowCreateTableMergedResult(shardingRule, mock(SQLStatementContext.class), schema, Collections.singletonList(mockQueryResult())).next());
     }
     
     @Test
     void assertGetValueForTableRulePresent() throws SQLException {
-        SQLStatementContext<?> sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
-        ShowCreateTableMergedResult actual = new ShowCreateTableMergedResult(shardingRule, sqlStatementContext, schema, Collections.singletonList(mockQueryResult()));
+        ShowCreateTableMergedResult actual = new ShowCreateTableMergedResult(shardingRule, mock(SQLStatementContext.class), schema, Collections.singletonList(mockQueryResult()));
         assertTrue(actual.next());
         assertThat(actual.getValue(1, String.class), is("t_order"));
         assertThat(actual.getValue(2, String.class), is("CREATE TABLE `t_order` (\n"

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowIndexMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowIndexMergedResultTest.java
@@ -51,9 +51,7 @@ class ShowIndexMergedResultTest {
     
     @Test
     void assertNextForTableRuleIsPresent() throws SQLException {
-        SQLStatementContext<?> sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("t_order"));
-        assertTrue(new ShowIndexMergedResult(shardingRule, sqlStatementContext, schema, Collections.singletonList(mockQueryResult())).next());
+        assertTrue(new ShowIndexMergedResult(shardingRule, mock(SQLStatementContext.class), schema, Collections.singletonList(mockQueryResult())).next());
     }
     
     private QueryResult mockQueryResult() throws SQLException {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTableStatusMergedResultTest.java
@@ -72,9 +72,7 @@ class ShowTableStatusMergedResultTest {
     
     @Test
     void assertNextForTableRuleIsPresent() throws SQLException {
-        SQLStatementContext<?> sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("table"));
-        MergedResult mergedResult = new ShowTableStatusMergedResult(shardingRule, sqlStatementContext, schema, Collections.singletonList(mockQueryResult()));
+        MergedResult mergedResult = new ShowTableStatusMergedResult(shardingRule, mock(SQLStatementContext.class), schema, Collections.singletonList(mockQueryResult()));
         assertTrue(mergedResult.next());
         assertFalse(mergedResult.next());
     }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTablesMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowTablesMergedResultTest.java
@@ -63,9 +63,7 @@ class ShowTablesMergedResultTest {
     
     @Test
     void assertNextForActualTableNameInTableRule() throws SQLException {
-        SQLStatementContext<?> sqlStatementContext = mock(SQLStatementContext.class, RETURNS_DEEP_STUBS);
-        when(sqlStatementContext.getTablesContext().getTableNames()).thenReturn(Collections.singletonList("table"));
-        assertTrue(new LogicTablesMergedResult(shardingRule, sqlStatementContext, schema, Collections.singletonList(mockQueryResult("table_0"))).next());
+        assertTrue(new LogicTablesMergedResult(shardingRule, mock(SQLStatementContext.class), schema, Collections.singletonList(mockQueryResult("table_0"))).next());
     }
     
     private QueryResult mockQueryResult(final String value) throws SQLException {

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/ShardingMetaDataReviseEngineTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/ShardingMetaDataReviseEngineTest.java
@@ -66,6 +66,6 @@ class ShardingMetaDataReviseEngineTest {
                 new ColumnMetaData("pwd_cipher", Types.VARCHAR, false, false, true, true, false),
                 new ColumnMetaData("pwd_plain", Types.VARCHAR, false, false, true, true, false),
                 new ColumnMetaData("product_id", Types.INTEGER, false, false, true, true, false));
-        return new TableMetaData("t_order", "ds_0", columns, Collections.emptyList(), Collections.emptyList());
+        return new TableMetaData("t_order", columns, Collections.emptyList(), Collections.emptyList());
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rule/ShardingRuleTest.java
@@ -126,11 +126,13 @@ class ShardingRuleTest {
     }
     
     @Test
-    void assertFindTableRuleByDataSourceAndActualTable() {
-        ShardingRule sameActualTableShardingRule = createSameActualTableShardingRule();
-        assertTrue(sameActualTableShardingRule.findTableRuleByDataSourceAndActualTable("ds_0", "table").isPresent());
-        assertTrue(sameActualTableShardingRule.findTableRuleByDataSourceAndActualTable("ds_1", "table").isPresent());
-        assertFalse(sameActualTableShardingRule.findTableRuleByDataSourceAndActualTable("ds_2", "table").isPresent());
+    void assertFindTableRuleByActualTable() {
+        assertTrue(createMaximumShardingRule().findTableRuleByActualTable("table_0").isPresent());
+    }
+    
+    @Test
+    void assertNotFindTableRuleByActualTable() {
+        assertFalse(createMaximumShardingRule().findTableRuleByActualTable("table_3").isPresent());
     }
     
     @Test
@@ -482,13 +484,6 @@ class ShardingRuleTest {
         ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
         ShardingTableRuleConfiguration shardingTableRuleConfig = createTableRuleConfiguration("LOGIC_TABLE", "ds_${0..1}.table_${0..2}");
         shardingRuleConfig.getTables().add(shardingTableRuleConfig);
-        return new ShardingRule(shardingRuleConfig, createDataSourceNames(), mock(InstanceContext.class));
-    }
-    
-    private ShardingRule createSameActualTableShardingRule() {
-        ShardingRuleConfiguration shardingRuleConfig = new ShardingRuleConfiguration();
-        shardingRuleConfig.getTables().add(createTableRuleConfiguration("LOGIC_TABLE0", "ds_0.table"));
-        shardingRuleConfig.getTables().add(createTableRuleConfiguration("LOGIC_TABLE1", "ds_1.table"));
         return new ShardingRule(shardingRuleConfig, createDataSourceNames(), mock(InstanceContext.class));
     }
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/common/TableMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/common/TableMetaDataLoader.java
@@ -40,17 +40,16 @@ public final class TableMetaDataLoader {
      * Load table meta data.
      *
      * @param dataSource data source
-     * @param dataSourceName data source name
      * @param tableNamePattern table name pattern
      * @param databaseType database type
      * @return table meta data
      * @throws SQLException SQL exception
      */
-    public static Optional<TableMetaData> load(final DataSource dataSource, final String dataSourceName, final String tableNamePattern, final DatabaseType databaseType) throws SQLException {
+    public static Optional<TableMetaData> load(final DataSource dataSource, final String tableNamePattern, final DatabaseType databaseType) throws SQLException {
         try (MetaDataLoaderConnectionAdapter connectionAdapter = new MetaDataLoaderConnectionAdapter(databaseType, dataSource.getConnection())) {
             String formattedTableNamePattern = databaseType.formatTableNamePattern(tableNamePattern);
             return isTableExist(connectionAdapter, formattedTableNamePattern)
-                    ? Optional.of(new TableMetaData(tableNamePattern, dataSourceName, ColumnMetaDataLoader.load(
+                    ? Optional.of(new TableMetaData(tableNamePattern, ColumnMetaDataLoader.load(
                             connectionAdapter, formattedTableNamePattern, databaseType), IndexMetaDataLoader.load(connectionAdapter, formattedTableNamePattern), Collections.emptyList()))
                     : Optional.empty();
         }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/DialectSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/DialectSchemaMetaDataLoader.java
@@ -35,11 +35,10 @@ public interface DialectSchemaMetaDataLoader extends TypedSPI {
      * Load schema meta data.
      *
      * @param dataSource data source
-     * @param dataSourceName data source name
      * @param tables tables
      * @param defaultSchemaName default schema name
      * @return schema meta data collection
      * @throws SQLException SQL exception
      */
-    Collection<SchemaMetaData> load(DataSource dataSource, String dataSourceName, Collection<String> tables, String defaultSchemaName) throws SQLException;
+    Collection<SchemaMetaData> load(DataSource dataSource, Collection<String> tables, String defaultSchemaName) throws SQLException;
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/SchemaMetaDataLoaderEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/SchemaMetaDataLoaderEngine.java
@@ -78,7 +78,7 @@ public final class SchemaMetaDataLoaderEngine {
         Optional<DialectSchemaMetaDataLoader> dialectSchemaMetaDataLoader = TypedSPILoader.findService(DialectSchemaMetaDataLoader.class, material.getStorageType().getType());
         if (dialectSchemaMetaDataLoader.isPresent()) {
             try {
-                return dialectSchemaMetaDataLoader.get().load(material.getDataSource(), material.getDataSourceName(), material.getActualTableNames(), material.getDefaultSchemaName());
+                return dialectSchemaMetaDataLoader.get().load(material.getDataSource(), material.getActualTableNames(), material.getDefaultSchemaName());
                 // TODO replace Exception to SQLException when all dialect loader can handle meta data load normally
                 // CHECKSTYLE:OFF
             } catch (final Exception ex) {
@@ -92,7 +92,7 @@ public final class SchemaMetaDataLoaderEngine {
     private static Collection<SchemaMetaData> loadByDefault(final SchemaMetaDataLoaderMaterial material) throws SQLException {
         Collection<TableMetaData> tableMetaData = new LinkedList<>();
         for (String each : material.getActualTableNames()) {
-            TableMetaDataLoader.load(material.getDataSource(), material.getDataSourceName(), each, material.getStorageType()).ifPresent(tableMetaData::add);
+            TableMetaDataLoader.load(material.getDataSource(), each, material.getStorageType()).ifPresent(tableMetaData::add);
         }
         return Collections.singletonList(new SchemaMetaData(material.getDefaultSchemaName(), tableMetaData));
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/SchemaMetaDataLoaderMaterial.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/SchemaMetaDataLoaderMaterial.java
@@ -33,8 +33,6 @@ public final class SchemaMetaDataLoaderMaterial {
     
     private final Collection<String> actualTableNames;
     
-    private final String dataSourceName;
-    
     private final DataSource dataSource;
     
     private final DatabaseType storageType;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/H2SchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/H2SchemaMetaDataLoader.java
@@ -67,14 +67,14 @@ public final class H2SchemaMetaDataLoader implements DialectSchemaMetaDataLoader
     private static final String GENERATED_INFO_SQL_IN_TABLES = GENERATED_INFO_SQL + " AND UPPER(C.TABLE_NAME) IN (%s)";
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         try (Connection connection = dataSource.getConnection()) {
             Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(connection, tables);
             Map<String, Collection<IndexMetaData>> indexMetaDataMap = columnMetaDataMap.isEmpty() ? Collections.emptyMap() : loadIndexMetaData(connection, columnMetaDataMap.keySet());
             for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
                 Collection<IndexMetaData> indexMetaDataList = indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
-                tableMetaDataList.add(new TableMetaData(entry.getKey(), dataSourceName, entry.getValue(), indexMetaDataList, Collections.emptyList()));
+                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList()));
             }
         }
         return Collections.singletonList(new SchemaMetaData(defaultSchemaName, tableMetaDataList));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/MySQLSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/MySQLSchemaMetaDataLoader.java
@@ -63,7 +63,7 @@ public final class MySQLSchemaMetaDataLoader implements DialectSchemaMetaDataLoa
             + "WHERE TABLE_NAME IN (%s) AND REFERENCED_TABLE_SCHEMA IS NOT NULL";
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(dataSource, tables);
         Map<String, Collection<IndexMetaData>> indexMetaDataMap = columnMetaDataMap.isEmpty() ? Collections.emptyMap() : loadIndexMetaData(dataSource, columnMetaDataMap.keySet());
@@ -71,7 +71,7 @@ public final class MySQLSchemaMetaDataLoader implements DialectSchemaMetaDataLoa
         for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
             Collection<IndexMetaData> indexMetaDataList = indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
             Collection<ConstraintMetaData> constraintMetaDataList = constraintMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
-            tableMetaDataList.add(new TableMetaData(entry.getKey(), dataSourceName, entry.getValue(), indexMetaDataList, constraintMetaDataList));
+            tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, constraintMetaDataList));
         }
         return Collections.singletonList(new SchemaMetaData(defaultSchemaName, tableMetaDataList));
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OpenGaussSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OpenGaussSchemaMetaDataLoader.java
@@ -61,7 +61,7 @@ public final class OpenGaussSchemaMetaDataLoader implements DialectSchemaMetaDat
     private static final String BASIC_INDEX_META_DATA_SQL = "SELECT tablename, indexname, schemaname FROM pg_indexes WHERE schemaname IN (%s)";
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             Collection<String> schemaNames = SchemaMetaDataLoader.loadSchemaNames(connection, TypedSPILoader.getService(DatabaseType.class, "openGauss"));
             Map<String, Multimap<String, IndexMetaData>> schemaIndexMetaDataMap = loadIndexMetaDataMap(connection, schemaNames);
@@ -70,7 +70,7 @@ public final class OpenGaussSchemaMetaDataLoader implements DialectSchemaMetaDat
             for (String each : schemaNames) {
                 Multimap<String, IndexMetaData> tableIndexMetaDataMap = schemaIndexMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
                 Multimap<String, ColumnMetaData> tableColumnMetaDataMap = schemaColumnMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
-                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap, dataSourceName)));
+                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap)));
             }
             return result;
         }
@@ -146,13 +146,12 @@ public final class OpenGaussSchemaMetaDataLoader implements DialectSchemaMetaDat
         return new ColumnMetaData(columnName, dataTypeMap.get(dataType), isPrimaryKey, generated, caseSensitive, true, false);
     }
     
-    private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap,
-                                                              final String dataSourceName) {
+    private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap) {
         Collection<TableMetaData> result = new LinkedList<>();
         for (String each : tableColumnMetaDataMap.keySet()) {
             Collection<ColumnMetaData> columnMetaDataList = tableColumnMetaDataMap.get(each);
             Collection<IndexMetaData> indexMetaDataList = tableIndexMetaDataMap.get(each);
-            result.add(new TableMetaData(each, dataSourceName, columnMetaDataList, indexMetaDataList, Collections.emptyList()));
+            result.add(new TableMetaData(each, columnMetaDataList, indexMetaDataList, Collections.emptyList()));
         }
         return result;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OracleSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OracleSchemaMetaDataLoader.java
@@ -73,7 +73,7 @@ public final class OracleSchemaMetaDataLoader implements DialectSchemaMetaDataLo
     private static final int MAX_EXPRESSION_SIZE = 1000;
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         Map<String, Collection<ColumnMetaData>> columnMetaDataMap = new HashMap<>(tables.size(), 1);
         Map<String, Collection<IndexMetaData>> indexMetaDataMap = new HashMap<>(tables.size(), 1);
         try (Connection connection = new MetaDataLoaderConnectionAdapter(TypedSPILoader.getService(DatabaseType.class, "Oracle"), dataSource.getConnection())) {
@@ -84,7 +84,7 @@ public final class OracleSchemaMetaDataLoader implements DialectSchemaMetaDataLo
         }
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
-            tableMetaDataList.add(new TableMetaData(entry.getKey(), dataSourceName, entry.getValue(), indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList()), Collections.emptyList()));
+            tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList()), Collections.emptyList()));
         }
         // TODO Load views from Oracle database.
         return Collections.singletonList(new SchemaMetaData(defaultSchemaName, tableMetaDataList));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/PostgreSQLSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/PostgreSQLSchemaMetaDataLoader.java
@@ -71,7 +71,7 @@ public final class PostgreSQLSchemaMetaDataLoader implements DialectSchemaMetaDa
     private static final String LOAD_FILTERED_ROLE_TABLE_GRANTS_SQL = LOAD_ALL_ROLE_TABLE_GRANTS_SQL + " WHERE table_name IN (%s)";
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         try (Connection connection = dataSource.getConnection()) {
             Collection<String> schemaNames = SchemaMetaDataLoader.loadSchemaNames(connection, TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"));
             Map<String, Multimap<String, IndexMetaData>> schemaIndexMetaDataMap = loadIndexMetaDataMap(connection, schemaNames);
@@ -82,7 +82,7 @@ public final class PostgreSQLSchemaMetaDataLoader implements DialectSchemaMetaDa
                 Multimap<String, IndexMetaData> tableIndexMetaDataMap = schemaIndexMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
                 Multimap<String, ColumnMetaData> tableColumnMetaDataMap = schemaColumnMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
                 Multimap<String, ConstraintMetaData> tableConstraintMetaDataMap = schemaConstraintMetaDataMap.getOrDefault(each, LinkedHashMultimap.create());
-                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap, tableConstraintMetaDataMap, dataSourceName)));
+                result.add(new SchemaMetaData(each, createTableMetaDataList(tableIndexMetaDataMap, tableColumnMetaDataMap, tableConstraintMetaDataMap)));
             }
             return result;
         }
@@ -197,13 +197,13 @@ public final class PostgreSQLSchemaMetaDataLoader implements DialectSchemaMetaDa
     }
     
     private Collection<TableMetaData> createTableMetaDataList(final Multimap<String, IndexMetaData> tableIndexMetaDataMap, final Multimap<String, ColumnMetaData> tableColumnMetaDataMap,
-                                                              final Multimap<String, ConstraintMetaData> tableConstraintMetaDataMap, final String dataSourceName) {
+                                                              final Multimap<String, ConstraintMetaData> tableConstraintMetaDataMap) {
         Collection<TableMetaData> result = new LinkedList<>();
         for (String each : tableColumnMetaDataMap.keySet()) {
             Collection<ColumnMetaData> columnMetaDataList = tableColumnMetaDataMap.get(each);
             Collection<IndexMetaData> indexMetaDataList = tableIndexMetaDataMap.get(each);
             Collection<ConstraintMetaData> constraintMetaDataList = tableConstraintMetaDataMap.get(each);
-            result.add(new TableMetaData(each, dataSourceName, columnMetaDataList, indexMetaDataList, constraintMetaDataList));
+            result.add(new TableMetaData(each, columnMetaDataList, indexMetaDataList, constraintMetaDataList));
         }
         return result;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/SQLServerSchemaMetaDataLoader.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/SQLServerSchemaMetaDataLoader.java
@@ -63,14 +63,14 @@ public final class SQLServerSchemaMetaDataLoader implements DialectSchemaMetaDat
     private static final int HIDDEN_COLUMN_START_MAJOR_VERSION = 15;
     
     @Override
-    public Collection<SchemaMetaData> load(final DataSource dataSource, final String dataSourceName, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
+    public Collection<SchemaMetaData> load(final DataSource dataSource, final Collection<String> tables, final String defaultSchemaName) throws SQLException {
         Collection<TableMetaData> tableMetaDataList = new LinkedList<>();
         Map<String, Collection<ColumnMetaData>> columnMetaDataMap = loadColumnMetaDataMap(dataSource, tables);
         if (!columnMetaDataMap.isEmpty()) {
             Map<String, Collection<IndexMetaData>> indexMetaDataMap = loadIndexMetaData(dataSource, columnMetaDataMap.keySet());
             for (Entry<String, Collection<ColumnMetaData>> entry : columnMetaDataMap.entrySet()) {
                 Collection<IndexMetaData> indexMetaDataList = indexMetaDataMap.getOrDefault(entry.getKey(), Collections.emptyList());
-                tableMetaDataList.add(new TableMetaData(entry.getKey(), dataSourceName, entry.getValue(), indexMetaDataList, Collections.emptyList()));
+                tableMetaDataList.add(new TableMetaData(entry.getKey(), entry.getValue(), indexMetaDataList, Collections.emptyList()));
             }
         }
         return Collections.singletonList(new SchemaMetaData(defaultSchemaName, tableMetaDataList));

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/model/TableMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/model/TableMetaData.java
@@ -35,8 +35,6 @@ public final class TableMetaData {
     
     private final String name;
     
-    private final String dataSourceName;
-    
     private final Collection<ColumnMetaData> columns;
     
     private final Collection<IndexMetaData> indexes;

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEntry.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/MetaDataReviseEntry.java
@@ -97,10 +97,9 @@ public interface MetaDataReviseEntry<T extends ShardingSphereRule> extends Order
      *
      * @param rule rule
      * @param tableName table name
-     * @param dataSourceName data source name
      * @return column generated reviser
      */
-    default Optional<? extends ColumnGeneratedReviser> getColumnGeneratedReviser(final T rule, final String dataSourceName, final String tableName) {
+    default Optional<? extends ColumnGeneratedReviser> getColumnGeneratedReviser(final T rule, final String tableName) {
         return Optional.empty();
     }
     
@@ -109,10 +108,9 @@ public interface MetaDataReviseEntry<T extends ShardingSphereRule> extends Order
      *
      * @param rule rule
      * @param tableName table name
-     * @param dataSourceName data source name
      * @return index reviser
      */
-    default Optional<? extends IndexReviser<T>> getIndexReviser(final T rule, final String dataSourceName, final String tableName) {
+    default Optional<? extends IndexReviser<T>> getIndexReviser(final T rule, final String tableName) {
         return Optional.empty();
     }
     
@@ -121,10 +119,9 @@ public interface MetaDataReviseEntry<T extends ShardingSphereRule> extends Order
      *
      * @param rule rule
      * @param tableName table name
-     * @param dataSourceName data source name
      * @return constraint reviser
      */
-    default Optional<? extends ConstraintReviser<T>> getConstraintReviser(final T rule, final String dataSourceName, final String tableName) {
+    default Optional<? extends ConstraintReviser<T>> getConstraintReviser(final T rule, final String tableName) {
         return Optional.empty();
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/column/ColumnReviseEngine.java
@@ -46,17 +46,16 @@ public final class ColumnReviseEngine<T extends ShardingSphereRule> {
     
     /**
      * Revise column meta data.
-     *
+     * 
      * @param tableName table name
      * @param originalMetaDataList original column meta data list
-     * @param dataSourceName data source name
      * @return revised column meta data
      */
-    public Collection<ColumnMetaData> revise(final String tableName, final Collection<ColumnMetaData> originalMetaDataList, final String dataSourceName) {
+    public Collection<ColumnMetaData> revise(final String tableName, final Collection<ColumnMetaData> originalMetaDataList) {
         Optional<? extends ColumnExistedReviser> existedReviser = reviseEntry.getColumnExistedReviser(rule, tableName);
         Optional<? extends ColumnNameReviser> nameReviser = reviseEntry.getColumnNameReviser(rule, tableName);
         Optional<? extends ColumnDataTypeReviser> dataTypeReviser = reviseEntry.getColumnDataTypeReviser(rule, tableName);
-        Optional<? extends ColumnGeneratedReviser> generatedReviser = reviseEntry.getColumnGeneratedReviser(rule, dataSourceName, tableName);
+        Optional<? extends ColumnGeneratedReviser> generatedReviser = reviseEntry.getColumnGeneratedReviser(rule, tableName);
         Collection<ColumnMetaData> result = new LinkedHashSet<>();
         for (ColumnMetaData each : originalMetaDataList) {
             if (existedReviser.isPresent() && !existedReviser.get().isExisted(each.getName())) {

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/constraint/ConstraintReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/constraint/ConstraintReviseEngine.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.reviser.constraint;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
 import java.util.Collection;
@@ -41,17 +41,16 @@ public final class ConstraintReviseEngine<T extends ShardingSphereRule> {
     
     /**
      * Revise constraint meta data.
-     *
+     * 
      * @param tableName table name
      * @param originalMetaDataList original constraint meta data list
-     * @param dataSourceName data source name
      * @return revised constraint meta data
      */
-    public Collection<ConstraintMetaData> revise(final String tableName, final Collection<ConstraintMetaData> originalMetaDataList, final String dataSourceName) {
-        Optional<? extends ConstraintReviser<T>> reviser = reviseEntry.getConstraintReviser(rule, dataSourceName, tableName);
+    public Collection<ConstraintMetaData> revise(final String tableName, final Collection<ConstraintMetaData> originalMetaDataList) {
+        Optional<? extends ConstraintReviser<T>> reviser = reviseEntry.getConstraintReviser(rule, tableName);
         return reviser.isPresent()
                 ? originalMetaDataList.stream()
-                        .map(each -> reviser.get().revise(dataSourceName, tableName, each, rule)).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toCollection(LinkedHashSet::new))
+                        .map(each -> reviser.get().revise(tableName, each, rule)).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toCollection(LinkedHashSet::new))
                 : originalMetaDataList;
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/constraint/ConstraintReviser.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/constraint/ConstraintReviser.java
@@ -31,12 +31,11 @@ public interface ConstraintReviser<T extends ShardingSphereRule> {
     
     /**
      * Revise constraint meta data.
-     *
-     * @param dataSourceName data source name
+     * 
      * @param tableName table name
      * @param originalMetaData original constraint meta data
      * @param rule rule
      * @return revised constraint meta data
      */
-    Optional<ConstraintMetaData> revise(String dataSourceName, String tableName, ConstraintMetaData originalMetaData, T rule);
+    Optional<ConstraintMetaData> revise(String tableName, ConstraintMetaData originalMetaData, T rule);
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/index/IndexReviseEngine.java
@@ -18,8 +18,8 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.reviser.index;
 
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.reviser.MetaDataReviseEntry;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.IndexMetaData;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 
 import java.util.Collection;
@@ -41,14 +41,13 @@ public final class IndexReviseEngine<T extends ShardingSphereRule> {
     
     /**
      * Revise index meta data.
-     *
+     * 
      * @param tableName table name
      * @param originalMetaDataList original index meta data list
-     * @param dataSourceName data source name
      * @return revised index meta data
      */
-    public Collection<IndexMetaData> revise(final String tableName, final Collection<IndexMetaData> originalMetaDataList, final String dataSourceName) {
-        Optional<? extends IndexReviser<T>> reviser = reviseEntry.getIndexReviser(rule, dataSourceName, tableName);
+    public Collection<IndexMetaData> revise(final String tableName, final Collection<IndexMetaData> originalMetaDataList) {
+        Optional<? extends IndexReviser<T>> reviser = reviseEntry.getIndexReviser(rule, tableName);
         return reviser.isPresent()
                 ? originalMetaDataList.stream()
                         .map(each -> reviser.get().revise(tableName, each, rule)).filter(Optional::isPresent).map(Optional::get).collect(Collectors.toCollection(LinkedHashSet::new))

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableMetaDataReviseEngine.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableMetaDataReviseEngine.java
@@ -53,10 +53,9 @@ public final class TableMetaDataReviseEngine<T extends ShardingSphereRule> {
      */
     public TableMetaData revise(final TableMetaData originalMetaData) {
         Optional<? extends TableNameReviser<T>> tableNameReviser = reviseEntry.getTableNameReviser();
-        String revisedTableName = tableNameReviser.map(optional -> optional.revise(originalMetaData.getName(), originalMetaData.getDataSourceName(), rule)).orElse(originalMetaData.getName());
-        return new TableMetaData(revisedTableName, originalMetaData.getDataSourceName(),
-                new ColumnReviseEngine<>(rule, databaseType, dataSource, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getColumns(), originalMetaData.getDataSourceName()),
-                new IndexReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getIndexes(), originalMetaData.getDataSourceName()),
-                new ConstraintReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getConstrains(), originalMetaData.getDataSourceName()));
+        String revisedTableName = tableNameReviser.map(optional -> optional.revise(originalMetaData.getName(), rule)).orElse(originalMetaData.getName());
+        return new TableMetaData(revisedTableName, new ColumnReviseEngine<>(rule, databaseType, dataSource, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getColumns()),
+                new IndexReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getIndexes()),
+                new ConstraintReviseEngine<>(rule, reviseEntry).revise(originalMetaData.getName(), originalMetaData.getConstrains()));
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableNameReviser.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/reviser/table/TableNameReviser.java
@@ -28,11 +28,10 @@ public interface TableNameReviser<T extends ShardingSphereRule> {
     
     /**
      * Revise table meta data.
-     *
+     * 
      * @param originalName original table name
-     * @param dataSourceName data source name
      * @param rule rule
      * @return revised table name
      */
-    String revise(String originalName, String dataSourceName, T rule);
+    String revise(String originalName, T rule);
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SchemaMetaDataUtils.java
@@ -28,12 +28,13 @@ import org.apache.shardingsphere.infra.metadata.database.schema.exception.Unsupp
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.SchemaMetaDataLoaderMaterial;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 
+import javax.sql.DataSource;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Schema meta data utility class.
@@ -62,22 +63,12 @@ public final class SchemaMetaDataUtils {
                 addOneActualTableDataNode(material, dataSourceTableGroups, dataNodes, each);
             }
         }
-        return createSchemaMetaDataLoaderMaterials(dataSourceTableGroups, material);
+        return dataSourceTableGroups.entrySet().stream().map(entry -> new SchemaMetaDataLoaderMaterial(entry.getValue(),
+                getDataSource(material, entry.getKey()), material.getStorageTypes().get(entry.getKey()), material.getDefaultSchemaName())).collect(Collectors.toList());
     }
     
-    private static Collection<SchemaMetaDataLoaderMaterial> createSchemaMetaDataLoaderMaterials(final Map<String, Collection<String>> dataSourceTableGroups,
-                                                                                                final GenericSchemaBuilderMaterial material) {
-        Collection<SchemaMetaDataLoaderMaterial> result = new LinkedList<>();
-        for (Entry<String, Collection<String>> entry : dataSourceTableGroups.entrySet()) {
-            String dataSourceName = getDataSourceName(entry.getKey());
-            result.add(new SchemaMetaDataLoaderMaterial(entry.getValue(), dataSourceName, material.getDataSourceMap().get(dataSourceName), material.getStorageTypes().get(entry.getKey()),
-                    material.getDefaultSchemaName()));
-        }
-        return result;
-    }
-    
-    private static String getDataSourceName(final String dataSourceName) {
-        return dataSourceName.contains(".") ? dataSourceName.split("\\.")[0] : dataSourceName;
+    private static DataSource getDataSource(final GenericSchemaBuilderMaterial material, final String dataSourceName) {
+        return material.getDataSourceMap().get(dataSourceName.contains(".") ? dataSourceName.split("\\.")[0] : dataSourceName);
     }
     
     private static void checkDataSourceTypeIncludeInstanceAndSetDatabaseTableMap(final Collection<DatabaseType> notSupportThreeTierStructureStorageTypes, final DataNodes dataNodes,

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/GenericSchemaBuilderTest.java
@@ -88,7 +88,7 @@ class GenericSchemaBuilderTest {
     private Map<String, SchemaMetaData> createSchemaMetaDataMap(final Collection<String> tableNames, final GenericSchemaBuilderMaterial material) {
         if (!tableNames.isEmpty() && (tableNames.contains("data_node_routed_table1") || tableNames.contains("data_node_routed_table2"))) {
             Collection<TableMetaData> tableMetaDataList = tableNames.stream()
-                    .map(each -> new TableMetaData(each, "ds_0", Collections.emptyList(), Collections.emptyList(), Collections.emptyList())).collect(Collectors.toList());
+                    .map(each -> new TableMetaData(each, Collections.emptyList(), Collections.emptyList(), Collections.emptyList())).collect(Collectors.toList());
             return Collections.singletonMap(material.getDefaultSchemaName(), new SchemaMetaData(material.getDefaultSchemaName(), tableMetaDataList));
         }
         return Collections.emptyMap();

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/common/TableMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/common/TableMetaDataLoaderTest.java
@@ -109,9 +109,8 @@ class TableMetaDataLoaderTest {
         DatabaseType databaseType = mock(DatabaseType.class, RETURNS_DEEP_STUBS);
         when(databaseType.formatTableNamePattern(TEST_TABLE)).thenReturn(TEST_TABLE);
         Map<String, SchemaMetaData> actual = SchemaMetaDataLoaderEngine.load(Collections.singletonList(
-                new SchemaMetaDataLoaderMaterial(Collections.singletonList(TEST_TABLE), "ds_0", dataSource, databaseType, "sharding_db")));
+                new SchemaMetaDataLoaderMaterial(Collections.singletonList(TEST_TABLE), dataSource, databaseType, "sharding_db")));
         TableMetaData tableMetaData = actual.get("sharding_db").getTables().iterator().next();
-        assertThat(tableMetaData.getDataSourceName(), is("ds_0"));
         Collection<ColumnMetaData> columns = tableMetaData.getColumns();
         assertThat(columns.size(), is(2));
         Iterator<ColumnMetaData> columnsIterator = columns.iterator();
@@ -133,7 +132,7 @@ class TableMetaDataLoaderTest {
     @Test
     void assertLoadWithNotExistedTable() throws SQLException {
         Map<String, SchemaMetaData> actual = SchemaMetaDataLoaderEngine.load(Collections.singletonList(
-                new SchemaMetaDataLoaderMaterial(Collections.singletonList(TEST_TABLE), "ds_0", dataSource, mock(DatabaseType.class), "sharding_db")));
+                new SchemaMetaDataLoaderMaterial(Collections.singletonList(TEST_TABLE), dataSource, mock(DatabaseType.class), "sharding_db")));
         assertFalse(actual.isEmpty());
         assertTrue(actual.containsKey("sharding_db"));
         assertTrue(actual.get("sharding_db").getTables().isEmpty());

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/H2SchemaMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/H2SchemaMetaDataLoaderTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.dialect;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.DialectSchemaMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.SchemaMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.TableMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.DialectSchemaMetaDataLoader;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
@@ -64,7 +64,7 @@ class H2SchemaMetaDataLoaderTest {
                 "SELECT C.TABLE_NAME TABLE_NAME, C.COLUMN_NAME COLUMN_NAME, COALESCE(I.IS_GENERATED, FALSE) IS_GENERATED FROM INFORMATION_SCHEMA.COLUMNS C RIGHT JOIN"
                         + " INFORMATION_SCHEMA.INDEXES I ON C.TABLE_NAME=I.TABLE_NAME WHERE C.TABLE_CATALOG=? AND C.TABLE_SCHEMA=?")
                 .executeQuery()).thenReturn(generatedInfo);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.emptyList(), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.emptyList(), "sharding_db"));
     }
     
     @Test
@@ -88,7 +88,7 @@ class H2SchemaMetaDataLoaderTest {
                 "SELECT C.TABLE_NAME TABLE_NAME, C.COLUMN_NAME COLUMN_NAME, COALESCE(I.IS_GENERATED, FALSE) IS_GENERATED FROM INFORMATION_SCHEMA.COLUMNS C"
                         + " RIGHT JOIN INFORMATION_SCHEMA.INDEXES I ON C.TABLE_NAME=I.TABLE_NAME WHERE C.TABLE_CATALOG=? AND C.TABLE_SCHEMA=? AND C.TABLE_NAME IN ('tbl')")
                 .executeQuery()).thenReturn(generatedInfo);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singletonList("tbl"), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.singletonList("tbl"), "sharding_db"));
     }
     
     private DataSource mockDataSource() throws SQLException {
@@ -160,6 +160,5 @@ class H2SchemaMetaDataLoaderTest {
         assertThat(actualTableMetaData.getIndexes().size(), is(1));
         Iterator<IndexMetaData> indexesIterator = actualTableMetaData.getIndexes().iterator();
         assertThat(indexesIterator.next(), is(new IndexMetaData("id")));
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/MySQLSchemaMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/MySQLSchemaMetaDataLoaderTest.java
@@ -54,7 +54,7 @@ class MySQLSchemaMetaDataLoaderTest {
         ResultSet indexResultSet = mockIndexMetaDataResultSet();
         when(dataSource.getConnection().prepareStatement("SELECT TABLE_NAME, INDEX_NAME "
                 + "FROM information_schema.statistics WHERE TABLE_SCHEMA=? and TABLE_NAME IN ('tbl')").executeQuery()).thenReturn(indexResultSet);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.emptyList(), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.emptyList(), "sharding_db"));
     }
     
     @Test
@@ -68,7 +68,7 @@ class MySQLSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(
                 "SELECT TABLE_NAME, INDEX_NAME FROM information_schema.statistics WHERE TABLE_SCHEMA=? and TABLE_NAME IN ('tbl')")
                 .executeQuery()).thenReturn(indexResultSet);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singletonList("tbl"), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.singletonList("tbl"), "sharding_db"));
     }
     
     private DataSource mockDataSource() throws SQLException {
@@ -118,7 +118,6 @@ class MySQLSchemaMetaDataLoaderTest {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
         assertThat(actualTableMetaData.getColumns().size(), is(9));
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
         assertThat(columnsIterator.next(), is(new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false)));
         assertThat(columnsIterator.next(), is(new ColumnMetaData("name", Types.VARCHAR, false, false, false, false, false)));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OracleSchemaMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/OracleSchemaMetaDataLoaderTest.java
@@ -84,10 +84,9 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITHOUT_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(12);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(2);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
         assertThat(columnsIterator.next(), is(new ColumnMetaData("id", Types.INTEGER, false, true, true, true, false)));
         assertThat(columnsIterator.next(), is(new ColumnMetaData("name", Types.VARCHAR, false, false, false, false, false)));
@@ -104,7 +103,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITHOUT_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(12);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(1);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -123,7 +122,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITHOUT_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(11);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(2);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -142,7 +141,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITH_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(12);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(2);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -161,7 +160,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITH_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(12);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(1);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -180,7 +179,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITH_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(11);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(2);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -199,7 +198,7 @@ class OracleSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(ALL_CONSTRAINTS_SQL_WITH_TABLES).executeQuery()).thenReturn(primaryKeys);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(12);
         when(dataSource.getConnection().getMetaData().getDatabaseMinorVersion()).thenReturn(2);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singleton("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singleton("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -273,7 +272,6 @@ class OracleSchemaMetaDataLoaderTest {
     private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList) {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
         assertThat(actualTableMetaData.getColumns().size(), is(3));
         assertThat(actualTableMetaData.getIndexes().size(), is(1));
         Iterator<IndexMetaData> indexesIterator = actualTableMetaData.getIndexes().iterator();

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/PostgreSQLSchemaMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/PostgreSQLSchemaMetaDataLoaderTest.java
@@ -81,7 +81,7 @@ class PostgreSQLSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(BASIC_CONSTRAINT_META_DATA_SQL).executeQuery()).thenReturn(constraintResultSet);
         ResultSet roleTableGrantsResultSet = mockRoleTableGrantsResultSet();
         when(dataSource.getConnection().prepareStatement(startsWith(LOAD_ALL_ROLE_TABLE_GRANTS_SQL)).executeQuery()).thenReturn(roleTableGrantsResultSet);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.emptyList(), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.emptyList(), "sharding_db"));
     }
     
     private ResultSet mockSchemaMetaDataResultSet() throws SQLException {
@@ -106,7 +106,7 @@ class PostgreSQLSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(BASIC_CONSTRAINT_META_DATA_SQL).executeQuery()).thenReturn(constraintResultSet);
         ResultSet roleTableGrantsResultSet = mockRoleTableGrantsResultSet();
         when(dataSource.getConnection().prepareStatement(startsWith(LOAD_ALL_ROLE_TABLE_GRANTS_SQL)).executeQuery()).thenReturn(roleTableGrantsResultSet);
-        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singletonList("tbl"), "sharding_db"));
+        assertTableMetaDataMap(getDialectTableMetaDataLoader().load(dataSource, Collections.singletonList("tbl"), "sharding_db"));
     }
     
     private ResultSet mockRoleTableGrantsResultSet() throws SQLException {
@@ -182,7 +182,6 @@ class PostgreSQLSchemaMetaDataLoaderTest {
     private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList) {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
         assertThat(actualTableMetaData.getColumns().size(), is(2));
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
         assertThat(columnsIterator.next(), is(new ColumnMetaData("id", Types.INTEGER, true, true, true, true, false)));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/SQLServerSchemaMetaDataLoaderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/loader/metadata/dialect/SQLServerSchemaMetaDataLoaderTest.java
@@ -18,11 +18,11 @@
 package org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.dialect;
 
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.DialectSchemaMetaDataLoader;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ColumnMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.IndexMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.SchemaMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.TableMetaData;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.metadata.DialectSchemaMetaDataLoader;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +85,7 @@ class SQLServerSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(LOAD_INDEX_META_DATA)
                 .executeQuery()).thenReturn(indexResultSet);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(15);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.emptyList(), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.emptyList(), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -103,7 +103,7 @@ class SQLServerSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(LOAD_INDEX_META_DATA)
                 .executeQuery()).thenReturn(indexResultSet);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(14);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.emptyList(), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.emptyList(), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -120,7 +120,7 @@ class SQLServerSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(LOAD_INDEX_META_DATA)
                 .executeQuery()).thenReturn(indexResultSet);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(15);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singletonList("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singletonList("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -137,7 +137,7 @@ class SQLServerSchemaMetaDataLoaderTest {
         when(dataSource.getConnection().prepareStatement(LOAD_INDEX_META_DATA)
                 .executeQuery()).thenReturn(indexResultSet);
         when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(14);
-        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, "ds_0", Collections.singletonList("tbl"), "sharding_db");
+        Collection<SchemaMetaData> actual = getDialectTableMetaDataLoader().load(dataSource, Collections.singletonList("tbl"), "sharding_db");
         assertTableMetaDataMap(actual);
         TableMetaData actualTableMetaData = actual.iterator().next().getTables().iterator().next();
         Iterator<ColumnMetaData> columnsIterator = actualTableMetaData.getColumns().iterator();
@@ -199,7 +199,6 @@ class SQLServerSchemaMetaDataLoaderTest {
     private void assertTableMetaDataMap(final Collection<SchemaMetaData> schemaMetaDataList) {
         assertThat(schemaMetaDataList.size(), is(1));
         TableMetaData actualTableMetaData = schemaMetaDataList.iterator().next().getTables().iterator().next();
-        assertThat(actualTableMetaData.getDataSourceName(), is("ds_0"));
         assertThat(actualTableMetaData.getColumns().size(), is(2));
         assertThat(actualTableMetaData.getIndexes().size(), is(1));
         Iterator<IndexMetaData> indexesIterator = actualTableMetaData.getIndexes().iterator();

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/TableMetaDataTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/model/TableMetaDataTest.java
@@ -36,8 +36,7 @@ class TableMetaDataTest {
     
     @BeforeEach
     void setUp() {
-        tableMetaData =
-                new TableMetaData(null, "ds_0", Collections.singletonList(new ColumnMetaData("test", Types.INTEGER, true, false, true, true, false)), Collections.emptyList(), Collections.emptyList());
+        tableMetaData = new TableMetaData(null, Collections.singletonList(new ColumnMetaData("test", Types.INTEGER, true, false, true, true, false)), Collections.emptyList(), Collections.emptyList());
     }
     
     @Test

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/DatabaseMetaDataResultSet.java
@@ -18,9 +18,9 @@
 package org.apache.shardingsphere.driver.jdbc.core.resultset;
 
 import lombok.EqualsAndHashCode;
-import org.apache.shardingsphere.driver.jdbc.exception.connection.ResultSetClosedException;
 import org.apache.shardingsphere.driver.jdbc.exception.syntax.ColumnIndexOutOfRangeException;
 import org.apache.shardingsphere.driver.jdbc.exception.syntax.ColumnLabelNotFoundException;
+import org.apache.shardingsphere.driver.jdbc.exception.connection.ResultSetClosedException;
 import org.apache.shardingsphere.driver.jdbc.unsupported.AbstractUnsupportedDatabaseMetaDataResultSet;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.util.ResultSetUtils;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/metadata/reviser/SingleMetaDataReviseEntry.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/metadata/reviser/SingleMetaDataReviseEntry.java
@@ -31,12 +31,12 @@ import java.util.Optional;
 public final class SingleMetaDataReviseEntry implements MetaDataReviseEntry<SingleRule> {
     
     @Override
-    public Optional<SingleIndexReviser> getIndexReviser(final SingleRule rule, final String dataSourceName, final String tableName) {
+    public Optional<SingleIndexReviser> getIndexReviser(final SingleRule rule, final String tableName) {
         return Optional.of(new SingleIndexReviser());
     }
     
     @Override
-    public Optional<SingleConstraintReviser> getConstraintReviser(final SingleRule rule, final String dataSourceName, final String tableName) {
+    public Optional<SingleConstraintReviser> getConstraintReviser(final SingleRule rule, final String tableName) {
         return Optional.of(new SingleConstraintReviser());
     }
     

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/metadata/reviser/constraint/SingleConstraintReviser.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/metadata/reviser/constraint/SingleConstraintReviser.java
@@ -17,8 +17,8 @@
 
 package org.apache.shardingsphere.single.metadata.reviser.constraint;
 
-import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.reviser.constraint.ConstraintReviser;
+import org.apache.shardingsphere.infra.metadata.database.schema.loader.model.ConstraintMetaData;
 import org.apache.shardingsphere.infra.metadata.database.schema.util.IndexMetaDataUtils;
 import org.apache.shardingsphere.single.rule.SingleRule;
 
@@ -30,7 +30,7 @@ import java.util.Optional;
 public final class SingleConstraintReviser implements ConstraintReviser<SingleRule> {
     
     @Override
-    public Optional<ConstraintMetaData> revise(final String dataSourceName, final String tableName, final ConstraintMetaData originalMetaData, final SingleRule rule) {
+    public Optional<ConstraintMetaData> revise(final String tableName, final ConstraintMetaData originalMetaData, final SingleRule rule) {
         return Optional.of(new ConstraintMetaData(IndexMetaDataUtils.getLogicIndexName(originalMetaData.getName(), tableName), originalMetaData.getReferencedTableName()));
     }
 }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/metadata/SingleMetaDataReviseEngineTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/metadata/SingleMetaDataReviseEngineTest.java
@@ -61,6 +61,6 @@ class SingleMetaDataReviseEngineTest {
                 new ColumnMetaData("name", Types.VARCHAR, false, false, false, true, false),
                 new ColumnMetaData("doc", Types.LONGVARCHAR, false, false, false, true, false));
         Collection<IndexMetaData> indexMetaDataList = Arrays.asList(new IndexMetaData("id_" + TABLE_NAME), new IndexMetaData("idx_name_" + TABLE_NAME));
-        return new TableMetaData(TABLE_NAME, "ds_0", columns, indexMetaDataList, Collections.emptyList());
+        return new TableMetaData(TABLE_NAME, columns, indexMetaDataList, Collections.emptyList());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1085,6 +1085,7 @@
     
     <reporting>
         <plugins>
+
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>


### PR DESCRIPTION
This reverts commit 6fea4ec5bf9b69b12b3e1dbf92e23f75ffc14d7f.

Ref #24982.

Changes proposed in this pull request:
  - Revert "Fix wrong logic table metadata when config same actual table name in different storage unit  (#25037)"

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
