### PR TITLE
DataSource objects created in the order in the configuration file

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/YamlRootConfiguration.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/pojo/YamlRootConfiguration.java
@@ -25,7 +25,7 @@ import org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfigurati
 import org.apache.shardingsphere.infra.yaml.config.pojo.rule.YamlRuleConfiguration;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Properties;
@@ -47,7 +47,7 @@ public final class YamlRootConfiguration implements YamlConfiguration {
     @Deprecated
     private String schemaName;
     
-    private Map<String, Map<String, Object>> dataSources = new HashMap<>();
+    private Map<String, Map<String, Object>> dataSources = new LinkedHashMap<>();
     
     private Collection<YamlRuleConfiguration> rules = new LinkedList<>();
     

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/yaml/config/swapper/resource/YamlDataSourceConfigurationSwapper.java
@@ -56,7 +56,8 @@ public final class YamlDataSourceConfigurationSwapper {
      * @return data sources
      */
     public Map<String, DataSource> swapToDataSources(final Map<String, Map<String, Object>> yamlDataSources, final boolean cacheEnabled) {
-        return DataSourcePoolCreator.create(yamlDataSources.entrySet().stream().collect(Collectors.toMap(Entry::getKey, entry -> swapToDataSourceProperties(entry.getValue()))), cacheEnabled);
+        return DataSourcePoolCreator.create(yamlDataSources.entrySet().stream().collect(
+                Collectors.toMap(Entry::getKey, entry -> swapToDataSourceProperties(entry.getValue()), (key, value) -> value, LinkedHashMap::new)), cacheEnabled);
     }
     
     /**


### PR DESCRIPTION
DataSource objects created in the order in the configuration file, the objects are stored in LinkedHashMap

Changes proposed in this pull request:
  - DataSource objects created in the order in the configuration file, the objects are stored in LinkedHashMap

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
