### PR TITLE
Add new encrypt yaml api and rename old api tag to COMPATIBLE_ENCRYPT

### DIFF
--- a/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/update/RuleDefinitionAlterUpdater.java
+++ b/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/update/RuleDefinitionAlterUpdater.java
@@ -34,7 +34,7 @@ public interface RuleDefinitionAlterUpdater<T extends SQLStatement, R extends Ru
      * @param sqlStatement SQL statement
      * @return built to be altered rule configuration
      */
-    RuleConfiguration buildToBeAlteredRuleConfiguration(T sqlStatement);
+    R buildToBeAlteredRuleConfiguration(T sqlStatement);
     
     /**
      * Update current rule configuration.

--- a/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/update/RuleDefinitionCreateUpdater.java
+++ b/distsql/handler/src/main/java/org/apache/shardingsphere/distsql/handler/update/RuleDefinitionCreateUpdater.java
@@ -35,7 +35,7 @@ public interface RuleDefinitionCreateUpdater<T extends SQLStatement, R extends R
      * @param sqlStatement SQL statement
      * @return built to be created rule configuration
      */
-    RuleConfiguration buildToBeCreatedRuleConfiguration(R currentRuleConfig, T sqlStatement);
+    R buildToBeCreatedRuleConfiguration(R currentRuleConfig, T sqlStatement);
     
     /**
      * Update current rule configuration.

--- a/docs/document/content/reference/encrypt/_index.cn.md
+++ b/docs/document/content/reference/encrypt/_index.cn.md
@@ -76,10 +76,12 @@ Apache ShardingSphere 接收到该 SQL，通过用户提供的加密配置，发
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
-          assistedQueryColumn: pwd_assisted_query
-          assistedQueryEncryptorName: pwd_assisted_query_cipher
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: pwd_assisted_query
+            encryptorName: pwd_assisted_query_cipher
 ```
 
 使用这套配置， Apache ShardingSphere 只需将 logicColumn 和 cipherColumn，assistedQueryColumn 进行转换，底层数据表不存储明文，只存储了密文，这也是安全审计部分的要求所在。

--- a/docs/document/content/reference/encrypt/_index.en.md
+++ b/docs/document/content/reference/encrypt/_index.en.md
@@ -60,19 +60,21 @@ Solution description: after selecting the appropriate encryption algorithm, such
 
 ```yaml
 -!ENCRYPT
- encryptors:
-  aes_encryptor:
-   type: AES
-   props:
-    aes-key-value: 123456abc
- tables:
-  t_user:
-   columns:
-    pwd:
-     cipherColumn: pwd_cipher
-     encryptorName: aes_encryptor
-     assistedQueryColumn: pwd_assisted_query
-     assistedQueryEncryptorName: pwd_assisted_query_cipher
+  encryptors:
+    aes_encryptor:
+      type: AES
+      props:
+        aes-key-value: 123456abc
+  tables:
+    t_user:
+      columns:
+        pwd:
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: pwd_assisted_query
+            encryptorName: pwd_assisted_query_cipher
 ```
 
 With the above configuration, Apache ShardingSphere only needs to convert `logicColumn`, `cipherColumn`, and `assistedQueryColumn`. 

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/encrypt.cn.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/encrypt.cn.md
@@ -94,10 +94,12 @@ rules:
     t_user:
       columns:
         username:
-          cipherColumn: username
-          encryptorName: name_encryptor
-          likeQueryColumn: name_like
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: username
+            encryptorName: name_encryptor
+          likeQuery:
+            name: name_like
+            encryptorName: like_encryptor
   encryptors:
     like_encryptor:
       type: CHAR_DIGEST_LIKE

--- a/docs/document/content/user-manual/common-config/builtin-algorithm/encrypt.en.md
+++ b/docs/document/content/user-manual/common-config/builtin-algorithm/encrypt.en.md
@@ -94,10 +94,12 @@ rules:
     t_user:
       columns:
         username:
-          cipherColumn: username
-          encryptorName: name_encryptor
-          likeQueryColumn: name_like
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: username
+            encryptorName: name_encryptor
+          likeQuery:
+            name: name_like
+            encryptorName: like_encryptor
   encryptors:
     like_encryptor:
       type: CHAR_DIGEST_LIKE

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/encrypt.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/encrypt.cn.md
@@ -16,12 +16,15 @@ rules:
     <table_name> (+): # 加密表名称
       columns:
         <column_name> (+): # 加密列名称
-          cipherColumn: # 密文列名称
-          encryptorName: # 密文列加密算法名称
-          assistedQueryColumn (?):  # 查询辅助列名称
-          assistedQueryEncryptorName:  # 查询辅助列加密算法名称
-          likeQueryColumn (?):  # 模糊查询列名称
-          likeQueryEncryptorName:  # 模糊查询列加密算法名称
+          cipher:
+            name: # 密文列名称
+            encryptorName: # 密文列加密算法名称
+          assistedQuery (?):  
+            name: # 查询辅助列名称
+            encryptorName:  # 查询辅助列加密算法名称
+          likeQuery (?):
+            name: # 模糊查询列名称
+            encryptorName:  # 模糊查询列加密算法名称
     
   # 加密算法配置
   encryptors:
@@ -57,17 +60,22 @@ rules:
     t_user:
       columns:
         username:
-          cipherColumn: username
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_username
-          assistedQueryEncryptorName: assisted_encryptor
-          likeQueryColumn: like_query_username
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: username
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_username
+            encryptorName: assisted_encryptor
+          likeQuery:
+            name: like_query_username
+            encryptorName: like_encryptor
         pwd:
-          cipherColumn: pwd
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_pwd
-          assistedQueryEncryptorName: assisted_encryptor
+          cipher:
+            name: pwd
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_pwd
+            encryptorName: assisted_encryptor
   encryptors:
     aes_encryptor:
       type: AES

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/encrypt.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/encrypt.en.md
@@ -17,12 +17,15 @@ rules:
     <table_name> (+): # Encrypt table name
       columns:
         <column_name> (+): # Encrypt logic column name
-          cipherColumn: # Cipher column name
-          encryptorName: # Cipher encrypt algorithm name
-          assistedQueryColumn (?):  # Assisted query column name
-          assistedQueryEncryptorName:  # Assisted query encrypt algorithm name
-          likeQueryColumn (?):  # Like query column name
-          likeQueryEncryptorName:  # Like query encrypt algorithm name 
+          cipher:
+            name: # Cipher column name
+            encryptorName: # Cipher encrypt algorithm name
+          assistedQuery (?):
+            name: # Assisted query column name
+            encryptorName:  # Assisted query encrypt algorithm name
+          likeQuery (?):
+            name: # Like query column name
+            encryptorName:  # Like query encrypt algorithm name 
     
   # Encrypt algorithm configuration
   encryptors:
@@ -58,17 +61,22 @@ rules:
     t_user:
       columns:
         username:
-          cipherColumn: username
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_username
-          assistedQueryEncryptorName: assisted_encryptor
-          likeQueryColumn: like_query_username
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: username
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_username
+            encryptorName: assisted_encryptor
+          likeQuery:
+            name: like_query_username
+            encryptorName: like_encryptor
         pwd:
-          cipherColumn: pwd
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_pwd
-          assistedQueryEncryptorName: assisted_encryptor
+          cipher:
+            name: pwd
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_pwd
+            encryptorName: assisted_encryptor
   encryptors:
     aes_encryptor:
       type: AES

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/mix.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/mix.cn.md
@@ -50,12 +50,15 @@ rules:
     <table_name>: # 加密表名称
       columns:
         <column_name> (+): # 加密列名称
-          cipherColumn: # 密文列名称
-          encryptorName: # 密文列加密算法名称
-          assistedQueryColumn (?):  # 查询辅助列名称
-          assistedQueryEncryptorName:  # 查询辅助列加密算法名称
-          likeQueryColumn (?):  # 模糊查询列名称
-          likeQueryEncryptorName:  # 模糊查询列加密算法名称
+          cipher:
+            name: # 密文列名称
+            encryptorName: # 密文列加密算法名称
+          assistedQuery (?):
+            name: # 查询辅助列名称
+            encryptorName:  # 查询辅助列加密算法名称
+          likeQuery (?):
+            name: # 模糊查询列名称
+            encryptorName:  # 模糊查询列加密算法名称
 ```
 
 ## 配置示例
@@ -107,13 +110,17 @@ rules:
     t_encrypt:
       columns:
         user_id:
-          cipherColumn: user_cipher
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_user
-          assistedQueryEncryptorName: assisted_encryptor
-          likeQueryColumn: like_query_user
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_cipher
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_user
+            encryptorName: assisted_encryptor
+          likeQuery:
+            name: like_query_user
+            encryptorName: like_encryptor
         order_id:
-          cipherColumn: order_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_cipher
+            encryptorName: aes_encryptor
 ```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/mix.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/mix.en.md
@@ -51,12 +51,15 @@ rules:
     <table_name>: # Encryption table name
       columns:
         <column_name> (+): # Encrypt logic column name
-          cipherColumn: # Cipher column name
-          encryptorName: # Cipher encrypt algorithm name
-          assistedQueryColumn (?):  # Assisted query column name
-          assistedQueryEncryptorName:  # Assisted query encrypt algorithm name
-          likeQueryColumn (?):  # Like query column name
-          likeQueryEncryptorName:  # Like query encrypt algorithm name 
+          cipher:
+            name: # Cipher column name
+            encryptorName: # Cipher encrypt algorithm name
+          assistedQuery (?):
+            name: # Assisted query column name
+            encryptorName:  # Assisted query encrypt algorithm name
+          likeQuery (?):
+            name: # Like query column name
+            encryptorName:  # Like query encrypt algorithm name 
 ```
 
 ## Samples
@@ -108,13 +111,17 @@ rules:
     t_encrypt:
       columns:
         user_id:
-          cipherColumn: user_cipher
-          encryptorName: aes_encryptor
-          assistedQueryColumn: assisted_query_user
-          assistedQueryEncryptorName: assisted_encryptor
-          likeQueryColumn: like_query_user
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_cipher
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: assisted_query_user
+            encryptorName: assisted_encryptor
+          likeQuery:
+            name: like_query_user
+            encryptorName: like_encryptor
         order_id:
-          cipherColumn: order_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_cipher
+            encryptorName: aes_encryptor
 ```

--- a/examples/shardingsphere-example-generator/src/main/resources/template/jdbc/resources/yaml/feature/encrypt.ftl
+++ b/examples/shardingsphere-example-generator/src/main/resources/template/jdbc/resources/yaml/feature/encrypt.ftl
@@ -19,13 +19,16 @@
     t_order:
       columns:
         status:
-          cipherColumn: status
-          encryptorName: string_encryptor
-          assistedQueryColumn: assisted_query_status
-          assistedQueryEncryptorName: string_encryptor
+          cipher: 
+            name: status
+            encryptorName: string_encryptor
+          assistedQuery: 
+            name: assisted_query_status
+            encryptorName: string_encryptor
         phone:
-          cipherColumn: phone
-          encryptorName: phone_encryptor
+          cipher: 
+            name: phone
+            encryptorName: phone_encryptor
 
   encryptors:
     string_encryptor:

--- a/examples/shardingsphere-example-generator/src/main/resources/template/proxy/feature/encrypt.ftl
+++ b/examples/shardingsphere-example-generator/src/main/resources/template/proxy/feature/encrypt.ftl
@@ -19,8 +19,9 @@
       t_order:
         columns:
           columnName:
-            cipherColumn: cipher
-            encryptorName: encryptor
+            cipher: 
+              name: cipher
+              encryptorName: encryptor
     encryptors:
       encryptor:
         type: AES

--- a/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/config/CompatibleEncryptRuleConfiguration.java
+++ b/features/encrypt/api/src/main/java/org/apache/shardingsphere/encrypt/api/config/CompatibleEncryptRuleConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.api.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
+import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
+import org.apache.shardingsphere.infra.config.rule.function.EnhancedRuleConfiguration;
+import org.apache.shardingsphere.infra.config.rule.scope.DatabaseRuleConfiguration;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Encrypt rule configuration.
+ *
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@RequiredArgsConstructor
+@Getter
+@Deprecated
+public final class CompatibleEncryptRuleConfiguration implements DatabaseRuleConfiguration, EnhancedRuleConfiguration {
+    
+    private final Collection<EncryptTableRuleConfiguration> tables;
+    
+    private final Map<String, AlgorithmConfiguration> encryptors;
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/CompatibleEncryptRuleConfigurationChecker.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/checker/CompatibleEncryptRuleConfigurationChecker.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.checker;
+
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.constant.EncryptOrder;
+import org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker;
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Encrypt rule configuration checker.
+ * 
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@Deprecated
+public final class CompatibleEncryptRuleConfigurationChecker implements RuleConfigurationChecker<CompatibleEncryptRuleConfiguration> {
+    
+    private final EncryptRuleConfigurationChecker delegate = new EncryptRuleConfigurationChecker();
+    
+    @Override
+    public void check(final String databaseName, final CompatibleEncryptRuleConfiguration config, final Map<String, DataSource> dataSourceMap, final Collection<ShardingSphereRule> rules) {
+        delegate.check(databaseName, new EncryptRuleConfiguration(config.getTables(), config.getEncryptors()), dataSourceMap, rules);
+    }
+    
+    @Override
+    public int getOrder() {
+        return EncryptOrder.COMPATIBLE_ORDER;
+    }
+    
+    @Override
+    public Class<CompatibleEncryptRuleConfiguration> getTypeClass() {
+        return CompatibleEncryptRuleConfiguration.class;
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptOrder.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptOrder.java
@@ -30,4 +30,9 @@ public final class EncryptOrder {
      * Encrypt order.
      */
     public static final int ORDER = 10;
+    
+    /**
+     * Compatible encrypt order.
+     */
+    public static final int COMPATIBLE_ORDER = ORDER + 1;
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/EncryptRule.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.encrypt.rule;
 
 import lombok.Getter;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.context.EncryptContext;
 import org.apache.shardingsphere.encrypt.api.encrypt.assisted.AssistedEncryptAlgorithm;
@@ -63,6 +64,13 @@ public final class EncryptRule implements DatabaseRule, TableContainedRule, Colu
     private final Map<String, EncryptTable> tables = new LinkedHashMap<>();
     
     public EncryptRule(final EncryptRuleConfiguration ruleConfig) {
+        configuration = ruleConfig;
+        ruleConfig.getEncryptors().forEach((key, value) -> putAllEncryptors(key, TypedSPILoader.getService(EncryptAlgorithm.class, value.getType(), value.getProps())));
+        ruleConfig.getTables().forEach(each -> tables.put(each.getName().toLowerCase(), new EncryptTable(each)));
+    }
+    
+    @Deprecated
+    public EncryptRule(final CompatibleEncryptRuleConfiguration ruleConfig) {
         configuration = ruleConfig;
         ruleConfig.getEncryptors().forEach((key, value) -> putAllEncryptors(key, TypedSPILoader.getService(EncryptAlgorithm.class, value.getType(), value.getProps())));
         ruleConfig.getTables().forEach(each -> tables.put(each.getName().toLowerCase(), new EncryptTable(each)));

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/builder/CompatibleEncryptRuleBuilder.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rule/builder/CompatibleEncryptRuleBuilder.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.rule.builder;
+
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.constant.EncryptOrder;
+import org.apache.shardingsphere.encrypt.rule.EncryptRule;
+import org.apache.shardingsphere.infra.instance.InstanceContext;
+import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
+import org.apache.shardingsphere.infra.rule.builder.database.DatabaseRuleBuilder;
+
+import javax.sql.DataSource;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Encrypt rule builder.
+ * 
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@Deprecated
+public final class CompatibleEncryptRuleBuilder implements DatabaseRuleBuilder<CompatibleEncryptRuleConfiguration> {
+    
+    @Override
+    public EncryptRule build(final CompatibleEncryptRuleConfiguration config, final String databaseName,
+                             final Map<String, DataSource> dataSources, final Collection<ShardingSphereRule> builtRules, final InstanceContext instanceContext) {
+        return new EncryptRule(config);
+    }
+    
+    @Override
+    public int getOrder() {
+        return EncryptOrder.COMPATIBLE_ORDER;
+    }
+    
+    @Override
+    public Class<CompatibleEncryptRuleConfiguration> getTypeClass() {
+        return CompatibleEncryptRuleConfiguration.class;
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/YamlCompatibleEncryptRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/YamlCompatibleEncryptRuleConfiguration.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.encrypt.yaml.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlCompatibleEncryptTableRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
@@ -42,7 +42,7 @@ public final class YamlCompatibleEncryptRuleConfiguration implements YamlRuleCon
     private Map<String, YamlAlgorithmConfiguration> encryptors = new LinkedHashMap<>();
     
     @Override
-    public Class<EncryptRuleConfiguration> getRuleConfigurationType() {
-        return EncryptRuleConfiguration.class;
+    public Class<CompatibleEncryptRuleConfiguration> getRuleConfigurationType() {
+        return CompatibleEncryptRuleConfiguration.class;
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/YamlEncryptRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/YamlEncryptRuleConfiguration.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
+import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Encrypt rule configuration for YAML.
+ */
+@Getter
+@Setter
+public final class YamlEncryptRuleConfiguration implements YamlRuleConfiguration {
+    
+    private Map<String, YamlEncryptTableRuleConfiguration> tables = new LinkedHashMap<>();
+    
+    private Map<String, YamlAlgorithmConfiguration> encryptors = new LinkedHashMap<>();
+    
+    @Override
+    public Class<EncryptRuleConfiguration> getRuleConfigurationType() {
+        return EncryptRuleConfiguration.class;
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptColumnItemRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptColumnItemRuleConfiguration.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.config.rule;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
+
+/**
+ * Encrypt column rule configuration for YAML.
+ */
+@Getter
+@Setter
+public final class YamlEncryptColumnItemRuleConfiguration implements YamlConfiguration {
+    
+    private String name;
+    
+    private String encryptorName;
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptColumnRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptColumnRuleConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.config.rule;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
+
+/**
+ * Encrypt column rule configuration for YAML.
+ */
+@Getter
+@Setter
+public final class YamlEncryptColumnRuleConfiguration implements YamlConfiguration {
+    
+    private String name;
+    
+    private YamlEncryptColumnItemRuleConfiguration cipher;
+    
+    private YamlEncryptColumnItemRuleConfiguration assistedQuery;
+    
+    private YamlEncryptColumnItemRuleConfiguration likeQuery;
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptTableRuleConfiguration.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/config/rule/YamlEncryptTableRuleConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.config.rule;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.infra.util.yaml.YamlConfiguration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Encrypt table rule configuration for YAML.
+ */
+@Getter
+@Setter
+public final class YamlEncryptTableRuleConfiguration implements YamlConfiguration {
+    
+    private String name;
+    
+    private Map<String, YamlEncryptColumnRuleConfiguration> columns = new LinkedHashMap<>();
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapper.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.yaml.swapper;
 
-import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.constant.EncryptOrder;
 import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
@@ -40,14 +40,14 @@ import java.util.Map.Entry;
  * @deprecated Should use new api, compatible api will remove in next version.
  */
 @Deprecated
-public final class YamlCompatibleEncryptRuleConfigurationSwapper implements YamlRuleConfigurationSwapper<YamlCompatibleEncryptRuleConfiguration, EncryptRuleConfiguration> {
+public final class YamlCompatibleEncryptRuleConfigurationSwapper implements YamlRuleConfigurationSwapper<YamlCompatibleEncryptRuleConfiguration, CompatibleEncryptRuleConfiguration> {
     
     private final YamlCompatibleEncryptTableRuleConfigurationSwapper tableSwapper = new YamlCompatibleEncryptTableRuleConfigurationSwapper();
     
     private final YamlAlgorithmConfigurationSwapper algorithmSwapper = new YamlAlgorithmConfigurationSwapper();
     
     @Override
-    public YamlCompatibleEncryptRuleConfiguration swapToYamlConfiguration(final EncryptRuleConfiguration data) {
+    public YamlCompatibleEncryptRuleConfiguration swapToYamlConfiguration(final CompatibleEncryptRuleConfiguration data) {
         YamlCompatibleEncryptRuleConfiguration result = new YamlCompatibleEncryptRuleConfiguration();
         data.getTables().forEach(each -> result.getTables().put(each.getName(), tableSwapper.swapToYamlConfiguration(each)));
         data.getEncryptors().forEach((key, value) -> result.getEncryptors().put(key, algorithmSwapper.swapToYamlConfiguration(value)));
@@ -55,8 +55,8 @@ public final class YamlCompatibleEncryptRuleConfigurationSwapper implements Yaml
     }
     
     @Override
-    public EncryptRuleConfiguration swapToObject(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
-        return new EncryptRuleConfiguration(swapTables(yamlConfig), swapEncryptAlgorithm(yamlConfig));
+    public CompatibleEncryptRuleConfiguration swapToObject(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
+        return new CompatibleEncryptRuleConfiguration(swapTables(yamlConfig), swapEncryptAlgorithm(yamlConfig));
     }
     
     private Collection<EncryptTableRuleConfiguration> swapTables(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
@@ -78,8 +78,8 @@ public final class YamlCompatibleEncryptRuleConfigurationSwapper implements Yaml
     }
     
     @Override
-    public Class<EncryptRuleConfiguration> getTypeClass() {
-        return EncryptRuleConfiguration.class;
+    public Class<CompatibleEncryptRuleConfiguration> getTypeClass() {
+        return CompatibleEncryptRuleConfiguration.class;
     }
     
     @Override
@@ -89,6 +89,6 @@ public final class YamlCompatibleEncryptRuleConfigurationSwapper implements Yaml
     
     @Override
     public int getOrder() {
-        return EncryptOrder.ORDER;
+        return EncryptOrder.COMPATIBLE_ORDER;
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlEncryptRuleConfigurationSwapper.java
@@ -20,9 +20,9 @@ package org.apache.shardingsphere.encrypt.yaml.swapper;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.constant.EncryptOrder;
-import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
-import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlCompatibleEncryptTableRuleConfiguration;
-import org.apache.shardingsphere.encrypt.yaml.swapper.rule.YamlCompatibleEncryptTableRuleConfigurationSwapper;
+import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.swapper.rule.YamlEncryptTableRuleConfigurationSwapper;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.swapper.algorithm.YamlAlgorithmConfigurationSwapper;
@@ -36,40 +36,37 @@ import java.util.Map.Entry;
 
 /**
  * YAML encrypt rule configuration swapper.
- *
- * @deprecated Should use new api, compatible api will remove in next version.
  */
-@Deprecated
-public final class YamlCompatibleEncryptRuleConfigurationSwapper implements YamlRuleConfigurationSwapper<YamlCompatibleEncryptRuleConfiguration, EncryptRuleConfiguration> {
+public final class YamlEncryptRuleConfigurationSwapper implements YamlRuleConfigurationSwapper<YamlEncryptRuleConfiguration, EncryptRuleConfiguration> {
     
-    private final YamlCompatibleEncryptTableRuleConfigurationSwapper tableSwapper = new YamlCompatibleEncryptTableRuleConfigurationSwapper();
+    private final YamlEncryptTableRuleConfigurationSwapper tableSwapper = new YamlEncryptTableRuleConfigurationSwapper();
     
     private final YamlAlgorithmConfigurationSwapper algorithmSwapper = new YamlAlgorithmConfigurationSwapper();
     
     @Override
-    public YamlCompatibleEncryptRuleConfiguration swapToYamlConfiguration(final EncryptRuleConfiguration data) {
-        YamlCompatibleEncryptRuleConfiguration result = new YamlCompatibleEncryptRuleConfiguration();
+    public YamlEncryptRuleConfiguration swapToYamlConfiguration(final EncryptRuleConfiguration data) {
+        YamlEncryptRuleConfiguration result = new YamlEncryptRuleConfiguration();
         data.getTables().forEach(each -> result.getTables().put(each.getName(), tableSwapper.swapToYamlConfiguration(each)));
         data.getEncryptors().forEach((key, value) -> result.getEncryptors().put(key, algorithmSwapper.swapToYamlConfiguration(value)));
         return result;
     }
     
     @Override
-    public EncryptRuleConfiguration swapToObject(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
+    public EncryptRuleConfiguration swapToObject(final YamlEncryptRuleConfiguration yamlConfig) {
         return new EncryptRuleConfiguration(swapTables(yamlConfig), swapEncryptAlgorithm(yamlConfig));
     }
     
-    private Collection<EncryptTableRuleConfiguration> swapTables(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
+    private Collection<EncryptTableRuleConfiguration> swapTables(final YamlEncryptRuleConfiguration yamlConfig) {
         Collection<EncryptTableRuleConfiguration> result = new LinkedList<>();
-        for (Entry<String, YamlCompatibleEncryptTableRuleConfiguration> entry : yamlConfig.getTables().entrySet()) {
-            YamlCompatibleEncryptTableRuleConfiguration yamlEncryptTableRuleConfig = entry.getValue();
+        for (Entry<String, YamlEncryptTableRuleConfiguration> entry : yamlConfig.getTables().entrySet()) {
+            YamlEncryptTableRuleConfiguration yamlEncryptTableRuleConfig = entry.getValue();
             yamlEncryptTableRuleConfig.setName(entry.getKey());
             result.add(tableSwapper.swapToObject(yamlEncryptTableRuleConfig));
         }
         return result;
     }
     
-    private Map<String, AlgorithmConfiguration> swapEncryptAlgorithm(final YamlCompatibleEncryptRuleConfiguration yamlConfig) {
+    private Map<String, AlgorithmConfiguration> swapEncryptAlgorithm(final YamlEncryptRuleConfiguration yamlConfig) {
         Map<String, AlgorithmConfiguration> result = new LinkedHashMap<>(yamlConfig.getEncryptors().size(), 1);
         for (Entry<String, YamlAlgorithmConfiguration> entry : yamlConfig.getEncryptors().entrySet()) {
             result.put(entry.getKey(), algorithmSwapper.swapToObject(entry.getValue()));
@@ -84,7 +81,7 @@ public final class YamlCompatibleEncryptRuleConfigurationSwapper implements Yaml
     
     @Override
     public String getRuleTagName() {
-        return "COMPATIBLE_ENCRYPT";
+        return "ENCRYPT";
     }
     
     @Override

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptColumnItemRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptColumnItemRuleConfigurationSwapper.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.swapper.rule;
+
+import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnItemRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnItemRuleConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
+
+/**
+ * YAML encrypt column item rule configuration swapper.
+ */
+public final class YamlEncryptColumnItemRuleConfigurationSwapper implements YamlConfigurationSwapper<YamlEncryptColumnItemRuleConfiguration, EncryptColumnItemRuleConfiguration> {
+    
+    @Override
+    public YamlEncryptColumnItemRuleConfiguration swapToYamlConfiguration(final EncryptColumnItemRuleConfiguration data) {
+        YamlEncryptColumnItemRuleConfiguration result = new YamlEncryptColumnItemRuleConfiguration();
+        result.setName(data.getName());
+        result.setEncryptorName(data.getEncryptorName());
+        return result;
+    }
+    
+    @Override
+    public EncryptColumnItemRuleConfiguration swapToObject(final YamlEncryptColumnItemRuleConfiguration yamlConfig) {
+        return new EncryptColumnItemRuleConfiguration(yamlConfig.getName(), yamlConfig.getEncryptorName());
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptColumnRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptColumnRuleConfigurationSwapper.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.swapper.rule;
+
+import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
+
+/**
+ * YAML encrypt column rule configuration swapper.
+ */
+public final class YamlEncryptColumnRuleConfigurationSwapper implements YamlConfigurationSwapper<YamlEncryptColumnRuleConfiguration, EncryptColumnRuleConfiguration> {
+    
+    private final YamlEncryptColumnItemRuleConfigurationSwapper columnItemSwapper = new YamlEncryptColumnItemRuleConfigurationSwapper();
+    
+    @Override
+    public YamlEncryptColumnRuleConfiguration swapToYamlConfiguration(final EncryptColumnRuleConfiguration data) {
+        YamlEncryptColumnRuleConfiguration result = new YamlEncryptColumnRuleConfiguration();
+        result.setName(data.getName());
+        result.setCipher(columnItemSwapper.swapToYamlConfiguration(data.getCipher()));
+        data.getLikeQuery().ifPresent(optional -> result.setLikeQuery(columnItemSwapper.swapToYamlConfiguration(optional)));
+        data.getAssistedQuery().ifPresent(optional -> result.setAssistedQuery(columnItemSwapper.swapToYamlConfiguration(optional)));
+        return result;
+    }
+    
+    @Override
+    public EncryptColumnRuleConfiguration swapToObject(final YamlEncryptColumnRuleConfiguration yamlConfig) {
+        EncryptColumnRuleConfiguration result = new EncryptColumnRuleConfiguration(yamlConfig.getName(), columnItemSwapper.swapToObject(yamlConfig.getCipher()));
+        if (null != yamlConfig.getAssistedQuery()) {
+            result.setAssistedQuery(columnItemSwapper.swapToObject(yamlConfig.getAssistedQuery()));
+        }
+        if (null != yamlConfig.getLikeQuery()) {
+            result.setLikeQuery(columnItemSwapper.swapToObject(yamlConfig.getLikeQuery()));
+        }
+        return result;
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptTableRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptTableRuleConfigurationSwapper.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.yaml.swapper.rule;
+
+import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptColumnRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlEncryptTableRuleConfiguration;
+import org.apache.shardingsphere.infra.util.yaml.swapper.YamlConfigurationSwapper;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.Map.Entry;
+
+/**
+ * YAML encrypt table configuration swapper.
+ */
+public final class YamlEncryptTableRuleConfigurationSwapper implements YamlConfigurationSwapper<YamlEncryptTableRuleConfiguration, EncryptTableRuleConfiguration> {
+    
+    private final YamlEncryptColumnRuleConfigurationSwapper columnSwapper = new YamlEncryptColumnRuleConfigurationSwapper();
+    
+    @Override
+    public YamlEncryptTableRuleConfiguration swapToYamlConfiguration(final EncryptTableRuleConfiguration data) {
+        YamlEncryptTableRuleConfiguration result = new YamlEncryptTableRuleConfiguration();
+        for (EncryptColumnRuleConfiguration each : data.getColumns()) {
+            result.getColumns().put(each.getName(), columnSwapper.swapToYamlConfiguration(each));
+        }
+        result.setName(data.getName());
+        return result;
+    }
+    
+    @Override
+    public EncryptTableRuleConfiguration swapToObject(final YamlEncryptTableRuleConfiguration yamlConfig) {
+        Collection<EncryptColumnRuleConfiguration> columns = new LinkedList<>();
+        for (Entry<String, YamlEncryptColumnRuleConfiguration> entry : yamlConfig.getColumns().entrySet()) {
+            columns.add(columnSwapper.swapToObject(entry.getValue()));
+        }
+        return new EncryptTableRuleConfiguration(yamlConfig.getName(), columns);
+    }
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptTableRuleConfigurationSwapper.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/yaml/swapper/rule/YamlEncryptTableRuleConfigurationSwapper.java
@@ -48,6 +48,7 @@ public final class YamlEncryptTableRuleConfigurationSwapper implements YamlConfi
     public EncryptTableRuleConfiguration swapToObject(final YamlEncryptTableRuleConfiguration yamlConfig) {
         Collection<EncryptColumnRuleConfiguration> columns = new LinkedList<>();
         for (Entry<String, YamlEncryptColumnRuleConfiguration> entry : yamlConfig.getColumns().entrySet()) {
+            entry.getValue().setName(entry.getKey());
             columns.add(columnSwapper.swapToObject(entry.getValue()));
         }
         return new EncryptTableRuleConfiguration(yamlConfig.getName(), columns);

--- a/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker
+++ b/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.config.rule.checker.RuleConfigurationChecker
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.encrypt.checker.EncryptRuleConfigurationChecker
+org.apache.shardingsphere.encrypt.checker.CompatibleEncryptRuleConfigurationChecker

--- a/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.database.DatabaseRuleBuilder
+++ b/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.rule.builder.database.DatabaseRuleBuilder
@@ -16,3 +16,4 @@
 #
 
 org.apache.shardingsphere.encrypt.rule.builder.EncryptRuleBuilder
+org.apache.shardingsphere.encrypt.rule.builder.CompatibleEncryptRuleBuilder

--- a/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper
+++ b/features/encrypt/core/src/main/resources/META-INF/services/org.apache.shardingsphere.infra.yaml.config.swapper.rule.YamlRuleConfigurationSwapper
@@ -15,4 +15,5 @@
 # limitations under the License.
 #
 
+org.apache.shardingsphere.encrypt.yaml.swapper.YamlEncryptRuleConfigurationSwapper
 org.apache.shardingsphere.encrypt.yaml.swapper.YamlCompatibleEncryptRuleConfigurationSwapper

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/EncryptRuleConfigurationYamlIT.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/EncryptRuleConfigurationYamlIT.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.yaml;
 
-import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.test.it.yaml.YamlRuleConfigurationIT;
 
@@ -32,28 +32,28 @@ class EncryptRuleConfigurationYamlIT extends YamlRuleConfigurationIT {
     
     @Override
     protected void assertYamlRootConfiguration(final YamlRootConfiguration actual) {
-        assertEncryptRule((YamlCompatibleEncryptRuleConfiguration) actual.getRules().iterator().next());
+        assertEncryptRule((YamlEncryptRuleConfiguration) actual.getRules().iterator().next());
     }
     
-    private void assertEncryptRule(final YamlCompatibleEncryptRuleConfiguration actual) {
+    private void assertEncryptRule(final YamlEncryptRuleConfiguration actual) {
         assertColumns(actual);
         assertEncryptAlgorithm(actual);
     }
     
-    private void assertColumns(final YamlCompatibleEncryptRuleConfiguration actual) {
+    private void assertColumns(final YamlEncryptRuleConfiguration actual) {
         assertThat(actual.getTables().size(), is(1));
         assertThat(actual.getTables().get("t_user").getColumns().size(), is(1));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getCipherColumn(), is("username_cipher"));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getEncryptorName(), is("username_encryptor"));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getAssistedQueryColumn(), is("assisted_query_username"));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getAssistedQueryEncryptorName(), is("assisted_encryptor"));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getLikeQueryColumn(), is("like_query_username"));
-        assertThat(actual.getTables().get("t_user").getColumns().get("username").getLikeQueryEncryptorName(), is("like_encryptor"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getCipher().getName(), is("username_cipher"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getCipher().getEncryptorName(), is("aes_encryptor"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getAssistedQuery().getName(), is("assisted_query_username"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getAssistedQuery().getEncryptorName(), is("assisted_encryptor"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getLikeQuery().getName(), is("like_query_username"));
+        assertThat(actual.getTables().get("t_user").getColumns().get("username").getLikeQuery().getEncryptorName(), is("like_encryptor"));
     }
     
-    private void assertEncryptAlgorithm(final YamlCompatibleEncryptRuleConfiguration actual) {
-        assertThat(actual.getEncryptors().size(), is(2));
-        assertThat(actual.getEncryptors().get("username_encryptor").getType(), is("AES"));
-        assertThat(actual.getEncryptors().get("username_encryptor").getProps().get("aes-key-value"), is("123456abc"));
+    private void assertEncryptAlgorithm(final YamlEncryptRuleConfiguration actual) {
+        assertThat(actual.getEncryptors().size(), is(3));
+        assertThat(actual.getEncryptors().get("aes_encryptor").getType(), is("AES"));
+        assertThat(actual.getEncryptors().get("aes_encryptor").getProps().get("aes-key-value"), is("123456abc"));
     }
 }

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapperTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/yaml/swapper/YamlCompatibleEncryptRuleConfigurationSwapperTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.encrypt.yaml.swapper;
 
-import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.config.rule.YamlCompatibleEncryptTableRuleConfiguration;
@@ -45,15 +45,15 @@ class YamlCompatibleEncryptRuleConfigurationSwapperTest {
         assertThat(actual.getEncryptors().size(), is(1));
     }
     
-    private EncryptRuleConfiguration createEncryptRuleConfiguration() {
+    private CompatibleEncryptRuleConfiguration createEncryptRuleConfiguration() {
         Collection<EncryptTableRuleConfiguration> tables = Collections.singletonList(new EncryptTableRuleConfiguration("tbl", Collections.emptyList()));
         Map<String, AlgorithmConfiguration> encryptors = Collections.singletonMap("myEncryptor", new AlgorithmConfiguration("FIXTURE", new Properties()));
-        return new EncryptRuleConfiguration(tables, encryptors);
+        return new CompatibleEncryptRuleConfiguration(tables, encryptors);
     }
     
     @Test
     void assertSwapToObject() {
-        EncryptRuleConfiguration actual = getSwapper().swapToObject(createYamlEncryptRuleConfiguration());
+        CompatibleEncryptRuleConfiguration actual = getSwapper().swapToObject(createYamlEncryptRuleConfiguration());
         assertThat(actual.getTables().size(), is(1));
         assertThat(actual.getEncryptors().size(), is(1));
     }
@@ -70,7 +70,7 @@ class YamlCompatibleEncryptRuleConfigurationSwapperTest {
     }
     
     private YamlCompatibleEncryptRuleConfigurationSwapper getSwapper() {
-        EncryptRuleConfiguration ruleConfig = mock(EncryptRuleConfiguration.class);
+        CompatibleEncryptRuleConfiguration ruleConfig = mock(CompatibleEncryptRuleConfiguration.class);
         return (YamlCompatibleEncryptRuleConfigurationSwapper) OrderedSPILoader.getServices(YamlRuleConfigurationSwapper.class, Collections.singleton(ruleConfig)).get(ruleConfig);
     }
 }

--- a/features/encrypt/core/src/test/resources/yaml/encrypt-rule.yaml
+++ b/features/encrypt/core/src/test/resources/yaml/encrypt-rule.yaml
@@ -16,26 +16,28 @@
 #
 
 rules:
-  - !ENCRYPT
-    tables:
-      t_user:
-        columns:
-          username:
-            cipherColumn: username_cipher
-            encryptorName: username_encryptor
-            assistedQueryColumn: assisted_query_username
-            assistedQueryEncryptorName: assisted_encryptor
-            likeQueryColumn: like_query_username
-            likeQueryEncryptorName: like_encryptor
-    encryptors:
-      username_encryptor:
-        type: AES
-        props:
-          aes-key-value: 123456abc
-      assisted_encryptor:
-        type: AES
-        props:
-          aes-key-value: 123456abc
-    likeEncryptors:
-      like_encryptor:
-        type: CHAR_DIGEST_LIKE
+- !ENCRYPT
+  tables:
+    t_user:
+      columns:
+        username:
+          cipher: 
+            name: username_cipher
+            encryptorName: aes_encryptor
+          assistedQuery: 
+            name: assisted_query_username
+            encryptorName: assisted_encryptor
+          likeQuery: 
+            name: like_query_username
+            encryptorName: like_encryptor
+  encryptors:
+    aes_encryptor:
+      type: AES
+      props:
+        aes-key-value: 123456abc
+    assisted_encryptor:
+      type: AES
+      props:
+        aes-key-value: 123456abc
+    like_encryptor:
+      type: CHAR_DIGEST_LIKE

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterCompatibleEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterCompatibleEncryptRuleStatementUpdater.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.distsql.handler.update;
+
+import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionAlterUpdater;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.distsql.parser.statement.AlterEncryptRuleStatement;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+
+/**
+ * Alter encrypt rule statement updater.
+ * 
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@Deprecated
+public final class AlterCompatibleEncryptRuleStatementUpdater implements RuleDefinitionAlterUpdater<AlterEncryptRuleStatement, CompatibleEncryptRuleConfiguration> {
+    
+    private final AlterEncryptRuleStatementUpdater delegate = new AlterEncryptRuleStatementUpdater();
+    
+    @Override
+    public void checkSQLStatement(final ShardingSphereDatabase database, final AlterEncryptRuleStatement sqlStatement, final CompatibleEncryptRuleConfiguration currentRuleConfig) {
+        delegate.checkSQLStatement(database, sqlStatement, new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public CompatibleEncryptRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterEncryptRuleStatement sqlStatement) {
+        EncryptRuleConfiguration ruleConfig = delegate.buildToBeAlteredRuleConfiguration(sqlStatement);
+        return new CompatibleEncryptRuleConfiguration(ruleConfig.getTables(), ruleConfig.getEncryptors());
+    }
+    
+    @Override
+    public void updateCurrentRuleConfiguration(final CompatibleEncryptRuleConfiguration currentRuleConfig, final CompatibleEncryptRuleConfiguration toBeAlteredRuleConfig) {
+        delegate.updateCurrentRuleConfiguration(new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()),
+                new EncryptRuleConfiguration(toBeAlteredRuleConfig.getTables(), toBeAlteredRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public Class<CompatibleEncryptRuleConfiguration> getRuleConfigurationClass() {
+        return CompatibleEncryptRuleConfiguration.class;
+    }
+    
+    @Override
+    public String getType() {
+        return AlterEncryptRuleStatement.class.getName();
+    }
+}

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdater.java
@@ -30,7 +30,6 @@ import org.apache.shardingsphere.encrypt.distsql.parser.segment.EncryptColumnSeg
 import org.apache.shardingsphere.encrypt.distsql.parser.segment.EncryptRuleSegment;
 import org.apache.shardingsphere.encrypt.distsql.parser.statement.AlterEncryptRuleStatement;
 import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
@@ -93,7 +92,7 @@ public final class AlterEncryptRuleStatementUpdater implements RuleDefinitionAlt
     }
     
     @Override
-    public RuleConfiguration buildToBeAlteredRuleConfiguration(final AlterEncryptRuleStatement sqlStatement) {
+    public EncryptRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterEncryptRuleStatement sqlStatement) {
         return EncryptRuleStatementConverter.convert(sqlStatement.getRules());
     }
     

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateCompatibleEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateCompatibleEncryptRuleStatementUpdater.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.distsql.handler.update;
+
+import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionCreateUpdater;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.distsql.parser.statement.CreateEncryptRuleStatement;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+
+/**
+ * Create encrypt rule statement updater.
+ * 
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@Deprecated
+public final class CreateCompatibleEncryptRuleStatementUpdater implements RuleDefinitionCreateUpdater<CreateEncryptRuleStatement, CompatibleEncryptRuleConfiguration> {
+    
+    private final CreateEncryptRuleStatementUpdater delegate = new CreateEncryptRuleStatementUpdater();
+    
+    @Override
+    public void checkSQLStatement(final ShardingSphereDatabase database, final CreateEncryptRuleStatement sqlStatement, final CompatibleEncryptRuleConfiguration currentRuleConfig) {
+        delegate.checkSQLStatement(database, sqlStatement, new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public CompatibleEncryptRuleConfiguration buildToBeCreatedRuleConfiguration(final CompatibleEncryptRuleConfiguration currentRuleConfig, final CreateEncryptRuleStatement sqlStatement) {
+        EncryptRuleConfiguration ruleConfig = delegate.buildToBeCreatedRuleConfiguration(new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()), sqlStatement);
+        return new CompatibleEncryptRuleConfiguration(ruleConfig.getTables(), ruleConfig.getEncryptors());
+    }
+    
+    @Override
+    public void updateCurrentRuleConfiguration(final CompatibleEncryptRuleConfiguration currentRuleConfig, final CompatibleEncryptRuleConfiguration toBeCreatedRuleConfig) {
+        delegate.updateCurrentRuleConfiguration(new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()),
+                new EncryptRuleConfiguration(toBeCreatedRuleConfig.getTables(), toBeCreatedRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public Class<CompatibleEncryptRuleConfiguration> getRuleConfigurationClass() {
+        return CompatibleEncryptRuleConfiguration.class;
+    }
+    
+    @Override
+    public String getType() {
+        return CreateEncryptRuleStatement.class.getName();
+    }
+}

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropCompatibleEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/DropCompatibleEncryptRuleStatementUpdater.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.distsql.handler.update;
+
+import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionDropUpdater;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.distsql.parser.statement.DropEncryptRuleStatement;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+
+/**
+ * Drop encrypt rule statement updater.
+ * 
+ * @deprecated Should use new api, compatible api will remove in next version.
+ */
+@Deprecated
+public final class DropCompatibleEncryptRuleStatementUpdater implements RuleDefinitionDropUpdater<DropEncryptRuleStatement, CompatibleEncryptRuleConfiguration> {
+    
+    private final DropEncryptRuleStatementUpdater delegate = new DropEncryptRuleStatementUpdater();
+    
+    @Override
+    public void checkSQLStatement(final ShardingSphereDatabase database, final DropEncryptRuleStatement sqlStatement, final CompatibleEncryptRuleConfiguration currentRuleConfig) {
+        delegate.checkSQLStatement(database, sqlStatement, new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public boolean hasAnyOneToBeDropped(final DropEncryptRuleStatement sqlStatement, final CompatibleEncryptRuleConfiguration currentRuleConfig) {
+        return delegate.hasAnyOneToBeDropped(sqlStatement, new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public boolean updateCurrentRuleConfiguration(final DropEncryptRuleStatement sqlStatement, final CompatibleEncryptRuleConfiguration currentRuleConfig) {
+        return delegate.updateCurrentRuleConfiguration(sqlStatement, new EncryptRuleConfiguration(currentRuleConfig.getTables(), currentRuleConfig.getEncryptors()));
+    }
+    
+    @Override
+    public Class<CompatibleEncryptRuleConfiguration> getRuleConfigurationClass() {
+        return CompatibleEncryptRuleConfiguration.class;
+    }
+    
+    @Override
+    public String getType() {
+        return DropEncryptRuleStatement.class.getName();
+    }
+}

--- a/features/encrypt/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.update.RuleDefinitionUpdater
+++ b/features/encrypt/distsql/handler/src/main/resources/META-INF/services/org.apache.shardingsphere.distsql.handler.update.RuleDefinitionUpdater
@@ -16,5 +16,8 @@
 #
 
 org.apache.shardingsphere.encrypt.distsql.handler.update.CreateEncryptRuleStatementUpdater
+org.apache.shardingsphere.encrypt.distsql.handler.update.CreateCompatibleEncryptRuleStatementUpdater
 org.apache.shardingsphere.encrypt.distsql.handler.update.AlterEncryptRuleStatementUpdater
+org.apache.shardingsphere.encrypt.distsql.handler.update.AlterCompatibleEncryptRuleStatementUpdater
 org.apache.shardingsphere.encrypt.distsql.handler.update.DropEncryptRuleStatementUpdater
+org.apache.shardingsphere.encrypt.distsql.handler.update.DropCompatibleEncryptRuleStatementUpdater

--- a/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/AlterReadwriteSplittingRuleStatementUpdater.java
+++ b/features/readwrite-splitting/distsql/handler/src/main/java/org/apache/shardingsphere/readwritesplitting/distsql/handler/update/AlterReadwriteSplittingRuleStatementUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.readwritesplitting.distsql.handler.update;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionAlterUpdater;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.readwritesplitting.api.ReadwriteSplittingRuleConfiguration;
@@ -40,7 +39,7 @@ public final class AlterReadwriteSplittingRuleStatementUpdater implements RuleDe
     }
     
     @Override
-    public RuleConfiguration buildToBeAlteredRuleConfiguration(final AlterReadwriteSplittingRuleStatement sqlStatement) {
+    public ReadwriteSplittingRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterReadwriteSplittingRuleStatement sqlStatement) {
         return ReadwriteSplittingRuleStatementConverter.convert(sqlStatement.getRules());
     }
     

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/AlterDefaultShadowAlgorithmStatementUpdater.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/AlterDefaultShadowAlgorithmStatementUpdater.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.distsql.handler.exception.algorithm.MissingRequ
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionAlterUpdater;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
@@ -44,7 +43,7 @@ public final class AlterDefaultShadowAlgorithmStatementUpdater implements RuleDe
     private static final String DEFAULT_ALGORITHM_NAME = "default_shadow_algorithm";
     
     @Override
-    public RuleConfiguration buildToBeAlteredRuleConfiguration(final AlterDefaultShadowAlgorithmStatement sqlStatement) {
+    public ShadowRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterDefaultShadowAlgorithmStatement sqlStatement) {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
         result.setShadowAlgorithms(buildAlgorithmMap(sqlStatement));
         result.setDefaultShadowAlgorithmName(DEFAULT_ALGORITHM_NAME);

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/AlterShadowRuleStatementUpdater.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/AlterShadowRuleStatementUpdater.java
@@ -21,7 +21,6 @@ import org.apache.shardingsphere.distsql.handler.exception.algorithm.AlgorithmIn
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionAlterUpdater;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.shadow.api.config.ShadowRuleConfiguration;
@@ -44,7 +43,7 @@ import java.util.Map;
 public final class AlterShadowRuleStatementUpdater implements RuleDefinitionAlterUpdater<AlterShadowRuleStatement, ShadowRuleConfiguration> {
     
     @Override
-    public RuleConfiguration buildToBeAlteredRuleConfiguration(final AlterShadowRuleStatement sqlStatement) {
+    public ShadowRuleConfiguration buildToBeAlteredRuleConfiguration(final AlterShadowRuleStatement sqlStatement) {
         return ShadowRuleStatementConverter.convert(sqlStatement.getRules());
     }
     

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/CreateDefaultShadowAlgorithmStatementUpdater.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/CreateDefaultShadowAlgorithmStatementUpdater.java
@@ -23,7 +23,6 @@ import org.apache.shardingsphere.distsql.handler.exception.algorithm.InvalidAlgo
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionCreateUpdater;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
@@ -52,7 +51,7 @@ public final class CreateDefaultShadowAlgorithmStatementUpdater implements RuleD
     }
     
     @Override
-    public RuleConfiguration buildToBeCreatedRuleConfiguration(final ShadowRuleConfiguration currentRuleConfig, final CreateDefaultShadowAlgorithmStatement sqlStatement) {
+    public ShadowRuleConfiguration buildToBeCreatedRuleConfiguration(final ShadowRuleConfiguration currentRuleConfig, final CreateDefaultShadowAlgorithmStatement sqlStatement) {
         ShadowRuleConfiguration result = new ShadowRuleConfiguration();
         if (getDuplicatedRuleNames(currentRuleConfig).isEmpty()) {
             result = new ShadowRuleConfiguration();

--- a/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/CreateShadowRuleStatementUpdater.java
+++ b/features/shadow/distsql/handler/src/main/java/org/apache/shardingsphere/shadow/distsql/handler/update/CreateShadowRuleStatementUpdater.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.shadow.distsql.handler.update;
 
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionCreateUpdater;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
@@ -51,7 +50,7 @@ public final class CreateShadowRuleStatementUpdater implements RuleDefinitionCre
     }
     
     @Override
-    public RuleConfiguration buildToBeCreatedRuleConfiguration(final ShadowRuleConfiguration currentRuleConfig, final CreateShadowRuleStatement sqlStatement) {
+    public ShadowRuleConfiguration buildToBeCreatedRuleConfiguration(final ShadowRuleConfiguration currentRuleConfig, final CreateShadowRuleStatement sqlStatement) {
         Collection<ShadowRuleSegment> segments = sqlStatement.getRules();
         if (sqlStatement.isIfNotExists()) {
             Collection<String> toBeCreatedRuleNames = ShadowRuleStatementSupporter.getRuleNames(sqlStatement.getRules());

--- a/kernel/data-pipeline/core/pom.xml
+++ b/kernel/data-pipeline/core/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>HikariCP</artifactId>
             <scope>compile</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ConvertYamlConfigurationExecutor.java
@@ -27,7 +27,9 @@ import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnItemRuleCo
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.swapper.YamlCompatibleEncryptRuleConfigurationSwapper;
+import org.apache.shardingsphere.encrypt.yaml.swapper.YamlEncryptRuleConfigurationSwapper;
 import org.apache.shardingsphere.infra.config.algorithm.AlgorithmConfiguration;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
@@ -134,6 +136,9 @@ public final class ConvertYamlConfigurationExecutor implements QueryableRALExecu
             } else if (each instanceof YamlReadwriteSplittingRuleConfiguration) {
                 YamlReadwriteSplittingRuleConfigurationSwapper swapper = new YamlReadwriteSplittingRuleConfigurationSwapper();
                 result.put(swapper.getOrder(), swapper.swapToObject((YamlReadwriteSplittingRuleConfiguration) each));
+            } else if (each instanceof YamlEncryptRuleConfiguration) {
+                YamlEncryptRuleConfigurationSwapper swapper = new YamlEncryptRuleConfigurationSwapper();
+                result.put(swapper.getOrder(), swapper.swapToObject((YamlEncryptRuleConfiguration) each));
             } else if (each instanceof YamlCompatibleEncryptRuleConfiguration) {
                 YamlCompatibleEncryptRuleConfigurationSwapper swapper = new YamlCompatibleEncryptRuleConfigurationSwapper();
                 result.put(swapper.getOrder(), swapper.swapToObject((YamlCompatibleEncryptRuleConfiguration) each));

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/util/YamlDatabaseConfigurationImportExecutor.java
@@ -22,10 +22,13 @@ import org.apache.shardingsphere.distsql.handler.exception.DistSQLException;
 import org.apache.shardingsphere.distsql.handler.exception.datasource.MissingRequiredDataSourcesException;
 import org.apache.shardingsphere.distsql.handler.exception.storageunit.InvalidStorageUnitsException;
 import org.apache.shardingsphere.distsql.handler.validate.DataSourcePropertiesValidateHandler;
+import org.apache.shardingsphere.encrypt.api.config.CompatibleEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.yaml.swapper.YamlCompatibleEncryptRuleConfigurationSwapper;
+import org.apache.shardingsphere.encrypt.yaml.swapper.YamlEncryptRuleConfigurationSwapper;
 import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeEngine;
@@ -171,7 +174,12 @@ public final class YamlDatabaseConfigurationImportExecutor {
                 ruleConfigsMap.get(swapper.getOrder()).add(readwriteSplittingRuleConfig);
             } else if (each instanceof YamlCompatibleEncryptRuleConfiguration) {
                 YamlCompatibleEncryptRuleConfigurationSwapper swapper = new YamlCompatibleEncryptRuleConfigurationSwapper();
-                EncryptRuleConfiguration encryptRuleConfig = swapper.swapToObject((YamlCompatibleEncryptRuleConfiguration) each);
+                CompatibleEncryptRuleConfiguration encryptRuleConfig = swapper.swapToObject((YamlCompatibleEncryptRuleConfiguration) each);
+                ruleConfigsMap.computeIfAbsent(swapper.getOrder(), key -> new LinkedList<>());
+                ruleConfigsMap.get(swapper.getOrder()).add(encryptRuleConfig);
+            } else if (each instanceof YamlEncryptRuleConfiguration) {
+                YamlEncryptRuleConfigurationSwapper swapper = new YamlEncryptRuleConfigurationSwapper();
+                EncryptRuleConfiguration encryptRuleConfig = swapper.swapToObject((YamlEncryptRuleConfiguration) each);
                 ruleConfigsMap.computeIfAbsent(swapper.getOrder(), key -> new LinkedList<>());
                 ruleConfigsMap.get(swapper.getOrder()).add(encryptRuleConfig);
             } else if (each instanceof YamlShadowRuleConfiguration) {

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/config/ProxyConfigurationLoaderTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.shardingsphere.proxy.backend.config;
 
-import org.apache.shardingsphere.encrypt.yaml.config.YamlCompatibleEncryptRuleConfiguration;
+import org.apache.shardingsphere.encrypt.yaml.config.YamlEncryptRuleConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 import org.apache.shardingsphere.proxy.backend.config.yaml.YamlProxyDataSourceConfiguration;
@@ -77,7 +77,7 @@ class ProxyConfigurationLoaderTest {
         assertTrue(shardingRuleConfig.isPresent());
         assertShardingRuleConfiguration(shardingRuleConfig.get());
         assertFalse(
-                actual.getRules().stream().filter(each -> each instanceof YamlCompatibleEncryptRuleConfiguration).findFirst().map(each -> (YamlCompatibleEncryptRuleConfiguration) each).isPresent());
+                actual.getRules().stream().filter(each -> each instanceof YamlEncryptRuleConfiguration).findFirst().map(each -> (YamlEncryptRuleConfiguration) each).isPresent());
     }
     
     private void assertShardingRuleConfiguration(final YamlShardingRuleConfiguration actual) {
@@ -98,7 +98,7 @@ class ProxyConfigurationLoaderTest {
         assertDataSourceConfiguration(actual.getDataSources().get("read_ds_1"), "jdbc:mysql://127.0.0.1:3306/read_ds_1");
         assertFalse(actual.getRules().stream().filter(each -> each instanceof YamlShardingRuleConfiguration).findFirst().map(each -> (YamlShardingRuleConfiguration) each).isPresent());
         assertFalse(
-                actual.getRules().stream().filter(each -> each instanceof YamlCompatibleEncryptRuleConfiguration).findFirst().map(each -> (YamlCompatibleEncryptRuleConfiguration) each).isPresent());
+                actual.getRules().stream().filter(each -> each instanceof YamlEncryptRuleConfiguration).findFirst().map(each -> (YamlEncryptRuleConfiguration) each).isPresent());
         Optional<YamlReadwriteSplittingRuleConfiguration> ruleConfig = actual.getRules().stream()
                 .filter(each -> each instanceof YamlReadwriteSplittingRuleConfiguration).findFirst().map(each -> (YamlReadwriteSplittingRuleConfiguration) each);
         assertTrue(ruleConfig.isPresent());
@@ -118,13 +118,13 @@ class ProxyConfigurationLoaderTest {
         assertDataSourceConfiguration(actual.getDataSources().get("ds_0"), "jdbc:mysql://127.0.0.1:3306/encrypt_ds");
         assertFalse(actual.getRules().stream()
                 .filter(each -> each instanceof YamlShardingRuleConfiguration).findFirst().map(each -> (YamlShardingRuleConfiguration) each).isPresent());
-        Optional<YamlCompatibleEncryptRuleConfiguration> encryptRuleConfig = actual.getRules().stream()
-                .filter(each -> each instanceof YamlCompatibleEncryptRuleConfiguration).findFirst().map(each -> (YamlCompatibleEncryptRuleConfiguration) each);
+        Optional<YamlEncryptRuleConfiguration> encryptRuleConfig = actual.getRules().stream()
+                .filter(each -> each instanceof YamlEncryptRuleConfiguration).findFirst().map(each -> (YamlEncryptRuleConfiguration) each);
         assertTrue(encryptRuleConfig.isPresent());
         assertEncryptRuleConfiguration(encryptRuleConfig.get());
     }
     
-    private void assertEncryptRuleConfiguration(final YamlCompatibleEncryptRuleConfiguration actual) {
+    private void assertEncryptRuleConfiguration(final YamlEncryptRuleConfiguration actual) {
         assertThat(actual.getEncryptors().size(), is(2));
         assertTrue(actual.getEncryptors().containsKey("aes_encryptor"));
         assertTrue(actual.getEncryptors().containsKey("rc4_encryptor"));

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/fixture/FixtureRuleDefinitionCreateUpdater.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/fixture/FixtureRuleDefinitionCreateUpdater.java
@@ -18,13 +18,12 @@
 package org.apache.shardingsphere.proxy.backend.handler.distsql.fixture;
 
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionCreateUpdater;
-import org.apache.shardingsphere.infra.config.rule.RuleConfiguration;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 
 public final class FixtureRuleDefinitionCreateUpdater implements RuleDefinitionCreateUpdater<CreateFixtureRuleStatement, FixtureRuleConfiguration> {
     
     @Override
-    public RuleConfiguration buildToBeCreatedRuleConfiguration(final FixtureRuleConfiguration currentRuleConfig, final CreateFixtureRuleStatement sqlStatement) {
+    public FixtureRuleConfiguration buildToBeCreatedRuleConfiguration(final FixtureRuleConfiguration currentRuleConfig, final CreateFixtureRuleStatement sqlStatement) {
         return new FixtureRuleConfiguration();
     }
     

--- a/proxy/backend/core/src/test/resources/conf/config_loader/config-encrypt.yaml
+++ b/proxy/backend/core/src/test/resources/conf/config_loader/config-encrypt.yaml
@@ -34,11 +34,13 @@ rules:
     t_encrypt:
       columns:
         pwd:
-          cipherColumn: pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd
+            encryptorName: aes_encryptor
         name:
-          cipherColumn: name
-          encryptorName: rc4_encryptor
+          cipher:
+            name: name
+            encryptorName: rc4_encryptor
   encryptors:
     aes_encryptor:
       type: AES

--- a/proxy/backend/core/src/test/resources/conf/convert/config-encrypt.yaml
+++ b/proxy/backend/core/src/test/resources/conf/convert/config-encrypt.yaml
@@ -54,12 +54,16 @@ rules:
     t_encrypt:
       columns:
         user_id:
-          cipherColumn: user_cipher
-          encryptorName: aes_encryptor
-          assistedQueryColumn: user_assisted
-          assistedQueryEncryptorName: rc4_encryptor
-          likeQueryColumn: user_like
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_cipher
+            encryptorName: aes_encryptor
+          assistedQuery:
+            name: user_assisted
+            encryptorName: rc4_encryptor
+          likeQuery:
+            name: user_like
+            encryptorName: like_encryptor
         order_id:
-          cipherColumn: order_cipher
-          encryptorName: rc4_encryptor
+          cipher:
+            name: order_cipher
+            encryptorName: rc4_encryptor

--- a/proxy/backend/core/src/test/resources/conf/convert/config-mix.yaml
+++ b/proxy/backend/core/src/test/resources/conf/convert/config-mix.yaml
@@ -133,12 +133,16 @@ rules:
       t_encrypt:
         columns:
           user_id:
-            cipherColumn: user_cipher
-            encryptorName: aes_encryptor
-            assistedQueryColumn: user_assisted
-            assistedQueryEncryptorName: rc4_encryptor
-            likeQueryColumn: user_like
-            likeQueryEncryptorName: like_encryptor
+            cipher:
+              name: user_cipher
+              encryptorName: aes_encryptor
+            assistedQuery:
+              name: user_assisted
+              encryptorName: rc4_encryptor
+            likeQuery:
+              name: user_like
+              encryptorName: like_encryptor
           order_id:
-            cipherColumn: order_cipher
-            encryptorName: rc4_encryptor
+            cipher:
+              name: order_cipher
+              encryptorName: rc4_encryptor

--- a/proxy/backend/core/src/test/resources/conf/import/config-encrypt.yaml
+++ b/proxy/backend/core/src/test/resources/conf/import/config-encrypt.yaml
@@ -52,8 +52,10 @@ rules:
       t_encrypt:
         columns:
           user_id:
-            cipherColumn: user_cipher
-            encryptorName: aes_encryptor
+            cipher:
+              name: user_cipher
+              encryptorName: aes_encryptor
           order_id:
-            cipherColumn: order_cipher
-            encryptorName: rc4_encryptor
+            cipher:
+              name: order_cipher
+              encryptorName: rc4_encryptor

--- a/proxy/bootstrap/src/main/resources/conf/config-encrypt.yaml
+++ b/proxy/bootstrap/src/main/resources/conf/config-encrypt.yaml
@@ -59,11 +59,13 @@
 #    t_encrypt:
 #      columns:
 #        user_id:
-#          cipherColumn: user_cipher
-#          encryptorName: aes_encryptor
+#          cipher:
+#            name: user_cipher
+#            encryptorName: aes_encryptor
 #        order_id:
-#          cipherColumn: order_encrypt
-#          encryptorName: rc4_encryptor
+#          cipher:
+#            name: order_encrypt
+#            encryptorName: rc4_encryptor
 
 ######################################################################################################
 #
@@ -108,8 +110,10 @@
 #    t_encrypt:
 #      columns:
 #        user_id:
-#          cipherColumn: user_cipher
-#          encryptorName: aes_encryptor
+#          cipher:
+#            name: user_cipher
+#            encryptorName: aes_encryptor
 #        order_id:
-#          cipherColumn: order_cipher
-#          encryptorName: rc4_encryptor
+#          cipher:
+#            name: order_encrypt
+#            encryptorName: rc4_encryptor

--- a/test/e2e/driver/src/test/resources/config/config-encrypt-query-with-cipher.yaml
+++ b/test/e2e/driver/src/test/resources/config/config-encrypt-query-with-cipher.yaml
@@ -23,23 +23,28 @@ rules:
     t_encrypt:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: jdbc_encryptor_fixture
+          cipher:
+            name: cipher_pwd
+            encryptorName: jdbc_encryptor_fixture
     t_query_encrypt:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          assistedQueryColumn: assist_pwd
-          encryptorName: jdbc_encryptor_fixture
-          assistedQueryEncryptorName: jdbc_query_assisted_encryptor_fixture
+          cipher:
+            name: cipher_pwd
+            encryptorName: jdbc_encryptor_fixture
+          assistedQuery:
+            name: assist_pwd
+            encryptorName: jdbc_query_assisted_encryptor_fixture
     t_encrypt_contains_column:
       columns:
         plain_pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: jdbc_encryptor_fixture
+          cipher:
+            name: cipher_pwd
+            encryptorName: jdbc_encryptor_fixture
         plain_pwd2:
-          cipherColumn: cipher_pwd2
-          encryptorName: jdbc_encryptor_fixture
+          cipher:
+            name: cipher_pwd2
+            encryptorName: jdbc_encryptor_fixture
   encryptors:
     jdbc_encryptor_fixture:
       type: JDBC.FIXTURE

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/mysql/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/mysql/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -389,23 +389,28 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/opengauss/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/opengauss/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -388,23 +388,28 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/postgresql/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/proxy/conf/postgresql/config-dbtbl-with-readwrite-splitting-and-encrypt.yaml
@@ -388,23 +388,28 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/dbtbl_with_readwrite_splitting_and_encrypt/rules.yaml
@@ -201,26 +201,31 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
 
 props:
   sql-federation-type: ADVANCED

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/mysql/config-encrypt.yaml
@@ -43,38 +43,50 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          likeQueryColumn: user_name_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: user_name_like
+            encryptorName: like_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          likeQueryColumn: business_code_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: business_code_like
+            encryptorName: like_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/opengauss/config-encrypt.yaml
@@ -43,38 +43,50 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          likeQueryColumn: user_name_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: user_name_like
+            encryptorName: like_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          likeQueryColumn: business_code_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: business_code_like
+            encryptorName: like_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
@@ -65,6 +65,7 @@ rules:
             name: telephone_like
             encryptorName: like_encryptor
     t_user_details:
+      columns:
         number:
           cipher:
             name: number_cipher

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/proxy/conf/postgresql/config-encrypt.yaml
@@ -43,38 +43,49 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          likeQueryColumn: user_name_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: user_name_like
+            encryptorName: like_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor
     t_user_details:
-      columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          likeQueryColumn: business_code_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: business_code_like
+            encryptorName: like_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/rules.yaml
@@ -30,38 +30,50 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          likeQueryColumn: user_name_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: user_name_like
+            encryptorName: like_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          likeQueryColumn: business_code_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
+          likeQuery: 
+            name: business_code_like
+            encryptorName: like_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          likeQueryColumn: telephone_like
-          encryptorName: aes_encryptor
-          likeQueryEncryptorName: like_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
+          likeQuery:
+            name: telephone_like
+            encryptorName: like_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/mysql/config-encrypt-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/mysql/config-encrypt-readwrite-splitting.yaml
@@ -60,31 +60,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/opengauss/config-encrypt-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/opengauss/config-encrypt-readwrite-splitting.yaml
@@ -60,31 +60,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/postgresql/config-encrypt-readwrite-splitting.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/proxy/conf/postgresql/config-encrypt-readwrite-splitting.yaml
@@ -60,31 +60,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_and_readwrite_splitting/rules.yaml
@@ -38,34 +38,41 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 
 props:
   sql-federation-type: ADVANCED

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/mysql/config-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/mysql/config-encrypt-shadow.yaml
@@ -126,13 +126,16 @@ rules:
     t_shadow:
       columns:
         order_name:
-          cipherColumn: order_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_name_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/opengauss/config-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/opengauss/config-encrypt-shadow.yaml
@@ -125,13 +125,16 @@ rules:
     t_shadow:
       columns:
         order_name:
-          cipherColumn: order_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_name_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/postgresql/config-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/proxy/conf/postgresql/config-encrypt-shadow.yaml
@@ -125,13 +125,16 @@ rules:
     t_shadow:
       columns:
         order_name:
-          cipherColumn: order_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_name_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt_shadow/rules.yaml
@@ -104,13 +104,16 @@ rules:
     t_shadow:
       columns:
         order_name:
-          cipherColumn: order_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: order_name_cipher
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/mysql/config-mask-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/mysql/config-mask-encrypt.yaml
@@ -63,14 +63,18 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/opengauss/config-mask-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/opengauss/config-mask-encrypt.yaml
@@ -63,14 +63,18 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/postgresql/config-mask-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/proxy/conf/postgresql/config-mask-encrypt.yaml
@@ -63,14 +63,18 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt/rules.yaml
@@ -50,14 +50,18 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/mysql/config-mask-encrypt-sharding.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/mysql/config-mask-encrypt-sharding.yaml
@@ -144,17 +144,21 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 - !SHARDING
   tables:
     t_user:

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/opengauss/config-mask-encrypt-sharding.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/opengauss/config-mask-encrypt-sharding.yaml
@@ -144,17 +144,21 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 - !SHARDING
   tables:
     t_user:

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/postgresql/config-mask-encrypt-sharding.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/proxy/conf/postgresql/config-mask-encrypt-sharding.yaml
@@ -144,17 +144,21 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 - !SHARDING
   tables:
     t_user:

--- a/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/mask_encrypt_sharding/rules.yaml
@@ -50,17 +50,21 @@ rules:
     t_user:
       columns:
         user_name:
-          cipherColumn: user_name_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: user_name_cipher
+            encryptorName: aes_encryptor
         password:
-          cipherColumn: password_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: password_cipher
+            encryptorName: aes_encryptor
         email:
-          cipherColumn: email_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: email_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 - !SHARDING
   tables:
     t_user:

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/mysql/config-sharding-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/mysql/config-sharding-and-encrypt.yaml
@@ -243,31 +243,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/opengauss/config-sharding-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/opengauss/config-sharding-and-encrypt.yaml
@@ -243,31 +243,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/postgresql/config-sharding-and-encrypt.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/proxy/conf/postgresql/config-sharding-and-encrypt.yaml
@@ -243,31 +243,38 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_and_encrypt/rules.yaml
@@ -149,34 +149,41 @@ rules:
     t_user:
       columns:
         pwd:
-          cipherColumn: pwd_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: pwd_cipher
+            encryptorName: aes_encryptor
     t_user_details:
       columns:
         number:
-          cipherColumn: number_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: number_cipher
+            encryptorName: aes_encryptor
         number_new:
-          cipherColumn: number_new_cipher
-          encryptorName: aes_encryptor
+          cipher: 
+            name: number_new_cipher
+            encryptorName: aes_encryptor
     t_user_encrypt_federate:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_user_encrypt_federate_sharding:
       columns:
         pwd:
-          cipherColumn: cipher_pwd
-          encryptorName: aes_encryptor
+          cipher:
+            name: cipher_pwd
+            encryptorName: aes_encryptor
     t_merchant:
       columns:
         business_code:
-          cipherColumn: business_code_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: business_code_cipher
+            encryptorName: aes_encryptor
         telephone:
-          cipherColumn: telephone_cipher
-          encryptorName: aes_encryptor
+          cipher:
+            name: telephone_cipher
+            encryptorName: aes_encryptor
 
 props:
   sql-federation-type: ADVANCED

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/mysql/config-sharding-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/mysql/config-sharding-encrypt-shadow.yaml
@@ -308,5 +308,6 @@ rules:
       t_shadow:
         columns:
           order_name:
-            cipherColumn: order_name_cipher
-            encryptorName: aes_encryptor
+            cipher:
+              name: order_name_cipher
+              encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/opengauss/config-sharding-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/opengauss/config-sharding-encrypt-shadow.yaml
@@ -308,5 +308,6 @@ rules:
       t_shadow:
         columns:
           order_name:
-            cipherColumn: order_name_cipher
-            encryptorName: aes_encryptor
+            cipher:
+              name: order_name_cipher
+              encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/postgresql/config-sharding-encrypt-shadow.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/proxy/conf/postgresql/config-sharding-encrypt-shadow.yaml
@@ -308,5 +308,6 @@ rules:
       t_shadow:
         columns:
           order_name:
-            cipherColumn: order_name_cipher
-            encryptorName: aes_encryptor
+            cipher:
+              name: order_name_cipher
+              encryptorName: aes_encryptor

--- a/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/sharding_encrypt_shadow/rules.yaml
@@ -124,5 +124,6 @@ rules:
       t_shadow:
         columns:
           order_name:
-            cipherColumn: order_name_cipher
-            encryptorName: aes_encryptor
+            cipher:
+              name: order_name_cipher
+              encryptorName: aes_encryptor

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/config/query-with-cipher.yaml
@@ -25,70 +25,95 @@ rules:
     t_account:
       columns:
         certificate_number:
-          cipherColumn: cipher_certificate_number
-          assistedQueryColumn: assisted_query_certificate_number
-          likeQueryColumn: like_query_certificate_number
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_certificate_number
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_certificate_number
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_certificate_number
+            encryptorName: rewrite_like_query_fixture
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          likeQueryColumn: like_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_password
+            encryptorName: rewrite_like_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher: 
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
         amount_new:
-          cipherColumn: amount_new_cipher
-          encryptorName: rewrite_normal_fixture
+          cipher: 
+            name: amount_new_cipher
+            encryptorName: rewrite_normal_fixture
     t_account_bak:
       columns:
         certificate_number:
-          cipherColumn: cipher_certificate_number
-          assistedQueryColumn: assisted_query_certificate_number
-          likeQueryColumn: like_query_certificate_number
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_certificate_number
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_certificate_number
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_certificate_number
+            encryptorName: rewrite_like_query_fixture
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          likeQueryColumn: like_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_password
+            encryptorName: rewrite_like_query_fixture
         password_new:
-          cipherColumn: password_new_cipher
-          assistedQueryColumn: password_new_assisted
-          likeQueryColumn: password_new_like
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: password_new_cipher
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: password_new_assisted
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: password_new_like
+            encryptorName: rewrite_like_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher: 
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
     t_account_detail:
       columns:
         certificate_number:
-          cipherColumn: cipher_certificate_number
-          assistedQueryColumn: assisted_query_certificate_number
-          likeQueryColumn: like_query_certificate_number
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_certificate_number
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_certificate_number
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_certificate_number
+            encryptorName: rewrite_like_query_fixture
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          likeQueryColumn: like_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
-          likeQueryEncryptorName: rewrite_like_query_fixture
+          cipher: 
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
+          likeQuery: 
+            name: like_query_password
+            encryptorName: rewrite_like_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher: 
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
   encryptors:
     rewrite_normal_fixture:
       type: REWRITE.NORMAL.FIXTURE

--- a/test/it/rewriter/src/test/resources/scenario/mix/config/query-with-cipher.yaml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/config/query-with-cipher.yaml
@@ -72,33 +72,42 @@ rules:
     t_account:
       columns:
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
+          cipher: 
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher:
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
     t_account_bak:
       columns:
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
+          cipher:
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery:
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher: 
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
     t_account_detail:
       columns:
         password:
-          cipherColumn: cipher_password
-          assistedQueryColumn: assisted_query_password
-          encryptorName: rewrite_normal_fixture
-          assistedQueryEncryptorName: rewrite_assisted_query_fixture
+          cipher: 
+            name: cipher_password
+            encryptorName: rewrite_normal_fixture
+          assistedQuery: 
+            name: assisted_query_password
+            encryptorName: rewrite_assisted_query_fixture
         amount:
-          cipherColumn: cipher_amount
-          encryptorName: rewrite_normal_fixture
+          cipher:
+            name: cipher_amount
+            encryptorName: rewrite_normal_fixture
   encryptors:
     rewrite_normal_fixture:
       type: REWRITE.NORMAL.FIXTURE


### PR DESCRIPTION
Ref #25521.

Changes proposed in this pull request:
  - Add new encrypt yaml api
  - rename old api tag to COMPATIBLE_ENCRYPT

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
