### PR TITLE
Supports compilation through OpenJDK 20 and its downstream distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11, 19 ]
+        java-version: [ 11, 20 ]
     steps:
       - uses: actions/checkout@v3
       - name: Cache Maven Repos

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        java-version: [ 11, 17, 19 ]
+        java-version: [ 11, 17, 20 ]
     steps:
       - name: Support long paths in Windows
         if: matrix.os == 'windows-latest'

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/builder/AgentTransformer.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/builder/AgentTransformer.java
@@ -37,6 +37,7 @@ import org.apache.shardingsphere.agent.core.plugin.PluginLifecycleServiceManager
 import org.apache.shardingsphere.agent.core.plugin.classloader.AgentPluginClassLoader;
 import org.apache.shardingsphere.agent.core.plugin.classloader.ClassLoaderContext;
 
+import java.security.ProtectionDomain;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,7 +63,7 @@ public final class AgentTransformer implements Transformer {
     
     @SuppressWarnings("NullableProblems")
     @Override
-    public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module) {
+    public Builder<?> transform(final Builder<?> builder, final TypeDescription typeDescription, final ClassLoader classLoader, final JavaModule module, final ProtectionDomain protectionDomain) {
         if (!advisorConfigs.containsKey(typeDescription.getTypeName())) {
             return builder;
         }

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -35,7 +35,7 @@
     </modules>
     
     <properties>
-        <bytebuddy.version>1.12.12</bytebuddy.version>
+        <bytebuddy.version>1.14.4</bytebuddy.version>
     </properties>
     
     <dependencyManagement>


### PR DESCRIPTION
Fixes #25126.

Changes proposed in this pull request:
  - Update Byte Buddy to 1.14.4.
  - Reference https://github.com/raphw/byte-buddy/commit/52479e4fd0dd50595786089bd00de2be750e8031 and https://github.com/graalvm/graalvm-ce-dev-builds/releases/tag/23.1.0-dev-20230414_0206 .
  - Associated with https://github.com/apache/shardingsphere/issues/25054 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
