### PR TITLE
Build failed with error Could not find resource 'src/resources/spotless/java.xml' if working dir is not root of ShardingSphere

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -856,10 +856,10 @@
                     <configuration>
                         <java>
                             <eclipse>
-                                <file>src/resources/spotless/java.xml</file>
+                                <file>${maven.multiModuleProjectDirectory}/src/resources/spotless/java.xml</file>
                             </eclipse>
                             <licenseHeader>
-                                <file>src/resources/spotless/copyright.txt</file>
+                                <file>${maven.multiModuleProjectDirectory}/src/resources/spotless/copyright.txt</file>
                             </licenseHeader>
                         </java>
                         <pom>


### PR DESCRIPTION
Fixes #25190 .

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
