### PR TITLE
Support Mysql ALTER TABLE RENAME COLUMN statement

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -665,6 +665,14 @@ constraintName
     : identifier
     ;
 
+oldColumn
+    : columnName
+    ;
+
+newColumn
+    : columnName
+    ;
+
 delimiterName
     : textOrIdentifier | ('\\'. | ~('\'' | '"' | '`' | '\\'))+
     ; 

--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/DDLStatement.g4
@@ -104,7 +104,7 @@ alterListItem
     | ALTER INDEX indexName visibility  # alterIndex
     | ALTER CHECK constraintName constraintEnforcement  # alterCheck
     | ALTER CONSTRAINT constraintName constraintEnforcement # alterConstraint
-    | RENAME COLUMN columnInternalRef=identifier TO identifier  # renameColumn
+    | RENAME COLUMN oldColumn TO newColumn  # renameColumn
     | RENAME (TO | AS)? tableName # alterRenameTable
     | RENAME keyOrIndex indexName TO indexName  # renameIndex
     | CONVERT TO charset charsetName collateClause?  # alterConvert

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDDLStatementVisitor.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
 import org.apache.shardingsphere.sql.parser.api.visitor.statement.type.DDLStatementVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddColumnContext;
+import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.RenameColumnContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AddTableConstraintContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterCheckContext;
 import org.apache.shardingsphere.sql.parser.autogen.MySQLStatementParser.AlterConstraintContext;
@@ -104,6 +105,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ChangeColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.DropColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ModifyColumnDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.RenameColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.position.ColumnAfterPositionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.position.ColumnFirstPositionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.position.ColumnPositionSegment;
@@ -292,6 +294,8 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
                     result.getDropIndexDefinitions().add((DropIndexDefinitionSegment) each);
                 } else if (each instanceof RenameIndexDefinitionSegment) {
                     result.getRenameIndexDefinitions().add((RenameIndexDefinitionSegment) each);
+                } else if (each instanceof RenameColumnSegment) {
+                    result.getRenameColumnDefinitions().add((RenameColumnSegment) each);
                 }
             }
         }
@@ -350,6 +354,9 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
             }
             if (each instanceof AlterConvertContext) {
                 result.getValue().add((ConvertTableDefinitionSegment) visit(each));
+            }
+            if (each instanceof RenameColumnContext) {
+                result.getValue().add((RenameColumnSegment) visit(each));
             }
             if (each instanceof RenameIndexContext) {
                 result.getValue().add((RenameIndexDefinitionSegment) visit(each));
@@ -452,6 +459,13 @@ public final class MySQLDDLStatementVisitor extends MySQLStatementVisitor implem
             result.setColumnPosition((ColumnPositionSegment) visit(ctx.place()));
         }
         return result;
+    }
+    
+    @Override
+    public ASTNode visitRenameColumn(final RenameColumnContext ctx) {
+        ColumnSegment oldColumnSegment = (ColumnSegment) visit(ctx.oldColumn());
+        ColumnSegment newColumnSegment = (ColumnSegment) visit(ctx.newColumn());
+        return new RenameColumnSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), oldColumnSegment, newColumnSegment);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/alter/RenameColumnSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/alter/RenameColumnSegment.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.SQLSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 
 /**
@@ -27,7 +27,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.Column
  */
 @RequiredArgsConstructor
 @Getter
-public final class RenameColumnSegment implements SQLSegment {
+public final class RenameColumnSegment implements AlterDefinitionSegment {
     
     private final int startIndex;
     

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterTableStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterTableStatement.java
@@ -68,7 +68,7 @@ public abstract class AlterTableStatement extends AbstractSQLStatement implement
     private final Collection<DropConstraintDefinitionSegment> dropConstraintDefinitions = new LinkedList<>();
     
     private final Collection<DropIndexDefinitionSegment> dropIndexDefinitions = new LinkedList<>();
-
+    
     private final Collection<RenameColumnSegment> renameColumnDefinitions = new LinkedList<>();
     
     private final Collection<RenameIndexDefinitionSegment> renameIndexDefinitions = new LinkedList<>();

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterTableStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/statement/ddl/AlterTableStatement.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ChangeColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.DropColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ModifyColumnDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.RenameColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.alter.AddConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.alter.DropConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.alter.ModifyConstraintDefinitionSegment;
@@ -67,6 +68,8 @@ public abstract class AlterTableStatement extends AbstractSQLStatement implement
     private final Collection<DropConstraintDefinitionSegment> dropConstraintDefinitions = new LinkedList<>();
     
     private final Collection<DropIndexDefinitionSegment> dropIndexDefinitions = new LinkedList<>();
+
+    private final Collection<RenameColumnSegment> renameColumnDefinitions = new LinkedList<>();
     
     private final Collection<RenameIndexDefinitionSegment> renameIndexDefinitions = new LinkedList<>();
     

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterTableStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ddl/impl/AlterTableStatementAssert.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ChangeColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.DropColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.ModifyColumnDefinitionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.alter.RenameColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.alter.AddConstraintDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.index.RenameIndexDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.table.ConvertTableDefinitionSegment;
@@ -45,6 +46,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedColumnDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedModifyColumnDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedRenameIndexDefinition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedRenameColumnDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ddl.AlterTableStatementTestCase;
 
 import java.util.Collection;
@@ -81,6 +83,7 @@ public final class AlterTableStatementAssert {
         assertChangeColumnDefinitions(assertContext, actual, expected);
         assertDropColumns(assertContext, actual, expected);
         assertRenameIndexDefinitions(assertContext, actual, expected);
+        assertRenameColumnDefinitions(assertContext, actual, expected);
         assertConvertTable(assertContext, actual, expected);
     }
     
@@ -206,6 +209,17 @@ public final class AlterTableStatementAssert {
             ExpectedRenameIndexDefinition expectedRenameIndexDefinition = expected.getRenameIndexes().get(count);
             IndexDefinitionAssert.assertIs(assertContext, each.getIndexSegment(), expectedRenameIndexDefinition.getIndexDefinition());
             IndexDefinitionAssert.assertIs(assertContext, each.getRenameIndexSegment(), expectedRenameIndexDefinition.getRenameIndexDefinition());
+            count++;
+        }
+    }
+    
+    private static void assertRenameColumnDefinitions(final SQLCaseAssertContext assertContext, final AlterTableStatement actual, final AlterTableStatementTestCase expected) {
+        assertThat(assertContext.getText("Rename columns definitions size assertion error:"), actual.getRenameColumnDefinitions().size(), is(expected.getRenameColumns().size()));
+        int count = 0;
+        for (RenameColumnSegment each : actual.getRenameColumnDefinitions()) {
+            ExpectedRenameColumnDefinition expectedRenameColumnDefinition = expected.getRenameColumns().get(count);
+            ColumnAssert.assertIs(assertContext, each.getOldColumnName(), expectedRenameColumnDefinition.getOldColumnName());
+            ColumnAssert.assertIs(assertContext, each.getColumnName(), expectedRenameColumnDefinition.getColumnName());
             count++;
         }
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/definition/ExpectedRenameColumnDefinition.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/definition/ExpectedRenameColumnDefinition.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.column.ExpectedColumn;
+
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Expected rename column definition.
+ */
+@Getter
+@Setter
+public final class ExpectedRenameColumnDefinition extends AbstractExpectedSQLSegment {
+    
+    @XmlElement(name = "old-column-name")
+    private ExpectedColumn oldColumnName;
+    
+    @XmlElement(name = "column-name")
+    private ExpectedColumn columnName;
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterTableStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ddl/AlterTableStatementTestCase.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedConvertTableDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedModifyColumnDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedRenameIndexDefinition;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.definition.ExpectedRenameColumnDefinition;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.table.ExpectedSimpleTable;
 
 import javax.xml.bind.annotation.XmlElement;
@@ -63,6 +64,9 @@ public final class AlterTableStatementTestCase extends SQLParserTestCase {
     
     @XmlElement(name = "rename-index")
     private final List<ExpectedRenameIndexDefinition> renameIndexes = new LinkedList<>();
+    
+    @XmlElement(name = "rename-column")
+    private final List<ExpectedRenameColumnDefinition> renameColumns = new LinkedList<>();
     
     @XmlElement(name = "drop-column")
     private final List<ExpectedColumn> dropColumns = new LinkedList<>();

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -47,6 +47,26 @@
     <alter-table sql-case-id="alter_table_with_force">
         <table name="t_order" start-index="12" stop-index="18" />
     </alter-table>
+
+    <alter-table sql-case-id="alter_table_with_single_rename_column">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <rename-column start-index="20" stop-index="55">
+            <old-column-name name="new_col" start-index="34" stop-index="40" />
+            <column-name name="renamed_col" start-index="45" stop-index="55" />
+        </rename-column>
+    </alter-table>
+
+    <alter-table sql-case-id="alter_table_with_multiple_rename_column">
+        <table name="t_order" start-index="12" stop-index="18" />
+        <rename-column start-index="20" stop-index="56">
+            <old-column-name name="first_name" start-index="34" stop-index="43" />
+            <column-name name="full_name" start-index="48" stop-index="56" />
+        </rename-column>
+        <rename-column start-index="58" stop-index="91">
+            <old-column-name name="last_name" start-index="72" stop-index="80" />
+            <column-name name="surname" start-index="85" stop-index="91" />
+        </rename-column>
+    </alter-table>
     
     <alter-table sql-case-id="alter_table_with_space">
         <table name="t_order" start-index="24" stop-index="30" />

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -30,6 +30,8 @@
     <sql-case id="alter_table_partition" value="alter table t1 partition by key(c1) partitions 5" db-types="MySQL" />
     <sql-case id="alter_table_if_exists_only" value="ALTER TABLE IF EXISTS ONLY t_log ADD name varchar" db-types="PostgreSQL,openGauss" />
     <sql-case id="alter_table_with_force" value="ALTER TABLE t_order FORCE" db-types="MySQL" />
+    <sql-case id="alter_table_with_single_rename_column" value="alter table t_order rename column new_col to renamed_col" db-types="MySQL" />
+    <sql-case id="alter_table_with_multiple_rename_column" value="ALTER TABLE t_order RENAME COLUMN first_name TO full_name,RENAME COLUMN last_name TO surname" db-types="MySQL" />
     <sql-case id="alter_table_with_space" value="    ALTER TABLE
         t_order" db-types="MySQL,Oracle" />
     <sql-case id="alter_table_with_back_quota" value="ALTER TABLE `t_order` FORCE" db-types="MySQL" />


### PR DESCRIPTION
Fixes #25852.

Changes proposed in this pull request:
  - Support Mysql ALTER TABLE RENAME COLUMN statement
  - Add test sql
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
