### PR TITLE
Fix NullPointerException when execute information schema query with sql federation

### DIFF
--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowCreateTableMergedResult.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/merge/dal/show/ShowCreateTableMergedResult.java
@@ -51,7 +51,7 @@ public final class ShowCreateTableMergedResult extends LogicTablesMergedResult {
             String actualIndexName = IndexMetaDataUtils.getActualIndexName(each, actualTableName);
             memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replace(actualIndexName, each));
         }
-        for (Entry<String, ShardingSphereConstraint> entry : table.getConstrains().entrySet()) {
+        for (Entry<String, ShardingSphereConstraint> entry : table.getConstraints().entrySet()) {
             String actualIndexName = IndexMetaDataUtils.getActualIndexName(entry.getKey(), actualTableName);
             memoryResultSetRow.setCell(2, memoryResultSetRow.getCell(2).toString().replace(actualIndexName, entry.getKey()));
             Optional<TableRule> tableRule = shardingRule.findTableRule(entry.getValue().getReferencedTableName());

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereTable.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/model/ShardingSphereTable.java
@@ -44,7 +44,7 @@ public final class ShardingSphereTable {
     
     private final Map<String, ShardingSphereIndex> indexes;
     
-    private final Map<String, ShardingSphereConstraint> constrains;
+    private final Map<String, ShardingSphereConstraint> constraints;
     
     private final List<String> columnNames = new ArrayList<>();
     
@@ -56,17 +56,17 @@ public final class ShardingSphereTable {
         this("", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
     }
     
-    public ShardingSphereTable(final String name, final Collection<ShardingSphereColumn> columnList,
-                               final Collection<ShardingSphereIndex> indexList, final Collection<ShardingSphereConstraint> constraintList) {
+    public ShardingSphereTable(final String name, final Collection<ShardingSphereColumn> columns,
+                               final Collection<ShardingSphereIndex> indexes, final Collection<ShardingSphereConstraint> constraints) {
         this.name = name;
-        columns = getColumns(columnList);
-        indexes = getIndexes(indexList);
-        constrains = getConstrains(constraintList);
+        this.columns = getColumns(columns);
+        this.indexes = getIndexes(indexes);
+        this.constraints = getConstraints(constraints);
     }
     
-    private Map<String, ShardingSphereColumn> getColumns(final Collection<ShardingSphereColumn> columnList) {
-        Map<String, ShardingSphereColumn> result = new LinkedHashMap<>(columnList.size(), 1);
-        for (ShardingSphereColumn each : columnList) {
+    private Map<String, ShardingSphereColumn> getColumns(final Collection<ShardingSphereColumn> columns) {
+        Map<String, ShardingSphereColumn> result = new LinkedHashMap<>(columns.size(), 1);
+        for (ShardingSphereColumn each : columns) {
             String lowerColumnName = each.getName().toLowerCase();
             result.put(lowerColumnName, each);
             columnNames.add(each.getName());
@@ -80,19 +80,29 @@ public final class ShardingSphereTable {
         return result;
     }
     
-    private Map<String, ShardingSphereIndex> getIndexes(final Collection<ShardingSphereIndex> indexList) {
-        Map<String, ShardingSphereIndex> result = new LinkedHashMap<>(indexList.size(), 1);
-        for (ShardingSphereIndex each : indexList) {
+    private Map<String, ShardingSphereIndex> getIndexes(final Collection<ShardingSphereIndex> indexes) {
+        Map<String, ShardingSphereIndex> result = new LinkedHashMap<>(indexes.size(), 1);
+        for (ShardingSphereIndex each : indexes) {
             result.put(each.getName().toLowerCase(), each);
         }
         return result;
     }
     
-    private Map<String, ShardingSphereConstraint> getConstrains(final Collection<ShardingSphereConstraint> constraintList) {
-        Map<String, ShardingSphereConstraint> result = new LinkedHashMap<>(constraintList.size(), 1);
-        for (ShardingSphereConstraint each : constraintList) {
+    private Map<String, ShardingSphereConstraint> getConstraints(final Collection<ShardingSphereConstraint> constraints) {
+        Map<String, ShardingSphereConstraint> result = new LinkedHashMap<>(constraints.size(), 1);
+        for (ShardingSphereConstraint each : constraints) {
             result.put(each.getName().toLowerCase(), each);
         }
         return result;
+    }
+    
+    /**
+     * Get table meta data via column name.
+     *
+     * @param columnName column name
+     * @return table meta data
+     */
+    public ShardingSphereColumn getColumn(final String columnName) {
+        return columns.get(columnName.toLowerCase());
     }
 }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlTableSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/schema/swapper/YamlTableSwapper.java
@@ -43,7 +43,7 @@ public final class YamlTableSwapper implements YamlConfigurationSwapper<YamlShar
         YamlShardingSphereTable result = new YamlShardingSphereTable();
         result.setColumns(swapYamlColumns(table.getColumns()));
         result.setIndexes(swapYamlIndexes(table.getIndexes()));
-        result.setConstraints(swapYamlConstraints(table.getConstrains()));
+        result.setConstraints(swapYamlConstraints(table.getConstraints()));
         result.setName(table.getName());
         return result;
     }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/AlterIndexStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/AlterIndexStatementSchemaRefresher.java
@@ -68,7 +68,7 @@ public final class AlterIndexStatementSchemaRefresher implements MetaDataRefresh
     
     private ShardingSphereTable newShardingSphereTable(final ShardingSphereTable table) {
         ShardingSphereTable result = new ShardingSphereTable(table.getName(), new LinkedHashMap<>(table.getColumns()),
-                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstrains()));
+                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstraints()));
         result.getColumnNames().addAll(table.getColumnNames());
         result.getVisibleColumns().addAll(table.getVisibleColumns());
         result.getPrimaryKeyColumns().addAll(table.getPrimaryKeyColumns());

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/CreateIndexStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/CreateIndexStatementSchemaRefresher.java
@@ -54,7 +54,7 @@ public final class CreateIndexStatementSchemaRefresher implements MetaDataRefres
     
     private ShardingSphereTable newShardingSphereTable(final ShardingSphereTable table) {
         ShardingSphereTable result = new ShardingSphereTable(table.getName(), new LinkedHashMap<>(table.getColumns()),
-                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstrains()));
+                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstraints()));
         result.getColumnNames().addAll(table.getColumnNames());
         result.getVisibleColumns().addAll(table.getVisibleColumns());
         result.getPrimaryKeyColumns().addAll(table.getPrimaryKeyColumns());

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/DropIndexStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/context/refresher/type/index/DropIndexStatementSchemaRefresher.java
@@ -68,7 +68,7 @@ public final class DropIndexStatementSchemaRefresher implements MetaDataRefreshe
     
     private ShardingSphereTable newShardingSphereTable(final ShardingSphereTable table) {
         ShardingSphereTable result = new ShardingSphereTable(table.getName(), new LinkedHashMap<>(table.getColumns()),
-                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstrains()));
+                new LinkedHashMap<>(table.getIndexes()), new LinkedHashMap<>(table.getConstraints()));
         result.getColumnNames().addAll(table.getColumnNames());
         result.getVisibleColumns().addAll(table.getVisibleColumns());
         result.getPrimaryKeyColumns().addAll(table.getPrimaryKeyColumns());

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/translatable/FederationTranslatableTable.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/translatable/FederationTranslatableTable.java
@@ -35,7 +35,6 @@ import org.apache.calcite.schema.Statistic;
 import org.apache.calcite.schema.TranslatableTable;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereColumn;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.util.exception.external.sql.type.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.sqlfederation.optimizer.executor.TableScanExecutor;
@@ -44,8 +43,6 @@ import org.apache.shardingsphere.sqlfederation.optimizer.metadata.statistic.Fede
 import org.apache.shardingsphere.sqlfederation.optimizer.util.SQLFederationDataTypeUtils;
 
 import java.lang.reflect.Type;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Federation translatable table.
@@ -114,10 +111,8 @@ public final class FederationTranslatableTable extends AbstractTable implements 
      * @return column data type
      */
     public int getColumnType(final int index) {
-        List columnNames = table.getVisibleColumns();
-        Map<String, ShardingSphereColumn> columnMap = table.getColumns();
-        ShardingSphereColumn column = columnMap.get(columnNames.get(index));
-        return column.getDataType();
+        String columnName = table.getColumnNames().get(index);
+        return table.getColumn(columnName).getDataType();
     }
     
     @Override


### PR DESCRIPTION
Fixes #25234.

Changes proposed in this pull request:
  - Fix NullPointerException when execute information schema query with sql federation

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
