### PR TITLE
Fix parse column with `SYSTEM`

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -455,6 +455,7 @@ identifierKeywordsUnambiguous
     | SUSPEND
     | SWAPS
     | SWITCHES
+    | SYSTEM
     | TABLES
     | TABLESPACE
     | TABLE_CHECKSUM

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -4939,4 +4939,28 @@
             </expression-projection>
         </projections>
     </select>
+
+    <select sql-case-id="select_with_keyword_system" parameters="0">
+        <from>
+            <simple-table name="vtx_project" start-index="14" stop-index="24" />
+        </from>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <where start-index="26" stop-index="41">
+            <expr>
+                <binary-operation-expression start-index="32" stop-index="41">
+                    <left>
+                        <column name="status" start-index="32" stop-index="37"/>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <literal-expression value="0" start-index="41" stop-index="41"/>
+                        <parameter-marker-expression parameter-index="0" start-index="41" stop-index="41"/>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
+
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -4951,7 +4951,7 @@
             <expr>
                 <binary-operation-expression start-index="32" stop-index="41">
                     <left>
-                        <column name="status" start-index="32" stop-index="37"/>
+                        <column name="system" start-index="32" stop-index="37"/>
                     </left>
                     <operator>=</operator>
                     <right>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -161,5 +161,5 @@
     <sql-case id="select_positional_parameter_type_cast_money" value="SELECT $1::money" db-types="PostgreSQL,openGauss" case-types="Placeholder" />
     <sql-case id="select_string_constant_type_cast" value="SELECT int4 '1', money '2'" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_constant_with_nested_type_cast" value="SELECT CAST(MONEY '1' AS VARCHAR)::CHAR(10)::VARCHAR::CHAR(4)" db-types="PostgreSQL,openGauss"  />
-    <sql-case id="select_with_keyword_system" value="SELECT * FROM vtx_project WHERE status = ?" />
+    <sql-case id="select_with_keyword_system" value="SELECT * FROM vtx_project WHERE system = ?" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -161,4 +161,5 @@
     <sql-case id="select_positional_parameter_type_cast_money" value="SELECT $1::money" db-types="PostgreSQL,openGauss" case-types="Placeholder" />
     <sql-case id="select_string_constant_type_cast" value="SELECT int4 '1', money '2'" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_constant_with_nested_type_cast" value="SELECT CAST(MONEY '1' AS VARCHAR)::CHAR(10)::VARCHAR::CHAR(4)" db-types="PostgreSQL,openGauss"  />
+    <sql-case id="select_with_keyword_system" value="SELECT * FROM vtx_project WHERE status = ?" />
 </sql-cases>


### PR DESCRIPTION
Fixes #25763.

Changes proposed in this pull request:
  - Add keyword SYSTEM in identifierKeywordsUnambiguous.
  - Add corresponding tests 'select_with_keyword_system'. 

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
