### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -128,7 +128,7 @@ public enum SystemSchemaBuilderRule {
      * Value of builder rule.
      *
      * @param databaseType database type
-     * @param schema       schema
+     * @param schema schema
      * @return builder rule
      */
     public static SystemSchemaBuilderRule valueOf(final String databaseType, final String schema) {
@@ -141,7 +141,7 @@ public enum SystemSchemaBuilderRule {
     /**
      * Judge whether current table is system table or not.
      *
-     * @param schema    schema
+     * @param schema schema
      * @param tableName table name
      * @return whether current table is system table or not
      */

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -65,7 +65,8 @@ public enum SystemSchemaBuilderRule {
             "memory_summary_by_account_by_event_name", "memory_summary_by_host_by_event_name", "memory_summary_by_thread_by_event_name", "memory_summary_by_user_by_event_name",
             "memory_summary_global_by_event_name", "metadata_locks", "mutex_instances", "objects_summary_global_by_type", "performance_timers", "prepared_statements_instances",
             "replication_applier_configuration", "replication_applier_status", "replication_applier_status_by_coordinator", "replication_applier_status_by_worker",
-            "replication_connection_configuration", "replication_connection_status"))),
+            "replication_connection_configuration", "replication_connection_status", "replication_group_member_stats", "replication_group_members", "rwlock_instances", "session_account_connect_attrs",
+            "session_connect_attrs", "session_status", "session_variables", "setup_actors", "setup_consumers", "setup_instruments"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     
@@ -127,7 +128,7 @@ public enum SystemSchemaBuilderRule {
      * Value of builder rule.
      *
      * @param databaseType database type
-     * @param schema schema
+     * @param schema       schema
      * @return builder rule
      */
     public static SystemSchemaBuilderRule valueOf(final String databaseType, final String schema) {
@@ -140,7 +141,7 @@ public enum SystemSchemaBuilderRule {
     /**
      * Judge whether current table is system table or not.
      *
-     * @param schema schema
+     * @param schema    schema
      * @param tableName table name
      * @return whether current table is system table or not
      */

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_group_member_stats.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_group_member_stats.yaml
@@ -1,0 +1,91 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_group_member_stats
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  view_id:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: VIEW_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  member_id:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: MEMBER_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_transactions_in_queue:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_TRANSACTIONS_IN_QUEUE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_transactions_checked:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_TRANSACTIONS_CHECKED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_conflicts_detected:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_CONFLICTS_DETECTED
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_transactions_rows_validating:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_TRANSACTIONS_ROWS_VALIDATING
+    primaryKey: false
+    unsigned: true
+    visible: true
+  transactions_committed_all_members:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: TRANSACTIONS_COMMITTED_ALL_MEMBERS
+    primaryKey: false
+    unsigned: false
+    visible: true
+  last_conflict_free_transaction:
+    caseSensitive: false
+    dataType: -1
+    generated: false
+    name: LAST_CONFLICT_FREE_TRANSACTION
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/replication_group_members.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/replication_group_members.yaml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: replication_group_members
+columns:
+  channel_name:
+    caseSensitive: false
+    dataType: 1
+    generated: false
+    name: CHANNEL_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  member_id:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: MEMBER_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  member_host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: MEMBER_HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  member_port:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MEMBER_PORT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  member_state:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: MEMBER_STATE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/rwlock_instances.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/rwlock_instances.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: rwlock_instances
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  write_locked_by_thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: WRITE_LOCKED_BY_THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  read_locked_by_count:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: READ_LOCKED_BY_COUNT
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/session_account_connect_attrs.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/session_account_connect_attrs.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: session_account_connect_attrs
+columns:
+  processlist_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: PROCESSLIST_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  attr_name:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: ATTR_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  attr_value:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: ATTR_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ordinal_position:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ORDINAL_POSITION
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/session_connect_attrs.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/session_connect_attrs.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: session_connect_attrs
+columns:
+  processlist_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: PROCESSLIST_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  attr_name:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: ATTR_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  attr_value:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: ATTR_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ordinal_position:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: ORDINAL_POSITION
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/session_status.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/session_status.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: session_status
+columns:
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/session_variables.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/session_variables.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: session_variables
+columns:
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/setup_actors.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/setup_actors.yaml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: setup_actors
+columns:
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  role:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: ROLE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  enabled:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ENABLED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  history:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: HISTORY
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/setup_consumers.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/setup_consumers.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: setup_consumers
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  enabled:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ENABLED
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/setup_instruments.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/setup_instruments.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: setup_instruments
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  enabled:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ENABLED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timed:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TIMED
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(59));
+        assertThat(actualPerformanceSchema.getTables().size(), is(69));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(59));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(69));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_group_member_stats.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_group_member_stats.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="view_id" />
+        <column name="member_id" />
+        <column name="count_transactions_in_queue" />
+        <column name="count_transactions_checked" />
+        <column name="count_conflicts_detected" />
+        <column name="count_transactions_rows_validating" />
+        <column name="transactions_committed_all_members" />
+        <column name="last_conflict_free_transaction" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_group_members.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_replication_group_members.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="channel_name" />
+        <column name="member_id" />
+        <column name="member_host" />
+        <column name="member_port" />
+        <column name="member_state" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_rwlock_instances.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_rwlock_instances.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="object_instance_begin" />
+        <column name="write_locked_by_thread_id" />
+        <column name="read_locked_by_count" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_account_connect_attrs.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_account_connect_attrs.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="processlist_id" />
+        <column name="attr_name" />
+        <column name="attr_value" />
+        <column name="ordinal_position" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_connect_attrs.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_connect_attrs.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="processlist_id" />
+        <column name="attr_name" />
+        <column name="attr_value" />
+        <column name="ordinal_position" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_status.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_status.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_variables.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_session_variables.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_actors.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_actors.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="host" />
+        <column name="user" />
+        <column name="role" />
+        <column name="enabled" />
+        <column name="history" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_consumers.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_consumers.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="enabled" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_instruments.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_instruments.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="enabled" />
+        <column name="timed" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -608,4 +608,44 @@
     <test-case sql="SELECT * FROM performance_schema.replication_connection_status" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_replication_connection_status.xml" />
     </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_group_member_stats" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_group_member_stats.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.replication_group_members" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_replication_group_members.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.rwlock_instances" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_rwlock_instances.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.session_account_connect_attrs" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_session_account_connect_attrs.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.session_connect_attrs" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_session_connect_attrs.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.session_status" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_session_status.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.session_variables" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_session_variables.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.setup_actors" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_setup_actors.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.setup_consumers" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_setup_consumers.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.setup_instruments" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_setup_instruments.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.