### PR TITLE
Add more mysql performance_schema tables

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -66,7 +66,8 @@ public enum SystemSchemaBuilderRule {
             "memory_summary_global_by_event_name", "metadata_locks", "mutex_instances", "objects_summary_global_by_type", "performance_timers", "prepared_statements_instances",
             "replication_applier_configuration", "replication_applier_status", "replication_applier_status_by_coordinator", "replication_applier_status_by_worker",
             "replication_connection_configuration", "replication_connection_status", "replication_group_member_stats", "replication_group_members", "rwlock_instances", "session_account_connect_attrs",
-            "session_connect_attrs", "session_status", "session_variables", "setup_actors", "setup_consumers", "setup_instruments"))),
+            "session_connect_attrs", "session_status", "session_variables", "setup_actors", "setup_consumers", "setup_instruments", "setup_objects", "setup_timers", "socket_instances",
+            "socket_summary_by_event_name", "socket_summary_by_instance", "status_by_account", "status_by_host", "status_by_thread", "status_by_user", "table_handles"))),
     
     MYSQL_SYS("MySQL", "sys", new HashSet<>(Collections.singleton("sys"))),
     

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/setup_objects.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/setup_objects.yaml
@@ -1,0 +1,59 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: setup_objects
+columns:
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  enabled:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: ENABLED
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timed:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TIMED
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/setup_timers.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/setup_timers.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: setup_timers
+columns:
+  name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  timer_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: TIMER_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/socket_instances.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/socket_instances.yaml
@@ -1,0 +1,75 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: socket_instances
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  socket_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SOCKET_ID
+    primaryKey: false
+    unsigned: false
+    visible: true
+  ip:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: IP
+    primaryKey: false
+    unsigned: false
+    visible: true
+  port:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: PORT
+    primaryKey: false
+    unsigned: false
+    visible: true
+  state:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: STATE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/socket_summary_by_event_name.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/socket_summary_by_event_name.yaml
@@ -1,0 +1,203 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: socket_summary_by_event_name
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/socket_summary_by_instance.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/socket_summary_by_instance.yaml
@@ -1,0 +1,211 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: socket_summary_by_instance
+columns:
+  event_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EVENT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_star:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_STAR
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_wait:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WAIT
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_read:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_READ
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_number_of_bytes_write:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_NUMBER_OF_BYTES_WRITE
+    primaryKey: false
+    unsigned: true
+    visible: true
+  count_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: COUNT_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  sum_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: SUM_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  min_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MIN_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  avg_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: AVG_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true
+  max_timer_misc:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: MAX_TIMER_MISC
+    primaryKey: false
+    unsigned: true
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_account.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_account.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: status_by_account
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_host.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_host.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: status_by_host
+columns:
+  host:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: HOST
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_thread.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_thread.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: status_by_thread
+columns:
+  thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_user.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/status_by_user.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: status_by_user
+columns:
+  user:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: USER
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  variable_value:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: VARIABLE_VALUE
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/main/resources/schema/mysql/performance_schema/table_handles.yaml
+++ b/infra/common/src/main/resources/schema/mysql/performance_schema/table_handles.yaml
@@ -1,0 +1,83 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: table_handles
+columns:
+  object_type:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_TYPE
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_schema:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_SCHEMA
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_name:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: OBJECT_NAME
+    primaryKey: false
+    unsigned: false
+    visible: true
+  object_instance_begin:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OBJECT_INSTANCE_BEGIN
+    primaryKey: false
+    unsigned: true
+    visible: true
+  owner_thread_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OWNER_THREAD_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  owner_event_id:
+    caseSensitive: false
+    dataType: 4
+    generated: false
+    name: OWNER_EVENT_ID
+    primaryKey: false
+    unsigned: true
+    visible: true
+  internal_lock:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: INTERNAL_LOCK
+    primaryKey: false
+    unsigned: false
+    visible: true
+  external_lock:
+    caseSensitive: false
+    dataType: 12
+    generated: false
+    name: EXTERNAL_LOCK
+    primaryKey: false
+    unsigned: false
+    visible: true

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -38,7 +38,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualMySQLSchema.getTables().size(), is(31));
         SystemSchemaBuilderRule actualPerformanceSchema = SystemSchemaBuilderRule.valueOf(new MySQLDatabaseType().getType(), "performance_schema");
         assertThat(actualPerformanceSchema, is(SystemSchemaBuilderRule.MYSQL_PERFORMANCE_SCHEMA));
-        assertThat(actualPerformanceSchema.getTables().size(), is(69));
+        assertThat(actualPerformanceSchema.getTables().size(), is(79));
     }
     
     @Test

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -44,7 +44,7 @@ class SystemSchemaBuilderTest {
         Map<String, ShardingSphereSchema> actualPerformanceSchema = SystemSchemaBuilder.build("performance_schema", new MySQLDatabaseType());
         assertThat(actualPerformanceSchema.size(), is(1));
         assertTrue(actualPerformanceSchema.containsKey("performance_schema"));
-        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(69));
+        assertThat(actualPerformanceSchema.get("performance_schema").getTables().size(), is(79));
     }
     
     @Test

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_objects.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_objects.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="enabled" />
+        <column name="timed" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_timers.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_setup_timers.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="name" />
+        <column name="timer_name" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_instances.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_instances.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="object_instance_begin" />
+        <column name="thread_id" />
+        <column name="socket_id" />
+        <column name="ip" />
+        <column name="port" />
+        <column name="state" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_summary_by_event_name.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_summary_by_event_name.xml
@@ -1,0 +1,44 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read" />
+        <column name="sum_timer_read" />
+        <column name="min_timer_read" />
+        <column name="avg_timer_read" />
+        <column name="max_timer_read" />
+        <column name="sum_number_of_bytes_read" />
+        <column name="count_write" />
+        <column name="sum_timer_write" />
+        <column name="min_timer_write" />
+        <column name="avg_timer_write" />
+        <column name="max_timer_write" />
+        <column name="sum_number_of_bytes_write" />
+        <column name="count_misc" />
+        <column name="sum_timer_misc" />
+        <column name="min_timer_misc" />
+        <column name="avg_timer_misc" />
+        <column name="max_timer_misc" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_summary_by_instance.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_socket_summary_by_instance.xml
@@ -1,0 +1,45 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="event_name" />
+        <column name="object_instance_begin" />
+        <column name="count_star" />
+        <column name="sum_timer_wait" />
+        <column name="min_timer_wait" />
+        <column name="avg_timer_wait" />
+        <column name="max_timer_wait" />
+        <column name="count_read" />
+        <column name="sum_timer_read" />
+        <column name="min_timer_read" />
+        <column name="avg_timer_read" />
+        <column name="max_timer_read" />
+        <column name="sum_number_of_bytes_read" />
+        <column name="count_write" />
+        <column name="sum_timer_write" />
+        <column name="min_timer_write" />
+        <column name="avg_timer_write" />
+        <column name="max_timer_write" />
+        <column name="sum_number_of_bytes_write" />
+        <column name="count_misc" />
+        <column name="sum_timer_misc" />
+        <column name="min_timer_misc" />
+        <column name="avg_timer_misc" />
+        <column name="max_timer_misc" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_account.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_account.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="host" />
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_host.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_host.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="host" />
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_thread.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_thread.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="thread_id" />
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_user.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_status_by_user.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="user" />
+        <column name="variable_name" />
+        <column name="variable_value" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_table_handles.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_mysql_performance_schema_table_handles.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="object_type" />
+        <column name="object_schema" />
+        <column name="object_name" />
+        <column name="object_instance_begin" />
+        <column name="owner_thread_id" />
+        <column name="owner_event_id" />
+        <column name="internal_lock" />
+        <column name="external_lock" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -648,4 +648,44 @@
     <test-case sql="SELECT * FROM performance_schema.setup_instruments" db-types="MySQL" scenario-types="db">
         <assertion expected-data-file="select_mysql_performance_schema_setup_instruments.xml" />
     </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.setup_objects" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_setup_objects.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.setup_timers" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_setup_timers.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.socket_instances" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_socket_instances.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.socket_summary_by_event_name" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_socket_summary_by_event_name.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.socket_summary_by_instance" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_socket_summary_by_instance.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.status_by_account" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_status_by_account.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.status_by_host" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_status_by_host.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.status_by_thread" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_status_by_thread.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.status_by_user" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_status_by_user.xml" />
+    </test-case>
+    
+    <test-case sql="SELECT * FROM performance_schema.table_handles" db-types="MySQL" scenario-types="db">
+        <assertion expected-data-file="select_mysql_performance_schema_table_handles.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #24662 .

Changes proposed in this pull request:
  - Add more mysql performance_schema tables

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.