### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -54,9 +54,9 @@ public enum SystemSchemaBuilderRule {
     
     MYSQL_PERFORMANCE_SCHEMA("MySQL", "performance_schema", new HashSet<>(Arrays.asList("accounts", "cond_instances", "events_stages_current", "events_stages_history", "events_stages_history_long",
             "events_stages_summary_by_account_by_event_name", "events_stages_summary_by_host_by_event_name", "events_stages_summary_by_thread_by_event_name",
-            "events_stages_summary_by_user_by_event_name", "events_statements_current", "events_statements_history", "events_statements_history_long", "events_statements_summary_by_account_by_event_name",
-            "events_statements_summary_by_digest", "events_statements_summary_by_host_by_event_name", "events_statements_summary_by_program", "events_statements_summary_by_thread_by_event_name",
-            "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name"))),
+            "events_stages_summary_by_user_by_event_name", "events_statements_current", "events_statements_history", "events_statements_history_long",
+            "events_statements_summary_by_account_by_event_name", "events_statements_summary_by_digest", "events_statements_summary_by_host_by_event_name", "events_statements_summary_by_program",
+            "events_statements_summary_by_thread_by_event_name", "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -54,7 +54,9 @@ public enum SystemSchemaBuilderRule {
     
     MYSQL_PERFORMANCE_SCHEMA("MySQL", "performance_schema", new HashSet<>(Arrays.asList("accounts", "cond_instances", "events_stages_current", "events_stages_history", "events_stages_history_long",
             "events_stages_summary_by_account_by_event_name", "events_stages_summary_by_host_by_event_name", "events_stages_summary_by_thread_by_event_name",
-            "events_stages_summary_by_user_by_event_name"))),
+            "events_stages_summary_by_user_by_event_name", "events_statements_current", "events_statements_history", "events_statements_history_long", "events_statements_summary_by_account_by_event_name",
+            "events_statements_summary_by_digest", "events_statements_summary_by_host_by_event_name", "events_statements_summary_by_program", "events_statements_summary_by_thread_by_event_name",
+            "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_current.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_current.yaml
@@ -1,0 +1,347 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_current
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sql_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: SQL_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: DIGEST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: DIGEST_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  current_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: CURRENT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  mysql_errno:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MYSQL_ERRNO
+    primaryKey: false
+    unsigned: false
+    visible: true
+  returned_sqlstate:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: RETURNED_SQLSTATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  message_text:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: MESSAGE_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  nesting_event_level:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_history.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_history.yaml
@@ -1,0 +1,347 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_history
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sql_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: SQL_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: DIGEST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: DIGEST_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  current_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: CURRENT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  mysql_errno:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MYSQL_ERRNO
+    primaryKey: false
+    unsigned: false
+    visible: true
+  returned_sqlstate:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: RETURNED_SQLSTATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  message_text:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: MESSAGE_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  nesting_event_level:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_history_long.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_history_long.yaml
@@ -1,0 +1,347 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_history_long
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sql_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: SQL_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: DIGEST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: DIGEST_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  current_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: CURRENT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  mysql_errno:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MYSQL_ERRNO
+    primaryKey: false
+    unsigned: false
+    visible: true
+  returned_sqlstate:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: RETURNED_SQLSTATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  message_text:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: MESSAGE_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  nesting_event_level:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_account_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_account_by_event_name.yaml
@@ -1,0 +1,235 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_account_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_digest.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_digest.yaml
@@ -1,0 +1,251 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_digest
+columns:
+  schema_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SCHEMA_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: DIGEST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  digest_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: DIGEST_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  first_seen:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: FIRST_SEEN
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_seen:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: LAST_SEEN
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_host_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_host_by_event_name.yaml
@@ -1,0 +1,227 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_host_by_event_name
+columns:
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_program.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_program.yaml
@@ -1,0 +1,275 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_program
+columns:
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_statements:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STATEMENTS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_statements_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_STATEMENTS_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_statements_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_STATEMENTS_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_statements_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_STATEMENTS_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_statements_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_STATEMENTS_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_thread_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_thread_by_event_name.yaml
@@ -1,0 +1,227 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_thread_by_event_name
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_user_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_by_user_by_event_name.yaml
@@ -1,0 +1,227 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_by_user_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_global_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_statements_summary_global_by_event_name.yaml
@@ -1,0 +1,219 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_statements_summary_global_by_event_name
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(9));
+        assertThat(actualPerformanceSchema.getTables().size(), is(19));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(9));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(19));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_current.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_current.xml
@@ -1,0 +1,62 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="lock_time" />
+        <column name="sql_text" />
+        <column name="digest" />
+        <column name="digest_text" />
+        <column name="current_schema" />
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="object_instance_begin" />
+        <column name="mysql_errno" />
+        <column name="returned_sqlstate" />
+        <column name="message_text" />
+        <column name="errors" />
+        <column name="warnings" />
+        <column name="rows_affected" />
+        <column name="rows_sent" />
+        <column name="rows_examined" />
+        <column name="created_tmp_disk_tables" />
+        <column name="created_tmp_tables" />
+        <column name="select_full_join" />
+        <column name="select_full_range_join" />
+        <column name="select_range" />
+        <column name="select_range_check" />
+        <column name="select_scan" />
+        <column name="sort_merge_passes" />
+        <column name="sort_range" />
+        <column name="sort_rows" />
+        <column name="sort_scan" />
+        <column name="no_index_used" />
+        <column name="no_good_index_used" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="nesting_event_level" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_history.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_history.xml
@@ -1,0 +1,62 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="lock_time" />
+        <column name="sql_text" />
+        <column name="digest" />
+        <column name="digest_text" />
+        <column name="current_schema" />
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="object_instance_begin" />
+        <column name="mysql_errno" />
+        <column name="returned_sqlstate" />
+        <column name="message_text" />
+        <column name="errors" />
+        <column name="warnings" />
+        <column name="rows_affected" />
+        <column name="rows_sent" />
+        <column name="rows_examined" />
+        <column name="created_tmp_disk_tables" />
+        <column name="created_tmp_tables" />
+        <column name="select_full_join" />
+        <column name="select_full_range_join" />
+        <column name="select_range" />
+        <column name="select_range_check" />
+        <column name="select_scan" />
+        <column name="sort_merge_passes" />
+        <column name="sort_range" />
+        <column name="sort_rows" />
+        <column name="sort_scan" />
+        <column name="no_index_used" />
+        <column name="no_good_index_used" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="nesting_event_level" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_history_long.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_history_long.xml
@@ -1,0 +1,62 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="lock_time" />
+        <column name="sql_text" />
+        <column name="digest" />
+        <column name="digest_text" />
+        <column name="current_schema" />
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="object_instance_begin" />
+        <column name="mysql_errno" />
+        <column name="returned_sqlstate" />
+        <column name="message_text" />
+        <column name="errors" />
+        <column name="warnings" />
+        <column name="rows_affected" />
+        <column name="rows_sent" />
+        <column name="rows_examined" />
+        <column name="created_tmp_disk_tables" />
+        <column name="created_tmp_tables" />
+        <column name="select_full_join" />
+        <column name="select_full_range_join" />
+        <column name="select_range" />
+        <column name="select_range_check" />
+        <column name="select_scan" />
+        <column name="sort_merge_passes" />
+        <column name="sort_range" />
+        <column name="sort_rows" />
+        <column name="sort_scan" />
+        <column name="no_index_used" />
+        <column name="no_good_index_used" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="nesting_event_level" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_account_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_account_by_event_name.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_digest.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_digest.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="schema_name" />
+        <column name="digest" />
+        <column name="digest_text" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+        <column name="first_seen" />
+        <column name="last_seen" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_host_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_host_by_event_name.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_program.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_program.xml
@@ -1,0 +1,53 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_statements" />
+        <column name="sum_statements_wait" />
+        <column name="min_statements_wait" />
+        <column name="avg_statements_wait" />
+        <column name="max_statements_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_thread_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_thread_by_event_name.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_user_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_by_user_by_event_name.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_global_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_statements_summary_global_by_event_name.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -408,4 +408,44 @@
     <test-case sql="SELECT * FROM performance_schema.events_stages_summary_global_by_event_name" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_events_stages_summary_global_by_event_name.xml" />
     </test-case>
+
+    <test-case sql="SELECT * FROM performance_schema.events_statements_current" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_current.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_history" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_history.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_history_long" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_history_long.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_account_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_account_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_digest" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_digest.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_host_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_host_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_program" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_program.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_thread_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_thread_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_by_user_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_by_user_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_statements_summary_global_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_global_by_event_name.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [v] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
