### PR TITLE
Fix object not found exception when config opengauss schema name as database name

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SystemSchemaUtils.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SystemSchemaUtils.java
@@ -48,6 +48,6 @@ public final class SystemSchemaUtils {
                 return true;
             }
         }
-        return databaseType.getSystemSchemas().contains(database.getName());
+        return databaseType instanceof SchemaSupportedDatabaseType ? false : databaseType.getSystemSchemas().contains(database.getName());
     }
 }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SystemSchemaUtilsTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/util/SystemSchemaUtilsTest.java
@@ -51,6 +51,8 @@ class SystemSchemaUtilsTest {
         assertFalse(SystemSchemaUtils.containsSystemSchema(new OpenGaussDatabaseType(), Collections.singletonList("sharding_db"), shardingSchemaDatabase));
         ShardingSphereDatabase customizedInformationSchemaDatabase = mockShardingSphereDatabase("information_schema", true);
         assertTrue(SystemSchemaUtils.containsSystemSchema(new OpenGaussDatabaseType(), Arrays.asList("information_schema", "pg_catalog"), customizedInformationSchemaDatabase));
+        ShardingSphereDatabase customizedGaussDBDatabase = mockShardingSphereDatabase("gaussdb", true);
+        assertFalse(SystemSchemaUtils.containsSystemSchema(new OpenGaussDatabaseType(), Collections.emptyList(), customizedGaussDBDatabase));
     }
     
     @Test


### PR DESCRIPTION
Fixes #25109.

Changes proposed in this pull request:
  - fix object not found exception when config opengauss schema name as database name

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
