### PR TITLE
Fix typo in enable-disable-compute-node.cn.md

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/circuit-breaker/enable-disable-compute-node.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/ral/circuit-breaker/enable-disable-compute-node.cn.md
@@ -5,7 +5,7 @@ weight = 4
 
 ## 描述
 
-`ENABLE/DISABLE COMPUTE NODE` 语法用于启用/禁用指定 proy 实例。
+`ENABLE/DISABLE COMPUTE NODE` 语法用于启用/禁用指定 proxy 实例。
 
 ### 语法定义
 


### PR DESCRIPTION
The word ‘proy’ in ‘enable-disable-compute-node.cn.md’ is wrong.It is shoud be 'proxy'.so changed it .