### PR TITLE
doc: Fix the documentation for configuring ShardingSphere with an absolute path

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/_index.cn.md
@@ -90,5 +90,5 @@ jdbc:shardingsphere:classpath:config.yaml
 
 加载绝对路径中 config.yaml 配置文件的 JDBC URL：
 ```
-jdbc:shardingsphere:/path/to/config.yaml
+jdbc:shardingsphere:absolutepath/path/to/config.yaml
 ```

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/jdbc-driver/_index.en.md
@@ -90,5 +90,5 @@ jdbc:shardingsphere:classpath:config.yaml
 
 Load JDBC URL of config.yaml profile in absolute path
 ```
-jdbc:shardingsphere:/path/to/config.yaml
+jdbc:shardingsphere:absolutepath/path/to/config.yaml
 ```


### PR DESCRIPTION
Changes proposed in this pull request:

The current documentation mentions:

>Load JDBC URL of config.yaml profile in absolute path
>
>`jdbc:shardingsphere:/path/to/config.yaml`

However, the [code](https://github.com/apache/shardingsphere/blob/955ea40a41f083529ce2b98cd239a16d984ffe4a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/AbsolutePathDriverURLProvider.java#L38-L43) is clear) tells a different story. It needs to be prefixed with `jdbc:shardingsphere:absolutepath:`

Hence, the change is:

>Load JDBC URL of config.yaml profile in absolute path
>
>`jdbc:shardingsphere:absolutepath:/path/to/config.yaml`

---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [X] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
