### PR TITLE
Query required variables in one SQL for MySQLDataSourceChecker

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
@@ -100,9 +100,7 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
                 preparedStatement.setString(parameterIndex++, entry.getKey());
             }
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                if (!resultSet.next()) {
-                    return;
-                }
+                resultSet.next();
                 String key = resultSet.getString(1).toUpperCase();
                 String toBeCheckedValue = REQUIRED_VARIABLES.get(key);
                 String actualValue = resultSet.getString(2);

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 /**
  * Data source checker for MySQL.
@@ -43,14 +44,16 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
     
     private static final String[][] REQUIRED_PRIVILEGES = {{"ALL PRIVILEGES", "ON *.*"}, {"REPLICATION SLAVE", "REPLICATION CLIENT", "ON *.*"}};
     
-    private static final String SHOW_VARIABLES_SQL = "SHOW VARIABLES LIKE ?";
-    
     private static final Map<String, String> REQUIRED_VARIABLES = new HashMap<>(3, 1);
+    
+    private static final String SHOW_VARIABLES_SQL;
     
     static {
         REQUIRED_VARIABLES.put("LOG_BIN", "ON");
         REQUIRED_VARIABLES.put("BINLOG_FORMAT", "ROW");
+        // It does not exist in all versions of MySQL
         REQUIRED_VARIABLES.put("BINLOG_ROW_IMAGE", "FULL");
+        SHOW_VARIABLES_SQL = String.format("SHOW VARIABLES WHERE Variable_name IN (%s)", REQUIRED_VARIABLES.keySet().stream().map(each -> "?").collect(Collectors.joining(",")));
     }
     
     @Override
@@ -89,25 +92,24 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
     }
     
     private void checkVariable(final DataSource dataSource) {
-        try (Connection connection = dataSource.getConnection()) {
+        try (
+                Connection connection = dataSource.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement(SHOW_VARIABLES_SQL)) {
+            int parameterIndex = 1;
             for (Entry<String, String> entry : REQUIRED_VARIABLES.entrySet()) {
-                checkVariable(connection, entry.getKey(), entry.getValue());
+                preparedStatement.setString(parameterIndex++, entry.getKey());
             }
-        } catch (final SQLException ex) {
-            throw new PrepareJobWithCheckPrivilegeFailedException(ex);
-        }
-    }
-    
-    private void checkVariable(final Connection connection, final String key, final String toBeCheckedValue) throws SQLException {
-        try (PreparedStatement preparedStatement = connection.prepareStatement(SHOW_VARIABLES_SQL)) {
-            preparedStatement.setString(1, key);
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
                 if (resultSet.next()) {
+                    String key = resultSet.getString(1);
+                    String toBeCheckedValue = REQUIRED_VARIABLES.get(key);
                     String actualValue = resultSet.getString(2);
                     ShardingSpherePreconditions.checkState(toBeCheckedValue.equalsIgnoreCase(actualValue),
                             () -> new PrepareJobWithInvalidSourceDataSourceException(key, toBeCheckedValue, actualValue));
                 }
             }
+        } catch (final SQLException ex) {
+            throw new PrepareJobWithCheckPrivilegeFailedException(ex);
         }
     }
     

--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceChecker.java
@@ -100,13 +100,14 @@ public final class MySQLDataSourceChecker extends AbstractDataSourceChecker {
                 preparedStatement.setString(parameterIndex++, entry.getKey());
             }
             try (ResultSet resultSet = preparedStatement.executeQuery()) {
-                if (resultSet.next()) {
-                    String key = resultSet.getString(1);
-                    String toBeCheckedValue = REQUIRED_VARIABLES.get(key);
-                    String actualValue = resultSet.getString(2);
-                    ShardingSpherePreconditions.checkState(toBeCheckedValue.equalsIgnoreCase(actualValue),
-                            () -> new PrepareJobWithInvalidSourceDataSourceException(key, toBeCheckedValue, actualValue));
+                if (!resultSet.next()) {
+                    return;
                 }
+                String key = resultSet.getString(1).toUpperCase();
+                String toBeCheckedValue = REQUIRED_VARIABLES.get(key);
+                String actualValue = resultSet.getString(2);
+                ShardingSpherePreconditions.checkState(toBeCheckedValue.equalsIgnoreCase(actualValue),
+                        () -> new PrepareJobWithInvalidSourceDataSourceException(key, toBeCheckedValue, actualValue));
             }
         } catch (final SQLException ex) {
             throw new PrepareJobWithCheckPrivilegeFailedException(ex);

--- a/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceCheckerTest.java
+++ b/kernel/data-pipeline/dialect/mysql/src/test/java/org/apache/shardingsphere/data/pipeline/mysql/check/datasource/MySQLDataSourceCheckerTest.java
@@ -90,14 +90,16 @@ class MySQLDataSourceCheckerTest {
     @Test
     void assertCheckVariableSuccess() throws SQLException {
         when(resultSet.next()).thenReturn(true, true);
+        when(resultSet.getString(1)).thenReturn("LOG_BIN", "BINLOG_FORMAT", "BINLOG_ROW_IMAGE");
         when(resultSet.getString(2)).thenReturn("ON", "ROW", "FULL");
         new MySQLDataSourceChecker().checkVariable(dataSources);
-        verify(preparedStatement, times(3)).executeQuery();
+        verify(preparedStatement, times(1)).executeQuery();
     }
     
     @Test
     void assertCheckVariableWithWrongVariable() throws SQLException {
         when(resultSet.next()).thenReturn(true, true);
+        when(resultSet.getString(1)).thenReturn("LOG_BIN", "BINLOG_FORMAT");
         when(resultSet.getString(2)).thenReturn("OFF", "ROW");
         assertThrows(PrepareJobWithInvalidSourceDataSourceException.class, () -> new MySQLDataSourceChecker().checkVariable(dataSources));
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Query required variables in one SQL for MySQLDataSourceChecker

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
