### PR TITLE
test case addition & NotConverter enhancements

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/NotExpressionConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/NotExpressionConverter.java
@@ -39,6 +39,9 @@ public final class NotExpressionConverter implements SQLSegmentConverter<NotExpr
         SqlNode expression = new ExpressionConverter().convert(segment.getExpression()).orElseThrow(IllegalStateException::new);
         List<SqlNode> sqlNodes = new LinkedList<>();
         sqlNodes.add(expression);
+        if (segment.getNotSign().equals(true)) {
+            return Optional.of(new SqlBasicCall(SQLExtensionOperatorTable.NOT_SIGN, sqlNodes, SqlParserPos.ZERO));
+        }
         return Optional.of(new SqlBasicCall(SqlStdOperatorTable.NOT, sqlNodes, SqlParserPos.ZERO));
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/SQLExtensionOperatorTable.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/SQLExtensionOperatorTable.java
@@ -21,6 +21,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlPrefixOperator;
 
 /**
  * SQL extension operator table.
@@ -37,4 +38,6 @@ public final class SQLExtensionOperatorTable {
     public static final SqlBinaryOperator SIGNED_LEFT_SHIFT = new SqlBinaryOperator("<<", SqlKind.OTHER, 30, true, null, null, null);
     
     public static final SqlBinaryOperator SIGNED_RIGHT_SHIFT = new SqlBinaryOperator(">>", SqlKind.OTHER, 30, true, null, null, null);
+    
+    public static final SqlPrefixOperator NOT_SIGN = new SqlPrefixOperator("!", SqlKind.OTHER, 26, null, null, null);
 }

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -409,7 +409,7 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
         if (null != ctx.orOperator()) {
             return createBinaryOperationExpression(ctx, ctx.orOperator().getText());
         }
-        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)));
+        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)), false);
     }
     
     private BinaryOperationExpression createBinaryOperationExpression(final ExprContext ctx, final String operator) {
@@ -604,11 +604,15 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
         }
         if (null != ctx.notOperator()) {
             ASTNode expression = visit(ctx.simpleExpr(0));
+            Boolean notSign = false;
             if (expression instanceof ExistsSubqueryExpression) {
                 ((ExistsSubqueryExpression) expression).setNot(true);
                 return expression;
             }
-            return new NotExpression(startIndex, stopIndex, (ExpressionSegment) expression);
+            if ("!".equalsIgnoreCase(ctx.notOperator().getText())) {
+                notSign = true;
+            }
+            return new NotExpression(startIndex, stopIndex, (ExpressionSegment) expression, notSign);
         }
         if (null != ctx.LP_() && 1 == ctx.expr().size()) {
             return visit(ctx.expr(0));

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -336,7 +336,7 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         if (null != ctx.datetimeExpr()) {
             return createDatetimeExpression(ctx, ctx.datetimeExpr());
         }
-        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)));
+        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)), false);
     }
     
     private ASTNode createDatetimeExpression(final ExprContext ctx, final DatetimeExprContext datetimeExpr) {

--- a/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/SQL92StatementVisitor.java
+++ b/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/SQL92StatementVisitor.java
@@ -240,7 +240,7 @@ public abstract class SQL92StatementVisitor extends SQL92StatementBaseVisitor<AS
         if (null != ctx.orOperator()) {
             return createBinaryOperationExpression(ctx, ctx.orOperator().getText());
         }
-        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)));
+        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)), false);
     }
     
     private ASTNode createBinaryOperationExpression(final ExprContext ctx, final String operator) {

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -355,7 +355,7 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
         if (null != ctx.orOperator()) {
             return createBinaryOperationExpression(ctx, ctx.orOperator().getText());
         }
-        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)));
+        return new NotExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), (ExpressionSegment) visit(ctx.expr(0)), false);
     }
     
     private ASTNode createBinaryOperationExpression(final ExprContext ctx, final String operator) {

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/NotExpression.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/NotExpression.java
@@ -29,4 +29,6 @@ public final class NotExpression implements ExpressionSegment {
     private final int stopIndex;
     
     private final ExpressionSegment expression;
+    
+    private final Boolean notSign;
 }

--- a/test/it/optimizer/src/test/resources/converter/select-expression.xml
+++ b/test/it/optimizer/src/test/resources/converter/select-expression.xml
@@ -27,4 +27,14 @@
     <test-cases sql-case-id="select_where_with_bit_expr_with_signed_right_shift" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` &gt;&gt; ?" db-types="MySQL" sql-case-types="PLACEHOLDER" />
     <test-cases sql-case-id="select_where_with_bit_expr_with_signed_left_shift" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` &lt;&lt; 1" db-types="MySQL" sql-case-types="LITERAL" />
     <test-cases sql-case-id="select_where_with_bit_expr_with_signed_left_shift" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` &lt;&lt; ?" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_bit_expr_with_mod" expected-sql="SELECT * FROM `t_order` WHERE MOD(`t_order`.`order_id`, 1)" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_bit_expr_with_mod" expected-sql="SELECT * FROM `t_order` WHERE MOD(`t_order`.`order_id`, ?)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_bit_expr_with_vertical_bar" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` | 1" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_bit_expr_with_vertical_bar" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` | ?" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_expr_with_not_sign" expected-sql="SELECT * FROM `t_order` WHERE ! 1 = `t_order`.`order_id`" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_expr_with_not_sign" expected-sql="SELECT * FROM `t_order` WHERE ! ? = `t_order`.`order_id`" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_predicate_with_in_subquery" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` NOT IN (SELECT `order_id` FROM `t_order_item` WHERE `status` &gt; 1)" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_predicate_with_in_subquery" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` NOT IN (SELECT `order_id` FROM `t_order_item` WHERE `status` &gt; ?)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_expr_with_not" expected-sql="SELECT * FROM `t_order` WHERE NOT 1 = `t_order`.`order_id`" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_expr_with_not" expected-sql="SELECT * FROM `t_order` WHERE NOT ? = `t_order`.`order_id`" db-types="MySQL" sql-case-types="PLACEHOLDER" />
 </sql-node-converter-test-cases>


### PR DESCRIPTION
Enhancement of the PR #25865 .
Ref #24200 
Changes proposed in this pull request:
---Test case addition for :
1.select_where_with_bit_expr_with_mod
2.select_where_with_bit_expr_with_vertical_bar
3.select_where_with_expr_with_not_sign
4.select_where_with_predicate_with_in_subquery
5.select_where_with_expr_with_not

---Enhanced NotConverter & visitor Files for Not Sign (!) 

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
