### PR TITLE
Refactor Thread.sleep usage in UT for Sonar rules

### DIFF
--- a/agent/plugins/core/pom.xml
+++ b/agent/plugins/core/pom.xml
@@ -31,6 +31,13 @@
         <target.directory>${project.basedir}/target/lib</target.directory>
     </properties>
     
+    <dependencies>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+    </dependencies>
+    
     <build>
         <plugins>
             <plugin>

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
@@ -33,7 +33,7 @@ class MethodTimeRecorderTest {
     void assertGetElapsedTimeAndCleanWithRecorded() throws NoSuchMethodException {
         MethodTimeRecorder methodTimeRecorder = new MethodTimeRecorder(AgentAdvice.class);
         methodTimeRecorder.recordNow(Object.class.getDeclaredMethod("toString"));
-        Awaitility.await().atMost(5L, TimeUnit.MILLISECONDS);
+        Awaitility.await().pollDelay(5L, TimeUnit.MILLISECONDS).until(() -> true);
         assertThat(methodTimeRecorder.getElapsedTimeAndClean(Object.class.getDeclaredMethod("toString")), greaterThanOrEqualTo(5L));
     }
     

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 class MethodTimeRecorderTest {
     
     @Test
-    void assertGetElapsedTimeAndCleanWithRecorded() throws InterruptedException, NoSuchMethodException {
+    void assertGetElapsedTimeAndCleanWithRecorded() throws NoSuchMethodException {
         MethodTimeRecorder methodTimeRecorder = new MethodTimeRecorder(AgentAdvice.class);
         methodTimeRecorder.recordNow(Object.class.getDeclaredMethod("toString"));
         Awaitility.await().atMost(5L, TimeUnit.MILLISECONDS);

--- a/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
+++ b/agent/plugins/core/src/test/java/org/apache/shardingsphere/agent/plugin/core/recorder/MethodTimeRecorderTest.java
@@ -18,7 +18,10 @@
 package org.apache.shardingsphere.agent.plugin.core.recorder;
 
 import org.apache.shardingsphere.agent.api.advice.AgentAdvice;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +33,7 @@ class MethodTimeRecorderTest {
     void assertGetElapsedTimeAndCleanWithRecorded() throws InterruptedException, NoSuchMethodException {
         MethodTimeRecorder methodTimeRecorder = new MethodTimeRecorder(AgentAdvice.class);
         methodTimeRecorder.recordNow(Object.class.getDeclaredMethod("toString"));
-        Thread.sleep(5L);
+        Awaitility.await().atMost(5L, TimeUnit.MILLISECONDS);
         assertThat(methodTimeRecorder.getElapsedTimeAndClean(Object.class.getDeclaredMethod("toString")), greaterThanOrEqualTo(5L));
     }
     

--- a/agent/plugins/metrics/core/pom.xml
+++ b/agent/plugins/metrics/core/pom.xml
@@ -92,6 +92,10 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
     </dependencies>
     
     <build>

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
@@ -22,10 +22,12 @@ import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollecto
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.collector.MetricsCollectorFixture;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.TargetAdviceObjectFixture;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -46,7 +48,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Thread.sleep(200L);
+        Awaitility.await().atMost(200L, TimeUnit.MILLISECONDS);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(200d));
     }
@@ -57,7 +59,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Thread.sleep(200L);
+        Awaitility.await().atMost(200L, TimeUnit.MILLISECONDS);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(200d));
     }

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
@@ -43,7 +43,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
     }
     
     @Test
-    void assertWithStatement() throws InterruptedException {
+    void assertWithStatement() {
         StatementExecuteLatencyHistogramAdvice advice = new StatementExecuteLatencyHistogramAdvice();
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
@@ -54,7 +54,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
     }
     
     @Test
-    void assertWithPreparedStatement() throws InterruptedException {
+    void assertWithPreparedStatement() {
         PreparedStatementExecuteLatencyHistogramAdvice advice = new PreparedStatementExecuteLatencyHistogramAdvice();
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/jdbc/AbstractExecuteLatencyHistogramAdviceTest.java
@@ -48,7 +48,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Awaitility.await().atMost(200L, TimeUnit.MILLISECONDS);
+        Awaitility.await().pollDelay(200L, TimeUnit.MILLISECONDS).until(() -> true);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(200d));
     }
@@ -59,7 +59,7 @@ class AbstractExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Awaitility.await().atMost(200L, TimeUnit.MILLISECONDS);
+        Awaitility.await().pollDelay(200L, TimeUnit.MILLISECONDS).until(() -> true);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(200d));
     }

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
@@ -44,7 +44,7 @@ class ExecuteLatencyHistogramAdviceTest {
     }
     
     @Test
-    void assertExecuteLatencyHistogram() throws InterruptedException {
+    void assertExecuteLatencyHistogram() {
         ExecuteLatencyHistogramAdvice advice = new ExecuteLatencyHistogramAdvice();
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
@@ -49,7 +49,7 @@ class ExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Awaitility.await().atMost(500L, TimeUnit.MILLISECONDS);
+        Awaitility.await().pollDelay(500L, TimeUnit.MILLISECONDS).until(() -> true);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(500d));
     }

--- a/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
+++ b/agent/plugins/metrics/core/src/test/java/org/apache/shardingsphere/agent/plugin/metrics/core/advice/proxy/ExecuteLatencyHistogramAdviceTest.java
@@ -22,11 +22,13 @@ import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricCollecto
 import org.apache.shardingsphere.agent.plugin.metrics.core.config.MetricConfiguration;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.collector.MetricsCollectorFixture;
 import org.apache.shardingsphere.agent.plugin.metrics.core.fixture.TargetAdviceObjectFixture;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -47,7 +49,7 @@ class ExecuteLatencyHistogramAdviceTest {
         TargetAdviceObjectFixture targetObject = new TargetAdviceObjectFixture();
         Method method = mock(Method.class);
         advice.beforeMethod(targetObject, method, new Object[]{}, "FIXTURE");
-        Thread.sleep(500L);
+        Awaitility.await().atMost(500L, TimeUnit.MILLISECONDS);
         advice.afterMethod(targetObject, method, new Object[]{}, null, "FIXTURE");
         assertThat(Double.parseDouble(MetricsCollectorRegistry.get(config, "FIXTURE").toString()), greaterThanOrEqualTo(500d));
     }


### PR DESCRIPTION
Changes proposed in this pull request:
  - fix sleep usage in UT for sonarcloud rule : https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=apache_shardingsphere&open=AYePEBwAmlEb3_PqvliE

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
