### PR TITLE
Add reset for property AGENT_PLUGINS_ENABLED in unit test

### DIFF
--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/plugin/PluginContextTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/plugin/PluginContextTest.java
@@ -17,12 +17,18 @@
 
 package org.apache.shardingsphere.agent.core.plugin;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class PluginContextTest {
+    
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty("AGENT_PLUGINS_ENABLED");
+    }
     
     @Test
     void assertNotPluginEnabledKey() {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
@@ -32,6 +32,7 @@ import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.apache.shardingsphere.transaction.api.TransactionType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -50,6 +51,11 @@ class ShowDistVariableExecutorTest {
     private final ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
     
     private final ConnectionSession connectionSession = mock(ConnectionSession.class, RETURNS_DEEP_STUBS);
+    
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty("AGENT_PLUGINS_ENABLED");
+    }
     
     @Test
     void assertGetColumns() {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
@@ -61,7 +61,6 @@ class ShowDistVariablesExecutorTest {
         when(metaData.getProps()).thenReturn(new ConfigurationProperties(PropertiesBuilder.build(new Property("system_log_level", "INFO"))));
         when(metaData.getInternalProps()).thenReturn(new InternalConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
         when(metaData.getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(new LoggingRule(new DefaultLoggingRuleConfigurationBuilder().build()))));
-        System.setProperty("AGENT_PLUGINS_ENABLED", "true");
         ShowDistVariablesExecutor executor = new ShowDistVariablesExecutor();
         Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, connectionSession, mock(ShowDistVariablesStatement.class));
         assertThat(actual.size(), is(23));

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
@@ -42,6 +42,7 @@ import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.test.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.mock.StaticMockSettings;
 import org.apache.shardingsphere.transaction.api.TransactionType;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -58,6 +59,11 @@ class SetDistVariableUpdaterTest {
     
     @Mock
     private ConnectionSession connectionSession;
+    
+    @AfterAll
+    static void tearDown() {
+        System.clearProperty("AGENT_PLUGINS_ENABLED");
+    }
     
     @Test
     void assertExecuteWithTransactionType() {


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add reset for property AGENT_PLUGINS_ENABLED in unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
