### PR TITLE
Remove redundant separator in metadata converter

### DIFF
--- a/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/metadata/converter/ReadwriteSplittingNodeConverter.java
+++ b/features/readwrite-splitting/core/src/main/java/org/apache/shardingsphere/readwritesplitting/metadata/converter/ReadwriteSplittingNodeConverter.java
@@ -39,7 +39,7 @@ public final class ReadwriteSplittingNodeConverter {
      * @return group name path
      */
     public static String getGroupNamePath(final String groupName) {
-        return String.join("/", "", DATA_SOURCES_NODE, groupName);
+        return String.join("/", DATA_SOURCES_NODE, groupName);
     }
     
     /**
@@ -49,7 +49,7 @@ public final class ReadwriteSplittingNodeConverter {
      * @return load balancer path
      */
     public static String getLoadBalancerPath(final String loadBalancerName) {
-        return String.join("/", "", LOAD_BALANCER_NODE, loadBalancerName);
+        return String.join("/", LOAD_BALANCER_NODE, loadBalancerName);
     }
     
     /**

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/metadata/converter/ReadwriteSplittingNodeConverterTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/metadata/converter/ReadwriteSplittingNodeConverterTest.java
@@ -29,12 +29,12 @@ class ReadwriteSplittingNodeConverterTest {
     
     @Test
     void assertGetGroupNamePath() {
-        assertThat(ReadwriteSplittingNodeConverter.getGroupNamePath("group_0"), is("/data_sources/group_0"));
+        assertThat(ReadwriteSplittingNodeConverter.getGroupNamePath("group_0"), is("data_sources/group_0"));
     }
     
     @Test
     void assertGetLoadBalancerPath() {
-        assertThat(ReadwriteSplittingNodeConverter.getLoadBalancerPath("random"), is("/load_balancers/random"));
+        assertThat(ReadwriteSplittingNodeConverter.getLoadBalancerPath("random"), is("load_balancers/random"));
     }
     
     @Test

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/NewYamlReadwriteSplittingRuleConfigurationSwapperTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/yaml/swapper/NewYamlReadwriteSplittingRuleConfigurationSwapperTest.java
@@ -42,7 +42,7 @@ class NewYamlReadwriteSplittingRuleConfigurationSwapperTest {
                 "write_ds", Arrays.asList("read_ds_0", "read_ds_1"), null)), Collections.emptyMap());
         Collection<YamlDataNode> result = swapper.swapToDataNodes(config);
         assertThat(result.size(), is(1));
-        assertThat(result.iterator().next().getKey(), is("/data_sources/group_0"));
+        assertThat(result.iterator().next().getKey(), is("data_sources/group_0"));
     }
     
     @Test
@@ -52,7 +52,7 @@ class NewYamlReadwriteSplittingRuleConfigurationSwapperTest {
         Collection<YamlDataNode> result = swapper.swapToDataNodes(config);
         assertThat(result.size(), is(2));
         Iterator<YamlDataNode> iterator = result.iterator();
-        assertThat(iterator.next().getKey(), is("/data_sources/group_0"));
-        assertThat(iterator.next().getKey(), is("/load_balancers/random"));
+        assertThat(iterator.next().getKey(), is("data_sources/group_0"));
+        assertThat(iterator.next().getKey(), is("load_balancers/random"));
     }
 }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/converter/ShardingNodeConverter.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/metadata/converter/ShardingNodeConverter.java
@@ -63,7 +63,7 @@ public final class ShardingNodeConverter {
      * @return table name path
      */
     public static String getTableNamePath(final String tableName) {
-        return String.join("/", "", TABLES, String.format(TABLE_NAME, tableName));
+        return String.join("/", TABLES, String.format(TABLE_NAME, tableName));
     }
     
     /**
@@ -73,7 +73,7 @@ public final class ShardingNodeConverter {
      * @return auto table name path
      */
     public static String getAutoTableNamePath(final String tableName) {
-        return String.join("/", "", AUTO_TABLES, String.format(AUTO_TABLE_NAME, tableName));
+        return String.join("/", AUTO_TABLES, String.format(AUTO_TABLE_NAME, tableName));
     }
     
     /**
@@ -83,7 +83,7 @@ public final class ShardingNodeConverter {
      * @return binding table name path
      */
     public static String getBindingTableNamePath(final String tableName) {
-        return String.join("/", "", BINDING_TABLES, String.format(BINDING_TABLE_NAME, tableName));
+        return String.join("/", BINDING_TABLES, String.format(BINDING_TABLE_NAME, tableName));
     }
     
     /**
@@ -92,7 +92,7 @@ public final class ShardingNodeConverter {
      * @return broadcast tables path
      */
     public static String getBroadcastTablesPath() {
-        return String.join("/", "", BROADCAST_TABLES);
+        return String.join("/", BROADCAST_TABLES);
     }
     
     /**
@@ -101,7 +101,7 @@ public final class ShardingNodeConverter {
      * @return default database strategy path
      */
     public static String getDefaultDatabaseStrategyPath() {
-        return String.join("/", "", DEFAULT_STRATEGY, DEFAULT_DATABASE_STRATEGY);
+        return String.join("/", DEFAULT_STRATEGY, DEFAULT_DATABASE_STRATEGY);
     }
     
     /**
@@ -110,7 +110,7 @@ public final class ShardingNodeConverter {
      * @return default table strategy path
      */
     public static String getDefaultTableStrategyPath() {
-        return String.join("/", "", DEFAULT_STRATEGY, DEFAULT_TABLE_STRATEGY);
+        return String.join("/", DEFAULT_STRATEGY, DEFAULT_TABLE_STRATEGY);
     }
     
     /**
@@ -119,7 +119,7 @@ public final class ShardingNodeConverter {
      * @return default key generate path
      */
     public static String getDefaultKeyGenerateStrategyPath() {
-        return String.join("/", "", DEFAULT_STRATEGY, DEFAULT_KEY_GENERATE_STRATEGY);
+        return String.join("/", DEFAULT_STRATEGY, DEFAULT_KEY_GENERATE_STRATEGY);
     }
     
     /**
@@ -128,7 +128,7 @@ public final class ShardingNodeConverter {
      * @return default audit strategy path
      */
     public static String getDefaultAuditStrategyPath() {
-        return String.join("/", "", DEFAULT_STRATEGY, DEFAULT_AUDIT_STRATEGY);
+        return String.join("/", DEFAULT_STRATEGY, DEFAULT_AUDIT_STRATEGY);
     }
     
     /**
@@ -137,7 +137,7 @@ public final class ShardingNodeConverter {
      * @return default sharding column path
      */
     public static String getDefaultShardingColumnPath() {
-        return String.join("/", "", DEFAULT_STRATEGY, DEFAULT_SHARDING_COLUMN);
+        return String.join("/", DEFAULT_STRATEGY, DEFAULT_SHARDING_COLUMN);
     }
     
     /**
@@ -147,7 +147,7 @@ public final class ShardingNodeConverter {
      * @return sharding algorithm path
      */
     public static String getShardingAlgorithmPath(final String shardingAlgorithmName) {
-        return String.join("/", "", SHARDING_ALGORITHMS, shardingAlgorithmName);
+        return String.join("/", SHARDING_ALGORITHMS, shardingAlgorithmName);
     }
     
     /**
@@ -157,7 +157,7 @@ public final class ShardingNodeConverter {
      * @return key generator path
      */
     public static String getKeyGeneratorPath(final String keyGeneratorName) {
-        return String.join("/", "", KEY_GENERATORS, keyGeneratorName);
+        return String.join("/", KEY_GENERATORS, keyGeneratorName);
     }
     
     /**
@@ -167,7 +167,7 @@ public final class ShardingNodeConverter {
      * @return auditor path
      */
     public static String getAuditorPath(final String auditorName) {
-        return String.join("/", "", AUDITORS, auditorName);
+        return String.join("/", AUDITORS, auditorName);
     }
     
     /**
@@ -176,6 +176,6 @@ public final class ShardingNodeConverter {
      * @return sharding cache path
      */
     public static String getShardingCachePath() {
-        return String.join("/", "", SHARDING_CACHE);
+        return String.join("/", SHARDING_CACHE);
     }
 }

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/NewYamlShardingRuleConfigurationSwapperTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/yaml/swapper/NewYamlShardingRuleConfigurationSwapperTest.java
@@ -52,20 +52,20 @@ class NewYamlShardingRuleConfigurationSwapperTest {
         Collection<YamlDataNode> result = swapper.swapToDataNodes(config);
         assertThat(result.size(), is(14));
         Iterator<YamlDataNode> iterator = result.iterator();
-        assertThat(iterator.next().getKey(), is("/tables/table_LOGIC_TABLE"));
-        assertThat(iterator.next().getKey(), is("/tables/table_SUB_LOGIC_TABLE"));
-        assertThat(iterator.next().getKey(), is("/binding_tables/binding_table_foo"));
-        assertThat(iterator.next().getKey(), is("/broadcast_tables"));
-        assertThat(iterator.next().getKey(), is("/default_strategy/default_database_strategy"));
-        assertThat(iterator.next().getKey(), is("/default_strategy/default_table_strategy"));
-        assertThat(iterator.next().getKey(), is("/default_strategy/default_key_generate_strategy"));
-        assertThat(iterator.next().getKey(), is("/default_strategy/default_audit_strategy"));
-        assertThat(iterator.next().getKey(), is("/sharding_algorithms/core_standard_fixture"));
-        assertThat(iterator.next().getKey(), is("/key_generators/uuid"));
-        assertThat(iterator.next().getKey(), is("/key_generators/default"));
-        assertThat(iterator.next().getKey(), is("/key_generators/auto_increment"));
-        assertThat(iterator.next().getKey(), is("/auditors/audit_algorithm"));
-        assertThat(iterator.next().getKey(), is("/default_strategy/default_sharding_column"));
+        assertThat(iterator.next().getKey(), is("tables/table_LOGIC_TABLE"));
+        assertThat(iterator.next().getKey(), is("tables/table_SUB_LOGIC_TABLE"));
+        assertThat(iterator.next().getKey(), is("binding_tables/binding_table_foo"));
+        assertThat(iterator.next().getKey(), is("broadcast_tables"));
+        assertThat(iterator.next().getKey(), is("default_strategy/default_database_strategy"));
+        assertThat(iterator.next().getKey(), is("default_strategy/default_table_strategy"));
+        assertThat(iterator.next().getKey(), is("default_strategy/default_key_generate_strategy"));
+        assertThat(iterator.next().getKey(), is("default_strategy/default_audit_strategy"));
+        assertThat(iterator.next().getKey(), is("sharding_algorithms/core_standard_fixture"));
+        assertThat(iterator.next().getKey(), is("key_generators/uuid"));
+        assertThat(iterator.next().getKey(), is("key_generators/default"));
+        assertThat(iterator.next().getKey(), is("key_generators/auto_increment"));
+        assertThat(iterator.next().getKey(), is("auditors/audit_algorithm"));
+        assertThat(iterator.next().getKey(), is("default_strategy/default_sharding_column"));
     }
     
     private ShardingRuleConfiguration createMaximumShardingRule() {


### PR DESCRIPTION
For #25485.

Changes proposed in this pull request:
  - Refactor metadata converter, remove redundant separator
  - Update related test cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
