### PR TITLE
Remove @ToString from all CommandPacket

### DIFF
--- a/db-protocol/core/src/main/java/org/apache/shardingsphere/db/protocol/packet/SQLAwarePacket.java
+++ b/db-protocol/core/src/main/java/org/apache/shardingsphere/db/protocol/packet/SQLAwarePacket.java
@@ -15,19 +15,17 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.db.protocol.mysql.packet.command.admin.quit;
-
-import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
-import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
+package org.apache.shardingsphere.db.protocol.packet;
 
 /**
- * COM_QUIT command packet for MySQL.
- * 
- * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_quit.html">COM_QUIT</a>
+ * SQL aware packet.
  */
-public final class MySQLComQuitPacket extends MySQLCommandPacket {
+public interface SQLAwarePacket {
     
-    public MySQLComQuitPacket() {
-        super(MySQLCommandPacketType.COM_QUIT);
-    }
+    /**
+     * Get SQL.
+     * 
+     * @return SQL.
+     */
+    String getSQL();
 }

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/admin/MySQLUnsupportedCommandPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/admin/MySQLUnsupportedCommandPacket.java
@@ -17,14 +17,12 @@
 
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.admin;
 
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 
 /**
  * Unsupported command packet for MySQL.
  */
-@ToString
 public final class MySQLUnsupportedCommandPacket extends MySQLCommandPacket {
     
     public MySQLUnsupportedCommandPacket(final MySQLCommandPacketType type) {

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/admin/initdb/MySQLComInitDbPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/admin/initdb/MySQLComInitDbPacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.admin.initdb;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
@@ -29,7 +28,6 @@ import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_init_db.html">COM_INIT_DB</a>
  */
 @Getter
-@ToString
 public final class MySQLComInitDbPacket extends MySQLCommandPacket {
     
     private final String schema;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/binlog/MySQLComBinlogDumpCommandPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/binlog/MySQLComBinlogDumpCommandPacket.java
@@ -17,12 +17,10 @@
 
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.binlog;
 
+import lombok.Getter;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
-
-import lombok.Getter;
-import lombok.ToString;
 
 /**
  * COM_BINLOG_DUMP command packet for MySQL.
@@ -30,7 +28,6 @@ import lombok.ToString;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_binlog_dump.html">COM_BINLOG_DUMP</a>
  */
 @Getter
-@ToString
 public final class MySQLComBinlogDumpCommandPacket extends MySQLCommandPacket {
     
     /**

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/binlog/MySQLComRegisterSlaveCommandPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/binlog/MySQLComRegisterSlaveCommandPacket.java
@@ -17,18 +17,15 @@
 
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.binlog;
 
+import lombok.Getter;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
-
-import lombok.Getter;
-import lombok.ToString;
 
 /**
  * COM_REGISTER_SLAVE command packet for MySQL.
  */
 @Getter
-@ToString
 public final class MySQLComRegisterSlaveCommandPacket extends MySQLCommandPacket {
     
     private final int serverId;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/close/MySQLComStmtClosePacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/close/MySQLComStmtClosePacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.binary.close;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
@@ -29,7 +28,6 @@ import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_close.html">COM_STMT_CLOSE</a>
  */
 @Getter
-@ToString
 public final class MySQLComStmtClosePacket extends MySQLCommandPacket {
     
     private final int statementId;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacket.java
@@ -20,7 +20,6 @@ package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.binary.
 import com.google.common.base.Preconditions;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLBinaryColumnType;
 import org.apache.shardingsphere.db.protocol.mysql.constant.MySQLNewParametersBoundFlag;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
@@ -43,7 +42,6 @@ import java.util.Set;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_execute.html">COM_STMT_EXECUTE</a>
  */
 @Getter
-@ToString(of = "statementId")
 public final class MySQLComStmtExecutePacket extends MySQLCommandPacket {
     
     private static final int ITERATION_COUNT = 1;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPreparePacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPreparePacket.java
@@ -17,20 +17,17 @@
 
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.binary.prepare;
 
-import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 
 /**
  * COM_STMT_PREPARE command packet for MySQL.
  * 
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_prepare.html">COM_STMT_PREPARE</a>
  */
-@Getter
-@ToString
-public final class MySQLComStmtPreparePacket extends MySQLCommandPacket {
+public final class MySQLComStmtPreparePacket extends MySQLCommandPacket implements SQLAwarePacket {
     
     private final String sql;
     
@@ -42,5 +39,10 @@ public final class MySQLComStmtPreparePacket extends MySQLCommandPacket {
     @Override
     public void doWrite(final MySQLPacketPayload payload) {
         payload.writeStringEOF(sql);
+    }
+    
+    @Override
+    public String getSQL() {
+        return sql;
     }
 }

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/reset/MySQLComStmtResetPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/reset/MySQLComStmtResetPacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.binary.reset;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
@@ -29,7 +28,6 @@ import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_stmt_reset.html">COM_STMT_RESET</a>
  */
 @Getter
-@ToString
 public final class MySQLComStmtResetPacket extends MySQLCommandPacket {
     
     private final int statementId;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/fieldlist/MySQLComFieldListPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/fieldlist/MySQLComFieldListPacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.text.fieldlist;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
@@ -29,7 +28,6 @@ import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_field_list.html">COM_FIELD_LIST</a>
  */
 @Getter
-@ToString
 public final class MySQLComFieldListPacket extends MySQLCommandPacket {
     
     private final String table;

--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/query/MySQLComQueryPacket.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/query/MySQLComQueryPacket.java
@@ -18,10 +18,10 @@
 package org.apache.shardingsphere.db.protocol.mysql.packet.command.query.text.query;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.MySQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.mysql.payload.MySQLPacketPayload;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.hint.SQLHintUtils;
 
@@ -30,12 +30,11 @@ import org.apache.shardingsphere.infra.hint.SQLHintUtils;
  *
  * @see <a href="https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_com_query.html">COM_QUERY</a>
  */
-@Getter
-@ToString
-public final class MySQLComQueryPacket extends MySQLCommandPacket {
+public final class MySQLComQueryPacket extends MySQLCommandPacket implements SQLAwarePacket {
     
     private final String sql;
     
+    @Getter
     private final HintValueContext hintValueContext;
     
     public MySQLComQueryPacket(final String sql, final boolean sqlCommentParseEnabled) {
@@ -54,5 +53,10 @@ public final class MySQLComQueryPacket extends MySQLCommandPacket {
     @Override
     public void doWrite(final MySQLPacketPayload payload) {
         payload.writeStringEOF(sql);
+    }
+    
+    @Override
+    public String getSQL() {
+        return sql;
     }
 }

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacketTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/MySQLComStmtExecutePacketTest.java
@@ -86,6 +86,5 @@ class MySQLComStmtExecutePacketTest {
         assertThat(parameterTypes.get(0).getColumnType(), is(MySQLBinaryColumnType.MYSQL_TYPE_BLOB));
         assertThat(parameterTypes.get(0).getUnsignedFlag(), is(0));
         assertThat(actual.readParameters(parameterTypes, Collections.singleton(0), Collections.emptyList()), is(Collections.singletonList(null)));
-        assertThat(actual.toString(), is("MySQLComStmtExecutePacket(statementId=2)"));
     }
 }

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPreparePacketTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/prepare/MySQLComStmtPreparePacketTest.java
@@ -38,7 +38,7 @@ class MySQLComStmtPreparePacketTest {
     void assertNew() {
         when(payload.readStringEOF()).thenReturn("SELECT id FROM tbl WHERE id=?");
         MySQLComStmtPreparePacket actual = new MySQLComStmtPreparePacket(payload);
-        assertThat(actual.getSql(), is("SELECT id FROM tbl WHERE id=?"));
+        assertThat(actual.getSQL(), is("SELECT id FROM tbl WHERE id=?"));
     }
     
     @Test

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/query/MySQLComQueryPacketTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/text/query/MySQLComQueryPacketTest.java
@@ -39,7 +39,7 @@ class MySQLComQueryPacketTest {
     void assertNew() {
         when(payload.readStringEOF()).thenReturn("SELECT id FROM tbl");
         MySQLComQueryPacket actual = new MySQLComQueryPacket(payload, false);
-        assertThat(actual.getSql(), is("SELECT id FROM tbl"));
+        assertThat(actual.getSQL(), is("SELECT id FROM tbl"));
     }
     
     @Test

--- a/db-protocol/opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/query/extended/bind/OpenGaussComBatchBindPacket.java
+++ b/db-protocol/opengauss/src/main/java/org/apache/shardingsphere/db/protocol/opengauss/packet/command/query/extended/bind/OpenGaussComBatchBindPacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.opengauss.packet.command.query.extended.bind;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.opengauss.packet.command.OpenGaussCommandPacket;
 import org.apache.shardingsphere.db.protocol.opengauss.packet.command.OpenGaussCommandPacketType;
 import org.apache.shardingsphere.db.protocol.opengauss.packet.identifier.OpenGaussIdentifierTag;
@@ -39,7 +38,6 @@ import java.util.List;
  * Batch bind packet for openGauss.
  */
 @Getter
-@ToString
 public final class OpenGaussComBatchBindPacket extends OpenGaussCommandPacket {
     
     private final PostgreSQLPacketPayload payload;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/admin/PostgreSQLUnsupportedCommandPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/admin/PostgreSQLUnsupportedCommandPacket.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.admin;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
 import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacketPayload;
@@ -28,7 +27,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
  * Unsupported command packet for PostgreSQL.
  */
 @RequiredArgsConstructor
-@ToString
 public final class PostgreSQLUnsupportedCommandPacket extends PostgreSQLCommandPacket {
     
     @Getter

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLAggregatedCommandPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/PostgreSQLAggregatedCommandPacket.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.ex
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind.PostgreSQLComBindPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.execute.PostgreSQLComExecutePacket;
@@ -31,7 +30,6 @@ import java.util.List;
 import java.util.RandomAccess;
 
 @Getter
-@ToString
 public final class PostgreSQLAggregatedCommandPacket extends PostgreSQLCommandPacket {
     
     private final List<PostgreSQLCommandPacket> packets;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/bind/PostgreSQLComBindPacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.bind;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.constant.PostgreSQLValueFormat;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
@@ -41,7 +40,6 @@ import java.util.List;
  * Command bind packet for PostgreSQL.
  */
 @Getter
-@ToString
 public final class PostgreSQLComBindPacket extends PostgreSQLCommandPacket {
     
     private final PostgreSQLPacketPayload payload;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/close/PostgreSQLComClosePacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/close/PostgreSQLComClosePacket.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.ex
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.exception.PostgreSQLProtocolException;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
@@ -30,7 +29,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
  * Command close packet for PostgreSQL.
  */
 @Getter
-@ToString
 public final class PostgreSQLComClosePacket extends PostgreSQLCommandPacket {
     
     private final Type type;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/describe/PostgreSQLComDescribePacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/describe/PostgreSQLComDescribePacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.describe;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -28,7 +27,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
  * Command describe packet for PostgreSQL.
  */
 @Getter
-@ToString
 public final class PostgreSQLComDescribePacket extends PostgreSQLCommandPacket {
     
     private final char type;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/execute/PostgreSQLComExecutePacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/execute/PostgreSQLComExecutePacket.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.execute;
 
 import lombok.Getter;
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -28,7 +27,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
  * Command execute packet for PostgreSQL.
  */
 @Getter
-@ToString
 public final class PostgreSQLComExecutePacket extends PostgreSQLCommandPacket {
     
     private final String portal;

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/parse/PostgreSQLComParsePacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/parse/PostgreSQLComParsePacket.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.parse;
 
 import lombok.Getter;
-import lombok.ToString;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLColumnType;
@@ -32,8 +32,7 @@ import java.util.List;
  * Command parse packet for PostgreSQL.
  */
 @Getter
-@ToString
-public final class PostgreSQLComParsePacket extends PostgreSQLCommandPacket {
+public final class PostgreSQLComParsePacket extends PostgreSQLCommandPacket implements SQLAwarePacket {
     
     private final PostgreSQLPacketPayload payload;
     
@@ -69,5 +68,10 @@ public final class PostgreSQLComParsePacket extends PostgreSQLCommandPacket {
     @Override
     public PostgreSQLIdentifierTag getIdentifier() {
         return PostgreSQLCommandPacketType.PARSE_COMMAND;
+    }
+    
+    @Override
+    public String getSQL() {
+        return sql;
     }
 }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/sync/PostgreSQLComSyncPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/sync/PostgreSQLComSyncPacket.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.sync;
 
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -26,7 +25,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 /**
  * Command sync packet for PostgreSQL.
  */
-@ToString
 public final class PostgreSQLComSyncPacket extends PostgreSQLCommandPacket {
     
     public PostgreSQLComSyncPacket(final PostgreSQLPacketPayload payload) {

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/simple/PostgreSQLComQueryPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/simple/PostgreSQLComQueryPacket.java
@@ -17,8 +17,7 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.simple;
 
-import lombok.Getter;
-import lombok.ToString;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -27,9 +26,7 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 /**
  * Command query packet for PostgreSQL.
  */
-@Getter
-@ToString
-public final class PostgreSQLComQueryPacket extends PostgreSQLCommandPacket {
+public final class PostgreSQLComQueryPacket extends PostgreSQLCommandPacket implements SQLAwarePacket {
     
     private final String sql;
     
@@ -45,5 +42,10 @@ public final class PostgreSQLComQueryPacket extends PostgreSQLCommandPacket {
     @Override
     public PostgreSQLIdentifierTag getIdentifier() {
         return PostgreSQLCommandPacketType.SIMPLE_QUERY;
+    }
+    
+    @Override
+    public String getSQL() {
+        return sql;
     }
 }

--- a/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComTerminationPacket.java
+++ b/db-protocol/postgresql/src/main/java/org/apache/shardingsphere/db/protocol/postgresql/packet/generic/PostgreSQLComTerminationPacket.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.db.protocol.postgresql.packet.generic;
 
-import lombok.ToString;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.identifier.PostgreSQLIdentifierTag;
@@ -26,7 +25,6 @@ import org.apache.shardingsphere.db.protocol.postgresql.payload.PostgreSQLPacket
 /**
  * Command termination packet for PostgreSQL.
  */
-@ToString
 public final class PostgreSQLComTerminationPacket extends PostgreSQLCommandPacket {
     
     public PostgreSQLComTerminationPacket(final PostgreSQLPacketPayload payload) {

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/parse/PostgreSQLComParsePacketTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/extended/parse/PostgreSQLComParsePacketTest.java
@@ -45,7 +45,7 @@ class PostgreSQLComParsePacketTest {
         PostgreSQLComParsePacket actual = new PostgreSQLComParsePacket(payload);
         actual.write(payload);
         assertThat(actual.getIdentifier(), is(PostgreSQLCommandPacketType.PARSE_COMMAND));
-        assertThat(actual.getSql(), is("sql"));
+        assertThat(actual.getSQL(), is("sql"));
         assertThat(actual.getStatementId(), is("sql"));
         List<PostgreSQLColumnType> types = actual.readParameterTypes();
         assertThat(types.size(), is(1));

--- a/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/simple/PostgreSQLComQueryPacketTest.java
+++ b/db-protocol/postgresql/src/test/java/org/apache/shardingsphere/db/protocol/postgresql/packet/command/query/simple/PostgreSQLComQueryPacketTest.java
@@ -41,7 +41,7 @@ class PostgreSQLComQueryPacketTest {
         PostgreSQLComQueryPacket actual = new PostgreSQLComQueryPacket(payload);
         actual.write(payload);
         verify(payload).readInt4();
-        assertThat(actual.getSql(), is("sql"));
+        assertThat(actual.getSQL(), is("sql"));
         assertThat(actual.getIdentifier(), is(PostgreSQLCommandPacketType.SIMPLE_QUERY));
     }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandExecutorFactory.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandExecutorFactory.java
@@ -31,6 +31,7 @@ import org.apache.shardingsphere.db.protocol.mysql.packet.command.query.binary.r
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.query.text.fieldlist.MySQLComFieldListPacket;
 import org.apache.shardingsphere.db.protocol.mysql.packet.command.query.text.query.MySQLComQueryPacket;
 import org.apache.shardingsphere.db.protocol.packet.CommandPacket;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.proxy.backend.session.ConnectionSession;
 import org.apache.shardingsphere.proxy.frontend.command.executor.CommandExecutor;
 import org.apache.shardingsphere.proxy.frontend.mysql.command.admin.MySQLComResetConnectionExecutor;
@@ -66,7 +67,11 @@ public final class MySQLCommandExecutorFactory {
      * @throws SQLException SQL exception
      */
     public static CommandExecutor newInstance(final MySQLCommandPacketType commandPacketType, final CommandPacket commandPacket, final ConnectionSession connectionSession) throws SQLException {
-        log.debug("Execute packet type: {}, value: {}", commandPacketType, commandPacket);
+        if (commandPacket instanceof SQLAwarePacket) {
+            log.debug("Execute packet type: {}, sql: {}", commandPacketType, ((SQLAwarePacket) commandPacket).getSQL());
+        } else {
+            log.debug("Execute packet type: {}", commandPacketType);
+        }
         switch (commandPacketType) {
             case COM_QUIT:
                 return new MySQLComQuitExecutor();

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -77,14 +77,14 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         failedIfContainsMultiStatements();
         MetaDataContexts metaDataContexts = ProxyContext.getInstance().getContextManager().getMetaDataContexts();
         SQLParserRule sqlParserRule = metaDataContexts.getMetaData().getGlobalRuleMetaData().getSingleRule(SQLParserRule.class);
-        SQLStatement sqlStatement = sqlParserRule.getSQLParserEngine(TypedSPILoader.getService(DatabaseType.class, "MySQL").getType()).parse(packet.getSql(), true);
+        SQLStatement sqlStatement = sqlParserRule.getSQLParserEngine(TypedSPILoader.getService(DatabaseType.class, "MySQL").getType()).parse(packet.getSQL(), true);
         if (!MySQLComStmtPrepareChecker.isAllowedStatement(sqlStatement)) {
             throw new UnsupportedPreparedStatementException();
         }
         SQLStatementContext sqlStatementContext = SQLStatementContextFactory.newInstance(ProxyContext.getInstance().getContextManager().getMetaDataContexts().getMetaData(),
                 sqlStatement, connectionSession.getDefaultDatabaseName());
         int statementId = MySQLStatementIdGenerator.getInstance().nextStatementId(connectionSession.getConnectionId());
-        MySQLServerPreparedStatement serverPreparedStatement = new MySQLServerPreparedStatement(packet.getSql(), sqlStatementContext, new CopyOnWriteArrayList<>());
+        MySQLServerPreparedStatement serverPreparedStatement = new MySQLServerPreparedStatement(packet.getSQL(), sqlStatementContext, new CopyOnWriteArrayList<>());
         connectionSession.getServerPreparedStatementRegistry().addPreparedStatement(statementId, serverPreparedStatement);
         return createPackets(sqlStatementContext, statementId, serverPreparedStatement);
     }
@@ -93,7 +93,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         // TODO Multi statements should be identified by SQL Parser instead of checking if sql contains ";".
         if (connectionSession.getAttributeMap().hasAttr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS)
                 && MySQLComSetOptionPacket.MYSQL_OPTION_MULTI_STATEMENTS_ON == connectionSession.getAttributeMap().attr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS).get()
-                && packet.getSql().contains(";")) {
+                && packet.getSQL().contains(";")) {
             throw new UnsupportedPreparedStatementException();
         }
     }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutor.java
@@ -65,9 +65,9 @@ public final class MySQLComQueryPacketExecutor implements QueryCommandExecutor<M
     public MySQLComQueryPacketExecutor(final MySQLComQueryPacket packet, final ConnectionSession connectionSession) throws SQLException {
         this.connectionSession = connectionSession;
         DatabaseType databaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-        SQLStatement sqlStatement = parseSQL(packet.getSql(), databaseType);
-        proxyBackendHandler = areMultiStatements(connectionSession, sqlStatement, packet.getSql()) ? new MySQLMultiStatementsHandler(connectionSession, sqlStatement, packet.getSql())
-                : ProxyBackendHandlerFactory.newInstance(databaseType, packet.getSql(), sqlStatement, connectionSession, packet.getHintValueContext());
+        SQLStatement sqlStatement = parseSQL(packet.getSQL(), databaseType);
+        proxyBackendHandler = areMultiStatements(connectionSession, sqlStatement, packet.getSQL()) ? new MySQLMultiStatementsHandler(connectionSession, sqlStatement, packet.getSQL())
+                : ProxyBackendHandlerFactory.newInstance(databaseType, packet.getSQL(), sqlStatement, connectionSession, packet.getHintValueContext());
         characterSet = connectionSession.getAttributeMap().attr(MySQLConstants.MYSQL_CHARACTER_SET_ATTRIBUTE_KEY).get().getId();
     }
     

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandExecutorFactoryTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/MySQLCommandExecutorFactoryTest.java
@@ -96,7 +96,7 @@ class MySQLCommandExecutorFactoryTest {
     @Test
     void assertNewInstanceWithComQuery() throws SQLException {
         MySQLComQueryPacket packet = mock(MySQLComQueryPacket.class);
-        when(packet.getSql()).thenReturn("");
+        when(packet.getSQL()).thenReturn("");
         assertThat(MySQLCommandExecutorFactory.newInstance(MySQLCommandPacketType.COM_QUERY, packet, connectionSession), instanceOf(MySQLComQueryPacketExecutor.class));
     }
     

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutorTest.java
@@ -94,7 +94,7 @@ class MySQLComStmtPrepareExecutorTest {
     
     @Test
     void assertPrepareMultiStatements() {
-        when(packet.getSql()).thenReturn("update t set v=v+1 where id=1;update t set v=v+1 where id=2;update t set v=v+1 where id=3");
+        when(packet.getSQL()).thenReturn("update t set v=v+1 where id=1;update t set v=v+1 where id=2;update t set v=v+1 where id=3");
         when(connectionSession.getAttributeMap().hasAttr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS)).thenReturn(true);
         when(connectionSession.getAttributeMap().attr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS).get()).thenReturn(0);
         assertThrows(UnsupportedPreparedStatementException.class, () -> new MySQLComStmtPrepareExecutor(packet, connectionSession).execute());
@@ -103,7 +103,7 @@ class MySQLComStmtPrepareExecutorTest {
     @Test
     void assertPrepareSelectStatement() {
         String sql = "select name from foo_db.user where id = ?";
-        when(packet.getSql()).thenReturn(sql);
+        when(packet.getSQL()).thenReturn(sql);
         when(connectionSession.getConnectionId()).thenReturn(1);
         MySQLStatementIdGenerator.getInstance().registerConnection(1);
         ContextManager contextManager = mockContextManager();
@@ -125,7 +125,7 @@ class MySQLComStmtPrepareExecutorTest {
     @Test
     void assertPrepareSelectSubqueryStatement() {
         String sql = "select *, '' from (select u.id id_alias, name, age from foo_db.user u where id = ?) t";
-        when(packet.getSql()).thenReturn(sql);
+        when(packet.getSQL()).thenReturn(sql);
         int connectionId = 2;
         when(connectionSession.getConnectionId()).thenReturn(connectionId);
         MySQLStatementIdGenerator.getInstance().registerConnection(connectionId);
@@ -156,7 +156,7 @@ class MySQLComStmtPrepareExecutorTest {
     @Test
     void assertPrepareInsertStatement() {
         String sql = "insert into user (id, name, age) values (1, ?, ?), (?, 'bar', ?)";
-        when(packet.getSql()).thenReturn(sql);
+        when(packet.getSQL()).thenReturn(sql);
         int connectionId = 2;
         when(connectionSession.getConnectionId()).thenReturn(connectionId);
         when(connectionSession.getDefaultDatabaseName()).thenReturn("foo_db");
@@ -194,7 +194,7 @@ class MySQLComStmtPrepareExecutorTest {
     @Test
     void assertPrepareUpdateStatement() {
         String sql = "update user set name = ?, age = ? where id = ?";
-        when(packet.getSql()).thenReturn(sql);
+        when(packet.getSQL()).thenReturn(sql);
         when(connectionSession.getConnectionId()).thenReturn(1);
         when(connectionSession.getDefaultDatabaseName()).thenReturn("foo_db");
         MySQLStatementIdGenerator.getInstance().registerConnection(1);
@@ -216,7 +216,7 @@ class MySQLComStmtPrepareExecutorTest {
     
     @Test
     void assertPrepareNotAllowedStatement() {
-        when(packet.getSql()).thenReturn("begin");
+        when(packet.getSQL()).thenReturn("begin");
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
         assertThrows(UnsupportedPreparedStatementException.class, () -> new MySQLComStmtPrepareExecutor(packet, connectionSession).execute());

--- a/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
+++ b/proxy/frontend/type/mysql/src/test/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/text/query/MySQLComQueryPacketExecutorTest.java
@@ -86,7 +86,7 @@ class MySQLComQueryPacketExecutorTest {
     
     @BeforeEach
     void setUp() {
-        when(packet.getSql()).thenReturn("");
+        when(packet.getSQL()).thenReturn("");
         when(connectionSession.getAttributeMap().attr(MySQLConstants.MYSQL_CHARACTER_SET_ATTRIBUTE_KEY).get()).thenReturn(MySQLCharacterSet.UTF8MB4_GENERAL_CI);
     }
     
@@ -117,7 +117,7 @@ class MySQLComQueryPacketExecutorTest {
         when(connectionSession.getAttributeMap().hasAttr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS)).thenReturn(true);
         when(connectionSession.getAttributeMap().attr(MySQLConstants.MYSQL_OPTION_MULTI_STATEMENTS).get()).thenReturn(0);
         when(connectionSession.getDatabaseName()).thenReturn("foo_db");
-        when(packet.getSql()).thenReturn("update t set v=v+1 where id=1;update t set v=v+1 where id=2;update t set v=v+1 where id=3");
+        when(packet.getSQL()).thenReturn("update t set v=v+1 where id=1;update t set v=v+1 where id=2;update t set v=v+1 where id=3");
         ContextManager contextManager = mock(ContextManager.class);
         MetaDataContexts metaDataContexts = mockMetaDataContexts();
         when(contextManager.getMetaDataContexts()).thenReturn(metaDataContexts);

--- a/proxy/frontend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/OpenGaussCommandExecutorFactory.java
+++ b/proxy/frontend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/OpenGaussCommandExecutorFactory.java
@@ -23,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.db.protocol.opengauss.packet.command.OpenGaussCommandPacketType;
 import org.apache.shardingsphere.db.protocol.opengauss.packet.command.query.extended.bind.OpenGaussComBatchBindPacket;
 import org.apache.shardingsphere.db.protocol.packet.CommandPacketType;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLAggregatedCommandPacket;
@@ -72,7 +73,11 @@ public final class OpenGaussCommandExecutorFactory {
      */
     public static CommandExecutor newInstance(final CommandPacketType commandPacketType, final PostgreSQLCommandPacket commandPacket,
                                               final ConnectionSession connectionSession, final PortalContext portalContext) throws SQLException {
-        log.debug("Execute packet type: {}, value: {}", commandPacketType, commandPacket);
+        if (commandPacket instanceof SQLAwarePacket) {
+            log.debug("Execute packet type: {}, sql: {}", commandPacketType, ((SQLAwarePacket) commandPacket).getSQL());
+        } else {
+            log.debug("Execute packet type: {}", commandPacketType);
+        }
         if (!(commandPacket instanceof PostgreSQLAggregatedCommandPacket)) {
             return getCommandExecutor(commandPacketType, commandPacket, connectionSession, portalContext);
         }

--- a/proxy/frontend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutor.java
+++ b/proxy/frontend/type/opengauss/src/main/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutor.java
@@ -68,7 +68,7 @@ public final class OpenGaussComQueryExecutor implements QueryCommandExecutor<Pos
     
     public OpenGaussComQueryExecutor(final PortalContext portalContext, final PostgreSQLComQueryPacket comQueryPacket, final ConnectionSession connectionSession) throws SQLException {
         this.portalContext = portalContext;
-        proxyBackendHandler = ProxyBackendHandlerFactory.newInstance(TypedSPILoader.getService(DatabaseType.class, "openGauss"), comQueryPacket.getSql(), connectionSession);
+        proxyBackendHandler = ProxyBackendHandlerFactory.newInstance(TypedSPILoader.getService(DatabaseType.class, "openGauss"), comQueryPacket.getSQL(), connectionSession);
     }
     
     @Override

--- a/proxy/frontend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/OpenGaussCommandExecutorFactoryTest.java
+++ b/proxy/frontend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/OpenGaussCommandExecutorFactoryTest.java
@@ -85,7 +85,7 @@ class OpenGaussCommandExecutorFactoryTest {
     @Test
     void assertNewPostgreSQLSimpleQueryExecutor() throws SQLException {
         PostgreSQLComQueryPacket queryPacket = mock(PostgreSQLComQueryPacket.class);
-        when(queryPacket.getSql()).thenReturn("");
+        when(queryPacket.getSQL()).thenReturn("");
         CommandExecutor actual = OpenGaussCommandExecutorFactory.newInstance(PostgreSQLCommandPacketType.SIMPLE_QUERY, queryPacket, connectionSession, portalContext);
         assertThat(actual, instanceOf(OpenGaussComQueryExecutor.class));
     }

--- a/proxy/frontend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutorTest.java
+++ b/proxy/frontend/type/opengauss/src/test/java/org/apache/shardingsphere/proxy/frontend/opengauss/command/query/simple/OpenGaussComQueryExecutorTest.java
@@ -68,7 +68,7 @@ class OpenGaussComQueryExecutorTest {
     void setUp() throws SQLException {
         PostgreSQLComQueryPacket queryPacket = mock(PostgreSQLComQueryPacket.class);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
-        when(queryPacket.getSql()).thenReturn("");
+        when(queryPacket.getSQL()).thenReturn("");
         queryExecutor = new OpenGaussComQueryExecutor(portalContext, queryPacket, connectionSession);
         setMockFieldIntoExecutor(queryExecutor);
     }

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecutorFactory.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecutorFactory.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.proxy.frontend.postgresql.command;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.shardingsphere.db.protocol.packet.SQLAwarePacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacket;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.PostgreSQLCommandPacketType;
 import org.apache.shardingsphere.db.protocol.postgresql.packet.command.query.extended.PostgreSQLAggregatedCommandPacket;
@@ -67,7 +68,11 @@ public final class PostgreSQLCommandExecutorFactory {
      */
     public static CommandExecutor newInstance(final PostgreSQLCommandPacketType commandPacketType, final PostgreSQLCommandPacket commandPacket,
                                               final ConnectionSession connectionSession, final PortalContext portalContext) throws SQLException {
-        log.debug("Execute packet type: {}, value: {}", commandPacketType, commandPacket);
+        if (commandPacket instanceof SQLAwarePacket) {
+            log.debug("Execute packet type: {}, sql: {}", commandPacketType, ((SQLAwarePacket) commandPacket).getSQL());
+        } else {
+            log.debug("Execute packet type: {}", commandPacketType);
+        }
         if (!(commandPacket instanceof PostgreSQLAggregatedCommandPacket)) {
             return getCommandExecutor(commandPacketType, commandPacket, connectionSession, portalContext);
         }

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutor.java
@@ -59,7 +59,7 @@ public final class PostgreSQLComParseExecutor implements CommandExecutor {
     @Override
     public Collection<DatabasePacket> execute() {
         SQLParserEngine sqlParserEngine = createShardingSphereSQLParserEngine(connectionSession.getDatabaseName());
-        String sql = packet.getSql();
+        String sql = packet.getSQL();
         SQLStatement sqlStatement = sqlParserEngine.parse(sql, true);
         if (sqlStatement.getParameterCount() > 0) {
             sql = convertSQLToJDBCStyle(sqlStatement, sql);

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutor.java
@@ -68,7 +68,7 @@ public final class PostgreSQLComQueryExecutor implements QueryCommandExecutor<Po
     
     public PostgreSQLComQueryExecutor(final PortalContext portalContext, final PostgreSQLComQueryPacket comQueryPacket, final ConnectionSession connectionSession) throws SQLException {
         this.portalContext = portalContext;
-        proxyBackendHandler = ProxyBackendHandlerFactory.newInstance(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"), comQueryPacket.getSql(), connectionSession);
+        proxyBackendHandler = ProxyBackendHandlerFactory.newInstance(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"), comQueryPacket.getSQL(), connectionSession);
     }
     
     @Override

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecutorFactoryTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/PostgreSQLCommandExecutorFactoryTest.java
@@ -98,7 +98,7 @@ class PostgreSQLCommandExecutorFactoryTest {
     private PostgreSQLCommandPacket preparePacket(final Class<? extends PostgreSQLCommandPacket> commandPacketClass) {
         PostgreSQLCommandPacket result = mock(commandPacketClass);
         if (result instanceof PostgreSQLComQueryPacket) {
-            when(((PostgreSQLComQueryPacket) result).getSql()).thenReturn("");
+            when(((PostgreSQLComQueryPacket) result).getSQL()).thenReturn("");
         }
         return result;
     }

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutorTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/parse/PostgreSQLComParseExecutorTest.java
@@ -79,7 +79,7 @@ class PostgreSQLComParseExecutorTest {
     void assertExecuteWithEmptySQL() {
         final String expectedSQL = "";
         final String statementId = "S_1";
-        when(parsePacket.getSql()).thenReturn(expectedSQL);
+        when(parsePacket.getSQL()).thenReturn(expectedSQL);
         when(parsePacket.getStatementId()).thenReturn(statementId);
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);
@@ -98,7 +98,7 @@ class PostgreSQLComParseExecutorTest {
         final String rawSQL = "/*$0*/insert into sbtest1 /* $1 */ -- $2 \n (id, k, c, pad) \r values \r\n($1, $2, 'apsbd$31a', '$99')/*$0*/ \n--$0";
         final String expectedSQL = "/*$0*/insert into sbtest1 /* $1 */ -- $2 \n (id, k, c, pad) \r values \r\n(?, ?, 'apsbd$31a', '$99')/*$0*/ \n--$0";
         final String statementId = "S_2";
-        when(parsePacket.getSql()).thenReturn(rawSQL);
+        when(parsePacket.getSQL()).thenReturn(rawSQL);
         when(parsePacket.getStatementId()).thenReturn(statementId);
         when(parsePacket.readParameterTypes()).thenReturn(Collections.singletonList(PostgreSQLColumnType.POSTGRESQL_TYPE_INT4));
         when(connectionSession.getDefaultDatabaseName()).thenReturn("foo_db");
@@ -119,7 +119,7 @@ class PostgreSQLComParseExecutorTest {
     void assertExecuteWithDistSQL() {
         String sql = "SHOW DIST VARIABLE WHERE NAME = sql_show";
         String statementId = "";
-        when(parsePacket.getSql()).thenReturn(sql);
+        when(parsePacket.getSQL()).thenReturn(sql);
         when(parsePacket.getStatementId()).thenReturn(statementId);
         ContextManager contextManager = mockContextManager();
         when(ProxyContext.getInstance().getContextManager()).thenReturn(contextManager);

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/simple/PostgreSQLComQueryExecutorTest.java
@@ -68,7 +68,7 @@ class PostgreSQLComQueryExecutorTest {
     void setUp() throws SQLException {
         PostgreSQLComQueryPacket queryPacket = mock(PostgreSQLComQueryPacket.class);
         ConnectionSession connectionSession = mock(ConnectionSession.class);
-        when(queryPacket.getSql()).thenReturn("");
+        when(queryPacket.getSQL()).thenReturn("");
         queryExecutor = new PostgreSQLComQueryExecutor(portalContext, queryPacket, connectionSession);
         setMockFieldIntoExecutor(queryExecutor);
     }


### PR DESCRIPTION
Changes proposed in this pull request:
  - Add interface `SQLAwarePacket`
  - Remove @ToString from all CommandPacket
  - Update debug log for `XXXCommandExecutorFactory`

