### PR TITLE
Add openGauss/PostgreSQL dumper reconnect at pipeline

### DIFF
--- a/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
+++ b/kernel/data-pipeline/dialect/mysql/src/main/java/org/apache/shardingsphere/data/pipeline/mysql/ingest/client/MySQLClient.java
@@ -351,13 +351,12 @@ public final class MySQLClient {
         
         private void reconnect() {
             closeChannel();
-            if (reconnectTimes.get() > 3) {
-                log.warn("exceeds the maximum number of retry times, last binlog event:{}", lastBinlogEvent);
+            if (reconnectTimes.incrementAndGet() > 3) {
+                log.warn("Exceeds the maximum number of retry times, last binlog event:{}", lastBinlogEvent);
                 return;
             }
-            reconnectTimes.incrementAndGet();
             connect();
-            log.info("reconnect times {}", reconnectTimes.get());
+            log.info("Reconnect times {}", reconnectTimes.get());
             subscribe(lastBinlogEvent.get().getFileName(), lastBinlogEvent.get().getPosition());
         }
     }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Add openGauss/PostgreSQL dumper reconnect at pipeline
  - Simplify code at MySQLClient

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
