### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -63,7 +63,9 @@ public enum SystemSchemaBuilderRule {
             "events_waits_summary_by_host_by_event_name", "events_waits_summary_by_instance", "events_waits_summary_by_thread_by_event_name", "events_waits_summary_by_user_by_event_name",
             "events_waits_summary_global_by_event_name", "file_instances", "file_summary_by_event_name", "file_summary_by_instance", "global_status", "global_variables", "host_cache", "hosts",
             "memory_summary_by_account_by_event_name", "memory_summary_by_host_by_event_name", "memory_summary_by_thread_by_event_name", "memory_summary_by_user_by_event_name",
-            "memory_summary_global_by_event_name", "metadata_locks"))),
+            "memory_summary_global_by_event_name", "metadata_locks", "mutex_instances", "objects_summary_global_by_type", "performance_timers", "prepared_statements_instances",
+            "replication_applier_configuration", "replication_applier_status", "replication_applier_status_by_coordinator", "replication_applier_status_by_worker",
+            "replication_connection_configuration", "replication_connection_status"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/mutex_instances.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/mutex_instances.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: mutex_instances
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  locked_by_thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LOCKED_BY_THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/objects_summary_global_by_type.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/objects_summary_global_by_type.yaml
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: objects_summary_global_by_type
+columns:
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/performance_timers.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/performance_timers.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: performance_timers
+columns:
+  timer_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TIMER_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_frequency:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_FREQUENCY
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_resolution:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_RESOLUTION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_overhead:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_OVERHEAD
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/prepared_statements_instances.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/prepared_statements_instances.yaml
@@ -1,0 +1,299 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: prepared_statements_instances
+columns:
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  statement_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: STATEMENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  statement_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATEMENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  sql_text:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: SQL_TEXT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  owner_thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OWNER_THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  owner_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OWNER_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  owner_object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OWNER_OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  owner_object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OWNER_OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  owner_object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OWNER_OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_prepare:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: TIMER_PREPARE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_reprepare:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_REPREPARE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_execute:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_EXECUTE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_execute:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_EXECUTE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_execute:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_EXECUTE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_execute:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_EXECUTE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_execute:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_EXECUTE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_lock_time:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_LOCK_TIME
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_errors:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ERRORS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_warnings:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_WARNINGS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_affected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_AFFECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_sent:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_SENT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_rows_examined:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_ROWS_EXAMINED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_disk_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_DISK_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_created_tmp_tables:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_CREATED_TMP_TABLES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_full_range_join:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_FULL_RANGE_JOIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_range_check:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_RANGE_CHECK
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_select_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SELECT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_merge_passes:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_MERGE_PASSES
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_range:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_RANGE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_rows:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_ROWS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_sort_scan:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_SORT_SCAN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_no_good_index_used:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NO_GOOD_INDEX_USED
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_configuration.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_configuration.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_applier_configuration
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  desired_delay:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: DESIRED_DELAY
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_applier_status
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  service_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SERVICE_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  remaining_delay:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: REMAINING_DELAY
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_transactions_retries:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_TRANSACTIONS_RETRIES
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status_by_coordinator.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status_by_coordinator.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_applier_status_by_coordinator
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  service_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SERVICE_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_number:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LAST_ERROR_NUMBER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_message:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: LAST_ERROR_MESSAGE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_timestamp:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: LAST_ERROR_TIMESTAMP
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status_by_worker.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_applier_status_by_worker.yaml
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_applier_status_by_worker
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  worker_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: WORKER_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  service_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SERVICE_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_seen_transaction:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: LAST_SEEN_TRANSACTION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_number:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LAST_ERROR_NUMBER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_message:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: LAST_ERROR_MESSAGE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_timestamp:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: LAST_ERROR_TIMESTAMP
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_connection_configuration.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_connection_configuration.yaml
@@ -1,0 +1,171 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_connection_configuration
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  port:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: PORT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  network_interface:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: NETWORK_INTERFACE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  auto_position:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: AUTO_POSITION
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_allowed:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_ALLOWED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_ca_file:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CA_FILE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_ca_path:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CA_PATH
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_certificate:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CERTIFICATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_cipher:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CIPHER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_key:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_KEY
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_verify_server_certificate:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_VERIFY_SERVER_CERTIFICATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_crl_file:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CRL_FILE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ssl_crl_path:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SSL_CRL_PATH
+    primaryKey: false
+    unsigned: false
+    visible: true
+  connection_retry_interval:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CONNECTION_RETRY_INTERVAL
+    primaryKey: false
+    unsigned: false
+    visible: true
+  connection_retry_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: CONNECTION_RETRY_COUNT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  heartbeat_interval:
+    caseSensitive: false
+    dataType: 8
+    generated: false
+    name: HEARTBEAT_INTERVAL
+    primaryKey: false
+    unsigned: true
+    visible: true
+  tls_version:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TLS_VERSION
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_connection_status.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_connection_status.yaml
@@ -1,0 +1,107 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_connection_status
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  group_name:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: GROUP_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  source_uuid:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: SOURCE_UUID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  service_state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: SERVICE_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_received_heartbeats:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_RECEIVED_HEARTBEATS
+    primaryKey: false
+    unsigned: true
+    visible: true
+  last_heartbeat_timestamp:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: LAST_HEARTBEAT_TIMESTAMP
+    primaryKey: false
+    unsigned: false
+    visible: true
+  received_transaction_set:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: RECEIVED_TRANSACTION_SET
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_number:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: LAST_ERROR_NUMBER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_message:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: LAST_ERROR_MESSAGE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_error_timestamp:
+    caseSensitive: false
+    dataType: 93
+    generated: false
+    name: LAST_ERROR_TIMESTAMP
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(49));
+        assertThat(actualPerformanceSchema.getTables().size(), is(59));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(49));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(59));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_mutex_instances.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_mutex_instances.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="object_instance_begin" />
+        <column name="locked_by_thread_id" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_objects_summary_global_by_type.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_objects_summary_global_by_type.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_performance_timers.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_performance_timers.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="timer_name" />
+        <column name="timer_frequency" />
+        <column name="timer_resolution" />
+        <column name="timer_overhead" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_prepared_statements_instances.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_prepared_statements_instances.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="object_instance_begin" />
+        <column name="statement_id" />
+        <column name="statement_name" />
+        <column name="sql_text" />
+        <column name="owner_thread_id" />
+        <column name="owner_event_id" />
+        <column name="owner_object_type" />
+        <column name="owner_object_schema" />
+        <column name="owner_object_name" />
+        <column name="timer_prepare" />
+        <column name="count_reprepare" />
+        <column name="count_execute" />
+        <column name="sum_timer_execute" />
+        <column name="min_timer_execute" />
+        <column name="avg_timer_execute" />
+        <column name="max_timer_execute" />
+        <column name="sum_lock_time" />
+        <column name="sum_errors" />
+        <column name="sum_warnings" />
+        <column name="sum_rows_affected" />
+        <column name="sum_rows_sent" />
+        <column name="sum_rows_examined" />
+        <column name="sum_created_tmp_disk_tables" />
+        <column name="sum_created_tmp_tables" />
+        <column name="sum_select_full_join" />
+        <column name="sum_select_full_range_join" />
+        <column name="sum_select_range" />
+        <column name="sum_select_range_check" />
+        <column name="sum_select_scan" />
+        <column name="sum_sort_merge_passes" />
+        <column name="sum_sort_range" />
+        <column name="sum_sort_rows" />
+        <column name="sum_sort_scan" />
+        <column name="sum_no_index_used" />
+        <column name="sum_no_good_index_used" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_configuration.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_configuration.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="desired_delay" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="service_state" />
+        <column name="remaining_delay" />
+        <column name="count_transactions_retries" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status_by_coordinator.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status_by_coordinator.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="thread_id" />
+        <column name="service_state" />
+        <column name="last_error_number" />
+        <column name="last_error_message" />
+        <column name="last_error_timestamp" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status_by_worker.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_applier_status_by_worker.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="worker_id" />
+        <column name="thread_id" />
+        <column name="service_state" />
+        <column name="last_seen_transaction" />
+        <column name="last_error_number" />
+        <column name="last_error_message" />
+        <column name="last_error_timestamp" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_connection_configuration.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_connection_configuration.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="host" />
+        <column name="port" />
+        <column name="user" />
+        <column name="network_interface" />
+        <column name="auto_position" />
+        <column name="ssl_allowed" />
+        <column name="ssl_ca_file" />
+        <column name="ssl_ca_path" />
+        <column name="ssl_certificate" />
+        <column name="ssl_cipher" />
+        <column name="ssl_key" />
+        <column name="ssl_verify_server_certificate" />
+        <column name="ssl_crl_file" />
+        <column name="ssl_crl_path" />
+        <column name="connection_retry_interval" />
+        <column name="connection_retry_count" />
+        <column name="heartbeat_interval" />
+        <column name="tls_version" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_connection_status.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_connection_status.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="group_name" />
+        <column name="source_uuid" />
+        <column name="thread_id" />
+        <column name="service_state" />
+        <column name="count_received_heartbeats" />
+        <column name="last_heartbeat_timestamp" />
+        <column name="received_transaction_set" />
+        <column name="last_error_number" />
+        <column name="last_error_message" />
+        <column name="last_error_timestamp" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -568,4 +568,44 @@
     <test-case sql="SELECT * FROM performance_schema.metadata_locks" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_metadata_locks.xml" />
     </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.mutex_instances" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_mutex_instances.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.objects_summary_global_by_type" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_objects_summary_global_by_type.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.performance_timers" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_performance_timers.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.prepared_statements_instances" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_prepared_statements_instances.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_applier_configuration" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_applier_configuration.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_applier_status" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_applier_status.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_applier_status_by_coordinator" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_applier_status_by_coordinator.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_applier_status_by_worker" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_applier_status_by_worker.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_connection_configuration" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_connection_configuration.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_connection_status" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_connection_status.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
