### PR TITLE
Fix sonar issue: Catch a list of specific exception subtypes instead

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreator.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/pool/creator/DataSourcePoolCreator.java
@@ -64,7 +64,7 @@ public final class DataSourcePoolCreator {
             try {
                 dataSource = create(entry.getKey(), entry.getValue(), cacheEnabled);
                 // CHECKSTYLE:OFF
-            } catch (final Exception ex) {
+            } catch (final RuntimeException ex) {
                 // CHECKSTYLE:ON
                 if (!cacheEnabled) {
                     result.values().stream().map(DataSourcePoolDestroyer::new).forEach(DataSourcePoolDestroyer::asyncDestroy);

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlShardingSphereDataSourceFactory.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/api/yaml/YamlShardingSphereDataSourceFactory.java
@@ -63,7 +63,7 @@ public final class YamlShardingSphereDataSourceFactory {
         try {
             return createDataSource(dataSourceMap, rootConfig);
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             dataSourceMap.values().stream().map(DataSourcePoolDestroyer::new).forEach(DataSourcePoolDestroyer::asyncDestroy);
             throw ex;

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/datasource/ShardingSphereDataSource.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/datasource/ShardingSphereDataSource.java
@@ -141,7 +141,7 @@ public final class ShardingSphereDataSource extends AbstractDataSourceAdapter im
             try {
                 each.onDestroyed(databaseName, InstanceType.JDBC);
                 // CHECKSTYLE:OFF
-            } catch (final Exception ignored) {
+            } catch (final RuntimeException ignored) {
                 // CHECKSTYLE:ON
             }
         }

--- a/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/executor/AbstractLifecycleExecutor.java
+++ b/kernel/data-pipeline/api/src/main/java/org/apache/shardingsphere/data/pipeline/api/executor/AbstractLifecycleExecutor.java
@@ -68,7 +68,7 @@ public abstract class AbstractLifecycleExecutor implements LifecycleExecutor {
         try {
             doStop();
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             log.warn("doStop failed", ex);
         }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataMatchCalculatedResult.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/DataMatchCalculatedResult.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.data.pipeline.core.check.consistency;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -39,7 +38,6 @@ import java.util.Optional;
 @Slf4j
 public final class DataMatchCalculatedResult implements DataConsistencyCalculatedResult {
     
-    @NonNull
     private final Object maxUniqueKeyValue;
     
     private final int recordsCount;

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/DataMatchDataConsistencyCalculateAlgorithm.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/check/consistency/algorithm/DataMatchDataConsistencyCalculateAlgorithm.java
@@ -115,7 +115,7 @@ public final class DataMatchDataConsistencyCalculateAlgorithm extends AbstractSt
             calculationContext.close();
             throw ex;
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             calculationContext.close();
             throw new PipelineTableDataConsistencyCheckLoadingFailedException(param.getSchemaName(), param.getLogicTableName(), ex);
@@ -131,7 +131,7 @@ public final class DataMatchDataConsistencyCalculateAlgorithm extends AbstractSt
             result = createCalculationContext(param);
             fulfillCalculationContext(result, param);
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final SQLException | RuntimeException ex) {
             // CHECKSTYLE:ON
             CloseUtils.closeQuietly(result);
             throw new PipelineTableDataConsistencyCheckLoadingFailedException(param.getSchemaName(), param.getLogicTableName(), ex);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
@@ -94,7 +94,7 @@ public abstract class AbstractPipelineJob implements PipelineJob {
             processFailed(jobItemContext, ex);
             throw ex;
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final SQLException ex) {
             // CHECKSTYLE:ON
             processFailed(jobItemContext, ex);
             throw new PipelineInternalException(ex);

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/event/handler/impl/ConfigMetaDataChangedEventHandler.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/node/event/handler/impl/ConfigMetaDataChangedEventHandler.java
@@ -47,7 +47,7 @@ public final class ConfigMetaDataChangedEventHandler implements PipelineMetaData
         try {
             jobConfig = YamlEngine.unmarshal(event.getValue(), JobConfigurationPOJO.class, true).toJobConfiguration();
             // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
+        } catch (final RuntimeException ex) {
             // CHECKSTYLE:ON
             log.error("unmarshal job configuration pojo failed.", ex);
             return;

--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/initializer/BootstrapInitializer.java
@@ -77,7 +77,7 @@ public final class BootstrapInitializer {
             try {
                 each.onInitialized(null, contextManager);
                 // CHECKSTYLE:OFF
-            } catch (final Exception ex) {
+            } catch (final RuntimeException ex) {
                 // CHECKSTYLE:ON
                 log.error("contextManager onInitialized callback for '{}' failed", each.getClass().getName(), ex);
             }


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove `@NonNull` in DataMatchCalculatedResult
  - Fix sonar issue: Catch a list of specific exception subtypes instead

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
