### PR TITLE
Remove useless shardingsphere-sql-federation-executor-original dependency

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.cn.md
@@ -27,7 +27,6 @@ ShardingSphere 默认情况下仅包含核心 SPI 的实现，在 Git Source 存
 - `org.apache.shardingsphere:shardingsphere-single-core`，单表（所有的分片数据源中仅唯一存在的表）核心
 - `org.apache.shardingsphere:shardingsphere-sql-federation-core`，联邦查询执行器核心
 - `org.apache.shardingsphere:shardingsphere-sql-federation-executor-advanced`，联邦查询执行器的 `advanced` 实现
-- `org.apache.shardingsphere:shardingsphere-sql-federation-executor-original`，联邦查询执行器的 `original` 实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-mysql`， SQL 解析的 MySQL 方言实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-opengauss`， SQL 解析的 OpenGauss 方言实现
 - `org.apache.shardingsphere:shardingsphere-sql-parser-oracle`， SQL 解析的 Oracle 方言解析实现

--- a/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/optional-plugins/_index.en.md
@@ -27,7 +27,6 @@ All the built-in plugins for ShardingSphere-JDBC are listed below in the form of
 - `org.apache.shardingsphere:shardingsphere-single-core`, single-table (only the only table that exists in all sharded data sources) core
 - `org.apache.shardingsphere:shardingsphere-sql-federation-core`, federation query executor core
 - `org.apache.shardingsphere:shardingsphere-sql-federation-executor-advanced`, the `advanced` implementation of federated query executor
-- `org.apache.shardingsphere:shardingsphere-sql-federation-executor-original`, the `original` implementation of federated query executor
 - `org.apache.shardingsphere:shardingsphere-sql-parser-mysql`, MySQL dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-opengauss`, OpenGauss dialect implementation of SQL parsing
 - `org.apache.shardingsphere:shardingsphere-sql-parser-oracle`, Oracle dialect implementation of SQL parsing

--- a/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
+++ b/features/encrypt/distsql/parser/src/main/java/org/apache/shardingsphere/encrypt/distsql/parser/core/EncryptDistSQLStatementVisitor.java
@@ -86,10 +86,12 @@ public final class EncryptDistSQLStatementVisitor extends EncryptDistSQLStatemen
     public ASTNode visitEncryptColumnDefinition(final EncryptColumnDefinitionContext ctx) {
         return new EncryptColumnSegment(getIdentifierValue(ctx.columnDefinition().columnName()),
                 new EncryptColumnItemSegment(getIdentifierValue(ctx.cipherColumnDefinition().cipherColumnName()), (AlgorithmSegment) visit(ctx.encryptAlgorithm().algorithmDefinition())),
-                null == ctx.assistedQueryColumnDefinition() ? null : new EncryptColumnItemSegment(getIdentifierValue(ctx.assistedQueryColumnDefinition().assistedQueryColumnName()),
-                        null == ctx.assistedQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.assistedQueryAlgorithm().algorithmDefinition())),
-                null == ctx.likeQueryColumnDefinition() ? null : new EncryptColumnItemSegment(getIdentifierValue(ctx.likeQueryColumnDefinition().likeQueryColumnName()),
-                        null == ctx.likeQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.likeQueryAlgorithm().algorithmDefinition())));
+                null == ctx.assistedQueryColumnDefinition() ? null
+                        : new EncryptColumnItemSegment(getIdentifierValue(ctx.assistedQueryColumnDefinition().assistedQueryColumnName()),
+                                null == ctx.assistedQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.assistedQueryAlgorithm().algorithmDefinition())),
+                null == ctx.likeQueryColumnDefinition() ? null
+                        : new EncryptColumnItemSegment(getIdentifierValue(ctx.likeQueryColumnDefinition().likeQueryColumnName()),
+                                null == ctx.likeQueryAlgorithm() ? null : (AlgorithmSegment) visit(ctx.likeQueryAlgorithm().algorithmDefinition())));
     }
     
     @Override

--- a/jdbc/core/pom.xml
+++ b/jdbc/core/pom.xml
@@ -162,11 +162,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-sql-federation-executor-original</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-sql-parser-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/proxy/backend/core/pom.xml
+++ b/proxy/backend/core/pom.xml
@@ -205,11 +205,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-sql-federation-executor-original</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-logging-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -589,11 +589,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-sql-federation-executor-original</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-logging-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/distsql/rdl/EncryptColumnAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/distsql/rdl/EncryptColumnAssert.java
@@ -64,7 +64,7 @@ public final class EncryptColumnAssert {
                 assertThat(assertContext.getText(String.format("`%s`'s assertion error", actual.getClass().getSimpleName())),
                         actual.getLikeQuery().getName(), is(expected.getLikeQuery().getName()));
                 AlgorithmAssert.assertIs(assertContext, actual.getLikeQuery().getEncryptor(), expected.getLikeQuery().getEncryptor());
-            } 
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless shardingsphere-sql-federation-executor-original dependency

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
