### PR TITLE
Optimize the use of classloader in ClasspathDriverURLProvider

### DIFF
--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ClasspathDriverURLProvider.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/driver/spi/ClasspathDriverURLProvider.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /**
  * Classpath driver URL provider.
@@ -62,16 +61,10 @@ public final class ClasspathDriverURLProvider implements ShardingSphereDriverURL
     }
     
     private InputStream getResourceAsStream(final String resource) {
-        for (ClassLoader each : Arrays.asList(Thread.currentThread().getContextClassLoader(), getClass().getClassLoader(), ClassLoader.getSystemClassLoader())) {
-            if (null != each) {
-                InputStream result = each.getResourceAsStream(resource);
-                if (null == result) {
-                    result = each.getResourceAsStream("/" + resource);
-                }
-                if (null != result) {
-                    return result;
-                }
-            }
+        InputStream result = Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
+        result = null == result ? Thread.currentThread().getContextClassLoader().getResourceAsStream("/" + resource) : result;
+        if (null != result) {
+            return result;
         }
         throw new IllegalArgumentException(String.format("Can not find configuration file `%s`.", resource));
     }


### PR DESCRIPTION
Fixes #25948.

Changes proposed in this pull request:
  - Unify the use of classloader in ClasspathDriverURLProvider

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
