### PR TITLE
Restrict Espresso API to only detect JAVA_HOME under Native Image

### DIFF
--- a/infra/expr/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParser.java
+++ b/infra/expr/espresso/src/main/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParser.java
@@ -34,14 +34,14 @@ import java.util.Objects;
  */
 public final class EspressoInlineExpressionParser implements JVMInlineExpressionParser {
 
-    private static final String JAVA_HOME;
-
     private static final String JAVA_CLASSPATH;
 
     static {
         // TODO https://github.com/oracle/graal/issues/4555 not yet closed
-        JAVA_HOME = System.getenv("JAVA_HOME");
-        ShardingSpherePreconditions.checkNotNull(JAVA_HOME, () -> new RuntimeException("Failed to determine the system's environment variable JAVA_HOME!"));
+        if ("Substrate VM".equals(System.getProperty("java.vm.name"))) {
+            String javaHome = System.getenv("JAVA_HOME");
+            ShardingSpherePreconditions.checkNotNull(javaHome, () -> new RuntimeException("Failed to determine the system's environment variable JAVA_HOME!"));
+        }
         URL resource = Objects.requireNonNull(EspressoInlineExpressionParser.class.getClassLoader().getResource("espresso-need-libs"));
         String dir = resource.getPath();
         JAVA_CLASSPATH = String.join(":", dir + "/groovy.jar", dir + "/guava.jar", dir + "/shardingsphere-infra-expr-hotsopt.jar");
@@ -84,7 +84,7 @@ public final class EspressoInlineExpressionParser implements JVMInlineExpression
 
     private Context getContext() {
         return Context.newBuilder().allowAllAccess(true)
-                .option("java.Properties.org.graalvm.home", JAVA_HOME)
+                .option("java.Properties.org.graalvm.home", System.getenv("JAVA_HOME"))
                 .option("java.MultiThreaded", Boolean.TRUE.toString())
                 .option("java.Classpath", JAVA_CLASSPATH)
                 .build();


### PR DESCRIPTION
For #25509.

Changes proposed in this pull request:
  - Restrict Espresso API to only detect JAVA_HOME under Native Image.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
