### PR TITLE
Fix sonar volatile issue in `XAConnectionWrapper`

### DIFF
--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
@@ -35,13 +35,13 @@ public final class H2XAConnectionWrapper implements XAConnectionWrapper {
     
     private static final int XA_DATA_SOURCE_TRACE_TYPE_ID = 13;
     
-    private static Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static Constructor<?> xaConnectionConstructor;
+    private Constructor<?> xaConnectionConstructor;
     
-    private static Method nextIdMethod;
+    private Method nextIdMethod;
     
-    private static Object dataSourceFactory;
+    private Object dataSourceFactory;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for H2.
@@ -34,25 +35,24 @@ public final class H2XAConnectionWrapper implements XAConnectionWrapper {
     
     private static final int XA_DATA_SOURCE_TRACE_TYPE_ID = 13;
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private static Class<Connection> jdbcConnectionClass;
     
-    private static volatile Constructor<?> xaConnectionConstructor;
+    private static Constructor<?> xaConnectionConstructor;
     
-    private static volatile Method nextIdMethod;
+    private static Method nextIdMethod;
     
-    private static volatile Object dataSourceFactory;
-    
-    private static volatile boolean initialized;
+    private static Object dataSourceFactory;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-    
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
+    }
+
     private void loadReflection() {
         jdbcConnectionClass = getJDBCConnectionClass();
         xaConnectionConstructor = getXAConnectionConstructor();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/H2XAConnectionWrapper.java
@@ -47,12 +47,12 @@ public final class H2XAConnectionWrapper implements XAConnectionWrapper {
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();
     }
-
+    
     private void loadReflection() {
         jdbcConnectionClass = getJDBCConnectionClass();
         xaConnectionConstructor = getXAConnectionConstructor();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
@@ -25,25 +25,25 @@ import javax.sql.XADataSource;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for MariaDB.
  */
 public final class MariaDBXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private static Class<Connection> jdbcConnectionClass;
     
-    private static volatile Constructor<?> xaConnectionConstructor;
-    
-    private static volatile boolean initialized;
+    private static Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
+    }
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
     }
     
     private void loadReflection() {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
@@ -40,7 +40,7 @@ public final class MariaDBXAConnectionWrapper implements XAConnectionWrapper {
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MariaDBXAConnectionWrapper.java
@@ -32,9 +32,9 @@ import java.util.Properties;
  */
 public final class MariaDBXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static Constructor<?> xaConnectionConstructor;
+    private Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
@@ -25,25 +25,25 @@ import javax.sql.XADataSource;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for MySQL.
  */
 public final class MySQLXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private static Class<Connection> jdbcConnectionClass;
     
-    private static volatile Method xaConnectionCreatorMethod;
-    
-    private static volatile boolean initialized;
+    private static Method xaConnectionCreatorMethod;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(xaDataSource, connection.unwrap(jdbcConnectionClass));
+    }
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
     }
     
     private void loadReflection() {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
@@ -32,9 +32,9 @@ import java.util.Properties;
  */
 public final class MySQLXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static Method xaConnectionCreatorMethod;
+    private Method xaConnectionCreatorMethod;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/MySQLXAConnectionWrapper.java
@@ -40,7 +40,7 @@ public final class MySQLXAConnectionWrapper implements XAConnectionWrapper {
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(xaDataSource, connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
@@ -32,9 +32,9 @@ import java.util.Properties;
  */
 public final class OpenGaussXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static Constructor<?> xaConnectionConstructor;
+    private Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
@@ -40,7 +40,7 @@ public final class OpenGaussXAConnectionWrapper implements XAConnectionWrapper {
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OpenGaussXAConnectionWrapper.java
@@ -25,25 +25,25 @@ import javax.sql.XADataSource;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for openGauss.
  */
 public final class OpenGaussXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private static Class<Connection> jdbcConnectionClass;
     
-    private static volatile Constructor<?> xaConnectionConstructor;
-    
-    private static volatile boolean initialized;
+    private static Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
+    }
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
     }
     
     private void loadReflection() {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
@@ -40,7 +40,7 @@ public final class OracleXAConnectionWrapper implements XAConnectionWrapper {
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
@@ -25,6 +25,7 @@ import javax.sql.XADataSource;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for Oracle.
@@ -35,15 +36,14 @@ public final class OracleXAConnectionWrapper implements XAConnectionWrapper {
     
     private static volatile Constructor<?> xaConnectionConstructor;
     
-    private static volatile boolean initialized;
-    
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
+    }
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
     }
     
     private void loadReflection() {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/OracleXAConnectionWrapper.java
@@ -32,9 +32,9 @@ import java.util.Properties;
  */
 public final class OracleXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static volatile Constructor<?> xaConnectionConstructor;
+    private Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
@@ -25,25 +25,25 @@ import javax.sql.XADataSource;
 import java.lang.reflect.Constructor;
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * XA connection wrapper for PostgreSQL.
  */
 public final class PostgreSQLXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static volatile Class<Connection> jdbcConnectionClass;
+    private static Class<Connection> jdbcConnectionClass;
     
-    private static volatile Constructor<?> xaConnectionConstructor;
-    
-    private static volatile boolean initialized;
+    private static Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
-        if (!initialized) {
-            loadReflection();
-            initialized = true;
-        }
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
+    }
+
+    @Override
+    public void init(final Properties props) {
+        loadReflection();
     }
     
     private void loadReflection() {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
@@ -32,9 +32,9 @@ import java.util.Properties;
  */
 public final class PostgreSQLXAConnectionWrapper implements XAConnectionWrapper {
     
-    private static Class<Connection> jdbcConnectionClass;
+    private Class<Connection> jdbcConnectionClass;
     
-    private static Constructor<?> xaConnectionConstructor;
+    private Constructor<?> xaConnectionConstructor;
     
     @Override
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/connection/dialect/PostgreSQLXAConnectionWrapper.java
@@ -40,7 +40,7 @@ public final class PostgreSQLXAConnectionWrapper implements XAConnectionWrapper 
     public XAConnection wrap(final XADataSource xaDataSource, final Connection connection) throws SQLException {
         return createXAConnection(connection.unwrap(jdbcConnectionClass));
     }
-
+    
     @Override
     public void init(final Properties props) {
         loadReflection();

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
@@ -50,22 +50,22 @@ public final class XATransactionDataSource implements AutoCloseable {
     
     private final ThreadLocal<Map<Transaction, Connection>> enlistedTransactions = ThreadLocal.withInitial(HashMap::new);
     
-    private final DatabaseType databaseType;
-    
     private final String resourceName;
     
     private final DataSource dataSource;
     
     private XADataSource xaDataSource;
+
+    private XAConnectionWrapper xaConnectionWrapper;
     
     private XATransactionManagerProvider xaTransactionManagerProvider;
     
     public XATransactionDataSource(final DatabaseType databaseType, final String resourceName, final DataSource dataSource, final XATransactionManagerProvider xaTransactionManagerProvider) {
-        this.databaseType = databaseType;
         this.resourceName = resourceName;
         this.dataSource = dataSource;
         if (!CONTAINER_DATASOURCE_NAMES.contains(dataSource.getClass().getSimpleName())) {
             xaDataSource = new DataSourceSwapper(TypedSPILoader.getService(XADataSourceDefinition.class, databaseType.getType())).swap(dataSource);
+            xaConnectionWrapper = TypedSPILoader.getService(XAConnectionWrapper.class, databaseType.getType());
             this.xaTransactionManagerProvider = xaTransactionManagerProvider;
             xaTransactionManagerProvider.registerRecoveryResource(resourceName, xaDataSource);
         }
@@ -86,7 +86,7 @@ public final class XATransactionDataSource implements AutoCloseable {
         Transaction transaction = xaTransactionManagerProvider.getTransactionManager().getTransaction();
         if (!enlistedTransactions.get().containsKey(transaction)) {
             Connection connection = dataSource.getConnection();
-            XAConnection xaConnection = TypedSPILoader.getService(XAConnectionWrapper.class, databaseType.getType()).wrap(xaDataSource, connection);
+            XAConnection xaConnection = xaConnectionWrapper.wrap(xaDataSource, connection);
             transaction.enlistResource(new SingleXAResource(resourceName, xaConnection.getXAResource()));
             transaction.registerSynchronization(new Synchronization() {
                 

--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
@@ -55,7 +55,7 @@ public final class XATransactionDataSource implements AutoCloseable {
     private final DataSource dataSource;
     
     private XADataSource xaDataSource;
-
+    
     private XAConnectionWrapper xaConnectionWrapper;
     
     private XATransactionManagerProvider xaTransactionManagerProvider;


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix sonar volatile problem in `XAConnectionWrapper`
  -  Initialize`XAConnectionWrapper` when `XATransactionDataSource` is created

The sonar issue links of `XAConnectionWrapper` are as follows:

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEAKUmlEb3_PqvlbB

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEAK3mlEb3_Pqvlbc

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEAKumlEb3_PqvlbW

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEAKmmlEb3_PqvlbR

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEAKdmlEb3_PqvlbM

https://sonarcloud.io/project/issues?resolved=false&severities=MINOR&types=BUG&id=apache_shardingsphere&open=AYePEALAmlEb3_Pqvlbh

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
