### PR TITLE
Moved agent_plugins_enabled variable to global props

### DIFF
--- a/agent/core/pom.xml
+++ b/agent/core/pom.xml
@@ -37,6 +37,18 @@
             <artifactId>shardingsphere-agent-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-proxy-backend-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-jdbc-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
         
         <dependency>
             <groupId>net.bytebuddy</groupId>

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/ShardingSphereAgent.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/ShardingSphereAgent.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.agent.core.advisor.config.AdvisorConfiguration;
 import org.apache.shardingsphere.agent.core.advisor.config.AdvisorConfigurationLoader;
 import org.apache.shardingsphere.agent.core.builder.AgentBuilderFactory;
 import org.apache.shardingsphere.agent.core.path.AgentPath;
+import org.apache.shardingsphere.agent.core.plugin.PluginContext;
 import org.apache.shardingsphere.agent.core.plugin.config.PluginConfigurationLoader;
 import org.apache.shardingsphere.agent.core.plugin.jar.PluginJarLoader;
 
@@ -53,6 +54,7 @@ public final class ShardingSphereAgent {
         Map<String, PluginConfiguration> pluginConfigs = PluginConfigurationLoader.load(rootPath);
         Collection<JarFile> pluginJars = PluginJarLoader.load(rootPath);
         boolean isEnhancedForProxy = isEnhancedForProxy();
+        PluginContext.getInstance().setEnhancedForProxy(isEnhancedForProxy);
         Map<String, AdvisorConfiguration> advisorConfigs = AdvisorConfigurationLoader.load(pluginJars, pluginConfigs.keySet());
         AgentBuilderFactory.create(pluginConfigs, pluginJars, advisorConfigs, isEnhancedForProxy).installOn(instrumentation);
     }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/ConstructorAdviceExecutor.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/ConstructorAdviceExecutor.java
@@ -55,7 +55,7 @@ public final class ConstructorAdviceExecutor implements AdviceExecutor {
      */
     @RuntimeType
     public void advice(@This final TargetAdviceObject target, @AllArguments final Object[] args) {
-        boolean adviceEnabled = PluginContext.isPluginEnabled();
+        boolean adviceEnabled = PluginContext.getInstance().isPluginEnabled();
         try {
             if (adviceEnabled) {
                 for (Entry<String, Collection<ConstructorAdvice>> entry : advices.entrySet()) {

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/InstanceMethodAdviceExecutor.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/InstanceMethodAdviceExecutor.java
@@ -63,7 +63,7 @@ public final class InstanceMethodAdviceExecutor implements AdviceExecutor {
     @RuntimeType
     @SneakyThrows
     public Object advice(@This final TargetAdviceObject target, @Origin final Method method, @AllArguments final Object[] args, @SuperCall final Callable<?> callable) {
-        boolean adviceEnabled = PluginContext.isPluginEnabled();
+        boolean adviceEnabled = PluginContext.getInstance().isPluginEnabled();
         if (adviceEnabled) {
             adviceBefore(target, method, args);
         }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutor.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/advisor/executor/type/StaticMethodAdviceExecutor.java
@@ -61,7 +61,7 @@ public final class StaticMethodAdviceExecutor implements AdviceExecutor {
     @RuntimeType
     @SneakyThrows
     public Object advice(@Origin final Class<?> klass, @Origin final Method method, @AllArguments final Object[] args, @SuperCall final Callable<?> callable) {
-        boolean adviceEnabled = PluginContext.isPluginEnabled();
+        boolean adviceEnabled = PluginContext.getInstance().isPluginEnabled();
         if (adviceEnabled) {
             adviceBefore(klass, method, args);
         }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/plugin/PluginContext.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/plugin/PluginContext.java
@@ -71,7 +71,7 @@ public final class PluginContext {
     
     private Optional<ContextManager> getContextManager() {
         if (enhancedForProxy) {
-            return Optional.of(ProxyContext.getInstance().getContextManager());
+            return Optional.ofNullable(ProxyContext.getInstance().getContextManager());
         }
         Optional<ShardingSphereDriver> shardingSphereDriverOptional = getShardingSphereDriver();
         if (!shardingSphereDriverOptional.isPresent()) {
@@ -82,7 +82,7 @@ public final class PluginContext {
         for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
             ShardingSphereDataSource shardingSphereDataSource = (ShardingSphereDataSource) entry.getValue();
             ContextManager result = AgentReflectionUtils.getFieldValue(shardingSphereDataSource, "contextManager");
-            return Optional.of(result);
+            return Optional.ofNullable(result);
         }
         return Optional.empty();
     }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/plugin/PluginContext.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/plugin/PluginContext.java
@@ -19,21 +19,82 @@ package org.apache.shardingsphere.agent.core.plugin;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.apache.shardingsphere.agent.core.util.AgentReflectionUtils;
+import org.apache.shardingsphere.driver.ShardingSphereDriver;
+import org.apache.shardingsphere.driver.jdbc.core.datasource.ShardingSphereDataSource;
+import org.apache.shardingsphere.driver.jdbc.core.driver.DriverDataSourceCache;
+import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+
+import javax.sql.DataSource;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Plugin Context.
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Setter
 public final class PluginContext {
     
-    private static final String PLUGIN_ENABLED_KEY = "AGENT_PLUGINS_ENABLED";
+    private static final PluginContext INSTANCE = new PluginContext();
+    
+    private boolean enhancedForProxy;
+    
+    private ContextManager contextManager;
+    
+    /**
+     * Get instance of plugin context.
+     *
+     * @return instance
+     */
+    public static PluginContext getInstance() {
+        return INSTANCE;
+    }
     
     /**
      * Check if the plugin is enabled.
      *
      * @return the plugin enable value
      */
-    public static boolean isPluginEnabled() {
-        return !Boolean.FALSE.toString().equalsIgnoreCase(System.getProperty(PLUGIN_ENABLED_KEY)) && !"0".equals(System.getProperty(PLUGIN_ENABLED_KEY));
+    public boolean isPluginEnabled() {
+        if (null == contextManager) {
+            contextManager = getContextManager().orElse(null);
+        }
+        return null == contextManager ? true : contextManager.getMetaDataContexts().getMetaData().getProps().getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED);
+    }
+    
+    private Optional<ContextManager> getContextManager() {
+        if (enhancedForProxy) {
+            return Optional.of(ProxyContext.getInstance().getContextManager());
+        }
+        Optional<ShardingSphereDriver> shardingSphereDriverOptional = getShardingSphereDriver();
+        if (!shardingSphereDriverOptional.isPresent()) {
+            return Optional.empty();
+        }
+        DriverDataSourceCache dataSourceCache = AgentReflectionUtils.getFieldValue(shardingSphereDriverOptional.get(), "dataSourceCache");
+        Map<String, DataSource> dataSourceMap = AgentReflectionUtils.getFieldValue(dataSourceCache, "dataSourceMap");
+        for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
+            ShardingSphereDataSource shardingSphereDataSource = (ShardingSphereDataSource) entry.getValue();
+            ContextManager result = AgentReflectionUtils.getFieldValue(shardingSphereDataSource, "contextManager");
+            return Optional.of(result);
+        }
+        return Optional.empty();
+    }
+    
+    private Optional<ShardingSphereDriver> getShardingSphereDriver() {
+        Enumeration<Driver> driverEnumeration = DriverManager.getDrivers();
+        while (driverEnumeration.hasMoreElements()) {
+            Driver driver = driverEnumeration.nextElement();
+            if (driver instanceof ShardingSphereDriver) {
+                return Optional.of((ShardingSphereDriver) driver);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/agent/core/src/main/java/org/apache/shardingsphere/agent/core/util/AgentReflectionUtils.java
+++ b/agent/core/src/main/java/org/apache/shardingsphere/agent/core/util/AgentReflectionUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.agent.core.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * Agent reflection utility class.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class AgentReflectionUtils {
+    
+    /**
+     * Get field value.
+     *
+     * @param target target
+     * @param fieldName field name
+     * @param <T> type of field value
+     * @return field value
+     * @throws IllegalStateException illegal state exception
+     */
+    public static <T> T getFieldValue(final Object target, final String fieldName) {
+        Optional<Field> field = findField(fieldName, target.getClass());
+        if (field.isPresent()) {
+            return getFieldValue(target, field.get());
+        }
+        throw new IllegalStateException(String.format("Can not find field name `%s` in class %s.", fieldName, target.getClass()));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @SneakyThrows(IllegalAccessException.class)
+    private static <T> T getFieldValue(final Object target, final Field field) {
+        boolean accessible = field.isAccessible();
+        if (!accessible) {
+            field.setAccessible(true);
+        }
+        T result = (T) field.get(target);
+        if (!accessible) {
+            field.setAccessible(false);
+        }
+        return result;
+    }
+    
+    private static Optional<Field> findField(final String fieldName, final Class<?> targetClass) {
+        Class<?> currentTargetClass = targetClass;
+        while (Object.class != currentTargetClass) {
+            try {
+                return Optional.of(currentTargetClass.getDeclaredField(fieldName));
+            } catch (final NoSuchFieldException ignored) {
+                currentTargetClass = currentTargetClass.getSuperclass();
+            }
+        }
+        return Optional.empty();
+    }
+    
+    /**
+     * Invoke method.
+     * 
+     * @param method method
+     * @param target target
+     * @param args arguments
+     * @param <T> type of invoke result
+     * @return invoke result
+     */
+    @SuppressWarnings("unchecked")
+    @SneakyThrows(ReflectiveOperationException.class)
+    public static <T> T invokeMethod(final Method method, final Object target, final Object... args) {
+        boolean accessible = method.isAccessible();
+        if (!accessible) {
+            method.setAccessible(true);
+        }
+        T result = (T) method.invoke(target, args);
+        if (!accessible) {
+            method.setAccessible(false);
+        }
+        return result;
+    }
+}

--- a/agent/core/src/test/java/org/apache/shardingsphere/agent/core/plugin/PluginContextTest.java
+++ b/agent/core/src/test/java/org/apache/shardingsphere/agent/core/plugin/PluginContextTest.java
@@ -17,41 +17,45 @@
 
 package org.apache.shardingsphere.agent.core.plugin;
 
-import org.junit.jupiter.api.AfterAll;
+import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.mode.manager.ContextManager;
+import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
+import org.apache.shardingsphere.test.mock.AutoMockExtension;
+import org.apache.shardingsphere.test.mock.StaticMockSettings;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(AutoMockExtension.class)
+@StaticMockSettings(ProxyContext.class)
 class PluginContextTest {
     
-    @AfterAll
-    static void tearDown() {
-        System.clearProperty("AGENT_PLUGINS_ENABLED");
+    @AfterEach
+    void reset() {
+        PluginContext.getInstance().setContextManager(null);
     }
     
     @Test
-    void assertNotPluginEnabledKey() {
-        assertFalse(PluginContext.isPluginEnabled());
+    void assertPluginEnabledIsTrue() {
+        PluginContext.getInstance().setEnhancedForProxy(true);
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        when(contextManager.getMetaDataContexts().getMetaData().getProps().getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(true);
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        assertTrue(PluginContext.getInstance().isPluginEnabled());
     }
     
     @Test
-    void assertPluginEnabledKeyIsFalse() {
-        System.setProperty("AGENT_PLUGINS_ENABLED", "false");
-        assertFalse(PluginContext.isPluginEnabled());
-    }
-    
-    @Test
-    void assertPluginEnabledKeyIsZero() {
-        System.setProperty("AGENT_PLUGINS_ENABLED", "0");
-        assertFalse(PluginContext.isPluginEnabled());
-    }
-    
-    @Test
-    void assertPluginEnabled() {
-        System.setProperty("AGENT_PLUGINS_ENABLED", "1");
-        assertTrue(PluginContext.isPluginEnabled());
-        System.setProperty("AGENT_PLUGINS_ENABLED", "true");
-        assertTrue(PluginContext.isPluginEnabled());
+    void assertPluginEnabledIsFalse() {
+        PluginContext.getInstance().setEnhancedForProxy(true);
+        ContextManager contextManager = mock(ContextManager.class, RETURNS_DEEP_STUBS);
+        when(contextManager.getMetaDataContexts().getMetaData().getProps().getValue(ConfigurationPropertyKey.AGENT_PLUGINS_ENABLED)).thenReturn(false);
+        when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
+        assertFalse(PluginContext.getInstance().isPluginEnabled());
     }
 }

--- a/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorder.java
+++ b/agent/plugins/core/src/main/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorder.java
@@ -68,5 +68,8 @@ public final class MethodTimeRecorder {
     
     private void clean(final String key) {
         CURRENT_RECORDER.get().remove(key);
+        if (CURRENT_RECORDER.get().isEmpty()) {
+            CURRENT_RECORDER.remove();
+        }
     }
 }

--- a/agent/pom.xml
+++ b/agent/pom.xml
@@ -45,6 +45,12 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>${bytebuddy.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.shardingsphere</groupId>
+                <artifactId>shardingsphere-test-util</artifactId>
+                <version>${project.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     
@@ -62,6 +68,10 @@
                     <artifactId>checker-qual</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-test-util</artifactId>
         </dependency>
     </dependencies>
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/ConfigurationPropertyKey.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/config/props/ConfigurationPropertyKey.java
@@ -141,7 +141,12 @@ public enum ConfigurationPropertyKey implements TypedPropertyKey {
     /**
      * Proxy frontend SSL cipher.
      */
-    PROXY_FRONTEND_SSL_CIPHER("proxy-frontend-ssl-cipher", "", String.class, true);
+    PROXY_FRONTEND_SSL_CIPHER("proxy-frontend-ssl-cipher", "", String.class, true),
+    
+    /**
+     * Agent plugins enabled.
+     */
+    AGENT_PLUGINS_ENABLED("agent-plugins-enabled", String.valueOf(Boolean.TRUE), boolean.class, false);
     
     private final String key;
     

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/enums/VariableEnum.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/common/enums/VariableEnum.java
@@ -24,8 +24,6 @@ import org.apache.shardingsphere.proxy.backend.exception.UnsupportedVariableExce
  */
 public enum VariableEnum {
     
-    AGENT_PLUGINS_ENABLED,
-    
     CACHED_CONNECTIONS,
     
     TRANSACTION_TYPE;

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutor.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.proxy.backend.exception.UnsupportedVariableExce
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.executor.ConnectionSessionRequiredQueryableRALExecutor;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.transaction.api.TransactionType;
 
 import java.util.Arrays;
@@ -101,8 +100,6 @@ public final class ShowDistVariableExecutor implements ConnectionSessionRequired
     private String getSpecialValue(final ConnectionSession connectionSession, final String variableName) {
         VariableEnum variable = VariableEnum.getValueOf(variableName);
         switch (variable) {
-            case AGENT_PLUGINS_ENABLED:
-                return SystemPropertyUtils.getSystemProperty(variable.name(), Boolean.TRUE.toString());
             case CACHED_CONNECTIONS:
                 int connectionSize = connectionSession.getBackendConnection().getConnectionSize();
                 return String.valueOf(connectionSize);

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
@@ -28,7 +28,6 @@ import org.apache.shardingsphere.logging.util.LoggingUtils;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.executor.ConnectionSessionRequiredQueryableRALExecutor;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -54,8 +53,6 @@ public final class ShowDistVariablesExecutor implements ConnectionSessionRequire
         result.addAll(TemporaryConfigurationPropertyKey.getKeyNames().stream()
                 .map(each -> new LocalDataQueryResultRow(each.toLowerCase(), metaData.getTemporaryProps().getValue(TemporaryConfigurationPropertyKey.valueOf(each)).toString()))
                 .collect(Collectors.toList()));
-        result.add(new LocalDataQueryResultRow(
-                VariableEnum.AGENT_PLUGINS_ENABLED.name().toLowerCase(), SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.TRUE.toString())));
         result.add(new LocalDataQueryResultRow(VariableEnum.CACHED_CONNECTIONS.name().toLowerCase(), connectionSession.getBackendConnection().getConnectionSize()));
         result.add(new LocalDataQueryResultRow(VariableEnum.TRANSACTION_TYPE.name().toLowerCase(), connectionSession.getTransactionStatus().getTransactionType().name()));
         addLoggingPropsRows(metaData, result);

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdater.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdater.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.SetDistVariableStatement;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
@@ -37,7 +36,6 @@ import org.apache.shardingsphere.proxy.backend.exception.UnsupportedVariableExce
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.updatable.updater.ConnectionSessionRequiredRALUpdater;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.transaction.api.TransactionType;
 import org.slf4j.LoggerFactory;
 
@@ -125,10 +123,6 @@ public final class SetDistVariableUpdater implements ConnectionSessionRequiredRA
     private void handleVariables(final ConnectionSession connectionSession, final SetDistVariableStatement sqlStatement) {
         VariableEnum variable = VariableEnum.getValueOf(sqlStatement.getName());
         switch (variable) {
-            case AGENT_PLUGINS_ENABLED:
-                Boolean agentPluginsEnabled = BooleanUtils.toBooleanObject(sqlStatement.getValue());
-                SystemPropertyUtils.setSystemProperty(variable.name(), null == agentPluginsEnabled ? Boolean.FALSE.toString() : agentPluginsEnabled.toString());
-                break;
             case TRANSACTION_TYPE:
                 connectionSession.getTransactionStatus().setTransactionType(getTransactionType(sqlStatement.getValue()));
                 break;

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariableExecutorTest.java
@@ -26,13 +26,10 @@ import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRule
 import org.apache.shardingsphere.logging.rule.LoggingRule;
 import org.apache.shardingsphere.logging.rule.builder.DefaultLoggingRuleConfigurationBuilder;
 import org.apache.shardingsphere.proxy.backend.exception.UnsupportedVariableException;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.test.util.PropertiesBuilder;
 import org.apache.shardingsphere.test.util.PropertiesBuilder.Property;
 import org.apache.shardingsphere.transaction.api.TransactionType;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -51,11 +48,6 @@ class ShowDistVariableExecutorTest {
     private final ShardingSphereMetaData metaData = mock(ShardingSphereMetaData.class, RETURNS_DEEP_STUBS);
     
     private final ConnectionSession connectionSession = mock(ConnectionSession.class, RETURNS_DEEP_STUBS);
-    
-    @AfterAll
-    static void tearDown() {
-        System.clearProperty("AGENT_PLUGINS_ENABLED");
-    }
     
     @Test
     void assertGetColumns() {
@@ -87,17 +79,6 @@ class ShowDistVariableExecutorTest {
         LocalDataQueryResultRow row = actual.iterator().next();
         assertThat(row.getCell(1), is("cached_connections"));
         assertThat(row.getCell(2), is("1"));
-    }
-    
-    @Test
-    void assertShowAgentPluginsEnabled() {
-        SystemPropertyUtils.setSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.FALSE.toString());
-        ShowDistVariableExecutor executor = new ShowDistVariableExecutor();
-        Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, connectionSession, new ShowDistVariableStatement("AGENT_PLUGINS_ENABLED"));
-        assertThat(actual.size(), is(1));
-        LocalDataQueryResultRow row = actual.iterator().next();
-        assertThat(row.getCell(1), is("agent_plugins_enabled"));
-        assertThat(row.getCell(2), is("false"));
     }
     
     @Test

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdatableRALBackendHandlerTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdatableRALBackendHandlerTest.java
@@ -22,11 +22,9 @@ import org.apache.shardingsphere.distsql.parser.statement.ral.updatable.SetDistV
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
 import org.apache.shardingsphere.proxy.backend.exception.UnsupportedVariableException;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.UpdatableRALBackendHandler;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.transaction.api.TransactionType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,32 +86,5 @@ class SetDistVariableUpdatableRALBackendHandlerTest {
     void assertNotSupportedVariable() {
         UpdatableRALBackendHandler<?> handler = new UpdatableRALBackendHandler<>(new SetDistVariableStatement("@@session", "XXX"), connectionSession);
         assertThrows(UnsupportedVariableException.class, handler::execute);
-    }
-    
-    @Test
-    void assertSetAgentPluginsEnabledTrue() throws SQLException {
-        connectionSession.setCurrentDatabase(String.format(DATABASE_PATTERN, 0));
-        UpdatableRALBackendHandler<?> handler = new UpdatableRALBackendHandler<>(new SetDistVariableStatement(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.TRUE.toString()), null);
-        ResponseHeader actual = handler.execute();
-        assertThat(actual, instanceOf(UpdateResponseHeader.class));
-        assertThat(SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.FALSE.toString()), is(Boolean.TRUE.toString()));
-    }
-    
-    @Test
-    void assertSetAgentPluginsEnabledFalse() throws SQLException {
-        connectionSession.setCurrentDatabase(String.format(DATABASE_PATTERN, 0));
-        UpdatableRALBackendHandler<?> handler = new UpdatableRALBackendHandler<>(new SetDistVariableStatement(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.FALSE.toString()), null);
-        ResponseHeader actual = handler.execute();
-        assertThat(actual, instanceOf(UpdateResponseHeader.class));
-        assertThat(SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.FALSE.toString()), is(Boolean.FALSE.toString()));
-    }
-    
-    @Test
-    void assertSetAgentPluginsEnabledFalseWithUnknownValue() throws SQLException {
-        connectionSession.setCurrentDatabase(String.format(DATABASE_PATTERN, 0));
-        UpdatableRALBackendHandler<?> handler = new UpdatableRALBackendHandler<>(new SetDistVariableStatement(VariableEnum.AGENT_PLUGINS_ENABLED.name(), "xxx"), connectionSession);
-        ResponseHeader actual = handler.execute();
-        assertThat(actual, instanceOf(UpdateResponseHeader.class));
-        assertThat(SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), Boolean.FALSE.toString()), is(Boolean.FALSE.toString()));
     }
 }

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/updatable/SetDistVariableUpdaterTest.java
@@ -29,20 +29,17 @@ import org.apache.shardingsphere.infra.instance.workerid.WorkerIdGenerator;
 import org.apache.shardingsphere.infra.lock.LockContext;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.util.eventbus.EventBusContext;
+import org.apache.shardingsphere.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.mode.manager.ContextManager;
 import org.apache.shardingsphere.mode.manager.standalone.StandaloneModeContextManager;
 import org.apache.shardingsphere.mode.metadata.MetaDataContexts;
-import org.apache.shardingsphere.metadata.persist.MetaDataPersistService;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.exception.InvalidValueException;
-import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.backend.session.transaction.TransactionStatus;
-import org.apache.shardingsphere.proxy.backend.util.SystemPropertyUtils;
 import org.apache.shardingsphere.test.mock.AutoMockExtension;
 import org.apache.shardingsphere.test.mock.StaticMockSettings;
 import org.apache.shardingsphere.transaction.api.TransactionType;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -60,11 +57,6 @@ class SetDistVariableUpdaterTest {
     @Mock
     private ConnectionSession connectionSession;
     
-    @AfterAll
-    static void tearDown() {
-        System.clearProperty("AGENT_PLUGINS_ENABLED");
-    }
-    
     @Test
     void assertExecuteWithTransactionType() {
         SetDistVariableStatement statement = new SetDistVariableStatement("transaction_type", "local");
@@ -72,15 +64,6 @@ class SetDistVariableUpdaterTest {
         SetDistVariableUpdater updater = new SetDistVariableUpdater();
         updater.executeUpdate(connectionSession, statement);
         assertThat(connectionSession.getTransactionStatus().getTransactionType().name(), is(TransactionType.LOCAL.name()));
-    }
-    
-    @Test
-    void assertExecuteWithAgent() {
-        SetDistVariableStatement statement = new SetDistVariableStatement("AGENT_PLUGINS_ENABLED", Boolean.FALSE.toString());
-        SetDistVariableUpdater updater = new SetDistVariableUpdater();
-        updater.executeUpdate(connectionSession, statement);
-        String actualValue = SystemPropertyUtils.getSystemProperty(VariableEnum.AGENT_PLUGINS_ENABLED.name(), "default");
-        assertThat(actualValue, is(Boolean.FALSE.toString()));
     }
     
     @Test


### PR DESCRIPTION
Fixes #25371.

Changes proposed in this pull request:
  - Moved `agent_plugins_enabled` variable to global props

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
