### PR TITLE
Fix the error of incremental tasks caused by datetime containing zero value in MySQL

### DIFF
--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValue.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/binlog/row/column/value/time/MySQLDatetime2BinlogProtocolValue.java
@@ -48,6 +48,9 @@ public final class MySQLDatetime2BinlogProtocolValue implements MySQLBinlogProto
     
     private Serializable readDatetime(final MySQLBinlogColumnDef columnDef, final long datetime, final MySQLPacketPayload payload) {
         long datetimeWithoutSign = datetime & (0x8000000000L - 1);
+        if (0 == datetimeWithoutSign) {
+            return MySQLTimeValueUtils.DATETIME_OF_ZERO;
+        }
         long date = datetimeWithoutSign >> 17;
         long yearAndMonth = date >> 5;
         int year = (int) (yearAndMonth / 13);

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
@@ -173,6 +173,8 @@ public final class DataSourceReflection {
             String defaultPropertyValue = entry.getValue().toString();
             if (!containsDefaultProperty(defaultPropertyKey, jdbcConnectionProps.get(), queryProps)) {
                 jdbcConnectionProps.get().setProperty(defaultPropertyKey, defaultPropertyValue);
+            } else if (queryProps.containsKey(defaultPropertyKey) && jdbcConnectionProps.get().containsKey(defaultPropertyKey)) {
+                jdbcConnectionProps.get().setProperty(defaultPropertyKey, queryProps.getProperty(defaultPropertyKey));
             }
         }
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourceReflection.java
@@ -173,8 +173,6 @@ public final class DataSourceReflection {
             String defaultPropertyValue = entry.getValue().toString();
             if (!containsDefaultProperty(defaultPropertyKey, jdbcConnectionProps.get(), queryProps)) {
                 jdbcConnectionProps.get().setProperty(defaultPropertyKey, defaultPropertyValue);
-            } else if (queryProps.containsKey(defaultPropertyKey) && jdbcConnectionProps.get().containsKey(defaultPropertyKey)) {
-                jdbcConnectionProps.get().setProperty(defaultPropertyKey, queryProps.getProperty(defaultPropertyKey));
             }
         }
     }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfiguration.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/datasource/config/impl/ShardingSpherePipelineDataSourceConfiguration.java
@@ -58,8 +58,12 @@ public final class ShardingSpherePipelineDataSourceConfiguration implements Pipe
     private final DatabaseType databaseType;
     
     public ShardingSpherePipelineDataSourceConfiguration(final String param) {
-        parameter = param;
         rootConfig = YamlEngine.unmarshal(param, YamlRootConfiguration.class, true);
+        // Need remove dataSourceProperties, because if the parameter at dataSourceProperties will override parameter at jdbcUrl
+        for (Map<String, Object> each : rootConfig.getDataSources().values()) {
+            each.remove("dataSourceProperties");
+        }
+        parameter = YamlEngine.marshal(rootConfig);
         Map<String, Object> props = rootConfig.getDataSources().values().iterator().next();
         databaseType = DatabaseTypeEngine.getDatabaseType(getJdbcUrl(props));
         appendJdbcQueryProperties(databaseType.getType());

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
@@ -110,7 +110,6 @@ public final class MySQLClient {
                     }
                 }).connect(connectInfo.getHost(), connectInfo.getPort()).channel();
         serverInfo = waitExpectedResponse(ServerInfo.class);
-        reconnectTimes.set(0);
         running = true;
     }
     
@@ -305,6 +304,7 @@ public final class MySQLClient {
             if (msg instanceof AbstractBinlogEvent) {
                 lastBinlogEvent = (AbstractBinlogEvent) msg;
                 blockingEventQueue.put(lastBinlogEvent);
+                reconnectTimes.set(0);
             }
         }
         
@@ -332,6 +332,7 @@ public final class MySQLClient {
             }
             reconnectTimes.incrementAndGet();
             connect();
+            log.info("reconnect times {}", reconnectTimes.get());
             subscribe(lastBinlogEvent.getFileName(), lastBinlogEvent.getPosition());
         }
     }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
@@ -55,6 +55,7 @@ public class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
             String jobId = listJobId(containerComposer).get(0);
             containerComposer.waitJobPrepareSuccess(String.format("SHOW MIGRATION STATUS '%s'", jobId));
             insertOneRecordWithZeroValue(containerComposer, 2);
+            containerComposer.waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
             assertCheckMigrationSuccess(containerComposer, jobId, "DATA_MATCH");
         }
     }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLTimeTypesMigrationE2EIT.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.general;
+
+
+import org.apache.shardingsphere.data.pipeline.scenario.migration.MigrationJobType;
+import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.PipelineContainerComposer;
+import org.apache.shardingsphere.test.e2e.data.pipeline.cases.migration.AbstractMigrationE2EIT;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineE2ECondition;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineE2ESettings;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineE2ETestCaseArgumentsProvider;
+import org.apache.shardingsphere.test.e2e.data.pipeline.framework.param.PipelineTestParameter;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+/**
+ * E2E IT for time types of MySQL, includes:
+ * 1) datetime.
+ * 2) timestamp.
+ * 3) date
+ */
+@PipelineE2ESettings(fetchSingle = true, database = @PipelineE2ESettings.PipelineE2EDatabaseSettings(type = "MySQL", scenarioFiles = "env/common/none.xml"))
+public class MySQLTimeTypesMigrationE2EIT extends AbstractMigrationE2EIT {
+    
+    @ParameterizedTest(name = "{0}")
+    @EnabledIf("isEnabled")
+    @ArgumentsSource(PipelineE2ETestCaseArgumentsProvider.class)
+    void assertIllegalTimeTypesValueMigrationSuccess(final PipelineTestParameter testParam) throws Exception {
+        try (PipelineContainerComposer containerComposer = new PipelineContainerComposer(testParam, new MigrationJobType())) {
+            String sql = "CREATE TABLE `time_e2e` ( `id` int NOT NULL, `t_timestamp` timestamp NULL DEFAULT NULL, `t_datetime` datetime DEFAULT NULL, `t_date` date DEFAULT NULL, `t_year` year DEFAULT NULL, PRIMARY KEY (`id`)) ENGINE=InnoDB;";
+            containerComposer.sourceExecuteWithLog(sql);
+            try (Connection connection = containerComposer.getSourceDataSource().getConnection()) {
+                PreparedStatement preparedStatement = connection.prepareStatement("INSERT INTO `time_e2e`(id, t_timestamp, t_datetime, t_date, t_year) VALUES (?, ?, ?, ?, ?)");
+                preparedStatement.setObject(1, 1);
+                preparedStatement.setObject(2, "0000-00-00 00:00:00");
+                preparedStatement.setObject(3, "0000-00-00 00:00:00");
+                preparedStatement.setObject(4, "0000-00-00");
+                preparedStatement.setObject(5, "0000");
+                preparedStatement.execute();
+            }
+            addMigrationSourceResource(containerComposer);
+            addMigrationTargetResource(containerComposer);
+            startMigration(containerComposer, "time_e2e", "time_e2e");
+            String jobId = listJobId(containerComposer).get(0);
+            containerComposer.waitIncrementTaskFinished(String.format("SHOW MIGRATION STATUS '%s'", jobId));
+            assertCheckMigrationSuccess(containerComposer, jobId, "DATA_MATCH");
+        }
+    }
+    
+    private static boolean isEnabled() {
+        return PipelineE2ECondition.isEnabled(new MySQLDatabaseType());
+    }
+}


### PR DESCRIPTION
refer https://dev.mysql.com/doc/refman/8.0/en/datetime.html
MySQL may have the datetime value wiht '0000-00-00 00:00:00', but the value is illegal for `LocalDateTime` at java.

Changes proposed in this pull request:
  - Fix the error of incremental tasks caused by datetime containing zero value in MySQL
  - Fix MySQLClient always print error log when decode binlog failed.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
