### PR TITLE
Fix encrypt shorthand expansion wrong rewrite result when not config table alias quote

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptIndexColumnTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptIndexColumnTokenGenerator.java
@@ -73,13 +73,13 @@ public final class EncryptIndexColumnTokenGenerator implements CollectionSQLToke
     
     private Optional<SQLToken> getAssistedQueryColumnToken(final int startIndex, final int stopIndex, final String columnName, final QuoteCharacter quoteCharacter) {
         Collection<ColumnProjection> columnProjections = getColumnProjections(columnName);
-        return Optional.of(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, quoteCharacter));
+        return Optional.of(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, quoteCharacter, Collections.emptyList()));
     }
     
     private Optional<SQLToken> getCipherColumnToken(final String tableName, final int startIndex, final int stopIndex, final String columnName, final QuoteCharacter quoteCharacter) {
         String cipherColumn = encryptRule.getCipherColumn(tableName, columnName);
         Collection<ColumnProjection> columnProjections = getColumnProjections(cipherColumn);
-        return Optional.of(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, quoteCharacter));
+        return Optional.of(new SubstitutableColumnNameToken(startIndex, stopIndex, columnProjections, quoteCharacter, Collections.emptyList()));
     }
     
     private Collection<ColumnProjection> getColumnProjections(final String columnName) {

--- a/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/AbstractShadowDMLStatementRouteEngine.java
+++ b/features/shadow/core/src/main/java/org/apache/shardingsphere/shadow/route/engine/dml/AbstractShadowDMLStatementRouteEngine.java
@@ -68,7 +68,7 @@ public abstract class AbstractShadowDMLStatementRouteEngine implements ShadowRou
         Map<String, String> result = new LinkedHashMap<>();
         for (SimpleTableSegment each : tableSegments) {
             String tableName = each.getTableName().getIdentifier().getValue();
-            String alias = each.getAlias().isPresent() ? each.getAlias().get() : tableName;
+            String alias = each.getAliasName().isPresent() ? each.getAliasName().get() : tableName;
             result.put(alias, tableName);
         }
         return result;

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/impl/ShardingDropTableStatementValidator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/route/engine/validator/ddl/impl/ShardingDropTableStatementValidator.java
@@ -54,10 +54,11 @@ public final class ShardingDropTableStatementValidator extends ShardingDDLStatem
             String defaultSchemaName = DatabaseTypeEngine.getDefaultSchemaName(sqlStatementContext.getDatabaseType(), database.getName());
             ShardingSphereSchema schema = sqlStatementContext.getTablesContext().getSchemaName()
                     .map(database::getSchema).orElseGet(() -> database.getSchema(defaultSchemaName));
-            validateTableExist(schema, sqlStatementContext.getTablesContext().getTables());
+            validateTableExist(schema, sqlStatementContext.getTablesContext().getSimpleTableSegments());
         }
         if (DropTableStatementHandler.containsCascade(dropTableStatement)) {
-            throw new UnsupportedShardingOperationException("DROP TABLE ... CASCADE", sqlStatementContext.getTablesContext().getTables().iterator().next().getTableName().getIdentifier().getValue());
+            throw new UnsupportedShardingOperationException("DROP TABLE ... CASCADE",
+                    sqlStatementContext.getTablesContext().getSimpleTableSegments().iterator().next().getTableName().getIdentifier().getValue());
         }
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -111,11 +111,11 @@ public final class ProjectionEngine {
     }
     
     private ParameterMarkerProjection createProjection(final ParameterMarkerExpressionSegment projectionSegment) {
-        return new ParameterMarkerProjection(projectionSegment.getParameterMarkerIndex(), projectionSegment.getParameterMarkerType(), projectionSegment.getAlias().orElse(null));
+        return new ParameterMarkerProjection(projectionSegment.getParameterMarkerIndex(), projectionSegment.getParameterMarkerType(), projectionSegment.getAliasName().orElse(null));
     }
     
     private SubqueryProjection createProjection(final SubqueryProjectionSegment projectionSegment) {
-        return new SubqueryProjection(projectionSegment.getText(), projectionSegment.getAlias().orElse(null));
+        return new SubqueryProjection(projectionSegment.getText(), projectionSegment.getAliasName().orElse(null));
     }
     
     private ShorthandProjection createProjection(final TableSegment table, final ShorthandProjectionSegment projectionSegment) {
@@ -129,16 +129,16 @@ public final class ProjectionEngine {
     
     private ColumnProjection createProjection(final ColumnProjectionSegment projectionSegment) {
         String owner = projectionSegment.getColumn().getOwner().isPresent() ? projectionSegment.getColumn().getOwner().get().getIdentifier().getValue() : null;
-        return new ColumnProjection(owner, projectionSegment.getColumn().getIdentifier().getValue(), projectionSegment.getAlias().orElse(null));
+        return new ColumnProjection(owner, projectionSegment.getColumn().getIdentifier().getValue(), projectionSegment.getAliasName().orElse(null));
     }
     
     private ExpressionProjection createProjection(final ExpressionProjectionSegment projectionSegment) {
-        return new ExpressionProjection(projectionSegment.getText(), projectionSegment.getAlias().orElse(null));
+        return new ExpressionProjection(projectionSegment.getText(), projectionSegment.getAliasName().orElse(null));
     }
     
     private AggregationDistinctProjection createProjection(final AggregationDistinctProjectionSegment projectionSegment) {
         String innerExpression = projectionSegment.getInnerExpression();
-        String alias = projectionSegment.getAlias().orElseGet(() -> DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(aggregationDistinctDerivedColumnCount++));
+        String alias = projectionSegment.getAliasName().orElseGet(() -> DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(aggregationDistinctDerivedColumnCount++));
         AggregationDistinctProjection result = new AggregationDistinctProjection(
                 projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getType(), innerExpression, alias, projectionSegment.getDistinctExpression(), databaseType);
         if (AggregationType.AVG == result.getType()) {
@@ -149,7 +149,7 @@ public final class ProjectionEngine {
     
     private AggregationProjection createProjection(final AggregationProjectionSegment projectionSegment) {
         String innerExpression = projectionSegment.getInnerExpression();
-        AggregationProjection result = new AggregationProjection(projectionSegment.getType(), innerExpression, projectionSegment.getAlias().orElse(null), databaseType);
+        AggregationProjection result = new AggregationProjection(projectionSegment.getType(), innerExpression, projectionSegment.getAliasName().orElse(null), databaseType);
         if (AggregationType.AVG == result.getType()) {
             appendAverageDerivedProjection(result);
             // TODO replace avg to constant, avoid calculate useless avg
@@ -162,7 +162,7 @@ public final class ProjectionEngine {
             return Collections.emptyList();
         }
         String tableName = ((SimpleTableSegment) table).getTableName().getIdentifier().getValue();
-        String tableAlias = table.getAlias().orElse(tableName);
+        String tableAlias = table.getAliasName().orElse(tableName);
         String schemaName = ((SimpleTableSegment) table).getOwner().map(optional -> optional.getIdentifier().getValue())
                 .orElseGet(() -> DatabaseTypeEngine.getDefaultSchemaName(databaseType, databaseName)).toLowerCase();
         ShardingSphereSchema schema = schemas.get(schemaName);
@@ -183,7 +183,7 @@ public final class ProjectionEngine {
         SelectStatement subSelectStatement = ((SubqueryTableSegment) table).getSubquery().getSelect();
         Collection<Projection> projections = subSelectStatement.getProjections().getProjections().stream().map(each -> createProjection(subSelectStatement.getFrom(), each).orElse(null))
                 .filter(Objects::nonNull).collect(Collectors.toList());
-        String subqueryTableAlias = table.getAlias().orElse(null);
+        String subqueryTableAlias = table.getAliasName().orElse(null);
         return getSubqueryTableActualProjections(projections, subqueryTableAlias);
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/AlterViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/AlterViewStatementContext.java
@@ -60,6 +60,6 @@ public final class AlterViewStatementContext extends CommonSQLStatementContext i
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CommentStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CommentStatementContext.java
@@ -47,6 +47,6 @@ public final class CommentStatementContext extends CommonSQLStatementContext imp
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CreateViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CreateViewStatementContext.java
@@ -49,6 +49,6 @@ public final class CreateViewStatementContext extends CommonSQLStatementContext 
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementContext.java
@@ -83,7 +83,7 @@ public final class CursorStatementContext extends CommonSQLStatementContext impl
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/DropViewStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/DropViewStatementContext.java
@@ -46,6 +46,6 @@ public final class DropViewStatementContext extends CommonSQLStatementContext im
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/CopyStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/CopyStatementContext.java
@@ -46,6 +46,6 @@ public final class CopyStatementContext extends CommonSQLStatementContext implem
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/DeleteStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/DeleteStatementContext.java
@@ -74,7 +74,7 @@ public final class DeleteStatementContext extends CommonSQLStatementContext impl
     private Map<String, SimpleTableSegment> getAliasAndTableSegmentMap(final Collection<SimpleTableSegment> tableSegments) {
         Map<String, SimpleTableSegment> result = new HashMap<>(tableSegments.size(), 1F);
         for (SimpleTableSegment each : tableSegments) {
-            each.getAlias().ifPresent(optional -> result.putIfAbsent(optional, each));
+            each.getAliasName().ifPresent(optional -> result.putIfAbsent(optional, each));
         }
         return result;
     }
@@ -86,7 +86,7 @@ public final class DeleteStatementContext extends CommonSQLStatementContext impl
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementContext.java
@@ -263,7 +263,7 @@ public final class InsertStatementContext extends CommonSQLStatementContext impl
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/LoadDataStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/LoadDataStatementContext.java
@@ -46,6 +46,6 @@ public final class LoadDataStatementContext extends CommonSQLStatementContext im
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/LoadXMLStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/LoadXMLStatementContext.java
@@ -46,6 +46,6 @@ public final class LoadXMLStatementContext extends CommonSQLStatementContext imp
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -132,7 +132,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
     
     private Map<String, ShardingSphereSchema> getSchemas(final ShardingSphereMetaData metaData, final String databaseName) {
         if (null == databaseName) {
-            ShardingSpherePreconditions.checkState(tablesContext.getTables().isEmpty(), NoDatabaseSelectedException::new);
+            ShardingSpherePreconditions.checkState(tablesContext.getSimpleTableSegments().isEmpty(), NoDatabaseSelectedException::new);
             return Collections.emptyMap();
         }
         ShardingSphereDatabase database = metaData.getDatabase(databaseName);
@@ -305,7 +305,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/UpdateStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/UpdateStatementContext.java
@@ -64,7 +64,7 @@ public final class UpdateStatementContext extends CommonSQLStatementContext impl
     
     @Override
     public Collection<SimpleTableSegment> getAllTables() {
-        return tablesContext.getTables();
+        return tablesContext.getSimpleTableSegments();
     }
     
     @Override

--- a/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameTokenTest.java
+++ b/infra/rewrite/src/test/java/org/apache/shardingsphere/infra/rewrite/sql/token/pojo/generic/SubstitutableColumnNameTokenTest.java
@@ -20,6 +20,10 @@ package org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.QuoteCharacter;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
@@ -40,6 +44,16 @@ class SubstitutableColumnNameTokenTest {
     @Test
     void assertToStringWithQuote() {
         Collection<ColumnProjection> projections = Collections.singletonList(new ColumnProjection(null, "id", "id"));
-        assertThat(new SubstitutableColumnNameToken(0, 1, projections, QuoteCharacter.BACK_QUOTE).toString(mock(RouteUnit.class)), is("`id` AS `id`"));
+        assertThat(new SubstitutableColumnNameToken(0, 1, projections, QuoteCharacter.BACK_QUOTE, Collections.emptyList()).toString(mock(RouteUnit.class)), is("`id` AS `id`"));
+    }
+    
+    @Test
+    void assertToStringWithAliasQuote() {
+        Collection<ColumnProjection> projections = Collections.singletonList(new ColumnProjection("temp", "id", "id"));
+        SimpleTableSegment tableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
+        tableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("`temp`")));
+        assertThat(new SubstitutableColumnNameToken(0, 1, projections, QuoteCharacter.BACK_QUOTE, Collections.singletonList(tableSegment)).toString(mock(RouteUnit.class)), is("`temp`.`id` AS `id`"));
+        tableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("temp")));
+        assertThat(new SubstitutableColumnNameToken(0, 1, projections, QuoteCharacter.BACK_QUOTE, Collections.singletonList(tableSegment)).toString(mock(RouteUnit.class)), is("temp.`id` AS `id`"));
     }
 }

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/context/JDBCContextTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/context/JDBCContextTest.java
@@ -34,20 +34,20 @@ import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class JDBCContextTest {
-
+    
     @Test
     void assertNullCachedDbMetadataWithEmptyDatasource() throws Exception {
         JDBCContext actual = new JDBCContext(new HashMap<>());
         assertNull(actual.getCachedDatabaseMetaData());
     }
-
+    
     @Test
     void assertNotNullCashedDbMetadataWith() throws SQLException {
         Map<String, DataSource> dataSourceMap = getStringDataSourceMap();
         JDBCContext jdbcContext = new JDBCContext(dataSourceMap);
         assertNotNull(jdbcContext.getCachedDatabaseMetaData());
     }
-
+    
     @Test
     void assetNullMetadataAfterRefreshingExisting() throws SQLException {
         Map<String, DataSource> stringDataSourceMap = getStringDataSourceMap();
@@ -56,7 +56,7 @@ class JDBCContextTest {
         jdbcContext.refreshCachedDatabaseMetaData(event);
         assertNull(jdbcContext.getCachedDatabaseMetaData());
     }
-
+    
     private static Map<String, DataSource> getStringDataSourceMap() {
         Map<String, DataSource> result = new HashMap<>();
         result.put("test_db", new CircuitBreakerDataSource());

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/generator/PipelineDDLGenerator.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/metadata/generator/PipelineDDLGenerator.java
@@ -130,10 +130,10 @@ public final class PipelineDDLGenerator {
     }
     
     private void appendFromIndexAndConstraint(final Map<SQLSegment, String> replaceMap, final String targetTableName, final SQLStatementContext sqlStatementContext) {
-        if (!(sqlStatementContext instanceof TableAvailable) || ((TableAvailable) sqlStatementContext).getTablesContext().getTables().isEmpty()) {
+        if (!(sqlStatementContext instanceof TableAvailable) || ((TableAvailable) sqlStatementContext).getTablesContext().getSimpleTableSegments().isEmpty()) {
             return;
         }
-        TableNameSegment tableNameSegment = ((TableAvailable) sqlStatementContext).getTablesContext().getTables().iterator().next().getTableName();
+        TableNameSegment tableNameSegment = ((TableAvailable) sqlStatementContext).getTablesContext().getSimpleTableSegments().iterator().next().getTableName();
         if (!tableNameSegment.getIdentifier().getValue().equals(targetTableName)) {
             if (sqlStatementContext instanceof IndexAvailable) {
                 for (IndexSegment each : ((IndexAvailable) sqlStatementContext).getIndexes()) {
@@ -186,14 +186,14 @@ public final class PipelineDDLGenerator {
         SQLStatementContext sqlStatementContext = queryContext.getSqlStatementContext();
         if (sqlStatementContext instanceof CreateTableStatementContext || sqlStatementContext instanceof CommentStatementContext
                 || sqlStatementContext instanceof CreateIndexStatementContext || sqlStatementContext instanceof AlterTableStatementContext) {
-            if (sqlStatementContext.getTablesContext().getTables().isEmpty()) {
+            if (sqlStatementContext.getTablesContext().getSimpleTableSegments().isEmpty()) {
                 return sql;
             }
             if (sqlStatementContext.getTablesContext().getSchemaName().isPresent()) {
                 return sql;
             }
             Map<SQLSegment, String> replaceMap = new TreeMap<>(Comparator.comparing(SQLSegment::getStartIndex));
-            TableNameSegment tableNameSegment = sqlStatementContext.getTablesContext().getTables().iterator().next().getTableName();
+            TableNameSegment tableNameSegment = sqlStatementContext.getTablesContext().getSimpleTableSegments().iterator().next().getTableName();
             replaceMap.put(tableNameSegment, prefix + tableNameSegment.getIdentifier().getValue());
             return doDecorateActualTable(replaceMap, sql);
         }

--- a/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ddlgenerator/PostgreSQLColumnType.java
+++ b/kernel/data-pipeline/dialect/postgresql/src/main/java/org/apache/shardingsphere/data/pipeline/postgresql/ddlgenerator/PostgreSQLColumnType.java
@@ -27,13 +27,13 @@ import java.util.Arrays;
 @RequiredArgsConstructor
 public enum PostgreSQLColumnType {
     
-    NUMERIC(new Long[] {1231L, 1700L}),
+    NUMERIC(new Long[]{1231L, 1700L}),
     
-    DATE(new Long[] {1083L, 1114L, 1115L, 1183L, 1184L, 1185L, 1186L, 1187L, 1266L, 1270L}),
+    DATE(new Long[]{1083L, 1114L, 1115L, 1183L, 1184L, 1185L, 1186L, 1187L, 1266L, 1270L}),
     
-    VARCHAR(new Long[] {1560L, 1561L, 1562L, 1563L, 1042L, 1043L, 1014L, 1015L}),
+    VARCHAR(new Long[]{1560L, 1561L, 1562L, 1563L, 1042L, 1043L, 1014L, 1015L}),
     
-    UNKNOWN(new Long[] {});
+    UNKNOWN(new Long[]{});
     
     private final Long[] values;
     

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDecider.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/decider/SingleSQLFederationDecider.java
@@ -60,7 +60,7 @@ public final class SingleSQLFederationDecider implements SQLFederationDecider<Si
     
     private Collection<QualifiedTable> getSingleTableNames(final SQLStatementContext sqlStatementContext, final ShardingSphereDatabase database, final SingleRule rule) {
         DatabaseType databaseType = sqlStatementContext.getDatabaseType();
-        Collection<QualifiedTable> result = getQualifiedTables(database, databaseType, sqlStatementContext.getTablesContext().getTables());
+        Collection<QualifiedTable> result = getQualifiedTables(database, databaseType, sqlStatementContext.getTablesContext().getSimpleTableSegments());
         if (result.isEmpty() && sqlStatementContext instanceof IndexAvailable) {
             result = IndexMetaDataUtils.getTableNames(database, databaseType, ((IndexAvailable) sqlStatementContext).getIndexes());
         }

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/route/SingleSQLRouter.java
@@ -94,7 +94,7 @@ public final class SingleSQLRouter implements SQLRouter<SingleRule> {
     private Collection<QualifiedTable> getSingleTableNames(final SQLStatementContext sqlStatementContext,
                                                            final ShardingSphereDatabase database, final SingleRule rule, final RouteContext routeContext) {
         DatabaseType databaseType = sqlStatementContext.getDatabaseType();
-        Collection<QualifiedTable> result = getQualifiedTables(database, databaseType, sqlStatementContext.getTablesContext().getTables());
+        Collection<QualifiedTable> result = getQualifiedTables(database, databaseType, sqlStatementContext.getTablesContext().getSimpleTableSegments());
         if (result.isEmpty() && sqlStatementContext instanceof IndexAvailable) {
             result = IndexMetaDataUtils.getTableNames(database, databaseType, ((IndexAvailable) sqlStatementContext).getIndexes());
         }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SimpleTableConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SimpleTableConverter.java
@@ -45,8 +45,8 @@ public final class SimpleTableConverter implements SQLSegmentConverter<SimpleTab
         }
         names.add(tableName.getIdentifier().getValue());
         SqlNode tableNameSQLNode = new SqlIdentifier(names, SqlParserPos.ZERO);
-        if (segment.getAlias().isPresent()) {
-            SqlNode aliasSQLNode = new SqlIdentifier(segment.getAlias().get(), SqlParserPos.ZERO);
+        if (segment.getAliasName().isPresent()) {
+            SqlNode aliasSQLNode = new SqlIdentifier(segment.getAliasName().get(), SqlParserPos.ZERO);
             return Optional.of(new SqlBasicCall(SqlStdOperatorTable.AS, Arrays.asList(tableNameSQLNode, aliasSQLNode), SqlParserPos.ZERO));
         }
         return Optional.of(tableNameSQLNode);

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SubqueryTableConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/from/impl/SubqueryTableConverter.java
@@ -51,7 +51,7 @@ public final class SubqueryTableConverter implements SQLSegmentConverter<Subquer
         } else {
             sqlNodes.add(new SelectStatementConverter().convert(segment.getSubquery().getSelect()));
         }
-        segment.getAlias().ifPresent(optional -> sqlNodes.add(new SqlIdentifier(optional, SqlParserPos.ZERO)));
+        segment.getAliasName().ifPresent(optional -> sqlNodes.add(new SqlIdentifier(optional, SqlParserPos.ZERO)));
         return Optional.of(new SqlBasicCall(SqlStdOperatorTable.AS, new ArrayList<>(sqlNodes), SqlParserPos.ZERO));
     }
 }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/AggregationProjectionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/AggregationProjectionConverter.java
@@ -70,9 +70,9 @@ public final class AggregationProjectionConverter implements SQLSegmentConverter
         SqlAggFunction operator = convertOperator(segment.getType().name());
         List<SqlNode> params = convertParameters(segment.getParameters(), segment.getInnerExpression());
         SqlBasicCall sqlBasicCall = new SqlBasicCall(operator, params, SqlParserPos.ZERO, functionQuantifier);
-        if (segment.getAlias().isPresent()) {
+        if (segment.getAliasName().isPresent()) {
             return Optional.of(new SqlBasicCall(SqlStdOperatorTable.AS, Arrays.asList(sqlBasicCall,
-                    SqlIdentifier.star(Collections.singletonList(segment.getAlias().get()), SqlParserPos.ZERO, Collections.singletonList(SqlParserPos.ZERO))), SqlParserPos.ZERO));
+                    SqlIdentifier.star(Collections.singletonList(segment.getAliasName().get()), SqlParserPos.ZERO, Collections.singletonList(SqlParserPos.ZERO))), SqlParserPos.ZERO));
         }
         return Optional.of(sqlBasicCall);
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/ColumnProjectionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/ColumnProjectionConverter.java
@@ -36,9 +36,9 @@ public final class ColumnProjectionConverter implements SQLSegmentConverter<Colu
     
     @Override
     public Optional<SqlNode> convert(final ColumnProjectionSegment segment) {
-        if (segment.getAlias().isPresent()) {
+        if (segment.getAliasName().isPresent()) {
             Optional<SqlNode> column = new ColumnConverter().convert(segment.getColumn());
-            SqlIdentifier alias = new SqlIdentifier(segment.getAlias().get(), SqlParserPos.ZERO);
+            SqlIdentifier alias = new SqlIdentifier(segment.getAliasName().get(), SqlParserPos.ZERO);
             return column.map(optional -> new SqlBasicCall(new SqlAsOperator(), Arrays.asList(optional, alias), SqlParserPos.ZERO));
         }
         return new ColumnConverter().convert(segment.getColumn());

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/ExpressionProjectionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/ExpressionProjectionConverter.java
@@ -41,9 +41,9 @@ public final class ExpressionProjectionConverter implements SQLSegmentConverter<
             return Optional.empty();
         }
         Optional<SqlNode> result = new ExpressionConverter().convert(segment.getExpr());
-        if (result.isPresent() && segment.getAlias().isPresent()) {
+        if (result.isPresent() && segment.getAliasName().isPresent()) {
             return Optional.of(new SqlBasicCall(SqlStdOperatorTable.AS, Arrays.asList(result.get(),
-                    SqlIdentifier.star(Collections.singletonList(segment.getAlias().get()), SqlParserPos.ZERO, Collections.singletonList(SqlParserPos.ZERO))), SqlParserPos.ZERO));
+                    SqlIdentifier.star(Collections.singletonList(segment.getAliasName().get()), SqlParserPos.ZERO, Collections.singletonList(SqlParserPos.ZERO))), SqlParserPos.ZERO));
         }
         return result;
     }

--- a/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/SubqueryProjectionConverter.java
+++ b/kernel/sql-federation/optimizer/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/projection/impl/SubqueryProjectionConverter.java
@@ -42,7 +42,7 @@ public final class SubqueryProjectionConverter implements SQLSegmentConverter<Su
             return Optional.empty();
         }
         SqlNode sqlNode = new SelectStatementConverter().convert(segment.getSubquery().getSelect());
-        return segment.getAlias().isPresent() ? convertToSQLStatement(sqlNode, segment.getAlias().get()) : Optional.of(sqlNode);
+        return segment.getAliasName().isPresent() ? convertToSQLStatement(sqlNode, segment.getAliasName().get()) : Optional.of(sqlNode);
     }
     
     private Optional<SqlNode> convertToSQLStatement(final SqlNode sqlNode, final String alias) {

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDMLStatementVisitor.java
@@ -732,7 +732,7 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
             return null == datetimeExpression.getRight()
                     ? new DatetimeProjectionSegment(datetimeExpression.getStartIndex(), datetimeExpression.getStopIndex(), datetimeExpression.getLeft(), datetimeExpression.getText())
                     : new DatetimeProjectionSegment(datetimeExpression.getStartIndex(), datetimeExpression.getStopIndex(),
-                    datetimeExpression.getLeft(), datetimeExpression.getRight(), datetimeExpression.getText());
+                            datetimeExpression.getLeft(), datetimeExpression.getRight(), datetimeExpression.getText());
         }
         if (projection instanceof XmlQueryAndExistsFunctionSegment) {
             XmlQueryAndExistsFunctionSegment xmlExistsFunctionSegment = (XmlQueryAndExistsFunctionSegment) projection;
@@ -743,9 +743,9 @@ public final class OracleDMLStatementVisitor extends OracleStatementVisitor impl
             XmlPiFunctionSegment xmlPiFunctionSegment = (XmlPiFunctionSegment) projection;
             return null == xmlPiFunctionSegment.getIdentifier()
                     ? new XmlPiFunctionSegment(xmlPiFunctionSegment.getStartIndex(), xmlPiFunctionSegment.getStopIndex(),
-                    xmlPiFunctionSegment.getFunctionName(), xmlPiFunctionSegment.getEvalNameValueExpr(), xmlPiFunctionSegment.getValueExpr(), xmlPiFunctionSegment.getText())
+                            xmlPiFunctionSegment.getFunctionName(), xmlPiFunctionSegment.getEvalNameValueExpr(), xmlPiFunctionSegment.getValueExpr(), xmlPiFunctionSegment.getText())
                     : new XmlPiFunctionSegment(xmlPiFunctionSegment.getStartIndex(), xmlPiFunctionSegment.getStopIndex(),
-                    xmlPiFunctionSegment.getFunctionName(), xmlPiFunctionSegment.getIdentifier(), xmlPiFunctionSegment.getValueExpr(), xmlPiFunctionSegment.getText());
+                            xmlPiFunctionSegment.getFunctionName(), xmlPiFunctionSegment.getIdentifier(), xmlPiFunctionSegment.getValueExpr(), xmlPiFunctionSegment.getText());
         }
         if (projection instanceof XmlSerializeFunctionSegment) {
             XmlSerializeFunctionSegment xmlSerializeFunctionSegment = (XmlSerializeFunctionSegment) projection;

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractor.java
@@ -267,7 +267,7 @@ public final class TableExtractor {
      */
     public boolean needRewrite(final OwnerSegment owner) {
         for (TableSegment each : tableContext) {
-            if (owner.getIdentifier().getValue().equalsIgnoreCase(each.getAlias().orElse(null))) {
+            if (owner.getIdentifier().getValue().equalsIgnoreCase(each.getAliasName().orElse(null))) {
                 return false;
             }
         }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/simple/ParameterMarkerExpressionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/simple/ParameterMarkerExpressionSegment.java
@@ -56,8 +56,13 @@ public class ParameterMarkerExpressionSegment implements SimpleExpressionSegment
     }
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationProjectionSegment.java
@@ -55,7 +55,12 @@ public class AggregationProjectionSegment implements ProjectionSegment, AliasAva
     }
     
     @Override
-    public final Optional<String> getAlias() {
+    public final Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public final Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ColumnProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ColumnProjectionSegment.java
@@ -41,8 +41,13 @@ public final class ColumnProjectionSegment implements ProjectionSegment, AliasAv
     }
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ExpressionProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ExpressionProjectionSegment.java
@@ -59,8 +59,13 @@ public final class ExpressionProjectionSegment implements ProjectionSegment, Com
     }
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ShorthandProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/ShorthandProjectionSegment.java
@@ -49,7 +49,12 @@ public final class ShorthandProjectionSegment implements ProjectionSegment, Owne
     }
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/SubqueryProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/SubqueryProjectionSegment.java
@@ -41,8 +41,13 @@ public final class SubqueryProjectionSegment implements ProjectionSegment, Alias
     private AliasSegment alias;
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/AliasAvailable.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/AliasAvailable.java
@@ -27,11 +27,18 @@ import java.util.Optional;
 public interface AliasAvailable extends SQLSegment {
     
     /**
-     * Get alias.
+     * Get alias name.
      *
-     * @return alias
+     * @return alias name
      */
-    Optional<String> getAlias();
+    Optional<String> getAliasName();
+    
+    /**
+     * Get alias segment.
+     *
+     * @return alias segment
+     */
+    Optional<AliasSegment> getAlias();
     
     /**
      * Set alias.

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/DeleteMultiTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/DeleteMultiTableSegment.java
@@ -41,7 +41,12 @@ public final class DeleteMultiTableSegment implements TableSegment {
     private TableSegment relationTable;
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
         return Optional.empty();
     }
     

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/JoinTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/JoinTableSegment.java
@@ -50,7 +50,12 @@ public final class JoinTableSegment implements TableSegment {
     private List<ColumnSegment> using = Collections.emptyList();
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SimpleTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SimpleTableSegment.java
@@ -60,7 +60,12 @@ public final class SimpleTableSegment implements TableSegment, OwnerAvailable {
     }
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SubqueryTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/SubqueryTableSegment.java
@@ -38,8 +38,13 @@ public final class SubqueryTableSegment implements TableSegment {
     private AliasSegment alias;
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/XmlTableSegment.java
@@ -46,7 +46,12 @@ public final class XmlTableSegment implements TableSegment {
     private final String xmlTableFunctionAlias;
     
     @Override
-    public Optional<String> getAlias() {
+    public Optional<String> getAliasName() {
+        return Optional.empty();
+    }
+    
+    @Override
+    public Optional<AliasSegment> getAlias() {
         return Optional.empty();
     }
     

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/connector/sane/MySQLSaneQueryResultEngine.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/connector/sane/MySQLSaneQueryResultEngine.java
@@ -75,7 +75,7 @@ public final class MySQLSaneQueryResultEngine implements SaneQueryResultEngine {
             if (each instanceof ExpressionProjectionSegment) {
                 ExpressionProjectionSegment expressionProjection = (ExpressionProjectionSegment) each;
                 String text = expressionProjection.getText();
-                String alias = expressionProjection.getAlias().orElse(expressionProjection.getText());
+                String alias = expressionProjection.getAliasName().orElse(expressionProjection.getText());
                 queryResultColumnMetaDataList.add(createRawQueryResultColumnMetaData(text, alias));
                 String value = expressionProjection.getExpr() instanceof VariableSegment
                         ? MySQLSystemVariable.findSystemVariable(((VariableSegment) expressionProjection.getExpr()).getVariable()).map(MySQLSystemVariable::getDefaultValue).orElse("1")

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/MySQLSystemVariableQueryExecutor.java
@@ -68,7 +68,7 @@ public final class MySQLSystemVariableQueryExecutor implements DatabaseAdminQuer
             VariableSegment variableSegment = (VariableSegment) projection.getExpr();
             Scope scope = variableSegment.getScope().map(Scope::getScope).orElse(Scope.DEFAULT);
             columnsOfRow.add(variables.get(i).getValue(scope, connectionSession));
-            String name = projection.getAlias().orElseGet(() -> "@@" + variableSegment.getScope().map(s -> s + ".").orElse("") + variableSegment.getVariable());
+            String name = projection.getAliasName().orElseGet(() -> "@@" + variableSegment.getScope().map(s -> s + ".").orElse("") + variableSegment.getVariable());
             metaData.add(new RawQueryResultColumnMetaData("", name, name, Types.VARCHAR, "VARCHAR", 1024, 0));
         }
         queryResultMetaData = new RawQueryResultMetaData(metaData);

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowConnectionIdExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowConnectionIdExecutor.java
@@ -62,7 +62,7 @@ public final class ShowConnectionIdExecutor implements DatabaseAdminQueryExecuto
         Collection<ProjectionSegment> projections = sqlStatement.getProjections().getProjections();
         for (ProjectionSegment each : projections) {
             if (each instanceof ExpressionProjectionSegment) {
-                return ((ExpressionProjectionSegment) each).getAlias().orElse(FUNCTION_NAME);
+                return ((ExpressionProjectionSegment) each).getAliasName().orElse(FUNCTION_NAME);
             }
         }
         return FUNCTION_NAME;

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowVersionExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/ShowVersionExecutor.java
@@ -59,6 +59,6 @@ public final class ShowVersionExecutor implements DatabaseAdminQueryExecutor {
     
     private String getLabel() {
         return sqlStatement.getProjections().getProjections().stream()
-                .filter(ExpressionProjectionSegment.class::isInstance).findFirst().map(each -> ((ExpressionProjectionSegment) each).getAlias().orElse(FUNCTION_NAME)).orElse(FUNCTION_NAME);
+                .filter(ExpressionProjectionSegment.class::isInstance).findFirst().map(each -> ((ExpressionProjectionSegment) each).getAliasName().orElse(FUNCTION_NAME)).orElse(FUNCTION_NAME);
     }
 }

--- a/proxy/backend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/SelectDatabaseExecutor.java
+++ b/proxy/backend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/backend/postgresql/handler/admin/executor/SelectDatabaseExecutor.java
@@ -121,7 +121,7 @@ public final class SelectDatabaseExecutor extends DefaultDatabaseMetaDataExecuto
         }
         return projections.stream().map(each -> {
             ColumnProjectionSegment segment = (ColumnProjectionSegment) each;
-            return segment.getAlias().isPresent() ? segment.getAlias().get() : segment.getColumn().getIdentifier().getValue();
+            return segment.getAliasName().isPresent() ? segment.getAliasName().get() : segment.getColumn().getIdentifier().getValue();
         }).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 }

--- a/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/describe/PostgreSQLComDescribeExecutor.java
+++ b/proxy/frontend/type/postgresql/src/main/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/describe/PostgreSQLComDescribeExecutor.java
@@ -187,7 +187,7 @@ public final class PostgreSQLComDescribeExecutor implements CommandExecutor {
                 ColumnProjectionSegment segment = (ColumnProjectionSegment) each;
                 String columnName = segment.getColumn().getIdentifier().getValue();
                 ShardingSphereColumn column = table.containsColumn(columnName) ? table.getColumn(columnName) : generateDefaultColumn(segment);
-                String alias = segment.getAlias().orElseGet(column::getName);
+                String alias = segment.getAliasName().orElseGet(column::getName);
                 result.add(new PostgreSQLColumnDescription(alias, 0, column.getDataType(), estimateColumnLength(column.getDataType()), ""));
             }
             if (each instanceof ExpressionProjectionSegment) {
@@ -203,7 +203,7 @@ public final class PostgreSQLComDescribeExecutor implements CommandExecutor {
     
     private PostgreSQLColumnDescription convertExpressionToDescription(final ExpressionProjectionSegment expressionProjectionSegment) {
         ExpressionSegment expressionSegment = expressionProjectionSegment.getExpr();
-        String columnName = expressionProjectionSegment.getAlias().orElse(ANONYMOUS_COLUMN_NAME);
+        String columnName = expressionProjectionSegment.getAliasName().orElse(ANONYMOUS_COLUMN_NAME);
         if (expressionSegment instanceof LiteralExpressionSegment) {
             Object value = ((LiteralExpressionSegment) expressionSegment).getLiterals();
             if (value instanceof String) {

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
@@ -114,7 +114,7 @@ public final class ProjectionAssert {
     }
     
     private static void assertSubqueryProjection(final SQLCaseAssertContext assertContext, final SubqueryProjectionSegment actual, final ExpectedSubqueryProjection expected) {
-        assertThat(assertContext.getText("Subquery projection alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Subquery projection alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         String expectedText = SQLCaseType.LITERAL == assertContext.getCaseType() && null != expected.getLiteralText() ? expected.getLiteralText() : expected.getText();
         assertThat(assertContext.getText("Subquery projection text assertion error: "), actual.getText(), is(expectedText));
         SelectStatementAssert.assertIs(assertContext, actual.getSubquery().getSelect(), expected.getSubquery().getSelectTestCases());
@@ -131,7 +131,7 @@ public final class ProjectionAssert {
     
     private static void assertColumnProjection(final SQLCaseAssertContext assertContext, final ColumnProjectionSegment actual, final ExpectedColumnProjection expected) {
         IdentifierValueAssert.assertIs(assertContext, actual.getColumn().getIdentifier(), expected, "Column projection");
-        assertThat(assertContext.getText("Column projection alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Column projection alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         if (null == expected.getOwner()) {
             assertFalse(actual.getColumn().getOwner().isPresent(), assertContext.getText("Actual owner should not exist."));
         } else {
@@ -143,7 +143,7 @@ public final class ProjectionAssert {
     private static void assertAggregationProjection(final SQLCaseAssertContext assertContext, final AggregationProjectionSegment actual, final ExpectedAggregationProjection expected) {
         assertThat(assertContext.getText("Aggregation projection type assertion error: "), actual.getType().name(), is(expected.getType()));
         assertThat(assertContext.getText("Aggregation projection inner expression assertion error: "), actual.getInnerExpression(), is(expected.getInnerExpression()));
-        assertThat(assertContext.getText("Aggregation projection alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Aggregation projection alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         if (actual instanceof AggregationDistinctProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, instanceOf(ExpectedAggregationDistinctProjection.class));
             assertThat(assertContext.getText("Aggregation projection alias assertion error: "),
@@ -153,7 +153,7 @@ public final class ProjectionAssert {
     
     private static void assertExpressionProjection(final SQLCaseAssertContext assertContext, final ExpressionProjectionSegment actual, final ExpectedExpressionProjection expected) {
         assertThat(assertContext.getText("Expression projection alias assertion error: "),
-                actual.getAlias().orElse(null), is(expected.getAlias()));
+                actual.getAliasName().orElse(null), is(expected.getAlias()));
         String expectedText = SQLCaseType.LITERAL == assertContext.getCaseType() && null != expected.getLiteralText()
                 ? expected.getLiteralText()
                 : expected.getText();

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/table/TableAssert.java
@@ -100,7 +100,7 @@ public final class TableAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SimpleTableSegment actual, final ExpectedSimpleTable expected) {
         IdentifierValueAssert.assertIs(assertContext, actual.getTableName().getIdentifier(), expected, "Table");
-        assertThat(assertContext.getText("Table alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Table alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         if (null == expected.getOwner()) {
             assertFalse(actual.getOwner().isPresent(), assertContext.getText("Actual owner should not exist."));
         } else {
@@ -119,7 +119,7 @@ public final class TableAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final SubqueryTableSegment actual, final ExpectedSubqueryTable expected) {
         SelectStatementAssert.assertIs(assertContext, actual.getSubquery().getSelect(), expected.getSubquery().getSelectTestCases());
-        assertThat(assertContext.getText("Table alias assertion error: "), actual.getAlias().orElse(null), is(expected.getAlias()));
+        assertThat(assertContext.getText("Table alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
     }
     
     /**

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-join.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-join.xml
@@ -39,12 +39,12 @@
     
     <rewrite-assertion id="select_unqualified_shorthand_projection_with_join_for_parameters" db-types="MySQL">
         <input sql="SELECT * FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.password = ? OR b.amount = ? AND t.certificate_number like ?" parameters="1, 2, 3" />
-        <output sql="SELECT `t`.`account_id`, `t`.`cipher_certificate_number` AS `certificate_number`, `t`.`cipher_password` AS `password`, `t`.`cipher_amount` AS `amount`, `b`.`account_id`, `b`.`cipher_certificate_number` AS `certificate_number`, `b`.`cipher_password` AS `password`, `b`.`cipher_amount` AS `amount` FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.assisted_query_password = ? OR b.cipher_amount = ? AND t.like_query_certificate_number like ?" parameters="assisted_query_1, encrypt_2, like_query_3" />
+        <output sql="SELECT t.`account_id`, t.`cipher_certificate_number` AS `certificate_number`, t.`cipher_password` AS `password`, t.`cipher_amount` AS `amount`, b.`account_id`, b.`cipher_certificate_number` AS `certificate_number`, b.`cipher_password` AS `password`, b.`cipher_amount` AS `amount` FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.assisted_query_password = ? OR b.cipher_amount = ? AND t.like_query_certificate_number like ?" parameters="assisted_query_1, encrypt_2, like_query_3" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_unqualified_shorthand_projection_with_join_for_literals" db-types="MySQL">
         <input sql="SELECT * FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.password = 1 OR b.amount = 2 AND t.certificate_number like 3" />
-        <output sql="SELECT `t`.`account_id`, `t`.`cipher_certificate_number` AS `certificate_number`, `t`.`cipher_password` AS `password`, `t`.`cipher_amount` AS `amount`, `b`.`account_id`, `b`.`cipher_certificate_number` AS `certificate_number`, `b`.`cipher_password` AS `password`, `b`.`cipher_amount` AS `amount` FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.assisted_query_password = 'assisted_query_1' OR b.cipher_amount = 'encrypt_2' AND t.like_query_certificate_number like 'like_query_3'"/>
+        <output sql="SELECT t.`account_id`, t.`cipher_certificate_number` AS `certificate_number`, t.`cipher_password` AS `password`, t.`cipher_amount` AS `amount`, b.`account_id`, b.`cipher_certificate_number` AS `certificate_number`, b.`cipher_password` AS `password`, b.`cipher_amount` AS `amount` FROM t_account t INNER JOIN t_account_bak b ON t.id = b.id WHERE t.assisted_query_password = 'assisted_query_1' OR b.cipher_amount = 'encrypt_2' AND t.like_query_certificate_number like 'like_query_3'"/>
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_join_for_parameters" db-types="MySQL">

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-projection.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-projection.xml
@@ -24,12 +24,12 @@
     
     <rewrite-assertion id="select_with_qualified_shorthand_for_cipher" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account_bak a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_bak a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_bak a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_mix_qualified_shorthand_and_other_projection_for_cipher" db-types="MySQL">
         <input sql="SELECT a.*, account_id, 1+1 FROM t_account_bak a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_bak a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_bak a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_for_predicate_and_right_value_should_be_matched_for_cipher_for_parameters" db-types="MySQL">
@@ -54,12 +54,12 @@
     
     <rewrite-assertion id="select_with_qualified_shorthand" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_mix_qualified_shorthand_and_other_projection" db-types="MySQL">
         <input sql="SELECT a.*, account_id, 1+1 FROM t_account a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_schema_name_in_shorthand_projection_for_parameters" db-types="MySQL">

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -39,7 +39,12 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account a) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account a) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number`, a.`assisted_query_certificate_number`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` FROM t_account a) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
+        <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.cipher_certificate_number AS certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project" db-types="MySQL">
@@ -89,7 +94,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_tablesegment_ref_shorthand" db-types="MySQL">
         <input sql="SELECT b.* FROM (SELECT a.certificate_number as certificate_number, a.amount FROM t_account a WHERE a.amount = 1373) b" />
-        <output sql="SELECT `b`.`cipher_certificate_number` AS `certificate_number`, `b`.`cipher_amount` AS `amount` FROM (SELECT a.cipher_certificate_number, a.assisted_query_certificate_number, a.cipher_amount FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
+        <output sql="SELECT b.`cipher_certificate_number` AS `certificate_number`, b.`cipher_amount` AS `amount` FROM (SELECT a.cipher_certificate_number, a.assisted_query_certificate_number, a.cipher_amount FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_exists_sub_query" db-types="MySQL">
@@ -104,11 +109,11 @@
 
     <rewrite-assertion id="select_shorthand_from_sub_query_with_simple_select" db-types="MySQL">
         <input sql="SELECT * FROM (SELECT * FROM t_account a) AS temp" />
-        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account a) AS temp" />
+        <output sql="SELECT temp.`account_id`, temp.`cipher_certificate_number` AS `certificate_number`, temp.`cipher_password` AS `password`, temp.`cipher_amount` AS `amount` FROM (SELECT a.`account_id`, a.`cipher_certificate_number`, a.`assisted_query_certificate_number`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` FROM t_account a) AS temp" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_shorthand_from_sub_query_with_select_join" db-types="MySQL">
         <input sql="SELECT * FROM (SELECT a1.* FROM t_account a1 INNER JOIN t_account a2) AS temp" />
-        <output sql="SELECT `temp`.`account_id`, `temp`.`cipher_certificate_number` AS `certificate_number`, `temp`.`cipher_password` AS `password`, `temp`.`cipher_amount` AS `amount` FROM (SELECT `a1`.`account_id`, `a1`.`cipher_certificate_number`, `a1`.`assisted_query_certificate_number`, `a1`.`cipher_password`, `a1`.`assisted_query_password`, `a1`.`cipher_amount` FROM t_account a1 INNER JOIN t_account a2) AS temp" />
+        <output sql="SELECT temp.`account_id`, temp.`cipher_certificate_number` AS `certificate_number`, temp.`cipher_password` AS `password`, temp.`cipher_amount` AS `amount` FROM (SELECT a1.`account_id`, a1.`cipher_certificate_number`, a1.`assisted_query_certificate_number`, a1.`cipher_password`, a1.`assisted_query_password`, a1.`cipher_amount` FROM t_account a1 INNER JOIN t_account a2) AS temp" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-join.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-join.xml
@@ -19,21 +19,21 @@
 <rewrite-assertions yaml-rule="scenario/mix/config/query-with-cipher.yaml">
     <rewrite-assertion id="select_with_encrypt_left_join_table" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a left join t_account_bak b on a.password = b.account_id left join t_account_detail c on a.password = c.password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a left join t_account_bak_0 b on a.assisted_query_password = b.account_id left join t_account_detail_0 c on a.assisted_query_password = c.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a left join t_account_bak_1 b on a.assisted_query_password = b.account_id left join t_account_detail_0 c on a.assisted_query_password = c.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a left join t_account_bak_0 b on a.assisted_query_password = b.account_id left join t_account_detail_1 c on a.assisted_query_password = c.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a left join t_account_bak_1 b on a.assisted_query_password = b.account_id left join t_account_detail_1 c on a.assisted_query_password = c.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a left join t_account_bak_0 b on a.assisted_query_password = b.account_id left join t_account_detail_0 c on a.assisted_query_password = c.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a left join t_account_bak_1 b on a.assisted_query_password = b.account_id left join t_account_detail_0 c on a.assisted_query_password = c.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a left join t_account_bak_0 b on a.assisted_query_password = b.account_id left join t_account_detail_1 c on a.assisted_query_password = c.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a left join t_account_bak_1 b on a.assisted_query_password = b.account_id left join t_account_detail_1 c on a.assisted_query_password = c.assisted_query_password" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_encrypt_right_join_table" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a right join t_account_detail b on a.password = b.password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a right join t_account_detail_0 b on a.assisted_query_password = b.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a right join t_account_detail_1 b on a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a right join t_account_detail_0 b on a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a right join t_account_detail_1 b on a.assisted_query_password = b.assisted_query_password" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_encrypt_join_table" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a join t_account_detail b on a.password = b.password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a join t_account_detail_0 b on a.assisted_query_password = b.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a join t_account_detail_1 b on a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a join t_account_detail_0 b on a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a join t_account_detail_1 b on a.assisted_query_password = b.assisted_query_password" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-projection.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-projection.xml
@@ -24,7 +24,7 @@
     
     <rewrite-assertion id="select_with_qualified_shorthand" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a UNION ALL SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a UNION ALL SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_sharding_qualified_shorthand_join_table" db-types="MySQL">
@@ -35,13 +35,13 @@
     
     <rewrite-assertion id="select_with_encrypt_qualified_shorthand_join_table" db-types="MySQL">
         <input sql="SELECT a.* FROM t_account a, t_account_detail b where a.password = b.password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_0 a, t_account_detail_0 b where a.assisted_query_password = b.assisted_query_password" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount` FROM t_account_1 a, t_account_detail_1 b where a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_0 a, t_account_detail_0 b where a.assisted_query_password = b.assisted_query_password" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount` FROM t_account_1 a, t_account_detail_1 b where a.assisted_query_password = b.assisted_query_password" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_mix_qualified_shorthand_and_other_projection" db-types="MySQL">
         <input sql="SELECT a.*, account_id, 1+1 FROM t_account a" />
-        <output sql="SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_0 a UNION ALL SELECT `a`.`account_id`, `a`.`cipher_password` AS `password`, `a`.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_1 a" />
+        <output sql="SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_0 a UNION ALL SELECT a.`account_id`, a.`cipher_password` AS `password`, a.`cipher_amount` AS `amount`, account_id, 1+1 FROM t_account_1 a" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_with_table_qualified_shorthand" db-types="MySQL">

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/dml/select/select-subquery.xml
@@ -25,8 +25,14 @@
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account a) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account_0 a) o, t_account_0 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account_1 a) o, t_account_1 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT a.`account_id`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` FROM t_account_0 a) o, t_account_0 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT a.`account_id`, a.`cipher_password`, a.`assisted_query_password`, a.`cipher_amount` FROM t_account_1 a) o, t_account_1 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+    </rewrite-assertion>
+
+    <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
+        <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT `a`.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account_0 `a`) o, t_account_0 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_password`, `a`.`assisted_query_password`, `a`.`cipher_amount` FROM t_account_1 `a`) o, t_account_1 u WHERE o.certificate_number=u.certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
     
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">


### PR DESCRIPTION
Fixes #25987.

Changes proposed in this pull request:
  - Fix encrypt shorthand expansion wrong rewrite result when not config table alias quote


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
