### PR TITLE
Remove redundant code in JDBCRepository#persist

### DIFF
--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepository.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepository.java
@@ -135,9 +135,6 @@ public final class JDBCRepository implements StandalonePersistRepository {
                 String tempKey = tempPrefix + SEPARATOR + paths[i];
                 String tempKeyVal = getDirectly(tempKey);
                 if (Strings.isNullOrEmpty(tempKeyVal)) {
-                    if (i != 0) {
-                        parent = tempPrefix;
-                    }
                     insert(tempKey, "", parent);
                 }
                 tempPrefix = tempKey;


### PR DESCRIPTION

Changes proposed in this pull request:
  - Remove redundant code in JDBCRepository#persist

https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS4165&id=apache_shardingsphere&open=AYePEEOimlEb3_Pqvluq

The reproduction process has been verified without problems.

```java
@Override
public void persist(final String key, final String value) {
    try {
        if (isExisted(key)) {
            update(key, value);
            return;
        }
        String tempPrefix = "";
        String parent = SEPARATOR;
        // key = /a/b/c
        // paths = ["a", "b", "c"]
        String[] paths = Arrays.stream(key.split(SEPARATOR)).filter(each -> !Strings.isNullOrEmpty(each)).toArray(String[]::new);
        // Create key level directory recursively.
        for (int i = 0; i < paths.length - 1; i++) {
            // i = 0, tempKey = "" + "/" + "a" = "/a"
            // i = 1, tempKey = "/a" + "/" + "b" = "/a/b"
            String tempKey = tempPrefix + SEPARATOR + paths[i];
            // i = 0, tempKeyVal = xxx
            // i = 1, tempKeyVal = xxx
            String tempKeyVal = getDirectly(tempKey);
            if (Strings.isNullOrEmpty(tempKeyVal)) {
                if (i != 0) {
                    // i = 1, parent = "/a", tempPrefix = "/a", The two values are the same, just delete
                    parent = tempPrefix;
                }
                insert(tempKey, "", parent);
            }
            // i = 0, tempPrefix = "/a"
            tempPrefix = tempKey;
            // i = 0, parent = "/a"
            parent = tempKey;
        }
        insert(key, value, parent);
    } catch (final SQLException ex) {
        log.error("Persist {} data to key: {} failed", getType(), key, ex);
    }
}
```

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
