### PR TITLE
Fix build-proxy-native-image job on Nightly Build

### DIFF
--- a/infra/expr/core/src/main/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactory.java
+++ b/infra/expr/core/src/main/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactory.java
@@ -28,8 +28,8 @@ import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class InlineExpressionParserFactory {
     
-    // workaround for https://github.com/helidon-io/helidon-build-tools/issues/858
-    private static final boolean IS_SUBSTRATE_VM = "Substrate VM".equals(System.getProperty("java.vm.name"));
+    // workaround for https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/condition/EnabledInNativeImage.html
+    private static final boolean IS_SUBSTRATE_VM = "runtime".equals(System.getProperty("org.graalvm.nativeimage.imagecode"));
     
     /**
      * Create new instance of inline expression parser.

--- a/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
+++ b/infra/expr/core/src/test/java/org/apache/shardingsphere/infra/expr/core/InlineExpressionParserFactoryTest.java
@@ -26,21 +26,25 @@ import static org.hamcrest.Matchers.is;
 
 class InlineExpressionParserFactoryTest {
     
-    private String originalJavaVmName;
+    private String originalImageCode;
     
     @BeforeEach
     public void setUp() {
-        originalJavaVmName = System.getProperty("java.vm.name");
+        originalImageCode = System.getProperty("org.graalvm.nativeimage.imagecode");
     }
     
     @AfterEach
     public void tearDown() {
-        System.setProperty("java.vm.name", originalJavaVmName);
+        if (null != originalImageCode) {
+            System.setProperty("org.graalvm.nativeimage.imagecode", originalImageCode);
+        } else {
+            System.clearProperty("org.graalvm.nativeimage.imagecode");
+        }
     }
     
     @Test
     void assertNewInstance() {
-        System.setProperty("java.vm.name", "");
+        System.setProperty("org.graalvm.nativeimage.imagecode", "");
         assertThat(InlineExpressionParserFactory.newInstance().getType(), is("HOTSPOT"));
     }
 }

--- a/infra/expr/espresso/pom.xml
+++ b/infra/expr/espresso/pom.xml
@@ -68,11 +68,24 @@
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>org.apache.shardingsphere</groupId>
+                                    <artifactId>shardingsphere-infra-expr-spi</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.shardingsphere</groupId>
+                                    <artifactId>shardingsphere-infra-util</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.shardingsphere</groupId>
                                     <artifactId>shardingsphere-infra-expr-hotsopt</artifactId>
                                     <version>${project.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <destFileName>shardingsphere-infra-expr-hotsopt.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.groovy</groupId>
@@ -80,7 +93,6 @@
                                     <version>${groovy.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <destFileName>groovy.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>com.google.guava</groupId>
@@ -88,9 +100,9 @@
                                     <version>${guava.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
-                                    <destFileName>guava.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
+                            <stripVersion>true</stripVersion>
                             <outputDirectory>${project.build.outputDirectory}/espresso-need-libs</outputDirectory>
                         </configuration>
                     </execution>

--- a/infra/expr/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
+++ b/infra/expr/espresso/src/test/java/org/apache/shardingsphere/infra/expr/espresso/EspressoInlineExpressionParserTest.java
@@ -17,8 +17,9 @@
 
 package org.apache.shardingsphere.infra.expr.espresso;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledInNativeImage;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.condition.EnabledInNativeImage;
 
 import java.util.Collections;
@@ -29,6 +30,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @EnabledInNativeImage
+@DisabledIfSystemProperty(named = "org.graalvm.nativeimage.imagecode", matches = "agent", disabledReason = "Skip this unit test when using GraalVM Native Build Tools")
 class EspressoInlineExpressionParserTest {
     
     @Test
@@ -123,7 +125,7 @@ class EspressoInlineExpressionParserTest {
      * Because `org.graalvm.polyglot.Value#as` does not allow this type to be returned from the guest JVM.
      */
     @Test
-    @DisabledInNativeImage
+    @Disabled
     void assertEvaluateClosure() {
         assertThat(new EspressoInlineExpressionParser().evaluateClosure("${1+2}").call().toString(), is("3"));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dockerfile-maven.version>1.4.13</dockerfile-maven.version>
         <docker-compose-maven-plugin.version>4.0.0</docker-compose-maven-plugin.version>
         <os-maven-plugin.version>1.6.2</os-maven-plugin.version>
-        <native-maven-plugin.version>0.9.21</native-maven-plugin.version>
+        <native-maven-plugin.version>0.9.22</native-maven-plugin.version>
         
         <!-- Compile plugin versions -->
         <maven-enforcer-plugin.version>3.2.1</maven-enforcer-plugin.version>


### PR DESCRIPTION
For #25509.

Changes proposed in this pull request:
  - Fix build-proxy-native-image job on Nightly Build. Refer to https://github.com/apache/shardingsphere/actions/runs/4957033387/jobs/8868215699 .
  - Update GraalVM Native Build Tools to 0.9.22.
  - Disable some unit tests when using GraalVM Native Build Tools. Because the copy execution of org.apache.shardingsphere:shardingsphere-infra-expr-espresso is later than the life cycle of executing unit tests.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
