### PR TITLE
Update DataSourceStateManager.java

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/state/DataSourceStateManager.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/datasource/state/DataSourceStateManager.java
@@ -44,6 +44,8 @@ public final class DataSourceStateManager {
     
     private final Map<String, DataSourceState> dataSourceStates = new ConcurrentHashMap<>();
     
+    private final Map<String, DataSource> dataSourceMap = new ConcurrentHashMap<>();
+    
     private volatile boolean forceStart;
     
     private volatile boolean initialized;
@@ -55,6 +57,10 @@ public final class DataSourceStateManager {
      */
     public static DataSourceStateManager getInstance() {
         return INSTANCE;
+    }
+    
+    public static Map<String, DataSource> getDataSources() {
+        return dataSourceMap;
     }
     
     /**
@@ -83,6 +89,7 @@ public final class DataSourceStateManager {
     private void checkState(final String databaseName, final String actualDataSourceName, final DataSource dataSource) {
         try (Connection ignored = dataSource.getConnection()) {
             dataSourceStates.put(getCacheKey(databaseName, actualDataSourceName), DataSourceState.ENABLED);
+            dataSourceMap.put(databaseName, dataSource);
         } catch (final SQLException ex) {
             ShardingSpherePreconditions.checkState(forceStart, () -> new UnavailableDataSourceException(ex, actualDataSourceName));
             log.error("Data source unavailable, ignored with the -f parameter.", ex);


### PR DESCRIPTION
当服务启动时不初始化sharding数据源，在调用db时去初始化数据源的的场景时：此处采用DruidDataSource检测链接是否成功时，后续如果是因为分表规则有问题造成数据源初始化不成功，数据源链接一直没释放，会造成db连接数过多问题，应该提供用户获取数据源，在异常时手动处理关闭的途径

Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  -

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
