### PR TITLE
Support for AMPERSAND,CARET AND DIV

### DIFF
--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
@@ -24,6 +24,8 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.SqlBinaryOperator;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sqlfederation.optimizer.converter.segment.SQLSegmentConverter;
@@ -106,6 +108,15 @@ public final class BinaryOperationExpressionConverter implements SQLSegmentConve
             } else if ("NOT FALSE".equalsIgnoreCase(literals)) {
                 operator = "IS NOT FALSE";
             }
+        }
+        if ("&".equalsIgnoreCase(operator)) {
+            return new SqlBinaryOperator("&", SqlKind.OTHER, 30, true, null, null, null);
+        }
+        if ("^".equalsIgnoreCase(operator)) {
+            return new SqlBinaryOperator("^", SqlKind.OTHER, 30, true, null, null, null);
+        }
+        if ("DIV".equalsIgnoreCase(operator)) {
+            return new SqlBinaryOperator("DIV", SqlKind.OTHER, 30, true, null, null, null);
         }
         Preconditions.checkState(REGISTRY.containsKey(operator), "Unsupported SQL operator: `%s`", operator);
         return REGISTRY.get(operator);


### PR DESCRIPTION
Ref #24200 
Adds support for :
1.select_where_with_bit_expr_with_ampersand
2.select_where_with_bit_expr_with_caret
3.select_where_with_bit_expr_with_div


![Screenshot (324)](https://github.com/apache/shardingsphere/assets/92207457/863f4d60-c1e1-4ffa-b28f-3349f3f352d2)
![Screenshot (325)](https://github.com/apache/shardingsphere/assets/92207457/d675363e-873a-412c-8dce-7bd9e0b727ce)
![Screenshot (326)](https://github.com/apache/shardingsphere/assets/92207457/775790a9-6f23-48a9-b7a6-f8ae3a04ba74)
