### PR TITLE
Add like support for `SHOW DIST VARIABLES`

### DIFF
--- a/kernel/data-pipeline/core/pom.xml
+++ b/kernel/data-pipeline/core/pom.xml
@@ -78,7 +78,7 @@
             <artifactId>HikariCP</artifactId>
             <scope>compile</scope>
         </dependency>
-
+        
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-test-util</artifactId>

--- a/kernel/data-pipeline/dialect/opengauss/pom.xml
+++ b/kernel/data-pipeline/dialect/opengauss/pom.xml
@@ -39,7 +39,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
+        
         <dependency>
             <groupId>org.opengauss</groupId>
             <artifactId>opengauss-jdbc</artifactId>

--- a/parser/distsql/engine/src/main/antlr4/imports/RALStatement.g4
+++ b/parser/distsql/engine/src/main/antlr4/imports/RALStatement.g4
@@ -28,7 +28,7 @@ showDistVariable
     ;
 
 showDistVariables
-    : SHOW DIST VARIABLES
+    : SHOW DIST VARIABLES showLike?
     ;
 
 alterComputeNode
@@ -193,4 +193,12 @@ label
 
 intValue
     : INT_
+    ;
+
+showLike
+    : LIKE likePattern
+    ;
+
+likePattern
+    : STRING_
     ;

--- a/parser/distsql/engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
+++ b/parser/distsql/engine/src/main/java/org/apache/shardingsphere/distsql/parser/core/kernel/KernelDistSQLStatementVisitor.java
@@ -269,7 +269,7 @@ public final class KernelDistSQLStatementVisitor extends KernelDistSQLStatementB
     
     @Override
     public ASTNode visitShowDistVariables(final ShowDistVariablesContext ctx) {
-        return new ShowDistVariablesStatement();
+        return new ShowDistVariablesStatement(null == ctx.showLike() ? null : getIdentifierValue(ctx.showLike().likePattern()));
     }
     
     @Override

--- a/parser/distsql/statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/queryable/ShowDistVariablesStatement.java
+++ b/parser/distsql/statement/src/main/java/org/apache/shardingsphere/distsql/parser/statement/ral/queryable/ShowDistVariablesStatement.java
@@ -17,10 +17,25 @@
 
 package org.apache.shardingsphere.distsql.parser.statement.ral.queryable;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.distsql.parser.statement.ral.QueryableRALStatement;
+
+import java.util.Optional;
 
 /**
  * Show dist variables statement.
  */
+@RequiredArgsConstructor
 public final class ShowDistVariablesStatement extends QueryableRALStatement {
+    
+    private final String likePattern;
+    
+    /**
+     * Get like pattern.
+     *
+     * @return like pattern
+     */
+    public Optional<String> getLikePattern() {
+        return Optional.ofNullable(likePattern);
+    }
 }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutor.java
@@ -28,6 +28,8 @@ import org.apache.shardingsphere.logging.util.LoggingUtils;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.common.enums.VariableEnum;
 import org.apache.shardingsphere.proxy.backend.handler.distsql.ral.queryable.executor.ConnectionSessionRequiredQueryableRALExecutor;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
+import org.apache.shardingsphere.proxy.backend.util.RegularUtils;
+import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -55,6 +57,10 @@ public final class ShowDistVariablesExecutor implements ConnectionSessionRequire
                 .collect(Collectors.toList()));
         result.add(new LocalDataQueryResultRow(VariableEnum.CACHED_CONNECTIONS.name().toLowerCase(), connectionSession.getDatabaseConnectionManager().getConnectionSize()));
         addLoggingPropsRows(metaData, result);
+        if (sqlStatement.getLikePattern().isPresent()) {
+            String pattern = SQLUtils.convertLikePatternToRegex(sqlStatement.getLikePattern().get());
+            result = result.stream().filter(each -> RegularUtils.matchesCaseInsensitive(pattern, (String) each.getCell(1))).collect(Collectors.toList());
+        }
         return result.stream().sorted(Comparator.comparing(each -> each.getCell(1).toString())).collect(Collectors.toList());
     }
     

--- a/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
+++ b/proxy/backend/core/src/test/java/org/apache/shardingsphere/proxy/backend/handler/distsql/ral/queryable/ShowDistVariablesExecutorTest.java
@@ -68,4 +68,18 @@ class ShowDistVariablesExecutorTest {
         assertThat(row.getCell(1), is("agent_plugins_enabled"));
         assertThat(row.getCell(2), is("true"));
     }
+    
+    @Test
+    void assertExecuteWithLike() {
+        when(metaData.getProps()).thenReturn(new ConfigurationProperties(PropertiesBuilder.build(new Property("system_log_level", "INFO"))));
+        when(metaData.getTemporaryProps()).thenReturn(new TemporaryConfigurationProperties(PropertiesBuilder.build(new Property("proxy-meta-data-collector-enabled", Boolean.FALSE.toString()))));
+        when(metaData.getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Collections.singleton(new LoggingRule(new DefaultLoggingRuleConfigurationBuilder().build()))));
+        ShowDistVariablesExecutor executor = new ShowDistVariablesExecutor();
+        Collection<LocalDataQueryResultRow> actual = executor.getRows(metaData, connectionSession, new ShowDistVariablesStatement("sql_%"));
+        assertThat(actual.size(), is(3));
+        Iterator<LocalDataQueryResultRow> iterator = actual.iterator();
+        assertThat(iterator.next().getCell(1), is("sql_federation_type"));
+        assertThat(iterator.next().getCell(1), is("sql_show"));
+        assertThat(iterator.next().getCell(1), is("sql_simple"));
+    }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ral/impl/QueryableRALStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ral/impl/QueryableRALStatementAssert.java
@@ -38,11 +38,13 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAsse
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ExistingAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable.ConvertYamlConfigurationStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable.ShowDistVariableStatementAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable.ShowDistVariablesStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable.ShowTableMetaDataStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable.ShowTrafficRulesStatementAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ConvertYamlConfigurationStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ShowDistVariableStatementTestCase;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ShowDistVariablesStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ShowTableMetaDataStatementTestCase;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ShowTrafficRulesStatementTestCase;
 import org.apache.shardingsphere.traffic.distsql.parser.statement.queryable.ShowTrafficRulesStatement;
@@ -65,7 +67,7 @@ public final class QueryableRALStatementAssert {
         if (actual instanceof ShowDistVariableStatement) {
             ShowDistVariableStatementAssert.assertIs(assertContext, (ShowDistVariableStatement) actual, (ShowDistVariableStatementTestCase) expected);
         } else if (actual instanceof ShowDistVariablesStatement) {
-            ExistingAssert.assertIs(assertContext, actual, expected);
+            ShowDistVariablesStatementAssert.assertIs(assertContext, (ShowDistVariablesStatement) actual, (ShowDistVariablesStatementTestCase) expected);
         } else if (actual instanceof ShowComputeNodesStatement) {
             ExistingAssert.assertIs(assertContext, actual, expected);
         } else if (actual instanceof ShowStatusFromReadwriteSplittingRulesStatement) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ral/impl/queryable/ShowDistVariablesStatementAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/statement/ral/impl/queryable/ShowDistVariablesStatementAssert.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ral.impl.queryable;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.distsql.parser.statement.ral.queryable.ShowDistVariablesStatement;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.ExistingAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral.ShowDistVariablesStatementTestCase;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Show dist variables statement assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ShowDistVariablesStatementAssert {
+    
+    /**
+     * Assert show dist variables statement is correct with expected parser result.
+     *
+     * @param assertContext assert context
+     * @param actual actual show dist variables statement
+     * @param expected expected show dist variables statement test case
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ShowDistVariablesStatement actual, final ShowDistVariablesStatementTestCase expected) {
+        ExistingAssert.assertIs(assertContext, actual, expected);
+        assertLikePattern(assertContext, actual, expected);
+    }
+    
+    private static void assertLikePattern(final SQLCaseAssertContext assertContext, final ShowDistVariablesStatement actual, final ShowDistVariablesStatementTestCase expected) {
+        if (null == expected.getLikePattern()) {
+            assertFalse(actual.getLikePattern().isPresent(), assertContext.getText("Actual like pattern should not exist."));
+        } else {
+            assertTrue(actual.getLikePattern().isPresent(), assertContext.getText("Actual like pattern should exist."));
+            assertThat(assertContext.getText("Like pattern assertion error"), actual.getLikePattern().get(), is(expected.getLikePattern()));
+        }
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ral/ShowDistVariablesStatementTestCase.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/statement/ral/ShowDistVariablesStatementTestCase.java
@@ -17,10 +17,19 @@
 
 package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.statement.ral;
 
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.SQLParserTestCase;
+
+import javax.xml.bind.annotation.XmlAttribute;
 
 /**
  * Show dist variables statement test case.
  */
+@Getter
+@Setter
 public final class ShowDistVariablesStatementTestCase extends SQLParserTestCase {
+    
+    @XmlAttribute(name = "like-pattern")
+    private String likePattern;
 }

--- a/test/it/parser/src/main/resources/case/ral/queryable.xml
+++ b/test/it/parser/src/main/resources/case/ral/queryable.xml
@@ -19,6 +19,7 @@
 <sql-parser-test-cases>
     <show-dist-variable sql-case-id="show-dist-variable" name="CACHED_CONNECTIONS" />
     <show-dist-variables sql-case-id="show-dist-variables" />
+    <show-dist-variables sql-case-id="show-dist-variables-like" like-pattern="sql_%" />
     
     <show-status-from-readwrite-splitting-rules sql-case-id="show-status-from-readwrite-splitting-rules" />
     

--- a/test/it/parser/src/main/resources/sql/supported/ral/queryable.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ral/queryable.xml
@@ -19,6 +19,7 @@
 <sql-cases>
     <sql-case id="show-dist-variable" value="SHOW DIST VARIABLE WHERE NAME = 'CACHED_CONNECTIONS'" db-types="ShardingSphere" />
     <sql-case id="show-dist-variables" value="SHOW DIST VARIABLES" db-types="ShardingSphere" />
+    <sql-case id="show-dist-variables-like" value="SHOW DIST VARIABLES like 'sql_%'" db-types="ShardingSphere" />
     
     <sql-case id="show-status-from-readwrite-splitting-rules" value="SHOW STATUS FROM READWRITE_SPLITTING RULES" db-types="ShardingSphere" />
     


### PR DESCRIPTION
Fixes https://github.com/apache/shardingsphere/issues/25493

Changes proposed in this pull request:
  - Add like support for `SHOW DIST VARIABLES`


<img width="567" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/bec26795-1202-4f14-9de7-6ae9441bfe2b">


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
