### PR TITLE
Simplify ASSISTED_QUERY_COLUMN to ASSISTED_QUERY, LIKE_QUERY_COLUMN to LIKE_QUERY in DistSQL.

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/alter-encrypt-rule.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/alter-encrypt-rule.cn.md
@@ -19,7 +19,7 @@ encryptDefinition ::=
   ruleName '(' 'COLUMNS' '(' columnDefinition (',' columnDefinition)*  ')' ')'
 
 columnDefinition ::=
-  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY_COLUMN' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY_COLUMN' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
+  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
 
 encryptAlgorithmDefinition ::=
   'ENCRYPT_ALGORITHM' '(' 'TYPE' '(' 'NAME' '=' encryptAlgorithmType (',' propertiesDefinition)? ')'
@@ -65,7 +65,7 @@ value ::=
 
 ### 补充说明
 
-- `CIPHER` 指定密文数据列，`ASSISTED_QUERY_COLUMN` 指定辅助查询列，`LIKE_QUERY_COLUMN` 指定模糊查询列；
+- `CIPHER` 指定密文数据列，`ASSISTED_QUERY` 指定辅助查询列，`LIKE_QUERY` 指定模糊查询列；
 - `encryptAlgorithmType` 指定加密算法类型，请参考 [加密算法](/cn/user-manual/common-config/builtin-algorithm/encrypt/)；
 - 重复的 `ruleName` 将无法被创建。
 
@@ -83,7 +83,7 @@ COLUMNS(
 
 ### 保留字
 
-`ALTER`、`ENCRYPT`、`RULE`、`COLUMNS`、`NAME`、`CIPHER`、`ENCRYPT_ALGORITHM`、`TYPE`、`TRUE`、`FALSE`
+`ALTER`、`ENCRYPT`、`RULE`、`COLUMNS`、`NAME`、`CIPHER`、`ASSISTED_QUERY`、`LIKE_QUERY`、`ENCRYPT_ALGORITHM`、`ASSISTED_QUERY_ALGORITHM`、`LIKE_QUERY_ALGORITHM`、`TYPE`、`TRUE`、`FALSE`
 
 ### 相关链接
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/alter-encrypt-rule.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/alter-encrypt-rule.en.md
@@ -5,7 +5,7 @@ weight = 2
 
 ## Description
 
-The `ALTER ENCRYPT RULE` syntax is used to alter an encryption rule.
+The `ALTER ENCRYPT RULE` syntax is used to alter encryption rules.
 
 ### Syntax
 
@@ -19,7 +19,7 @@ encryptDefinition ::=
   ruleName '(' 'COLUMNS' '(' columnDefinition (',' columnDefinition)*  ')' ')'
 
 columnDefinition ::=
-  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY_COLUMN' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY_COLUMN' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
+  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
 
 encryptAlgorithmDefinition ::=
   'ENCRYPT_ALGORITHM' '(' 'TYPE' '(' 'NAME' '=' encryptAlgorithmType (',' propertiesDefinition)? ')'
@@ -65,7 +65,7 @@ value ::=
 
 ### Supplement
 
-- `CIPHER` specifies the cipher column, `ASSISTED_QUERY_COLUMN` specifies the assisted query column，`LIKE_QUERY_COLUMN` specifies the like query column
+- `CIPHER` specifies the cipher column, `ASSISTED_QUERY` specifies the assisted query column，`LIKE_QUERY` specifies the like query column
 - `encryptAlgorithmType` specifies the encryption algorithm type, please refer to [Encryption Algorithm](/en/user-manual/common-config/builtin-algorithm/encrypt/)
 
 ### Example
@@ -82,7 +82,7 @@ COLUMNS(
 
 ### Reserved words
 
-`ALTER`, `ENCRYPT`, `RULE`, `COLUMNS`, `NAME`, `CIPHER`, `ENCRYPT_ALGORITHM`, `TYPE`, `TRUE`, `FALSE`
+`ALTER`, `ENCRYPT`, `RULE`, `COLUMNS`, `NAME`, `CIPHER`, `ASSISTED_QUERY`, `LIKE_QUERY`, `ENCRYPT_ALGORITHM`, `ASSISTED_QUERY_ALGORITHM`, `LIKE_QUERY_ALGORITHM`, `TYPE`, `TRUE`, `FALSE`
 
 ### Related links
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/create-encrypt-rule.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/create-encrypt-rule.cn.md
@@ -22,7 +22,7 @@ encryptDefinition ::=
   ruleName '(' 'COLUMNS' '(' columnDefinition (',' columnDefinition)*  ')' ')'
 
 columnDefinition ::=
-  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY_COLUMN' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY_COLUMN' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
+  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
 
 encryptAlgorithmDefinition ::=
   'ENCRYPT_ALGORITHM' '(' 'TYPE' '(' 'NAME' '=' encryptAlgorithmType (',' propertiesDefinition)? ')'
@@ -68,7 +68,7 @@ value ::=
 
 ### 补充说明
 
-- `CIPHER` 指定密文数据列，`ASSISTED_QUERY_COLUMN` 指定辅助查询列，`LIKE_QUERY_COLUMN` 指定模糊查询列；
+- `CIPHER` 指定密文数据列，`ASSISTED_QUERY` 指定辅助查询列，`LIKE_QUERY` 指定模糊查询列；
 - `encryptAlgorithmType` 指定加密算法类型，请参考 [加密算法](/cn/user-manual/common-config/builtin-algorithm/encrypt/)；
 - 重复的 `ruleName` 将无法被创建；
 - `ifNotExists` 子句用于避免出现 `Duplicate encrypt rule` 错误。
@@ -107,7 +107,7 @@ COLUMNS(
 
 ### 保留字
 
-`CREATE`、`ENCRYPT`、`RULE`、`COLUMNS`、`NAME`、`CIPHER`、`ENCRYPT_ALGORITHM`、`TYPE`、`TRUE`、`FALSE`
+`CREATE`、`ENCRYPT`、`RULE`、`COLUMNS`、`NAME`、`CIPHER`、`ASSISTED_QUERY`、`LIKE_QUERY`、`ENCRYPT_ALGORITHM`、`ASSISTED_QUERY_ALGORITHM`、`LIKE_QUERY_ALGORITHM`、`TYPE`、`TRUE`、`FALSE`
 
 ### 相关链接
 

--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/create-encrypt-rule.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/rdl/rule-definition/encrypt/create-encrypt-rule.en.md
@@ -5,7 +5,7 @@ weight = 1
 
 ## Description
 
-The `CREATE ENCRYPT RULE` syntax is used to create a encrypt rule.
+The `CREATE ENCRYPT RULE` syntax is used to create encrypt rules.
 
 ### Syntax
 
@@ -22,7 +22,7 @@ encryptDefinition ::=
   ruleName '(' 'COLUMNS' '(' columnDefinition (',' columnDefinition)*  ')' ')'
 
 columnDefinition ::=
-  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY_COLUMN' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY_COLUMN' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
+  '(' 'NAME' '=' columnName ',' 'CIPHER' '=' cipherColumnName (',' 'ASSISTED_QUERY' '=' assistedQueryColumnName)? (',' 'LIKE_QUERY' '=' likeQueryColumnName)? ',' encryptAlgorithmDefinition (',' assistedQueryAlgorithmDefinition)? (',' likeQueryAlgorithmDefinition)? ')' 
 
 encryptAlgorithmDefinition ::=
   'ENCRYPT_ALGORITHM' '(' 'TYPE' '(' 'NAME' '=' encryptAlgorithmType (',' propertiesDefinition)? ')'
@@ -68,14 +68,14 @@ value ::=
 
 ### Supplement
 
-- `CIPHER` specifies the cipher column, `ASSISTED_QUERY_COLUMN` specifies the assisted query column，`LIKE_QUERY_COLUMN` specifies the like query column;
+- `CIPHER` specifies the cipher column, `ASSISTED_QUERY` specifies the assisted query column，`LIKE_QUERY` specifies the like query column;
 - `encryptAlgorithmType` specifies the encryption algorithm type, please refer to [Encryption Algorithm](/en/user-manual/common-config/builtin-algorithm/encrypt/);
 - Duplicate `ruleName` will not be created;
 - `ifNotExists` clause used for avoid `Duplicate encrypt rule` error.
 
 ### Example
 
-#### Create a encrypt rule
+#### Create an encrypt rule
 
 ```sql
 CREATE ENCRYPT RULE t_encrypt (
@@ -90,10 +90,10 @@ COLUMNS(
 ));
 ```
 
-#### Create a encrypt rule with `ifNotExists` clause
+#### Create an encrypt rule with `ifNotExists` clause
 
 ```sql
-CREATE ENCRYPT RULE t_encrypt IF NOT EXISTS (
+CREATE ENCRYPT RULE IF NOT EXISTS t_encrypt (
 COLUMNS(
 (NAME=user_id,CIPHER=user_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='AES',PROPERTIES('aes-key-value'='123456abc')))),
 (NAME=order_id, CIPHER =order_cipher,ENCRYPT_ALGORITHM(TYPE(NAME='MD5')))
@@ -107,7 +107,7 @@ COLUMNS(
 
 ### Reserved words
 
-`CREATE`, `ENCRYPT`, `RULE`, `COLUMNS`, `NAME`, `CIPHER`, `ENCRYPT_ALGORITHM`, `TYPE`, `TRUE`, `FALSE`
+`CREATE`, `ENCRYPT`, `RULE`, `COLUMNS`, `NAME`, `CIPHER`, `ASSISTED_QUERY`, `LIKE_QUERY`, `ENCRYPT_ALGORITHM`, `ASSISTED_QUERY_ALGORITHM`, `LIKE_QUERY_ALGORITHM`, `TYPE`, `TRUE`, `FALSE`
 
 ### Related links
 

--- a/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdater.java
+++ b/features/encrypt/distsql/handler/src/main/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdater.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
 import com.google.common.base.Preconditions;
-import org.apache.shardingsphere.distsql.handler.exception.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.distsql.handler.update.RuleDefinitionAlterUpdater;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
@@ -26,7 +25,6 @@ import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptColumnItemRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
 import org.apache.shardingsphere.encrypt.distsql.handler.converter.EncryptRuleStatementConverter;
-import org.apache.shardingsphere.encrypt.distsql.parser.segment.EncryptColumnSegment;
 import org.apache.shardingsphere.encrypt.distsql.parser.segment.EncryptRuleSegment;
 import org.apache.shardingsphere.encrypt.distsql.parser.statement.AlterEncryptRuleStatement;
 import org.apache.shardingsphere.encrypt.spi.EncryptAlgorithm;
@@ -35,7 +33,6 @@ import org.apache.shardingsphere.infra.util.exception.ShardingSpherePrecondition
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.Optional;
@@ -64,21 +61,10 @@ public final class AlterEncryptRuleStatementUpdater implements RuleDefinitionAlt
         if (!notExistEncryptTableNames.isEmpty()) {
             throw new MissingRequiredRuleException("Encrypt", databaseName, notExistEncryptTableNames);
         }
-        checkDataType(sqlStatement);
     }
     
     private Collection<String> getToBeAlteredEncryptTableNames(final AlterEncryptRuleStatement sqlStatement) {
         return sqlStatement.getRules().stream().map(EncryptRuleSegment::getTableName).collect(Collectors.toList());
-    }
-    
-    private void checkDataType(final AlterEncryptRuleStatement sqlStatement) {
-        Collection<String> invalidRules = sqlStatement.getRules().stream()
-                .map(each -> getInvalidColumns(each.getTableName(), each.getColumns())).flatMap(Collection::stream).collect(Collectors.toList());
-        ShardingSpherePreconditions.checkState(invalidRules.isEmpty(), () -> new InvalidRuleConfigurationException("encrypt", invalidRules, Collections.singleton("incomplete data type")));
-    }
-    
-    private Collection<String> getInvalidColumns(final String tableName, final Collection<EncryptColumnSegment> columns) {
-        return columns.stream().filter(each -> !each.isCorrectDataType()).map(each -> String.format("%s.%s", tableName, each.getName())).collect(Collectors.toList());
     }
     
     private void checkToBeAlteredEncryptors(final AlterEncryptRuleStatement sqlStatement) {

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdaterTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/AlterEncryptRuleStatementUpdaterTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
-import org.apache.shardingsphere.distsql.handler.exception.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.distsql.handler.exception.rule.MissingRequiredRuleException;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
@@ -68,17 +67,6 @@ class AlterEncryptRuleStatementUpdaterTest {
     @Test
     void assertCheckSQLStatementWithoutToBeAlteredEncryptors() {
         assertThrows(ServiceProviderNotFoundServerException.class, () -> updater.checkSQLStatement(database, createSQLStatement("INVALID_TYPE"), createCurrentRuleConfiguration()));
-    }
-    
-    @Test
-    void assertCheckSQLStatementWithIncompleteDataType() {
-        EncryptColumnSegment columnSegment = new EncryptColumnSegment("user_id", "user_cipher", "assisted_column", "like_column",
-                "int varchar(10)", null, null, null, new AlgorithmSegment("test", new Properties()),
-                new AlgorithmSegment("test", new Properties()),
-                new AlgorithmSegment("test", new Properties()));
-        EncryptRuleSegment ruleSegment = new EncryptRuleSegment("t_encrypt", Collections.singleton(columnSegment));
-        AlterEncryptRuleStatement statement = new AlterEncryptRuleStatement(Collections.singleton(ruleSegment));
-        assertThrows(InvalidRuleConfigurationException.class, () -> updater.checkSQLStatement(database, statement, createCurrentRuleConfiguration()));
     }
     
     @Test

--- a/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdaterTest.java
+++ b/features/encrypt/distsql/handler/src/test/java/org/apache/shardingsphere/encrypt/distsql/handler/update/CreateEncryptRuleStatementUpdaterTest.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.encrypt.distsql.handler.update;
 
 import org.apache.shardingsphere.distsql.handler.exception.rule.DuplicateRuleException;
-import org.apache.shardingsphere.distsql.handler.exception.rule.InvalidRuleConfigurationException;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
 import org.apache.shardingsphere.encrypt.api.config.EncryptRuleConfiguration;
 import org.apache.shardingsphere.encrypt.api.config.rule.EncryptTableRuleConfiguration;
@@ -63,17 +62,6 @@ class CreateEncryptRuleStatementUpdaterTest {
     @Test
     void assertCheckSQLStatementWithoutToBeCreatedEncryptors() {
         assertThrows(ServiceProviderNotFoundServerException.class, () -> updater.checkSQLStatement(database, createSQLStatement(false, "INVALID_TYPE"), null));
-    }
-    
-    @Test
-    void assertCheckSQLStatementWithIncompleteDataType() {
-        EncryptColumnSegment columnSegment = new EncryptColumnSegment("user_id", "user_cipher", "assisted_column", "like_column",
-                "int varchar(10)", null, null, null, new AlgorithmSegment("test", new Properties()),
-                new AlgorithmSegment("test", new Properties()),
-                new AlgorithmSegment("CHAR_DIGEST_LIKE", new Properties()));
-        EncryptRuleSegment ruleSegment = new EncryptRuleSegment("t_user", Collections.singleton(columnSegment));
-        CreateEncryptRuleStatement statement = new CreateEncryptRuleStatement(false, Collections.singleton(ruleSegment));
-        assertThrows(InvalidRuleConfigurationException.class, () -> updater.checkSQLStatement(database, statement, null));
     }
     
     @Test

--- a/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/Keyword.g4
+++ b/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/Keyword.g4
@@ -99,8 +99,16 @@ CIPHER
     : C I P H E R
     ;
 
+ASSISTED_QUERY
+    : A S S I S T E D UL_ Q U E R Y
+    ;
+
 ASSISTED_QUERY_COLUMN
     : A S S I S T E D UL_ Q U E R Y UL_ C O L U M N
+    ;
+
+LIKE_QUERY
+    : L I K E UL_ Q U E R Y
     ;
 
 LIKE_QUERY_COLUMN
@@ -113,26 +121,6 @@ TRUE
 
 FALSE
     : F A L S E
-    ;
-
-DATA_TYPE
-    : D A T A UL_ T Y P E
-    ;
-
-PLAIN_DATA_TYPE
-    : P L A I N UL_ D A T A UL_ T Y P E
-    ;
-
-CIPHER_DATA_TYPE
-    : C I P H E R UL_ D A T A UL_ T Y P E
-    ;
-
-ASSISTED_QUERY_DATA_TYPE
-    : A S S I S T E D UL_ Q U E R Y UL_ D A T A UL_ T Y P E
-    ;
-
-LIKE_QUERY_DATA_TYPE
-    : L I K E UL_ Q U E R Y UL_ D A T A UL_ T Y P E
     ;
 
 IF

--- a/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/RDLStatement.g4
+++ b/features/encrypt/distsql/parser/src/main/antlr4/imports/encrypt/RDLStatement.g4
@@ -44,19 +44,15 @@ encryptColumnDefinition
     ;
 
 columnDefinition
-    : NAME EQ_ columnName (COMMA_ DATA_TYPE EQ_ dataType)?
+    : NAME EQ_ columnName
     ;
 
 columnName
     : IDENTIFIER_
     ;
 
-dataType
-    : STRING_
-    ;
-
 cipherColumnDefinition
-    :  CIPHER EQ_ cipherColumnName (COMMA_ CIPHER_DATA_TYPE EQ_ dataType)?
+    :  CIPHER EQ_ cipherColumnName
     ;
 
 cipherColumnName
@@ -64,7 +60,7 @@ cipherColumnName
     ;
 
 assistedQueryColumnDefinition
-    : ASSISTED_QUERY_COLUMN EQ_ assistedQueryColumnName (COMMA_ ASSISTED_QUERY_DATA_TYPE EQ_ dataType)?
+    : (ASSISTED_QUERY | ASSISTED_QUERY_COLUMN) EQ_ assistedQueryColumnName
     ;
 
 assistedQueryColumnName
@@ -72,7 +68,7 @@ assistedQueryColumnName
     ;
 
 likeQueryColumnDefinition
-    : LIKE_QUERY_COLUMN EQ_ likeQueryColumnName (COMMA_ LIKE_QUERY_DATA_TYPE EQ_ dataType)?
+    : (LIKE_QUERY | LIKE_QUERY_COLUMN) EQ_ likeQueryColumnName
     ;
 
 likeQueryColumnName

--- a/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
+++ b/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
@@ -88,11 +88,7 @@ public final class EncryptDistSQLStatementVisitor extends EncryptDistSQLStatemen
                 getIdentifierValue(ctx.cipherColumnDefinition().cipherColumnName()),
                 null == ctx.assistedQueryColumnDefinition() ? null : getIdentifierValue(ctx.assistedQueryColumnDefinition().assistedQueryColumnName()),
                 null == ctx.likeQueryColumnDefinition() ? null : getIdentifierValue(ctx.likeQueryColumnDefinition().likeQueryColumnName()),
-                getIdentifierValue(ctx.columnDefinition().dataType()),
-                getIdentifierValue(ctx.cipherColumnDefinition().dataType()),
-                null == ctx.assistedQueryColumnDefinition() ? null : getIdentifierValue(ctx.assistedQueryColumnDefinition().dataType()),
-                null == ctx.likeQueryColumnDefinition() ? null : getIdentifierValue(ctx.likeQueryColumnDefinition().dataType()),
-                null == ctx.encryptAlgorithm() ? null : (AlgorithmSegment) visit(ctx.encryptAlgorithm().algorithmDefinition()),
+                (AlgorithmSegment) visit(ctx.encryptAlgorithm().algorithmDefinition()),
                 null == ctx.assistedQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.assistedQueryAlgorithm().algorithmDefinition()),
                 null == ctx.likeQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.likeQueryAlgorithm().algorithmDefinition()));
     }

--- a/features/encrypt/distsql/statement/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/segment/EncryptColumnSegment.java
+++ b/features/encrypt/distsql/statement/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/segment/EncryptColumnSegment.java
@@ -17,8 +17,6 @@
 
 package org.apache.shardingsphere.encrypt.distsql.parser.segment;
 
-import com.google.common.base.Strings;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.segment.AlgorithmSegment;
@@ -27,7 +25,6 @@ import org.apache.shardingsphere.sql.parser.api.ASTNode;
 /**
  * Encrypt column segment.
  */
-@AllArgsConstructor
 @RequiredArgsConstructor
 @Getter
 public final class EncryptColumnSegment implements ASTNode {
@@ -40,35 +37,9 @@ public final class EncryptColumnSegment implements ASTNode {
     
     private final String likeQueryColumn;
     
-    private String dataType;
-    
-    private String cipherDataType;
-    
-    private String assistedQueryDataType;
-    
-    private String likeQueryDataType;
-    
     private final AlgorithmSegment encryptor;
     
     private final AlgorithmSegment assistedQueryEncryptor;
     
     private final AlgorithmSegment likeQueryEncryptor;
-    
-    /**
-     * Is the data type correct.
-     *
-     * @return correct or not
-     */
-    public boolean isCorrectDataType() {
-        boolean requireDataType = !Strings.isNullOrEmpty(dataType);
-        return isCorrectDataType(requireDataType, name, dataType) && isCorrectDataType(requireDataType, cipherColumn, cipherDataType)
-                && isCorrectDataType(requireDataType, assistedQueryColumn, assistedQueryDataType) && isCorrectDataType(requireDataType, likeQueryColumn, likeQueryDataType);
-    }
-    
-    private boolean isCorrectDataType(final boolean requireDataType, final String field, final String fieldDataType) {
-        boolean noDataTypeRequired = !requireDataType && Strings.isNullOrEmpty(fieldDataType);
-        boolean requireDataTypeAndFieldExisted = requireDataType && !Strings.isNullOrEmpty(field) && !Strings.isNullOrEmpty(fieldDataType);
-        boolean requireDataTypeAndFieldNotExisted = requireDataType && Strings.isNullOrEmpty(field) && Strings.isNullOrEmpty(fieldDataType);
-        return noDataTypeRequired || requireDataTypeAndFieldExisted || requireDataTypeAndFieldNotExisted;
-    }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/external/loader/ExternalMySQLTestParameterLoader.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/external/loader/ExternalMySQLTestParameterLoader.java
@@ -31,9 +31,9 @@ import java.util.Objects;
  * External MySQL SQL parser test parameter loader.
  */
 public final class ExternalMySQLTestParameterLoader extends AbstractTestParameterLoader<ExternalSQLParserTestParameter> {
-
+    
     private static final int DELIMITER_COMMAND_LENGTH = "DELIMITER".length();
-
+    
     public ExternalMySQLTestParameterLoader(final TestParameterLoadStrategy loadStrategy) {
         super(loadStrategy);
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Simplify ASSISTED_QUERY_COLUMN to ASSISTED_QUERY, LIKE_QUERY_COLUMN to LIKE_QUERY in DistSQL.
  - Remove useless dataType in DistSQL.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
