### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -59,7 +59,9 @@ public enum SystemSchemaBuilderRule {
             "events_statements_summary_by_thread_by_event_name", "events_statements_summary_by_user_by_event_name", "events_statements_summary_global_by_event_name",
             "events_transactions_current", "events_transactions_history", "events_transactions_history_long", "events_transactions_summary_by_account_by_event_name",
             "events_transactions_summary_by_host_by_event_name", "events_transactions_summary_by_thread_by_event_name", "events_transactions_summary_by_user_by_event_name",
-            "events_transactions_summary_global_by_event_name", "events_waits_current", "events_waits_history"))),
+            "events_transactions_summary_global_by_event_name", "events_waits_current", "events_waits_history", "events_waits_history_long", "events_waits_summary_by_account_by_event_name",
+            "events_waits_summary_by_host_by_event_name", "events_waits_summary_by_instance", "events_waits_summary_by_thread_by_event_name", "events_waits_summary_by_user_by_event_name",
+            "events_waits_summary_global_by_event_name", "file_instances", "file_summary_by_event_name", "file_summary_by_instance"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_history_long.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_history_long.yaml
@@ -1,0 +1,171 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_history_long
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  end_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: END_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SOURCE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_start:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_START
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_end:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_END
+    primaryKey: false
+    unsigned: true
+    visible: true
+  timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  spins:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SPINS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  index_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: INDEX_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NESTING_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  nesting_event_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NESTING_EVENT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  operation:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OPERATION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  number_of_bytes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: NUMBER_OF_BYTES
+    primaryKey: false
+    unsigned: false
+    visible: true
+  flags:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: FLAGS
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_account_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_account_by_event_name.yaml
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_by_account_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_host_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_host_by_event_name.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_by_host_by_event_name
+columns:
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_instance.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_instance.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_by_instance
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_thread_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_thread_by_event_name.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_by_thread_by_event_name
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_user_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_by_user_by_event_name.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_by_user_by_event_name
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_global_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/events_waits_summary_global_by_event_name.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: events_waits_summary_global_by_event_name
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/file_instances.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/file_instances.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: file_instances
+columns:
+  file_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: FILE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  open_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OPEN_COUNT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/file_summary_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/file_summary_by_event_name.yaml
@@ -1,0 +1,203 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: file_summary_by_event_name
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_READ
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_WRITE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/file_summary_by_instance.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/file_summary_by_instance.yaml
@@ -1,0 +1,219 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: file_summary_by_instance
+columns:
+  file_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: FILE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_READ
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_WRITE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(29));
+        assertThat(actualPerformanceSchema.getTables().size(), is(39));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(29));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(39));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_history_long.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_history_long.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_id" />
+        <column name="end_event_id" />
+        <column name="event_name" />
+        <column name="source" />
+        <column name="timer_start" />
+        <column name="timer_end" />
+        <column name="timer_wait" />
+        <column name="spins" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="index_name" />
+        <column name="object_type" />
+        <column name="object_instance_begin" />
+        <column name="nesting_event_id" />
+        <column name="nesting_event_type" />
+        <column name="operation" />
+        <column name="number_of_bytes" />
+        <column name="flags" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_account_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_account_by_event_name.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_host_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_host_by_event_name.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="host" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_instance.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_instance.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="object_instance_begin" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_thread_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_thread_by_event_name.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_user_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_by_user_by_event_name.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_global_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_events_waits_summary_global_by_event_name.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_instances.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_instances.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="file_name" />
+        <column name="event_name" />
+        <column name="open_count" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_summary_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_summary_by_event_name.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read" />
+        <column name="sum_timer_read" />
+        <column name="min_timer_read" />
+        <column name="avg_timer_read" />
+        <column name="max_timer_read" />
+        <column name="sum_number_of_bytes_read" />
+        <column name="count_write" />
+        <column name="sum_timer_write" />
+        <column name="min_timer_write" />
+        <column name="avg_timer_write" />
+        <column name="max_timer_write" />
+        <column name="sum_number_of_bytes_write" />
+        <column name="count_misc" />
+        <column name="sum_timer_misc" />
+        <column name="min_timer_misc" />
+        <column name="avg_timer_misc" />
+        <column name="max_timer_misc" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_summary_by_instance.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_file_summary_by_instance.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="file_name" />
+        <column name="event_name" />
+        <column name="object_instance_begin" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read" />
+        <column name="sum_timer_read" />
+        <column name="min_timer_read" />
+        <column name="avg_timer_read" />
+        <column name="max_timer_read" />
+        <column name="sum_number_of_bytes_read" />
+        <column name="count_write" />
+        <column name="sum_timer_write" />
+        <column name="min_timer_write" />
+        <column name="avg_timer_write" />
+        <column name="max_timer_write" />
+        <column name="sum_number_of_bytes_write" />
+        <column name="count_misc" />
+        <column name="sum_timer_misc" />
+        <column name="min_timer_misc" />
+        <column name="avg_timer_misc" />
+        <column name="max_timer_misc" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -488,4 +488,44 @@
     <test-case sql="SELECT * FROM performance_schema.events_waits_history" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_events_waits_history.xml" />
     </test-case>
+
+    <test-case sql="SELECT * FROM performance_schema.events_waits_history_long" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_history_long.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_by_account_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_by_account_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_by_host_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_by_host_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_by_instance" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_by_instance.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_by_thread_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_by_thread_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_by_user_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_by_user_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.events_waits_summary_global_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_events_waits_summary_global_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.file_instances" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_file_instances.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.file_summary_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_file_summary_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.file_summary_by_instance" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_file_summary_by_instance.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
