### PR TITLE
Change redis default password is null at redis TSO

### DIFF
--- a/kernel/global-clock/type/tso/provider/redis/src/main/java/org/apache/shardingsphere/globalclock/type/tso/provider/RedisTSOPropertyKey.java
+++ b/kernel/global-clock/type/tso/provider/redis/src/main/java/org/apache/shardingsphere/globalclock/type/tso/provider/RedisTSOPropertyKey.java
@@ -32,7 +32,7 @@ public enum RedisTSOPropertyKey implements TypedPropertyKey {
     
     PORT("port", "6379", int.class),
     
-    PASSWORD("password", "", String.class),
+    PASSWORD("password", null, String.class),
     
     TIMEOUT_INTERVAL("timeoutInterval", "40000", int.class),
     


### PR DESCRIPTION

Changes proposed in this pull request:
  - Change redis default password is null at redis TSO, because empty string doesn't mean no password

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
