### PR TITLE
Optimize the definition and parsing of limit clause for PG/OG.

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DMLStatement.g4
@@ -212,10 +212,8 @@ qualifiedNameList
     ;
 
 selectLimit
-    : limitClause offsetClause
-    | offsetClause limitClause
-    | limitClause
-    | offsetClause
+    : limitClause offsetClause?
+    | offsetClause limitClause?
     ;
 
 valuesClause
@@ -226,30 +224,24 @@ valuesClause
 limitClause
     : LIMIT selectLimitValue
     | LIMIT selectOffsetValue COMMA_ selectLimitValue 
-    | FETCH firstOrNext selectFetchFirstValue rowOrRows ONLY
-    | FETCH firstOrNext selectFetchFirstValue rowOrRows WITH TIES
-    | FETCH firstOrNext rowOrRows ONLY
-    | FETCH firstOrNext rowOrRows WITH TIES
+    | FETCH firstOrNext selectFetchValue? rowOrRows onlyOrWithTies
     ;
 
 offsetClause
-    : OFFSET selectOffsetValue
-    | OFFSET selectOffsetValue rowOrRows
+    : OFFSET selectOffsetValue rowOrRows?
     ;
 
 selectLimitValue
-    : aExpr
+    : cExpr
     | ALL
     ;
 
 selectOffsetValue
-    : aExpr
+    : cExpr
     ;
 
-selectFetchFirstValue
+selectFetchValue
     : cExpr
-    | PLUS_ NUMBER_
-    | MINUS_ NUMBER_
     ;
 
 rowOrRows
@@ -258,6 +250,10 @@ rowOrRows
 
 firstOrNext
     : FIRST | NEXT
+    ;
+
+onlyOrWithTies
+    : ONLY | WITH TIES
     ;
 
 targetList

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -82,7 +82,7 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Rel
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SchemaNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectClauseNContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectContext;
-import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectFetchFirstValueContext;
+import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectFetchValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectLimitContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectLimitValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.SelectNoParensContext;
@@ -1265,7 +1265,7 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
         if (null != ctx.ALL()) {
             return null;
         }
-        ASTNode astNode = visit(ctx.aExpr());
+        ASTNode astNode = visit(ctx.cExpr());
         if (astNode instanceof ParameterMarkerExpressionSegment) {
             return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
@@ -1274,7 +1274,7 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
     
     @Override
     public ASTNode visitSelectOffsetValue(final SelectOffsetValueContext ctx) {
-        ASTNode astNode = visit(ctx.aExpr());
+        ASTNode astNode = visit(ctx.cExpr());
         if (astNode instanceof ParameterMarkerExpressionSegment) {
             return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
@@ -1282,15 +1282,12 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
     }
     
     @Override
-    public ASTNode visitSelectFetchFirstValue(final SelectFetchFirstValueContext ctx) {
+    public ASTNode visitSelectFetchValue(final SelectFetchValueContext ctx) {
         ASTNode astNode = visit(ctx.cExpr());
-        if (null != astNode) {
-            if (astNode instanceof ParameterMarkerLimitValueSegment) {
-                return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
-            }
-            return new NumberLiteralLimitValueSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), Long.parseLong(((LiteralExpressionSegment) astNode).getLiterals().toString()));
+        if (astNode instanceof ParameterMarkerExpressionSegment) {
+            return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
-        return visit(ctx.NUMBER_());
+        return new NumberLiteralLimitValueSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), Long.parseLong(((LiteralExpressionSegment) astNode).getLiterals().toString()));
     }
     
     private LimitSegment createLimitSegmentWhenLimitAndOffset(final SelectLimitContext ctx) {
@@ -1318,8 +1315,8 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
                 LimitValueSegment offset = (LimitValueSegment) visit(ctx.limitClause().selectOffsetValue());
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), offset, limit);
             }
-            if (null != ctx.limitClause().selectFetchFirstValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
+            if (null != ctx.limitClause().selectFetchValue()) {
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchValue());
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
             }
             LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());

--- a/parser/sql/dialect/postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
+++ b/parser/sql/dialect/postgresql/src/main/antlr4/imports/postgresql/DMLStatement.g4
@@ -215,10 +215,8 @@ qualifiedNameList
     ;
 
 selectLimit
-    : limitClause offsetClause
-    | offsetClause limitClause
-    | limitClause
-    | offsetClause
+    : limitClause offsetClause?
+    | offsetClause limitClause?
     ;
 
 valuesClause
@@ -228,30 +226,24 @@ valuesClause
 
 limitClause
     : LIMIT selectLimitValue
-    | FETCH firstOrNext selectFetchFirstValue rowOrRows ONLY
-    | FETCH firstOrNext selectFetchFirstValue rowOrRows WITH TIES
-    | FETCH firstOrNext rowOrRows ONLY
-    | FETCH firstOrNext rowOrRows WITH TIES
+    | FETCH firstOrNext selectFetchValue? rowOrRows onlyOrWithTies
     ;
 
 offsetClause
-    : OFFSET selectOffsetValue
-    | OFFSET selectOffsetValue rowOrRows
+    : OFFSET selectOffsetValue rowOrRows?
     ;
 
 selectLimitValue
-    : aExpr
+    : cExpr
     | ALL
     ;
 
 selectOffsetValue
-    : aExpr
+    : cExpr
     ;
 
-selectFetchFirstValue
+selectFetchValue
     : cExpr
-    | PLUS_ NUMBER_
-    | MINUS_ NUMBER_
     ;
 
 rowOrRows
@@ -260,6 +252,10 @@ rowOrRows
 
 firstOrNext
     : FIRST | NEXT
+    ;
+
+onlyOrWithTies
+    : ONLY | WITH TIES
     ;
 
 targetList

--- a/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -81,7 +81,7 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.Re
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SchemaNameContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectClauseNContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectContext;
-import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectFetchFirstValueContext;
+import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectFetchValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectLimitContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectLimitValueContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.SelectNoParensContext;
@@ -1232,7 +1232,7 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
         if (null != ctx.ALL()) {
             return null;
         }
-        ASTNode astNode = visit(ctx.aExpr());
+        ASTNode astNode = visit(ctx.cExpr());
         if (astNode instanceof ParameterMarkerExpressionSegment) {
             return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
@@ -1241,7 +1241,7 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
     
     @Override
     public ASTNode visitSelectOffsetValue(final SelectOffsetValueContext ctx) {
-        ASTNode astNode = visit(ctx.aExpr());
+        ASTNode astNode = visit(ctx.cExpr());
         if (astNode instanceof ParameterMarkerExpressionSegment) {
             return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
@@ -1249,15 +1249,12 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
     }
     
     @Override
-    public ASTNode visitSelectFetchFirstValue(final SelectFetchFirstValueContext ctx) {
+    public ASTNode visitSelectFetchValue(final SelectFetchValueContext ctx) {
         ASTNode astNode = visit(ctx.cExpr());
-        if (null != astNode) {
-            if (astNode instanceof ParameterMarkerLimitValueSegment) {
-                return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
-            }
-            return new NumberLiteralLimitValueSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), Long.parseLong(((LiteralExpressionSegment) astNode).getLiterals().toString()));
+        if (astNode instanceof ParameterMarkerExpressionSegment) {
+            return new ParameterMarkerLimitValueSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ((ParameterMarkerExpressionSegment) astNode).getParameterMarkerIndex());
         }
-        return visit(ctx.NUMBER_());
+        return new NumberLiteralLimitValueSegment(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), Long.parseLong(((LiteralExpressionSegment) astNode).getLiterals().toString()));
     }
     
     private LimitSegment createLimitSegmentWhenLimitAndOffset(final SelectLimitContext ctx) {
@@ -1280,8 +1277,8 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
     
     private LimitSegment createLimitSegmentWhenRowCountOrOffsetAbsent(final SelectLimitContext ctx) {
         if (null != ctx.limitClause()) {
-            if (null != ctx.limitClause().selectFetchFirstValue()) {
-                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchFirstValue());
+            if (null != ctx.limitClause().selectFetchValue()) {
+                LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectFetchValue());
                 return new LimitSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), null, limit);
             }
             LimitValueSegment limit = (LimitValueSegment) visit(ctx.limitClause().selectLimitValue());


### PR DESCRIPTION
Fixes #25669.

Changes proposed in this pull request:
  - Optimize the definition and parsing of limit clause for PG/OG.


#### PostgreSQL
https://www.postgresql.org/docs/15/sql-select.html#SQL-LIMIT
<img width="1056" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/e4485ec6-d05e-4927-b3d5-a0362b5ad66d">


#### openGauss
https://docs.opengauss.org/zh/docs/5.0.0/docs/SQLReference/SELECT.html
<img width="824" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/2d701c3b-819f-46bb-81b6-a4c05098a8ba">


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [-] I have made corresponding changes to the documentation.
- [-] I have added corresponding unit tests for my changes.
