### PR TITLE
Add xa transaction data source privilege checker

### DIFF
--- a/docs/document/content/dev-manual/transaction.cn.md
+++ b/docs/document/content/dev-manual/transaction.cn.md
@@ -76,3 +76,20 @@ XA 分布式事务管理器
 | *配置标识*                             | *详细说明*                 | *全限定类名*                                                                                                                                                                                                                                                                                                    |
 |------------------------------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | com.zaxxer.hikari.HikariDataSource | 用于获取 HikariCP 连接池的标准属性 | [`org.apache.shardingsphere.transaction.xa.jta.datasource.swapper.impl.HikariCPPropertyProvider`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/swapper/impl/HikariCPPropertyProvider.java) ｜ |
+
+## DataSourcePrivilegeChecker
+
+### 全限定类名
+
+[`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DataSourcePrivilegeChecker.java)
+
+### 定义
+
+用于通过数据源校验事务所需的权限
+
+### 已知实现
+
+| *配置标识*  | *详细说明*           | *全限定类名*                                                                                                                                                                                                                                                                                                                              |
+|---------|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MySQL   | 校验 MySQL XA 事务所需的权限 | [`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect.MySQLDataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java) ｜         |
+| Default | 默认不校验事务所需的权限     | [`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DefaultDataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/DefaultDataSourcePrivilegeChecker.java) ｜                 |

--- a/docs/document/content/dev-manual/transaction.en.md
+++ b/docs/document/content/dev-manual/transaction.en.md
@@ -76,3 +76,20 @@ Data source property provider service definition
 | *Configuration Type*               | *Description*                               | *Fully-qualified class name*                                                                                                                                                                                                                                                                             |
 |------------------------------------|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | com.zaxxer.hikari.HikariDataSource | Used to get standard properties of HikariCP | [`org.apache.shardingsphere.transaction.xa.jta.datasource.swapper.impl.HikariCPPropertyProvider`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/swapper/impl/HikariCPPropertyProvider.java) |
+
+## DataSourcePrivilegeChecker
+
+### Fully-qualified class name
+
+[`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DataSourcePrivilegeChecker.java)
+
+### Definition
+
+Check transaction privilege through the data source
+
+### Implementation classes
+
+| *配置标识*  | *详细说明*                                | *全限定类名*                                                                                                                                                                                                                                                                                                                              |
+|---------|---------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| MySQL   | Verify MySQL XA transaction privilege | [`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect.MySQLDataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java) ｜         |
+| Default | Not verify transaction privilege by default    | [`org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DefaultDataSourcePrivilegeChecker`](https://github.com/apache/shardingsphere/blob/master/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/DefaultDataSourcePrivilegeChecker.java) ｜                 |

--- a/docs/document/content/user-manual/error-code/sql-error-code.cn.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.cn.md
@@ -70,6 +70,8 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 25000     | 14200       | Can not start new XA transaction in a active transaction.                          |
 | 25000     | 14201       | Failed to create \`%s\` XA data source.                                            |
 | 25000     | 14202       | Max length of xa unique resource name \`%s\` exceeded: should be less than 45.     |
+| 25000     | 14203       | Check privileges failed on data source, reason is: \`%s\`     |
+| 25000     | 14204       | Failed to create XA transaction manager, requires \`%s\` privileges    |
 | 25000     | 14301       | ShardingSphere Seata-AT transaction has been disabled.                             |
 | 25000     | 14302       | Please config application id within seata.conf file.                               |
 
@@ -225,7 +227,6 @@ SQL 错误码以标准的 SQL State，Vendor Code 和详细错误信息提供，
 | 44000     | 20295       | Auto aware data source name is required in database \`%s\.`                                 |
 | 42S02     | 20296       | Not found load balance type in database \`%s\.`                                             |
 | 44000     | 20297       | Weight load balancer datasource name config does not match data sources in database \`%s\.` |
-
 
 ### 数据库高可用
 

--- a/docs/document/content/user-manual/error-code/sql-error-code.en.md
+++ b/docs/document/content/user-manual/error-code/sql-error-code.en.md
@@ -70,6 +70,8 @@ SQL error codes provide by standard `SQL State`, `Vendor Code` and `Reason`, whi
 | 25000     | 14200       | Can not start new XA transaction in a active transaction.                          |
 | 25000     | 14201       | Failed to create \`%s\` XA data source.                                            |
 | 25000     | 14202       | Max length of xa unique resource name \`%s\` exceeded: should be less than 45.     |
+| 25000     | 14203       | Check privileges failed on data source, reason is: \`%s\`     |
+| 25000     | 14204       | Failed to create XA transaction manager, requires \`%s\` privileges    |
 | 25000     | 14301       | ShardingSphere Seata-AT transaction has been disabled.                             |
 | 25000     | 14302       | Please config application id within seata.conf file.                               |
 

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
@@ -26,6 +26,7 @@ import org.apache.shardingsphere.transaction.core.ResourceDataSource;
 import org.apache.shardingsphere.transaction.exception.TransactionTimeoutException;
 import org.apache.shardingsphere.transaction.spi.ShardingSphereTransactionManager;
 import org.apache.shardingsphere.transaction.xa.jta.datasource.XATransactionDataSource;
+import org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker;
 import org.apache.shardingsphere.transaction.xa.spi.XATransactionManagerProvider;
 
 import javax.sql.DataSource;
@@ -38,6 +39,7 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -54,6 +56,7 @@ public final class XAShardingSphereTransactionManager implements ShardingSphereT
     
     @Override
     public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, DataSource> dataSources, final String providerType) {
+        dataSources.forEach((key, value) -> TypedSPILoader.getService(DataSourcePrivilegeChecker.class, databaseTypes.get(key).getType()).checkPrivilege(Collections.singletonList(value)));
         xaTransactionManagerProvider = TypedSPILoader.getService(XATransactionManagerProvider.class, providerType);
         xaTransactionManagerProvider.init();
         Map<String, ResourceDataSource> resourceDataSources = getResourceDataSources(dataSources);

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/XAShardingSphereTransactionManager.java
@@ -39,7 +39,6 @@ import javax.transaction.SystemException;
 import javax.transaction.TransactionManager;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -56,7 +55,7 @@ public final class XAShardingSphereTransactionManager implements ShardingSphereT
     
     @Override
     public void init(final Map<String, DatabaseType> databaseTypes, final Map<String, DataSource> dataSources, final String providerType) {
-        dataSources.forEach((key, value) -> TypedSPILoader.getService(DataSourcePrivilegeChecker.class, databaseTypes.get(key).getType()).checkPrivilege(Collections.singletonList(value)));
+        dataSources.forEach((key, value) -> TypedSPILoader.getService(DataSourcePrivilegeChecker.class, databaseTypes.get(key).getType()).checkPrivilege(value));
         xaTransactionManagerProvider = TypedSPILoader.getService(XATransactionManagerProvider.class, providerType);
         xaTransactionManagerProvider.init();
         Map<String, ResourceDataSource> resourceDataSources = getResourceDataSources(dataSources);

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DataSourcePrivilegeChecker.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.jta.datasource.checker;
+
+import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPI;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+
+/**
+ * Data source privilege checker.
+ */
+public interface DataSourcePrivilegeChecker extends TypedSPI {
+    
+    /**
+     * Check privilege.
+     *
+     * @param dataSources data sources
+     */
+    void checkPrivilege(Collection<? extends DataSource> dataSources);
+}

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DefaultDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DefaultDataSourcePrivilegeChecker.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.jta.datasource.checker;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+
+/**
+ * Default data source privilege checker.
+ */
+public final class DefaultDataSourcePrivilegeChecker implements DataSourcePrivilegeChecker {
+    
+    @Override
+    public void checkPrivilege(final Collection<? extends DataSource> dataSources) {
+    }
+    
+    @Override
+    public boolean isDefault() {
+        return true;
+    }
+}

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DefaultDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/DefaultDataSourcePrivilegeChecker.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.transaction.xa.jta.datasource.checker;
 
 import javax.sql.DataSource;
-import java.util.Collection;
 
 /**
  * Default data source privilege checker.
@@ -26,7 +25,7 @@ import java.util.Collection;
 public final class DefaultDataSourcePrivilegeChecker implements DataSourcePrivilegeChecker {
     
     @Override
-    public void checkPrivilege(final Collection<? extends DataSource> dataSources) {
+    public void checkPrivilege(final DataSource dataSource) {
     }
     
     @Override

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
@@ -41,6 +41,7 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
      * Check privilege.
      *
      * @param dataSource data source
+     * @throws XATransactionCheckPrivilegeFailedException XA transaction check privilege failed exception
      */
     public void checkPrivilege(final DataSource dataSource) {
         try (Connection connection = dataSource.getConnection()) {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect;
+
+import org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker;
+import org.apache.shardingsphere.transaction.xa.jta.exception.XATransactionPrivilegeException;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * MySQL data source privilege checker.
+ */
+public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivilegeChecker {
+    
+    private static final String SHOW_GRANTS_SQL = "SHOW GRANTS";
+    
+    private static final String[][] REQUIRED_PRIVILEGES = {{"ALL PRIVILEGES", "ON *.*"}, {"XA_RECOVER_ADMIN", "ON *.*"}};
+    
+    /**
+     * Check privilege.
+     *
+     * @param dataSources data sources
+     */
+    public void checkPrivilege(final Collection<? extends DataSource> dataSources) {
+        for (DataSource each : dataSources) {
+            try (Connection connection = each.getConnection()) {
+                if (8 == connection.getMetaData().getDatabaseMajorVersion()) {
+                    checkPrivilege(connection);
+                }
+            } catch (final SQLException ignored) {
+            }
+        }
+    }
+    
+    private void checkPrivilege(final Connection connection) {
+        try (
+                PreparedStatement preparedStatement = connection.prepareStatement(SHOW_GRANTS_SQL);
+                ResultSet resultSet = preparedStatement.executeQuery()) {
+            while (resultSet.next()) {
+                String privilege = resultSet.getString(1).toUpperCase();
+                if (matchPrivileges(privilege)) {
+                    return;
+                }
+            }
+        } catch (final SQLException ignored) {
+        }
+        throw new XATransactionPrivilegeException("XA_RECOVER_ADMIN");
+    }
+    
+    private boolean matchPrivileges(final String privilege) {
+        return Arrays.stream(REQUIRED_PRIVILEGES).anyMatch(each -> Arrays.stream(each).allMatch(privilege::contains));
+    }
+}

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
@@ -72,4 +72,9 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
     private boolean matchPrivileges(final String privilege) {
         return Arrays.stream(REQUIRED_PRIVILEGES).anyMatch(each -> Arrays.stream(each).allMatch(privilege::contains));
     }
+    
+    @Override
+    public String getType() {
+        return "MySQL";
+    }
 }

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
@@ -37,6 +37,8 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
     
     private static final String[][] REQUIRED_PRIVILEGES = {{"ALL PRIVILEGES", "ON *.*"}, {"XA_RECOVER_ADMIN", "ON *.*"}};
     
+    private static final int MYSQL_MAJOR_VERSION_8 = 8;
+    
     /**
      * Check privilege.
      *
@@ -45,7 +47,7 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
      */
     public void checkPrivilege(final DataSource dataSource) {
         try (Connection connection = dataSource.getConnection()) {
-            if (8 == connection.getMetaData().getDatabaseMajorVersion()) {
+            if (MYSQL_MAJOR_VERSION_8 == connection.getMetaData().getDatabaseMajorVersion()) {
                 checkPrivilege(connection);
             }
         } catch (final SQLException ex) {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/dialect/MySQLDataSourcePrivilegeChecker.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect;
 
 import org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker;
+import org.apache.shardingsphere.transaction.xa.jta.exception.XATransactionCheckPrivilegeFailedException;
 import org.apache.shardingsphere.transaction.xa.jta.exception.XATransactionPrivilegeException;
 
 import javax.sql.DataSource;
@@ -26,7 +27,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * MySQL data source privilege checker.
@@ -40,16 +40,15 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
     /**
      * Check privilege.
      *
-     * @param dataSources data sources
+     * @param dataSource data source
      */
-    public void checkPrivilege(final Collection<? extends DataSource> dataSources) {
-        for (DataSource each : dataSources) {
-            try (Connection connection = each.getConnection()) {
-                if (8 == connection.getMetaData().getDatabaseMajorVersion()) {
-                    checkPrivilege(connection);
-                }
-            } catch (final SQLException ignored) {
+    public void checkPrivilege(final DataSource dataSource) {
+        try (Connection connection = dataSource.getConnection()) {
+            if (8 == connection.getMetaData().getDatabaseMajorVersion()) {
+                checkPrivilege(connection);
             }
+        } catch (final SQLException ex) {
+            throw new XATransactionCheckPrivilegeFailedException(ex);
         }
     }
     
@@ -63,7 +62,8 @@ public final class MySQLDataSourcePrivilegeChecker implements DataSourcePrivileg
                     return;
                 }
             }
-        } catch (final SQLException ignored) {
+        } catch (final SQLException ex) {
+            throw new XATransactionCheckPrivilegeFailedException(ex);
         }
         throw new XATransactionPrivilegeException("XA_RECOVER_ADMIN");
     }

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionCheckPrivilegeFailedException.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionCheckPrivilegeFailedException.java
@@ -15,21 +15,21 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.transaction.xa.jta.datasource.checker;
+package org.apache.shardingsphere.transaction.xa.jta.exception;
 
-import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPI;
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.transaction.exception.TransactionSQLException;
 
-import javax.sql.DataSource;
+import java.sql.SQLException;
 
 /**
- * Data source privilege checker.
+ * XA transaction check privilege failed exception.
  */
-public interface DataSourcePrivilegeChecker extends TypedSPI {
+public final class XATransactionCheckPrivilegeFailedException extends TransactionSQLException {
     
-    /**
-     * Check privilege.
-     *
-     * @param dataSource data source
-     */
-    void checkPrivilege(DataSource dataSource);
+    private static final long serialVersionUID = 6073175429050058508L;
+    
+    public XATransactionCheckPrivilegeFailedException(final SQLException cause) {
+        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 203, String.format("Check privileges failed on data source, reason is: %s", cause.getMessage()), cause);
+    }
 }

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
@@ -28,6 +28,6 @@ public final class XATransactionPrivilegeException extends TransactionSQLExcepti
     private static final long serialVersionUID = -1565168229743080642L;
     
     public XATransactionPrivilegeException(final String errorMessage) {
-        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 204, "Failed to create XA data source, requires `%s` privileges", errorMessage);
+        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 204, "Failed to create XA transaction manager, requires `%s` privileges", errorMessage);
     }
 }

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
@@ -28,6 +28,6 @@ public final class XATransactionPrivilegeException extends TransactionSQLExcepti
     private static final long serialVersionUID = -1565168229743080642L;
     
     public XATransactionPrivilegeException(final String errorMessage) {
-        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 201, "Failed to create XA data source, needs `%s` privileges", errorMessage);
+        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 204, "Failed to create XA data source, requires `%s` privileges", errorMessage);
     }
 }

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/exception/XATransactionPrivilegeException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.jta.exception;
+
+import org.apache.shardingsphere.infra.util.exception.external.sql.sqlstate.XOpenSQLState;
+import org.apache.shardingsphere.transaction.exception.TransactionSQLException;
+
+/**
+ * XA transaction privilege exception.
+ */
+public final class XATransactionPrivilegeException extends TransactionSQLException {
+    
+    private static final long serialVersionUID = -1565168229743080642L;
+    
+    public XATransactionPrivilegeException(final String errorMessage) {
+        super(XOpenSQLState.INVALID_TRANSACTION_STATE, 201, "Failed to create XA data source, needs `%s` privileges", errorMessage);
+    }
+}

--- a/kernel/transaction/type/xa/core/src/main/resources/META-INF/services/org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker
+++ b/kernel/transaction/type/xa/core/src/main/resources/META-INF/services/org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DataSourcePrivilegeChecker
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.shardingsphere.transaction.xa.jta.datasource.checker.DefaultDataSourcePrivilegeChecker
+org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect.MySQLDataSourcePrivilegeChecker

--- a/kernel/transaction/type/xa/core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/MySQLDataSourcePrivilegeCheckerTest.java
+++ b/kernel/transaction/type/xa/core/src/test/java/org/apache/shardingsphere/transaction/xa/jta/datasource/checker/MySQLDataSourcePrivilegeCheckerTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.transaction.xa.jta.datasource.checker;
+
+import org.apache.shardingsphere.transaction.xa.jta.datasource.checker.dialect.MySQLDataSourcePrivilegeChecker;
+import org.apache.shardingsphere.transaction.xa.jta.exception.XATransactionCheckPrivilegeFailedException;
+import org.apache.shardingsphere.transaction.xa.jta.exception.XATransactionPrivilegeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MySQLDataSourcePrivilegeCheckerTest {
+    
+    @Mock
+    private PreparedStatement preparedStatement;
+    
+    @Mock
+    private ResultSet resultSet;
+    
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private DataSource dataSource;
+    
+    @BeforeEach
+    void setUp() throws SQLException {
+        when(dataSource.getConnection().prepareStatement(anyString())).thenReturn(preparedStatement);
+    }
+    
+    @Test
+    void assertCheckPrivilegeWithParticularSuccessInMySQL8() throws SQLException {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(8);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("GRANT XA_RECOVER_ADMIN ON *.* TO '%'@'%'");
+        new MySQLDataSourcePrivilegeChecker().checkPrivilege(dataSource);
+        verify(preparedStatement).executeQuery();
+    }
+    
+    @Test
+    void assertUnCheckPrivilegeInMySQL5() throws SQLException {
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(5);
+        new MySQLDataSourcePrivilegeChecker().checkPrivilege(dataSource);
+        verify(preparedStatement, times(0)).executeQuery();
+    }
+    
+    @Test
+    void assertCheckPrivilegeWithAllSuccessInMySQL8() throws SQLException {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(8);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getString(1)).thenReturn("GRANT ALL PRIVILEGES ON *.* TO '%'@'%'");
+        new MySQLDataSourcePrivilegeChecker().checkPrivilege(dataSource);
+        verify(preparedStatement).executeQuery();
+    }
+    
+    @Test
+    void assertCheckPrivilegeLackPrivilegesInMySQL8() throws SQLException {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(8);
+        assertThrows(XATransactionPrivilegeException.class, () -> new MySQLDataSourcePrivilegeChecker().checkPrivilege(dataSource));
+    }
+    
+    @Test
+    void assertCheckPrivilegeFailureInMySQL8() throws SQLException {
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(dataSource.getConnection().getMetaData().getDatabaseMajorVersion()).thenReturn(8);
+        when(resultSet.next()).thenThrow(new SQLException(""));
+        assertThrows(XATransactionCheckPrivilegeFailedException.class, () -> new MySQLDataSourcePrivilegeChecker().checkPrivilege(dataSource));
+    }
+}


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add xa transaction data source privilege checker

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
