### PR TITLE
Support the precision of the column as a decimal.

### DIFF
--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -221,6 +221,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQ
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLSelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLUpdateStatement;
 
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -1139,7 +1140,7 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
         DataTypeLengthSegment result = new DataTypeLengthSegment();
         result.setStartIndex(ctx.start.getStartIndex());
         result.setStopIndex(ctx.stop.getStartIndex());
-        result.setPrecision(Integer.parseInt(ctx.length.getText()));
+        result.setPrecision(new BigDecimal(ctx.length.getText()).intValue());
         return result;
     }
     

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1233,4 +1233,13 @@
     <alter-table sql-case-id="alter_table_drop_expression">
         <table name="t_order" start-index="12" stop-index="18" />
     </alter-table>
+
+    <alter-table sql-case-id="alter_table_modify_column_precision_with_decimal">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <modify-column>
+            <column-definition type="VARCHAR" start-index="34" stop-index="59">
+                <column name="a" stop-index="34" start-index="34" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -154,4 +154,5 @@
     <sql-case id="alter_table_reset" value="ALTER TABLE t_order RESET (fillfactor = 12)" db-types="PostgreSQL" />
     <sql-case id="alter_table_set_access_method" value="ALTER TABLE t_order SET ACCESS METHOD heap, SET ACCESS METHOD heap2" db-types="PostgreSQL" />
     <sql-case id="alter_table_drop_expression" value="ALTER TABLE t_order ALTER COLUMN a DROP EXPRESSION;" db-types="PostgreSQL" />
+    <sql-case id="alter_table_modify_column_precision_with_decimal" value="ALTER TABLE t_order MODIFY COLUMN a VARCHAR(10.000000000001)" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Fixes #25535.

Changes proposed in this pull request:
  - Support the precision of the column as a decimal.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
