### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -56,7 +56,10 @@ public enum SystemSchemaBuilderRule {
             "events_stages_summary_by_account_by_event_name", "events_stages_summary_by_host_by_event_name", "events_stages_summary_by_thread_by_event_name",
             "events_stages_summary_by_user_by_event_name", "events_statements_current", "events_statements_history", "events_statements_history_long",
             "events_statements_summary_by_account_by_event_name", "events_statements_summary_by_digest", "events_statements_summary_by_host_by_event_name", "events_statements_summary_by_program",
-            "events_statements_summary_by_thread_by_event_name", "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name"))),
+            "events_statements_summary_by_thread_by_event_name", "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name",
+            "events_transactions_current", "events_transactions_history", "events_transactions_history_long", "events_transactions_summary_by_account_by_event_name",
+            "events_transactions_summary_by_host_by_event_name", "events_transactions_summary_by_thread_by_event_name", "events_transactions_summary_by_user_by_event_name",
+            "events_transactions_summary_global_by_event_name", "events_waits_current", "events_waits_history"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_current.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_current.yaml
@@ -1,0 +1,211 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_current
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  trx_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TRX_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  gtid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: GTID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_format_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: XID_FORMAT_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_gtrid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_GTRID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_bqual:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_BQUAL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xa_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XA_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  access_mode:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ACCESS_MODE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  isolation_level:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ISOLATION_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  autocommit:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: AUTOCOMMIT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_savepoints:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_SAVEPOINTS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_rollback_to_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_ROLLBACK_TO_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_release_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_RELEASE_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_history.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_history.yaml
@@ -1,0 +1,211 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_history
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  trx_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TRX_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  gtid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: GTID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_format_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: XID_FORMAT_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_gtrid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_GTRID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_bqual:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_BQUAL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xa_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XA_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  access_mode:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ACCESS_MODE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  isolation_level:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ISOLATION_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  autocommit:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: AUTOCOMMIT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_savepoints:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_SAVEPOINTS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_rollback_to_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_ROLLBACK_TO_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_release_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_RELEASE_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_history_long.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_history_long.yaml
@@ -1,0 +1,211 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_history_long
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  trx_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TRX_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  gtid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: GTID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_format_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: XID_FORMAT_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_gtrid:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_GTRID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xid_bqual:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XID_BQUAL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  xa_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: XA_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  access_mode:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ACCESS_MODE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  isolation_level:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ISOLATION_LEVEL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  autocommit:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: AUTOCOMMIT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_savepoints:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_SAVEPOINTS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_rollback_to_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_ROLLBACK_TO_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  number_of_release_savepoint:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_RELEASE_SAVEPOINT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_account_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_account_by_event_name.yaml
@@ -1,0 +1,163 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_summary_by_account_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_host_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_host_by_event_name.yaml
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_summary_by_host_by_event_name
+columns:
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_thread_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_thread_by_event_name.yaml
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_summary_by_thread_by_event_name
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_user_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_by_user_by_event_name.yaml
@@ -1,0 +1,155 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_summary_by_user_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_global_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_transactions_summary_global_by_event_name.yaml
@@ -1,0 +1,147 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_transactions_summary_global_by_event_name
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read_only:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ_ONLY
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_current.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_current.yaml
@@ -1,0 +1,171 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_current
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  spins:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SPINS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  index_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: INDEX_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  operation:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OPERATION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_bytes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_BYTES
+    primaryKey: false
+    unsigned: false
+    visible: true
+  flags:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: FLAGS
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_history.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_history.yaml
@@ -1,0 +1,171 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_history
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  spins:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SPINS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  index_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: INDEX_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  operation:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OPERATION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_bytes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_BYTES
+    primaryKey: false
+    unsigned: false
+    visible: true
+  flags:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: FLAGS
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(19));
+        assertThat(actualPerformanceSchema.getTables().size(), is(29));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(19));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(29));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_current.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_current.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="state" />
+        <column name="trx_id" />
+        <column name="gtid" />
+        <column name="xid_format_id" />
+        <column name="xid_gtrid" />
+        <column name="xid_bqual" />
+        <column name="xa_state" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="access_mode" />
+        <column name="isolation_level" />
+        <column name="autocommit" />
+        <column name="number_of_savepoints" />
+        <column name="number_of_rollback_to_savepoint" />
+        <column name="number_of_release_savepoint" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_history.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_history.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="state" />
+        <column name="trx_id" />
+        <column name="gtid" />
+        <column name="xid_format_id" />
+        <column name="xid_gtrid" />
+        <column name="xid_bqual" />
+        <column name="xa_state" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="access_mode" />
+        <column name="isolation_level" />
+        <column name="autocommit" />
+        <column name="number_of_savepoints" />
+        <column name="number_of_rollback_to_savepoint" />
+        <column name="number_of_release_savepoint" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_history_long.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_history_long.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="state" />
+        <column name="trx_id" />
+        <column name="gtid" />
+        <column name="xid_format_id" />
+        <column name="xid_gtrid" />
+        <column name="xid_bqual" />
+        <column name="xa_state" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="access_mode" />
+        <column name="isolation_level" />
+        <column name="autocommit" />
+        <column name="number_of_savepoints" />
+        <column name="number_of_rollback_to_savepoint" />
+        <column name="number_of_release_savepoint" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_account_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_account_by_event_name.xml
@@ -1,0 +1,39 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read_write" />
+        <column name="sum_timer_read_write" />
+        <column name="min_timer_read_write" />
+        <column name="avg_timer_read_write" />
+        <column name="max_timer_read_write" />
+        <column name="count_read_only" />
+        <column name="sum_timer_read_only" />
+        <column name="min_timer_read_only" />
+        <column name="avg_timer_read_only" />
+        <column name="max_timer_read_only" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_host_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_host_by_event_name.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read_write" />
+        <column name="sum_timer_read_write" />
+        <column name="min_timer_read_write" />
+        <column name="avg_timer_read_write" />
+        <column name="max_timer_read_write" />
+        <column name="count_read_only" />
+        <column name="sum_timer_read_only" />
+        <column name="min_timer_read_only" />
+        <column name="avg_timer_read_only" />
+        <column name="max_timer_read_only" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_thread_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_thread_by_event_name.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read_write" />
+        <column name="sum_timer_read_write" />
+        <column name="min_timer_read_write" />
+        <column name="avg_timer_read_write" />
+        <column name="max_timer_read_write" />
+        <column name="count_read_only" />
+        <column name="sum_timer_read_only" />
+        <column name="min_timer_read_only" />
+        <column name="avg_timer_read_only" />
+        <column name="max_timer_read_only" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_user_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_by_user_by_event_name.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read_write" />
+        <column name="sum_timer_read_write" />
+        <column name="min_timer_read_write" />
+        <column name="avg_timer_read_write" />
+        <column name="max_timer_read_write" />
+        <column name="count_read_only" />
+        <column name="sum_timer_read_only" />
+        <column name="min_timer_read_only" />
+        <column name="avg_timer_read_only" />
+        <column name="max_timer_read_only" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_global_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_transactions_summary_global_by_event_name.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read_write" />
+        <column name="sum_timer_read_write" />
+        <column name="min_timer_read_write" />
+        <column name="avg_timer_read_write" />
+        <column name="max_timer_read_write" />
+        <column name="count_read_only" />
+        <column name="sum_timer_read_only" />
+        <column name="min_timer_read_only" />
+        <column name="avg_timer_read_only" />
+        <column name="max_timer_read_only" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_current.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_current.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="spins" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="index_name" />
+        <column name="object_type" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="operation" />
+        <column name="number_of_bytes" />
+        <column name="flags" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_history.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_history.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="spins" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="index_name" />
+        <column name="object_type" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="operation" />
+        <column name="number_of_bytes" />
+        <column name="flags" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -448,4 +448,44 @@
     <test-case sql="SELECT * FROM performance_schema.events_statements_summary_global_by_event_name" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_events_statements_summary_global_by_event_name.xml" />
     </test-case>
+
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_current" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_current.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_history" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_history.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_history_long" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_history_long.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_summary_by_account_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_summary_by_account_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_summary_by_host_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_summary_by_host_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_summary_by_thread_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_summary_by_thread_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_summary_by_user_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_summary_by_user_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_transactions_summary_global_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_transactions_summary_global_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_current" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_current.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_history" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_history.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
