### PR TITLE
Bump MySQL Connector/J from 5.1.47 to 5.1.49

### DIFF
--- a/docs/blog/content/material/proxyIntroduce.cn.md
+++ b/docs/blog/content/material/proxyIntroduce.cn.md
@@ -96,7 +96,7 @@ ShardingSphere-Proxy 的启动方式有三种：二进制包、Docker、Helm，�
 
 ### 1. 将 MySQL 的 JDBC 驱动复制到 ext-lib 包
 
-下载驱动 [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar) 放入 ext-lib 包。因为初始目录中并没有 ext-lib，需要自行创建。
+下载驱动 [mysql-connector-java-5.1.49.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar) 放入 ext-lib 包。因为初始目录中并没有 ext-lib，需要自行创建。
 
 ### 2. 修改 conf/server.yaml 配置文件
 

--- a/docs/document/content/quick-start/shardingsphere-proxy-quick-start.cn.md
+++ b/docs/document/content/quick-start/shardingsphere-proxy-quick-start.cn.md
@@ -42,7 +42,7 @@ ShardingSphere-Proxy 对系统库/表（如 information_schema、pg_catalog）�
 
 如果后端连接 PostgreSQL 或 openGauss 数据库，不需要引入额外依赖。
 
-如果后端连接 MySQL 数据库，请下载 [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar)，并将其放入 `%SHARDINGSPHERE_PROXY_HOME%/ext-lib` 目录。
+如果后端连接 MySQL 数据库，请下载 [mysql-connector-java-5.1.49.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar)，并将其放入 `%SHARDINGSPHERE_PROXY_HOME%/ext-lib` 目录。
 
 4. 启动服务
 

--- a/docs/document/content/quick-start/shardingsphere-proxy-quick-start.en.md
+++ b/docs/document/content/quick-start/shardingsphere-proxy-quick-start.en.md
@@ -42,7 +42,7 @@ Please refer to [Configuration Manual](/en/user-manual/shardingsphere-proxy/yaml
 
 If the backend database is PostgreSQL or openGauss, no additional dependencies are required.
 
-If the backend database is MySQL, please download [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar) or [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar) and put it into the `%SHARDINGSPHERE_PROXY_HOME%/ext-lib` directory.
+If the backend database is MySQL, please download [mysql-connector-java-5.1.49.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar) or [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar) and put it into the `%SHARDINGSPHERE_PROXY_HOME%/ext-lib` directory.
 
 4. Start server.
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/migration/build.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/migration/build.cn.md
@@ -43,7 +43,7 @@ proxy 已包含 PostgreSQL JDBC 驱动。
 
 | 数据库       | JDBC 驱动                                                                                                                               | 参考                                                                                               |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| MySQL     | [mysql-connector-java-5.1.47.jar]( https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar ) | [Connector/J Versions]( https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-versions.html ) |
+| MySQL     | [mysql-connector-java-5.1.49.jar]( https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar ) | [Connector/J Versions]( https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-versions.html ) |
 | openGauss | [opengauss-jdbc-3.0.0.jar]( https://repo1.maven.org/maven2/org/opengauss/opengauss-jdbc/3.0.0/opengauss-jdbc-3.0.0.jar )              |                                                                                                  |
 
 如果是异构迁移，源端支持范围更广的数据库。JDBC 驱动处理方式同上。

--- a/docs/document/content/user-manual/shardingsphere-proxy/migration/build.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/migration/build.en.md
@@ -43,7 +43,7 @@ If the backend is connected to the following databases, download the correspondi
 
 | Database  | JDBC Driver                                                                                                                           | Reference                                                                                        |
 |-----------|---------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|
-| MySQL     | [mysql-connector-java-5.1.47.jar]( https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar ) | [Connector/J Versions]( https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-versions.html ) |
+| MySQL     | [mysql-connector-java-5.1.49.jar]( https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar ) | [Connector/J Versions]( https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-versions.html ) |
 | openGauss | [opengauss-jdbc-3.0.0.jar]( https://repo1.maven.org/maven2/org/opengauss/opengauss-jdbc/3.0.0/opengauss-jdbc-3.0.0.jar )              |                                                                                                  |
 
 If you are migrating to a heterogeneous database, then you could use more types of database. Introduce JDBC driver as above too.

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.cn.md
@@ -34,7 +34,7 @@ ShardingSphere-Proxy 支持配置多个逻辑数据源，每个以 `config-` 前
 
 如果后端连接 PostgreSQL 或 openGauss 数据库，不需要引入额外依赖。
 
-如果后端连接 MySQL 数据库，请下载 [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar)，并将其放入 `ext-lib` 目录。
+如果后端连接 MySQL 数据库，请下载 [mysql-connector-java-5.1.49.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar) 或者 [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar)，并将其放入 `ext-lib` 目录。
 
 5. （可选）引入集群模式所需依赖
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/startup/bin.en.md
@@ -35,7 +35,7 @@ ShardingSphere-Proxy supports multiple logical data sources. Each YAML configura
 
 If the backend is connected to a PostgreSQL or openGauss database, no additional dependencies need to be introduced.
 
-If the backend is connected to a MySQL database, please download [mysql-connector-java-5.1.47.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar) or [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar), and put it into the `ext-lib` directory.
+If the backend is connected to a MySQL database, please download [mysql-connector-java-5.1.49.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar) or [mysql-connector-java-8.0.11.jar](https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.11/mysql-connector-java-8.0.11.jar), and put it into the `ext-lib` directory.
 
 5. Introduce dependencies required by the cluster mode (Optional)
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -43,7 +43,7 @@
         <spring-framework.version>5.2.15.RELEASE</spring-framework.version>
         <spring-boot.version>2.3.12.RELEASE</spring-boot.version>
         <hikari-cp.version>3.4.2</hikari-cp.version>
-        <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
+        <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
         <postgresql.version>42.4.1</postgresql.version>
         <h2.version>2.1.214</h2.version>
         <slf4j.version>1.7.7</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         
         <postgresql.version>42.4.1</postgresql.version>
         <opengauss.version>3.1.0-og</opengauss.version>
-        <mysql-connector-java.version>5.1.47</mysql-connector-java.version>
+        <mysql-connector-java.version>5.1.49</mysql-connector-java.version>
         <mariadb-java-client.version>2.4.2</mariadb-java-client.version>
         <h2.version>2.1.214</h2.version>
         <mssql.version>6.1.7.jre8-preview</mssql.version>

--- a/test/e2e/agent/plugins/logging/file/src/test/resources/docker/proxy/Dockerfile
+++ b/test/e2e/agent/plugins/logging/file/src/test/resources/docker/proxy/Dockerfile
@@ -22,5 +22,5 @@ ENV WAIT_VERSION 2.7.2
 
 ADD ${APP_NAME}.tar.gz /opt
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
-RUN chmod +x /wait && mv /opt/${APP_NAME} /opt/shardingsphere-proxy && wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -P /opt/shardingsphere-proxy/lib
+RUN chmod +x /wait && mv /opt/${APP_NAME} /opt/shardingsphere-proxy && wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar -P /opt/shardingsphere-proxy/lib
 ENTRYPOINT /wait && /opt/shardingsphere-proxy/bin/start.sh -g && tail -f /opt/shardingsphere-proxy/logs/stdout.log

--- a/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/docker/proxy/Dockerfile
+++ b/test/e2e/agent/plugins/metrics/prometheus/src/test/resources/docker/proxy/Dockerfile
@@ -24,5 +24,5 @@ ADD ${APP_NAME}.tar.gz /opt
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
 RUN chmod +x /wait
 RUN mv /opt/${APP_NAME} /opt/shardingsphere-proxy
-RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -P /opt/shardingsphere-proxy/lib
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar -P /opt/shardingsphere-proxy/lib
 ENTRYPOINT /wait && /opt/shardingsphere-proxy/bin/start.sh -g && tail -f /opt/shardingsphere-proxy/logs/stdout.log

--- a/test/e2e/agent/plugins/tracing/jaeger/src/test/resources/docker/proxy/Dockerfile
+++ b/test/e2e/agent/plugins/tracing/jaeger/src/test/resources/docker/proxy/Dockerfile
@@ -24,5 +24,5 @@ ADD ${APP_NAME}.tar.gz /opt
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
 RUN chmod +x /wait
 RUN mv /opt/${APP_NAME} /opt/shardingsphere-proxy
-RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -P /opt/shardingsphere-proxy/lib
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar -P /opt/shardingsphere-proxy/lib
 ENTRYPOINT /wait && /opt/shardingsphere-proxy/bin/start.sh -g && tail -f /opt/shardingsphere-proxy/logs/stdout.log

--- a/test/e2e/agent/plugins/tracing/zipkin/src/test/resources/docker/proxy/Dockerfile
+++ b/test/e2e/agent/plugins/tracing/zipkin/src/test/resources/docker/proxy/Dockerfile
@@ -24,5 +24,5 @@ ADD ${APP_NAME}.tar.gz /opt
 ADD https://github.com/ufoscout/docker-compose-wait/releases/download/$WAIT_VERSION/wait /wait
 RUN chmod +x /wait
 RUN mv /opt/${APP_NAME} /opt/shardingsphere-proxy
-RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.47/mysql-connector-java-5.1.47.jar -P /opt/shardingsphere-proxy/lib
+RUN wget https://repo1.maven.org/maven2/mysql/mysql-connector-java/5.1.49/mysql-connector-java-5.1.49.jar -P /opt/shardingsphere-proxy/lib
 ENTRYPOINT /wait && /opt/shardingsphere-proxy/bin/start.sh -g && tail -f /opt/shardingsphere-proxy/logs/stdout.log


### PR DESCRIPTION
Refer to https://bugs.mysql.com/bug.php?id=93590

Try eliminating warnings like

```
Tue May 09 11:34:28 UTC 2023 WARN: Caught while disconnecting...

EXCEPTION STACK TRACE:



** BEGIN NESTED EXCEPTION ** 

javax.net.ssl.SSLException
MESSAGE: closing inbound before receiving peer's close_notify

STACKTRACE:

javax.net.ssl.SSLException: closing inbound before receiving peer's close_notify
	at sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:740)
	at sun.security.ssl.SSLSocketImpl.shutdownInput(SSLSocketImpl.java:719)
	at com.mysql.jdbc.MysqlIO.quit(MysqlIO.java:2249)
	at com.mysql.jdbc.ConnectionImpl.realClose(ConnectionImpl.java:4232)
	at com.mysql.jdbc.ConnectionImpl.close(ConnectionImpl.java:1472)
	at org.apache.shardingsphere.test.e2e.env.container.wait.JdbcConnectionWaitStrategy.lambda$mockRateLimiter$0(JdbcConnectionWaitStrategy.java:48)
	at org.rnorth.ducttape.ratelimits.RateLimiter.doWhenReady(RateLimiter.java:27)
	at org.apache.shardingsphere.test.e2e.env.container.wait.JdbcConnectionWaitStrategy.mockRateLimiter(JdbcConnectionWaitStrategy.java:44)
	at org.rnorth.ducttape.unreliables.Unreliables.lambda$retryUntilSuccess$0(Unreliables.java:43)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)


** END NESTED EXCEPTION **
```