### PR TITLE
Fix wrong mask result when config same value of from-x and to-y with KEEP_FROM_X_TO_Y

### DIFF
--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithm.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.mask.algorithm.cover;
 
 import com.google.common.base.Strings;
+import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mask.algorithm.MaskAlgorithmPropsChecker;
+import org.apache.shardingsphere.mask.exception.algorithm.MaskAlgorithmInitializationException;
 import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
 
 import java.util.Properties;
@@ -45,6 +47,7 @@ public final class KeepFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
         fromX = createFromX(props);
         toY = createToY(props);
         replaceChar = createReplaceChar(props);
+        ShardingSpherePreconditions.checkState(fromX <= toY, () -> new MaskAlgorithmInitializationException(getType(), "fromX must be less than or equal to toY"));
     }
     
     private Integer createFromX(final Properties props) {
@@ -68,11 +71,8 @@ public final class KeepFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
         if (Strings.isNullOrEmpty(result)) {
             return result;
         }
-        if (result.length() <= fromX || toY <= fromX) {
-            return result;
-        }
         char[] chars = result.toCharArray();
-        for (int i = 0; i < fromX; i++) {
+        for (int i = 0; i < Math.min(fromX, result.length()); i++) {
             chars[i] = replaceChar;
         }
         for (int i = toY + 1; i < chars.length; i++) {

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithm.java
@@ -18,7 +18,9 @@
 package org.apache.shardingsphere.mask.algorithm.cover;
 
 import com.google.common.base.Strings;
+import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.mask.algorithm.MaskAlgorithmPropsChecker;
+import org.apache.shardingsphere.mask.exception.algorithm.MaskAlgorithmInitializationException;
 import org.apache.shardingsphere.mask.spi.MaskAlgorithm;
 
 import java.util.Properties;
@@ -45,6 +47,7 @@ public final class MaskFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
         fromX = createFromX(props);
         toY = createToY(props);
         replaceChar = createReplaceChar(props);
+        ShardingSpherePreconditions.checkState(fromX <= toY, () -> new MaskAlgorithmInitializationException(getType(), "fromX must be less than or equal to toY"));
     }
     
     private Integer createFromX(final Properties props) {
@@ -68,7 +71,7 @@ public final class MaskFromXToYMaskAlgorithm implements MaskAlgorithm<Object, St
         if (Strings.isNullOrEmpty(result)) {
             return result;
         }
-        if (result.length() <= fromX || toY < fromX) {
+        if (result.length() <= fromX) {
             return result;
         }
         char[] chars = result.toCharArray();

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFirstNLastMMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFirstNLastMMaskAlgorithmTest.java
@@ -31,20 +31,56 @@ class KeepFirstNLastMMaskAlgorithmTest {
     
     private KeepFirstNLastMMaskAlgorithm maskAlgorithm;
     
+    private KeepFirstNLastMMaskAlgorithm sameFirstNLastMMaskAlgorithm;
+    
     @BeforeEach
     void setUp() {
         maskAlgorithm = new KeepFirstNLastMMaskAlgorithm();
-        maskAlgorithm.init(PropertiesBuilder.build(new Property("first-n", "2"), new Property("last-m", "5"), new Property("replace-char", "*")));
+        maskAlgorithm.init(PropertiesBuilder.build(new Property("first-n", "3"), new Property("last-m", "5"), new Property("replace-char", "*")));
+        sameFirstNLastMMaskAlgorithm = new KeepFirstNLastMMaskAlgorithm();
+        sameFirstNLastMMaskAlgorithm.init(PropertiesBuilder.build(new Property("first-n", "5"), new Property("last-m", "5"), new Property("replace-char", "*")));
     }
     
     @Test
     void assertMask() {
-        assertThat(maskAlgorithm.mask("abc123456"), is("ab**23456"));
+        assertThat(maskAlgorithm.mask("abc123456"), is("abc*23456"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc123456789"), is("abc12**56789"));
     }
     
     @Test
-    void assertMaskWhenPlainValueLengthLessThenFirstNLastMSum() {
+    void assertMaskWhenPlainValueLengthLessThanFirstN() {
+        assertThat(maskAlgorithm.mask("ab"), is("ab"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc"), is("abc"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsFirstN() {
         assertThat(maskAlgorithm.mask("abc"), is("abc"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc12"), is("abc12"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanLastM() {
+        assertThat(maskAlgorithm.mask("abc1"), is("abc1"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc1"), is("abc1"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsLastM() {
+        assertThat(maskAlgorithm.mask("abc12"), is("abc12"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc12"), is("abc12"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanFirstNPlusLastM() {
+        assertThat(maskAlgorithm.mask("abc1234"), is("abc1234"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc123456"), is("abc123456"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsFirstNPlusLastM() {
+        assertThat(maskAlgorithm.mask("abc12345"), is("abc12345"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc1234567"), is("abc1234567"));
     }
     
     @Test

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/KeepFromXToYMaskAlgorithmTest.java
@@ -31,25 +31,44 @@ class KeepFromXToYMaskAlgorithmTest {
     
     private KeepFromXToYMaskAlgorithm maskAlgorithm;
     
+    private KeepFromXToYMaskAlgorithm sameFromXToYMaskAlgorithm;
+    
     @BeforeEach
     void setUp() {
         maskAlgorithm = new KeepFromXToYMaskAlgorithm();
-        maskAlgorithm.init(PropertiesBuilder.build(new Property("from-x", "2"), new Property("to-y", "5"), new Property("replace-char", "*")));
+        maskAlgorithm.init(PropertiesBuilder.build(new Property("from-x", "3"), new Property("to-y", "5"), new Property("replace-char", "*")));
+        sameFromXToYMaskAlgorithm = new KeepFromXToYMaskAlgorithm();
+        sameFromXToYMaskAlgorithm.init(PropertiesBuilder.build(new Property("from-x", "5"), new Property("to-y", "5"), new Property("replace-char", "*")));
     }
     
     @Test
     void assertMask() {
-        assertThat(maskAlgorithm.mask("abc123456"), is("**c123***"));
+        assertThat(maskAlgorithm.mask("abc123456"), is("***123***"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123456"), is("*****3***"));
     }
     
     @Test
-    void assertMaskWhenPlainValueLengthLessThanToY() {
-        assertThat(maskAlgorithm.mask("abc"), is("**c"));
+    void assertMaskWhenPlainValueLengthLessThanFromXPlusOne() {
+        assertThat(maskAlgorithm.mask("abc"), is("***"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc"), is("***"));
     }
     
     @Test
-    void assertMaskWhenPlainValueLengthLessThanFromX() {
-        assertThat(maskAlgorithm.mask("a"), is("a"));
+    void assertMaskWhenPlainValueLengthEqualsFromXPlusOne() {
+        assertThat(maskAlgorithm.mask("abc1"), is("***1"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123"), is("*****3"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanToYPlusOne() {
+        assertThat(maskAlgorithm.mask("abc12"), is("***12"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc12"), is("*****"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsToYPlusOne() {
+        assertThat(maskAlgorithm.mask("abc123"), is("***123"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123"), is("*****3"));
     }
     
     @Test
@@ -68,5 +87,11 @@ class KeepFromXToYMaskAlgorithmTest {
     void assertInitWhenReplaceCharIsEmpty() {
         assertThrows(MaskAlgorithmInitializationException.class,
                 () -> new KeepFirstNLastMMaskAlgorithm().init(PropertiesBuilder.build(new Property("from-x", "2"), new Property("to-y", "5"), new Property("replace-char", ""))));
+    }
+    
+    @Test
+    void assertInitWhenFromXGreaterThanToY() {
+        assertThrows(MaskAlgorithmInitializationException.class,
+                () -> new KeepFirstNLastMMaskAlgorithm().init(PropertiesBuilder.build(new Property("from-x", "5"), new Property("to-y", "2"), new Property("replace-char", ""))));
     }
 }

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFirstNLastMMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFirstNLastMMaskAlgorithmTest.java
@@ -31,20 +31,56 @@ class MaskFirstNLastMMaskAlgorithmTest {
     
     private MaskFirstNLastMMaskAlgorithm maskAlgorithm;
     
+    private MaskFirstNLastMMaskAlgorithm sameFirstNLastMMaskAlgorithm;
+    
     @BeforeEach
     void setUp() {
         maskAlgorithm = new MaskFirstNLastMMaskAlgorithm();
         maskAlgorithm.init(PropertiesBuilder.build(new Property("first-n", "3"), new Property("last-m", "5"), new Property("replace-char", "*")));
+        sameFirstNLastMMaskAlgorithm = new MaskFirstNLastMMaskAlgorithm();
+        sameFirstNLastMMaskAlgorithm.init(PropertiesBuilder.build(new Property("first-n", "5"), new Property("last-m", "5"), new Property("replace-char", "*")));
     }
     
     @Test
     void assertMask() {
-        assertThat(maskAlgorithm.mask("abc12345678"), is("***123*****"));
+        assertThat(maskAlgorithm.mask("abc123456"), is("***1*****"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc123456789"), is("*****34*****"));
     }
     
     @Test
     void assertMaskWhenPlainValueLengthLessThanFirstN() {
         assertThat(maskAlgorithm.mask("ab"), is("**"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc"), is("***"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsFirstN() {
+        assertThat(maskAlgorithm.mask("abc"), is("***"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc12"), is("*****"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanLastM() {
+        assertThat(maskAlgorithm.mask("abc1"), is("****"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc1"), is("****"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsLastM() {
+        assertThat(maskAlgorithm.mask("abc12"), is("*****"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc12"), is("*****"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanFirstNPlusLastM() {
+        assertThat(maskAlgorithm.mask("abc1234"), is("*******"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc123456"), is("*********"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsFirstNPlusLastM() {
+        assertThat(maskAlgorithm.mask("abc12345"), is("********"));
+        assertThat(sameFirstNLastMMaskAlgorithm.mask("abc1234567"), is("**********"));
     }
     
     @Test

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/algorithm/cover/MaskFromXToYMaskAlgorithmTest.java
@@ -31,25 +31,44 @@ class MaskFromXToYMaskAlgorithmTest {
     
     private MaskFromXToYMaskAlgorithm maskAlgorithm;
     
+    private MaskFromXToYMaskAlgorithm sameFromXToYMaskAlgorithm;
+    
     @BeforeEach
     void setUp() {
         maskAlgorithm = new MaskFromXToYMaskAlgorithm();
         maskAlgorithm.init(PropertiesBuilder.build(new Property("from-x", "3"), new Property("to-y", "5"), new Property("replace-char", "*")));
+        sameFromXToYMaskAlgorithm = new MaskFromXToYMaskAlgorithm();
+        sameFromXToYMaskAlgorithm.init(PropertiesBuilder.build(new Property("from-x", "5"), new Property("to-y", "5"), new Property("replace-char", "*")));
     }
     
     @Test
     void assertMask() {
-        assertThat(maskAlgorithm.mask("abc12345"), is("abc***45"));
+        assertThat(maskAlgorithm.mask("abc123456"), is("abc***456"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123456"), is("abc12*456"));
     }
     
     @Test
-    void assertMaskWhenPlainValueLengthLessThanFromX() {
-        assertThat(maskAlgorithm.mask("ab"), is("ab"));
+    void assertMaskWhenPlainValueLengthLessThanFromXPlusOne() {
+        assertThat(maskAlgorithm.mask("abc"), is("abc"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc"), is("abc"));
     }
     
     @Test
-    void assertMaskWhenPlainValueLengthLessThanToY() {
+    void assertMaskWhenPlainValueLengthEqualsFromXPlusOne() {
         assertThat(maskAlgorithm.mask("abc1"), is("abc*"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123"), is("abc12*"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthLessThanToYPlusOne() {
+        assertThat(maskAlgorithm.mask("abc12"), is("abc**"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc12"), is("abc12"));
+    }
+    
+    @Test
+    void assertMaskWhenPlainValueLengthEqualsToYPlusOne() {
+        assertThat(maskAlgorithm.mask("abc123"), is("abc***"));
+        assertThat(sameFromXToYMaskAlgorithm.mask("abc123"), is("abc12*"));
     }
     
     @Test
@@ -68,5 +87,11 @@ class MaskFromXToYMaskAlgorithmTest {
     void assertInitWhenReplaceCharIsEmpty() {
         assertThrows(MaskAlgorithmInitializationException.class,
                 () -> new MaskFromXToYMaskAlgorithm().init(PropertiesBuilder.build(new Property("from-x", "3"), new Property("to-y", "5"), new Property("replace-char", ""))));
+    }
+    
+    @Test
+    void assertInitWhenFromXGreaterThanToY() {
+        assertThrows(MaskAlgorithmInitializationException.class,
+                () -> new KeepFirstNLastMMaskAlgorithm().init(PropertiesBuilder.build(new Property("from-x", "5"), new Property("to-y", "2"), new Property("replace-char", ""))));
     }
 }


### PR DESCRIPTION
Fixes #25616.

Changes proposed in this pull request:
  - Fix wrong mask result when config same value of from-x and to-y with KEEP_FROM_X_TO_Y
  - add more unit test for mask algorithm

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
