### PR TITLE
Support MySQL Oracle DROP USER statement for SQL parsing based on IP address deletion.

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -567,11 +567,15 @@ identifierKeywordsAmbiguous4SystemVariables
     | PERSIST_ONLY
     | SESSION
     ;
-    
+
 textOrIdentifier
-    : identifier | string_
+    : identifier  | string_ | ipAddress
     ;
-    
+
+ipAddress
+    : IP_ADDRESS
+    ;
+
 variable
     : userVariable | systemVariable
     ;

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
@@ -66,13 +66,13 @@ BIT_NUM_
     ;
 
 IDENTIFIER_
-    :  IP_ADDRESS
+    :  IP_ADDRESS_
     |  [A-Za-z_$0-9\u0080-\uFFFF]*?[A-Za-z_$\u0080-\uFFFF]+?[A-Za-z_$0-9\u0080-\uFFFF]*
     |  BQ_ ~'`'+ BQ_
     ;
 
-IP_ADDRESS
-    : DIGIT+ '.' DIGIT+ '.' DIGIT+ '.' DIGIT+
+IP_ADDRESS_
+    : DIGIT+ DOT_ DIGIT+ DOT_ DIGIT+ DOT_ DIGIT+
     ;
 
 NOT_SUPPORT_

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
@@ -66,8 +66,13 @@ BIT_NUM_
     ;
 
 IDENTIFIER_
-    : [A-Za-z_$0-9\u0080-\uFFFF]*?[A-Za-z_$\u0080-\uFFFF]+?[A-Za-z_$0-9\u0080-\uFFFF]*
+    :  IP_ADDRESS
+    |  [A-Za-z_$0-9\u0080-\uFFFF]*?[A-Za-z_$\u0080-\uFFFF]+?[A-Za-z_$0-9\u0080-\uFFFF]*
     |  BQ_ ~'`'+ BQ_
+    ;
+
+IP_ADDRESS
+    : DIGIT+ '.' DIGIT+ '.' DIGIT+ '.' DIGIT+
     ;
 
 NOT_SUPPORT_

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/Literals.g4
@@ -66,13 +66,12 @@ BIT_NUM_
     ;
 
 IDENTIFIER_
-    :  IP_ADDRESS_
-    |  [A-Za-z_$0-9\u0080-\uFFFF]*?[A-Za-z_$\u0080-\uFFFF]+?[A-Za-z_$0-9\u0080-\uFFFF]*
+    :  [A-Za-z_$0-9\u0080-\uFFFF]*?[A-Za-z_$\u0080-\uFFFF]+?[A-Za-z_$0-9\u0080-\uFFFF]*
     |  BQ_ ~'`'+ BQ_
     ;
 
-IP_ADDRESS_
-    : DIGIT+ DOT_ DIGIT+ DOT_ DIGIT+ DOT_ DIGIT+
+IP_ADDRESS
+    : INT_NUM_ DOT_ INT_NUM_ DOT_ INT_NUM_ DOT_ INT_NUM_
     ;
 
 NOT_SUPPORT_

--- a/test/it/parser/src/main/resources/case/dcl/drop-user.xml
+++ b/test/it/parser/src/main/resources/case/dcl/drop-user.xml
@@ -19,6 +19,7 @@
 <sql-parser-test-cases>
     <drop-user sql-case-id="drop_user_without_hostname" />
     <drop-user sql-case-id="drop_user_with_hostname" />
+    <drop-user sql-case-id="drop_user_with_ip" />
     <drop-user sql-case-id="drop_user_cascade" />
     <drop-user sql-case-id="drop_user" />
     <drop-user sql-case-id="drop_users" />

--- a/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
@@ -19,7 +19,7 @@
 <sql-cases>
     <sql-case id="drop_user_without_hostname" value="DROP USER user_dev" db-types="Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_user_with_hostname" value="DROP USER user_dev@localhost" db-types="MySQL,Oracle" />
-    <sql-case id="drop_user_with_ip" value="DROP USER u1@120.0.0.1" />
+    <sql-case id="drop_user_with_ip" value="DROP USER u1@120.0.0.1" db-types="MySQL,Oracle" />
     <sql-case id="drop_user_cascade" value="DROP USER user_dev CASCADE" db-types="Oracle" />
     <sql-case id="drop_user" value="DROP USER user1" db-types="MySQL,Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_users" value="DROP USER user1, user2" db-types="MySQL,PostgreSQL,openGauss" />

--- a/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
@@ -19,6 +19,7 @@
 <sql-cases>
     <sql-case id="drop_user_without_hostname" value="DROP USER user_dev" db-types="Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_user_with_hostname" value="DROP USER user_dev@localhost" db-types="MySQL,Oracle" />
+    <sql-case id="drop_user_with_ip" value="DROP USER u1@120.0.0.1" />
     <sql-case id="drop_user_cascade" value="DROP USER user_dev CASCADE" db-types="Oracle" />
     <sql-case id="drop_user" value="DROP USER user1" db-types="MySQL,Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_users" value="DROP USER user1, user2" db-types="MySQL,PostgreSQL,openGauss" />


### PR DESCRIPTION
Fixes #25535 .

Changes proposed in this pull request:
  - MySQL Oracle DROP USER statement for SQL parsing based on IP address deletion

---

Before committing this PR, I'm sure that I have checked the following options:
- [✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [✓] I have added corresponding unit tests for my changes.
