### PR TITLE
Add openGauss timestamp alias select e2e test

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-projection.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-projection.xml
@@ -52,7 +52,7 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     
-    <test-case sql="SELECT order_id AS id FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
+    <test-case sql="SELECT order_id AS id, creation_date AS timestamp FROM t_order WHERE user_id = ? AND order_id = ?" db-types="MySQL,openGauss" scenario-types="db,tbl,dbtbl_with_readwrite_splitting,readwrite_splitting">
         <assertion parameters="10:int, 1000:int" expected-data-source-name="read_dataset" />
     </test-case>
     


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add openGauss timestamp alias select e2e test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
