### PR TITLE
Fix execute engine not closed after job stopping

### DIFF
--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJob.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJob.java
@@ -98,6 +98,9 @@ public final class CDCJob extends AbstractPipelineJob implements SimpleJob {
         prepare(jobItemContexts);
         executeInventoryTasks(jobItemContexts);
         executeIncrementalTasks(jobItemContexts);
+        for (PipelineTasksRunner each : getTasksRunners()) {
+            CloseUtils.closeQuietly(each.getJobItemContext().getJobProcessContext());
+        }
     }
     
     private CDCJobItemContext buildPipelineJobItemContext(final CDCJobConfiguration jobConfig, final int shardingItem) {

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJob.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/core/job/CDCJob.java
@@ -73,6 +73,14 @@ public final class CDCJob extends AbstractPipelineJob implements SimpleJob {
     
     @Override
     public void execute(final ShardingContext shardingContext) {
+        try {
+            execute0(shardingContext);
+        } finally {
+            clean();
+        }
+    }
+    
+    private void execute0(final ShardingContext shardingContext) {
         String jobId = shardingContext.getJobName();
         log.info("Execute job {}", jobId);
         CDCJobConfiguration jobConfig = new YamlCDCJobConfigurationSwapper().swapToObject(shardingContext.getJobParameter());
@@ -98,6 +106,9 @@ public final class CDCJob extends AbstractPipelineJob implements SimpleJob {
         prepare(jobItemContexts);
         executeInventoryTasks(jobItemContexts);
         executeIncrementalTasks(jobItemContexts);
+    }
+    
+    private void clean() {
         for (PipelineTasksRunner each : getTasksRunners()) {
             CloseUtils.closeQuietly(each.getJobItemContext().getJobProcessContext());
         }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/api/context/PipelineProcessContext.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/api/context/PipelineProcessContext.java
@@ -22,7 +22,7 @@ import org.apache.shardingsphere.data.pipeline.api.config.process.PipelineProces
 /**
  * Pipeline process context.
  */
-public interface PipelineProcessContext {
+public interface PipelineProcessContext extends AutoCloseable {
     
     /**
      * Get pipeline process config.

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
@@ -94,6 +94,7 @@ public final class ExecuteEngine {
             return;
         }
         executorService.shutdown();
+        executorService.shutdownNow();
     }
     
     /**

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
@@ -87,6 +87,16 @@ public final class ExecuteEngine {
     }
     
     /**
+     * Shutdown.
+     */
+    public void shutdown() {
+        if (executorService.isShutdown()) {
+            return;
+        }
+        executorService.shutdown();
+    }
+    
+    /**
      * Trigger.
      *
      * @param futures futures

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/execute/ExecuteEngine.java
@@ -87,6 +87,16 @@ public final class ExecuteEngine {
     }
     
     /**
+     * Submit a {@code LifecycleExecutor} to execute.
+     *
+     * @param lifecycleExecutor lifecycle executor
+     * @return execute future
+     */
+    public CompletableFuture<?> submit(final LifecycleExecutor lifecycleExecutor) {
+        return CompletableFuture.runAsync(lifecycleExecutor, executorService);
+    }
+    
+    /**
      * Shutdown.
      */
     public void shutdown() {

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
@@ -28,6 +28,7 @@ import org.apache.shardingsphere.data.pipeline.core.exception.PipelineInternalEx
 import org.apache.shardingsphere.data.pipeline.core.job.progress.persist.PipelineJobProgressPersistService;
 import org.apache.shardingsphere.data.pipeline.core.listener.PipelineElasticJobListener;
 import org.apache.shardingsphere.data.pipeline.core.metadata.node.PipelineMetaDataNode;
+import org.apache.shardingsphere.data.pipeline.core.util.CloseUtils;
 import org.apache.shardingsphere.data.pipeline.core.util.PipelineDistributedBarrier;
 import org.apache.shardingsphere.elasticjob.infra.listener.ElasticJobListener;
 import org.apache.shardingsphere.elasticjob.infra.spi.ElasticJobServiceLoader;
@@ -146,6 +147,7 @@ public abstract class AbstractPipelineJob implements PipelineJob {
         log.info("stop tasks runner, jobId={}", jobId);
         for (PipelineTasksRunner each : tasksRunnerMap.values()) {
             each.stop();
+            CloseUtils.closeQuietly(each.getJobItemContext().getJobProcessContext());
         }
         Optional<ElasticJobListener> pipelineJobListener = ElasticJobServiceLoader.getCachedTypedServiceInstance(ElasticJobListener.class, PipelineElasticJobListener.class.getName());
         pipelineJobListener.ifPresent(jobListener -> awaitJobStopped((PipelineElasticJobListener) jobListener, jobId, TimeUnit.SECONDS.toMillis(2)));

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractPipelineJob.java
@@ -177,7 +177,6 @@ public abstract class AbstractPipelineJob implements PipelineJob {
     }
     
     private void innerClean() {
-        tasksRunnerMap.clear();
         PipelineJobProgressPersistService.remove(jobId);
     }
     

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
@@ -46,6 +46,14 @@ public abstract class AbstractSimplePipelineJob extends AbstractPipelineJob impl
     
     @Override
     public void execute(final ShardingContext shardingContext) {
+        try {
+            execute0(shardingContext);
+        } finally {
+            clean();
+        }
+    }
+    
+    private void execute0(final ShardingContext shardingContext) {
         String jobId = shardingContext.getJobName();
         int shardingItem = shardingContext.getShardingItem();
         log.info("Execute job {}-{}", jobId, shardingItem);
@@ -62,6 +70,9 @@ public abstract class AbstractSimplePipelineJob extends AbstractPipelineJob impl
         prepare(jobItemContext);
         log.info("start tasks runner, jobId={}, shardingItem={}", jobId, shardingItem);
         tasksRunner.start();
+    }
+    
+    private void clean() {
         for (PipelineTasksRunner each : getTasksRunners()) {
             CloseUtils.closeQuietly(each.getJobItemContext().getJobProcessContext());
         }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/job/AbstractSimplePipelineJob.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.data.pipeline.core.job;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.data.pipeline.api.context.PipelineJobItemContext;
 import org.apache.shardingsphere.data.pipeline.api.task.PipelineTasksRunner;
+import org.apache.shardingsphere.data.pipeline.core.util.CloseUtils;
 import org.apache.shardingsphere.elasticjob.api.ShardingContext;
 import org.apache.shardingsphere.elasticjob.simple.job.SimpleJob;
 
@@ -61,5 +62,8 @@ public abstract class AbstractSimplePipelineJob extends AbstractPipelineJob impl
         prepare(jobItemContext);
         log.info("start tasks runner, jobId={}, shardingItem={}", jobId, shardingItem);
         tasksRunner.start();
+        for (PipelineTasksRunner each : getTasksRunners()) {
+            CloseUtils.closeQuietly(each.getJobItemContext().getJobProcessContext());
+        }
     }
 }

--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineLazyInitializer.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/util/PipelineLazyInitializer.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.core.util;
+
+import org.apache.commons.lang3.concurrent.ConcurrentException;
+import org.apache.commons.lang3.concurrent.LazyInitializer;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Pipeline lazy initializer.
+ *
+ * @param <T> the type of the object managed by this initializer class
+ */
+public abstract class PipelineLazyInitializer<T> extends LazyInitializer<T> {
+    
+    private final AtomicBoolean initialized = new AtomicBoolean();
+    
+    @Override
+    protected final T initialize() throws ConcurrentException {
+        T result = doInitialize();
+        initialized.set(true);
+        return result;
+    }
+    
+    public boolean isInitialized() {
+        return initialized.get();
+    }
+    
+    protected abstract T doInitialize() throws ConcurrentException;
+}

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContext.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContext.java
@@ -49,6 +49,8 @@ public final class ConsistencyCheckJobItemContext implements PipelineJobItemCont
     
     private final ConsistencyCheckJobItemProgressContext progressContext;
     
+    private final ConsistencyCheckProcessContext processContext = new ConsistencyCheckProcessContext();
+    
     public ConsistencyCheckJobItemContext(final ConsistencyCheckJobConfiguration jobConfig, final int shardingItem, final JobStatus status, final ConsistencyCheckJobItemProgress jobItemProgress) {
         this.jobConfig = jobConfig;
         jobId = jobConfig.getJobId();
@@ -63,6 +65,6 @@ public final class ConsistencyCheckJobItemContext implements PipelineJobItemCont
     
     @Override
     public PipelineProcessContext getJobProcessContext() {
-        throw new UnsupportedOperationException();
+        return processContext;
     }
 }

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContext.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckJobItemContext.java
@@ -49,7 +49,7 @@ public final class ConsistencyCheckJobItemContext implements PipelineJobItemCont
     
     private final ConsistencyCheckJobItemProgressContext progressContext;
     
-    private final ConsistencyCheckProcessContext processContext = new ConsistencyCheckProcessContext();
+    private final ConsistencyCheckProcessContext processContext;
     
     public ConsistencyCheckJobItemContext(final ConsistencyCheckJobConfiguration jobConfig, final int shardingItem, final JobStatus status, final ConsistencyCheckJobItemProgress jobItemProgress) {
         this.jobConfig = jobConfig;
@@ -61,6 +61,7 @@ public final class ConsistencyCheckJobItemContext implements PipelineJobItemCont
             progressContext.getCheckedRecordsCount().set(Optional.ofNullable(jobItemProgress.getCheckedRecordsCount()).orElse(0L));
             Optional.ofNullable(jobItemProgress.getTableCheckPositions()).ifPresent(progressContext.getTableCheckPositions()::putAll);
         }
+        processContext = new ConsistencyCheckProcessContext(jobId);
     }
     
     @Override

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckProcessContext.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/context/ConsistencyCheckProcessContext.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.data.pipeline.scenario.consistencycheck.context;
+
+import lombok.Getter;
+import org.apache.shardingsphere.data.pipeline.api.config.process.PipelineProcessConfiguration;
+import org.apache.shardingsphere.data.pipeline.api.context.PipelineProcessContext;
+import org.apache.shardingsphere.data.pipeline.core.config.process.PipelineProcessConfigurationUtils;
+
+/**
+ * Consistency check process context.
+ */
+@Getter
+public final class ConsistencyCheckProcessContext implements PipelineProcessContext {
+    
+    @Override
+    public PipelineProcessConfiguration getPipelineProcessConfig() {
+        return PipelineProcessConfigurationUtils.convertWithDefaultValue(null);
+    }
+    
+    @Override
+    public void close() throws Exception {
+    }
+}

--- a/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/task/ConsistencyCheckTasksRunner.java
+++ b/kernel/data-pipeline/scenario/consistencycheck/src/main/java/org/apache/shardingsphere/data/pipeline/scenario/consistencycheck/task/ConsistencyCheckTasksRunner.java
@@ -29,7 +29,6 @@ import org.apache.shardingsphere.data.pipeline.core.api.InventoryIncrementalJobA
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineAPIFactory;
 import org.apache.shardingsphere.data.pipeline.core.api.PipelineJobAPI;
 import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteCallback;
-import org.apache.shardingsphere.data.pipeline.core.execute.ExecuteEngine;
 import org.apache.shardingsphere.data.pipeline.core.job.PipelineJobIdUtils;
 import org.apache.shardingsphere.data.pipeline.scenario.consistencycheck.api.impl.ConsistencyCheckJobAPI;
 import org.apache.shardingsphere.data.pipeline.scenario.consistencycheck.config.ConsistencyCheckJobConfiguration;
@@ -80,8 +79,7 @@ public final class ConsistencyCheckTasksRunner implements PipelineTasksRunner {
             return;
         }
         TypedSPILoader.getService(PipelineJobAPI.class, PipelineJobIdUtils.parseJobType(jobItemContext.getJobId()).getTypeName()).persistJobItemProgress(jobItemContext);
-        ExecuteEngine executeEngine = ExecuteEngine.newFixedThreadInstance(1, checkJobId + "-check");
-        executeEngine.submit(checkExecutor, checkExecuteCallback);
+        jobItemContext.getProcessContext().getConsistencyCheckExecuteEngine().submit(checkExecutor, checkExecuteCallback);
     }
     
     @Override


### PR DESCRIPTION
Fixes #26195.

Changes proposed in this pull request:
  - Fix execute engine not closed after job stopping. Support migration job / consistency check job / CDC job / other sub-jobs of AbstractSimplePipelineJob.

Verified:
- Start a migration job, show threads; Stop job, show threads; And then start job again, show threads;
- On migration job completed, show threads;
- On migration job stopped or completed, related consistency check threads were reclaimed;

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
