### PR TITLE
Fix sonar issue of BitronixRecoveryResource, XATransactionDataSource

### DIFF
--- a/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
+++ b/kernel/transaction/type/xa/core/src/main/java/org/apache/shardingsphere/transaction/xa/jta/datasource/XATransactionDataSource.java
@@ -112,6 +112,7 @@ public final class XATransactionDataSource implements AutoCloseable {
         } else {
             xaTransactionManagerProvider.removeRecoveryResource(resourceName, xaDataSource);
         }
+        enlistedTransactions.remove();
     }
     
     private void close(final DataSource dataSource) {

--- a/kernel/transaction/type/xa/provider/bitronix/src/main/java/org/apache/shardingsphere/transaction/xa/bitronix/manager/BitronixRecoveryResource.java
+++ b/kernel/transaction/type/xa/provider/bitronix/src/main/java/org/apache/shardingsphere/transaction/xa/bitronix/manager/BitronixRecoveryResource.java
@@ -42,9 +42,9 @@ public final class BitronixRecoveryResource extends ResourceBean implements XARe
     
     private final String resourceName;
     
-    private final XADataSource xaDataSource;
+    private final transient XADataSource xaDataSource;
     
-    private XAConnection xaConnection;
+    private transient XAConnection xaConnection;
     
     @Override
     public void init() {


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix sonar issue of BitronixRecoveryResource, XATransactionDataSource

https://sonarcloud.io/project/issues?resolved=false&severities=CRITICAL&types=CODE_SMELL&id=apache_shardingsphere&open=AYePEAM8mlEb3_Pqvlbt
https://sonarcloud.io/project/issues?resolved=false&severities=MAJOR&types=BUG&id=apache_shardingsphere&open=AYePEAJcmlEb3_Pqvla8
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
