### PR TITLE
Synchronize the configuration of Checkstyle and Spotless

### DIFF
--- a/src/resources/checkstyle.xml
+++ b/src/resources/checkstyle.xml
@@ -33,8 +33,6 @@
     <module name="LineLength">
         <property name="fileExtensions" value="java" />
         <property name="max" value="200" />
-        <!-- TODO remove ignorePattern when fix spotless format bug -->
-        <property name="ignorePattern" value="@ExternalCaseSettings"/>
     </module>
     <module name="NewlineAtEndOfFile">
         <property name="lineSeparator" value="lf" />

--- a/src/resources/spotless/java.xml
+++ b/src/resources/spotless/java.xml
@@ -45,5 +45,6 @@
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="106" />
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="106" />
         <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80" />
+        <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16" />
     </profile>
 </profiles>


### PR DESCRIPTION
Synchronize the configuration of Checkstyle and Spotless regarding the line breaks in annotation parameters.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
