### PR TITLE
Fix pipeline ci failed when using mysql:8

### DIFF
--- a/test/e2e/operation/pipeline/src/test/resources/env/mysql/mysql8/02-initdb.sql
+++ b/test/e2e/operation/pipeline/src/test/resources/env/mysql/mysql8/02-initdb.sql
@@ -1,0 +1,18 @@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one or more
+-- contributor license agreements.  See the NOTICE file distributed with
+-- this work for additional information regarding copyright ownership.
+-- The ASF licenses this file to You under the Apache License, Version 2.0
+-- (the "License"); you may not use this file except in compliance with
+-- the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+
+GRANT XA_RECOVER_ADMIN ON *.* TO `test_user`@`%`;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix pipeline ci failed when using mysql:8, need add XA_RECOVER_ADMIN permission

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
