### PR TITLE
Rename internal props to temporary props

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationProperties.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationProperties.java
@@ -15,18 +15,18 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.config.props.internal;
+package org.apache.shardingsphere.infra.config.props.temporary;
 
 import org.apache.shardingsphere.infra.util.props.TypedProperties;
 
 import java.util.Properties;
 
 /**
- * Internal typed properties of configuration.
+ * Temporary typed properties of configuration.
  */
-public final class InternalConfigurationProperties extends TypedProperties<InternalConfigurationPropertyKey> {
+public final class TemporaryConfigurationProperties extends TypedProperties<TemporaryConfigurationPropertyKey> {
     
-    public InternalConfigurationProperties(final Properties props) {
-        super(InternalConfigurationPropertyKey.class, props);
+    public TemporaryConfigurationProperties(final Properties props) {
+        super(TemporaryConfigurationPropertyKey.class, props);
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationPropertyKey.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/temporary/TemporaryConfigurationPropertyKey.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.infra.config.props.internal;
+package org.apache.shardingsphere.infra.config.props.temporary;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +26,11 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
- * Internal typed property key of configuration.
+ * Temporary typed property key of configuration.
  */
 @RequiredArgsConstructor
 @Getter
-public enum InternalConfigurationPropertyKey implements TypedPropertyKey {
+public enum TemporaryConfigurationPropertyKey implements TypedPropertyKey {
     
     /**
      * Proxy meta data collector enabled.
@@ -51,6 +51,6 @@ public enum InternalConfigurationPropertyKey implements TypedPropertyKey {
      * @return collection of internal key names
      */
     public static Collection<String> getKeyNames() {
-        return Arrays.stream(values()).map(InternalConfigurationPropertyKey::name).collect(Collectors.toList());
+        return Arrays.stream(values()).map(TemporaryConfigurationPropertyKey::name).collect(Collectors.toList());
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/ShardingSphereMetaData.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.infra.metadata;
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationProperties;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationProperties;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -45,7 +45,7 @@ public final class ShardingSphereMetaData {
     
     private final ConfigurationProperties props;
     
-    private final InternalConfigurationProperties internalProps;
+    private final TemporaryConfigurationProperties temporaryProps;
     
     public ShardingSphereMetaData() {
         this(new LinkedHashMap<>(), new ShardingSphereRuleMetaData(Collections.emptyList()), new ConfigurationProperties(new Properties()));
@@ -56,7 +56,7 @@ public final class ShardingSphereMetaData {
         databases.forEach((key, value) -> this.databases.put(key.toLowerCase(), value));
         this.globalRuleMetaData = globalRuleMetaData;
         this.props = props;
-        internalProps = new InternalConfigurationProperties(props.getProps());
+        temporaryProps = new TemporaryConfigurationProperties(props.getProps());
     }
     
     /**

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ShardingSphereDataJobWorker.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ShardingSphereDataJobWorker.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.data.pipeline.core.execute;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,7 +39,7 @@ public final class ShardingSphereDataJobWorker {
      */
     public static void initialize(final ContextManager contextManager) {
         if (WORKER_INITIALIZED.compareAndSet(false, true)) {
-            boolean collectorEnabled = contextManager.getMetaDataContexts().getMetaData().getInternalProps().getValue(InternalConfigurationPropertyKey.PROXY_META_DATA_COLLECTOR_ENABLED);
+            boolean collectorEnabled = contextManager.getMetaDataContexts().getMetaData().getTemporaryProps().getValue(TemporaryConfigurationPropertyKey.PROXY_META_DATA_COLLECTOR_ENABLED);
             if (collectorEnabled) {
                 startScheduleThread(contextManager);
             }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutor.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable;
 
 import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowDistVariableStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.logging.constant.LoggingConstants;
@@ -56,8 +56,8 @@ public final class ShowDistVariableExecutor implements ConnectionSessionRequired
     private Collection<LocalDataQueryResultRow> buildSpecifiedRow(final ShardingSphereMetaData metaData, final ConnectionSession connectionSession, final String variableName) {
         if (isConfigurationKey(variableName)) {
             return Collections.singletonList(new LocalDataQueryResultRow(variableName.toLowerCase(), getConfigurationValue(metaData, variableName)));
-        } else if (isInternalConfigurationKey(variableName)) {
-            return Collections.singletonList(new LocalDataQueryResultRow(variableName.toLowerCase(), getInternalConfigurationValue(metaData, variableName)));
+        } else if (isTemporaryConfigurationKey(variableName)) {
+            return Collections.singletonList(new LocalDataQueryResultRow(variableName.toLowerCase(), getTemporaryConfigurationValue(metaData, variableName)));
         }
         return Collections.singletonList(new LocalDataQueryResultRow(variableName.toLowerCase(), getSpecialValue(connectionSession, variableName)));
     }
@@ -90,12 +90,12 @@ public final class ShowDistVariableExecutor implements ConnectionSessionRequired
         return metaData.getProps().getValue(ConfigurationPropertyKey.valueOf(variableName)).toString();
     }
     
-    private boolean isInternalConfigurationKey(final String variableName) {
-        return InternalConfigurationPropertyKey.getKeyNames().contains(variableName);
+    private boolean isTemporaryConfigurationKey(final String variableName) {
+        return TemporaryConfigurationPropertyKey.getKeyNames().contains(variableName);
     }
     
-    private String getInternalConfigurationValue(final ShardingSphereMetaData metaData, final String variableName) {
-        return metaData.getInternalProps().getValue(InternalConfigurationPropertyKey.valueOf(variableName)).toString();
+    private String getTemporaryConfigurationValue(final ShardingSphereMetaData metaData, final String variableName) {
+        return metaData.getTemporaryProps().getValue(TemporaryConfigurationPropertyKey.valueOf(variableName)).toString();
     }
     
     private String getSpecialValue(final ConnectionSession connectionSession, final String variableName) {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable;
 
 import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowDistVariablesStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.logging.constant.LoggingConstants;
@@ -51,8 +51,8 @@ public final class ShowDistVariablesExecutor implements ConnectionSessionRequire
     public Collection<LocalDataQueryResultRow> getRows(final ShardingSphereMetaData metaData, final ConnectionSession connectionSession, final ShowDistVariablesStatement sqlStatement) {
         Collection<LocalDataQueryResultRow> result = ConfigurationPropertyKey.getKeyNames().stream().filter(each -> !"sql_show".equalsIgnoreCase(each) && !"sql_simple".equalsIgnoreCase(each))
                 .map(each -> new LocalDataQueryResultRow(each.toLowerCase(), metaData.getProps().getValue(ConfigurationPropertyKey.valueOf(each)).toString())).collect(Collectors.toList());
-        result.addAll(InternalConfigurationPropertyKey.getKeyNames().stream()
-                .map(each -> new LocalDataQueryResultRow(each.toLowerCase(), metaData.getInternalProps().getValue(InternalConfigurationPropertyKey.valueOf(each)).toString()))
+        result.addAll(TemporaryConfigurationPropertyKey.getKeyNames().stream()
+                .map(each -> new LocalDataQueryResultRow(each.toLowerCase(), metaData.getTemporaryProps().getValue(TemporaryConfigurationPropertyKey.valueOf(each)).toString()))
                 .collect(Collectors.toList()));
         result.add(new LocalDataQueryResultRow(
                 VariableEnum.AGENT_PLUGINS_ENABLED.name().toLowerCase(), SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.TRUE.toString())));

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdater.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdater.java
@@ -23,7 +23,7 @@ import ch.qos.logback.classic.LoggerContext;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.SetDistVariableStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.util.props.TypedPropertyKey;
 import org.apache.shardingsphere.infra.util.props.TypedPropertyValue;
 import org.apache.shardingsphere.infra.util.props.exception.TypedPropertyValueException;
@@ -65,7 +65,7 @@ public final class SetDistVariableUpdater implements ConnectionSessionRequiredRA
             return ConfigurationPropertyKey.valueOf(name.toUpperCase());
         } catch (final IllegalArgumentException ex) {
             try {
-                return InternalConfigurationPropertyKey.valueOf(name.toUpperCase());
+                return TemporaryConfigurationPropertyKey.valueOf(name.toUpperCase());
             } catch (final IllegalArgumentException exception) {
                 return VariableEnum.getValueOf(name);
             }
@@ -77,7 +77,7 @@ public final class SetDistVariableUpdater implements ConnectionSessionRequiredRA
         MetaDataContexts metaDataContexts = contextManager.getMetaDataContexts();
         Properties props = new Properties();
         props.putAll(metaDataContexts.getMetaData().getProps().getProps());
-        props.putAll(metaDataContexts.getMetaData().getInternalProps().getProps());
+        props.putAll(metaDataContexts.getMetaData().getTemporaryProps().getProps());
         props.put(propertyKey.getKey(), getValue(propertyKey, value));
         contextManager.getInstanceContext().getModeContextManager().alterProperties(props);
         refreshRootLogger(props);

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable;
 
 import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowDistVariableStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationProperties;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationProperties;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -113,8 +113,8 @@ class ShowDistVariableExecutorTest {
     }
     
     @Test
-    void assertShowInternalPropsVariable() {
-        when(metaData.getInternalProps()).thenReturn(new InternalConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
+    void assertShowTemporaryPropsVariable() {
+        when(metaData.getTemporaryProps()).thenReturn(new TemporaryConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
         ShowDistVariableExecutor executor = new ShowDistVariableExecutor();
         Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, connectionSession, new ShowDistVariableStatement("PROXY_META_DATA_COLLECTOR_ENABLED"));
         assertThat(actual.size(), is(1));

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable;
 
 import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowDistVariablesStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationProperties;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationProperties;
 import org.apache.shardingsphere.infra.merge.result.impl.local.LocalDataQueryResultRow;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -59,7 +59,7 @@ class ShowDistVariablesExecutorTest {
     @Test
     void assertExecute() {
         when(metaData.getProps()).thenReturn(new ConfigurationProperties(PropertiesBuilder.build(new Property("system_log_level", "INFO"))));
-        when(metaData.getInternalProps()).thenReturn(new InternalConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
+        when(metaData.getTemporaryProps()).thenReturn(new TemporaryConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
         when(metaData.getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(new LoggingRule(new DefaultLoggingRuleConfigurationBuilder().build()))));
         ShowDistVariablesExecutor executor = new ShowDistVariablesExecutor();
         Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, connectionSession, mock(ShowDistVariablesStatement.class));

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
@@ -21,7 +21,7 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.SetDistV
 import org.apache.shardingsphere.infra.config.mode.ModeConfiguration;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.props.LoggerLevel;
-import org.apache.shardingsphere.infra.config.props.internal.InternalConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.instance.ComputeNodeInstance;
 import org.apache.shardingsphere.infra.instance.InstanceContext;
 import org.apache.shardingsphere.infra.instance.metadata.InstanceMetaData;
@@ -96,15 +96,15 @@ class SetDistVariableUpdaterTest {
     }
     
     @Test
-    void assertExecuteWithInternalConfigurationKey() {
+    void assertExecuteWithTemporaryConfigurationKey() {
         SetDistVariableStatement statement = new SetDistVariableStatement("proxy_meta_data_collector_enabled", "false");
         SetDistVariableUpdater updater = new SetDistVariableUpdater();
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         updater.executeUpdate(connectionSession, statement);
-        Object actualValue = contextManager.getMetaDataContexts().getMetaData().getInternalProps().getProps().get("proxy-meta-data-collector-enabled");
+        Object actualValue = contextManager.getMetaDataContexts().getMetaData().getTemporaryProps().getProps().get("proxy-meta-data-collector-enabled");
         assertThat(actualValue.toString(), is("false"));
-        assertThat(contextManager.getMetaDataContexts().getMetaData().getInternalProps().getValue(InternalConfigurationPropertyKey.PROXY_META_DATA_COLLECTOR_ENABLED), is(false));
+        assertThat(contextManager.getMetaDataContexts().getMetaData().getTemporaryProps().getValue(TemporaryConfigurationPropertyKey.PROXY_META_DATA_COLLECTOR_ENABLED), is(false));
     }
     
     @Test


### PR DESCRIPTION
Changes proposed in this pull request:
  - Rename internal props to temporary props, to prevent users misuse it, because these configuration items are temporary experimental configurations and may be deleted at any time.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
