### PR TITLE
Support for MOD, Vertical Bar

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
@@ -70,6 +70,8 @@ public final class BinaryOperationExpressionConverter implements SQLSegmentConve
         register(SqlStdOperatorTable.IS_FALSE);
         register(SqlStdOperatorTable.IS_NOT_FALSE);
         register(SqlStdOperatorTable.CONCAT);
+        register(SqlStdOperatorTable.PATTERN_ALTER);
+        register(SqlStdOperatorTable.MOD);
     }
     
     private static void register(final SqlOperator sqlOperator) {


### PR DESCRIPTION
Ref #24200 
This PR adds support for following case IDs

 1.select_where_with_bit_expr_with_mod
 2.select_where_with_bit_expr_with_vertical_bar
 3.select_where_with_expr_with_not_sign
(Below case IDs from previous PRs)
 4.select_where_with_predicate_with_in_subquery
 5.select_where_with_expr_with_not

