### PR TITLE
Add LineLength ignorePattern to avoid checkstyle exception temporarily

### DIFF
--- a/parser/sql/dialect/mysql/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/mysql/external/ExternalMySQLParserIT.java
+++ b/parser/sql/dialect/mysql/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/mysql/external/ExternalMySQLParserIT.java
@@ -27,5 +27,4 @@ class ExternalMySQLParserIT extends ExternalSQLParserIT {
     static final String CASE_URL = "https://github.com/mysql/mysql-server/tree/8.0/mysql-test/t";
     
     static final String RESULT_URL = "https://github.com/mysql/mysql-server/tree/8.0/mysql-test/r";
-    
 }

--- a/parser/sql/dialect/postgresql/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/postgresql/external/ExternalPostgreSQLParserIT.java
+++ b/parser/sql/dialect/postgresql/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/postgresql/external/ExternalPostgreSQLParserIT.java
@@ -21,12 +21,10 @@ import org.apache.shardingsphere.test.it.sql.parser.external.ExternalSQLParserIT
 import org.apache.shardingsphere.test.it.sql.parser.external.loader.ExternalPostgreSQLTestParameterLoader;
 import org.apache.shardingsphere.test.loader.ExternalCaseSettings;
 
-@ExternalCaseSettings(value = "PostgreSQL", caseURL = ExternalPostgreSQLParserIT.CASE_URL, resultURL = ExternalPostgreSQLParserIT.RESULT_URL,
-        testParameterLoader = ExternalPostgreSQLTestParameterLoader.class)
+@ExternalCaseSettings(value = "PostgreSQL", caseURL = ExternalPostgreSQLParserIT.CASE_URL, resultURL = ExternalPostgreSQLParserIT.RESULT_URL, testParameterLoader = ExternalPostgreSQLTestParameterLoader.class)
 class ExternalPostgreSQLParserIT extends ExternalSQLParserIT {
     
     static final String CASE_URL = "https://github.com/postgres/postgres/tree/master/src/test/regress/sql";
     
     static final String RESULT_URL = "https://github.com/postgres/postgres/tree/master/src/test/regress/expected";
-    
 }

--- a/src/resources/checkstyle.xml
+++ b/src/resources/checkstyle.xml
@@ -33,6 +33,8 @@
     <module name="LineLength">
         <property name="fileExtensions" value="java" />
         <property name="max" value="200" />
+        <!-- TODO remove ignorePattern when fix spotless format bug -->
+        <property name="ignorePattern" value="@ExternalCaseSettings"/>
     </module>
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf" />


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Add LineLength ignorePattern to avoid checkstyle exception temporarily

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
