### PR TITLE
Support for MySQL operators

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/BinaryOperationExpressionConverter.java
@@ -77,6 +77,11 @@ public final class BinaryOperationExpressionConverter implements SQLSegmentConve
         register(SQLExtensionOperatorTable.AMPERSAND);
         register(SQLExtensionOperatorTable.SIGNED_RIGHT_SHIFT);
         register(SQLExtensionOperatorTable.SIGNED_LEFT_SHIFT);
+        register(SQLExtensionOperatorTable.XOR);
+        register(SQLExtensionOperatorTable.LOGICAL_AND);
+        register(SQLExtensionOperatorTable.NOT_REGEXP);
+        register(SQLExtensionOperatorTable.SOUNDS_LIKE);
+        register(SQLExtensionOperatorTable.NULL_SAFE);
     }
     
     private static void register(final SqlOperator sqlOperator) {

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/SQLExtensionOperatorTable.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/converter/segment/expression/impl/SQLExtensionOperatorTable.java
@@ -40,4 +40,14 @@ public final class SQLExtensionOperatorTable {
     public static final SqlBinaryOperator SIGNED_RIGHT_SHIFT = new SqlBinaryOperator(">>", SqlKind.OTHER, 30, true, null, null, null);
     
     public static final SqlPrefixOperator NOT_SIGN = new SqlPrefixOperator("!", SqlKind.OTHER, 26, null, null, null);
+    
+    public static final SqlBinaryOperator XOR = new SqlBinaryOperator("XOR", SqlKind.OTHER, 30, true, null, null, null);
+    
+    public static final SqlBinaryOperator NULL_SAFE = new SqlBinaryOperator("<=>", SqlKind.OTHER, 30, true, null, null, null);
+    
+    public static final SqlBinaryOperator LOGICAL_AND = new SqlBinaryOperator("&&", SqlKind.OTHER, 24, true, null, null, null);
+    
+    public static final SqlBinaryOperator NOT_REGEXP = new SqlBinaryOperator("NOT REGEXP", SqlKind.OTHER, 30, true, null, null, null);
+    
+    public static final SqlBinaryOperator SOUNDS_LIKE = new SqlBinaryOperator("SOUNDS LIKE", SqlKind.OTHER, 30, true, null, null, null);
 }

--- a/test/it/optimizer/src/test/resources/converter/select-expression.xml
+++ b/test/it/optimizer/src/test/resources/converter/select-expression.xml
@@ -37,4 +37,11 @@
     <test-cases sql-case-id="select_where_with_predicate_with_in_subquery" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` NOT IN (SELECT `order_id` FROM `t_order_item` WHERE `status` &gt; ?)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
     <test-cases sql-case-id="select_where_with_expr_with_not" expected-sql="SELECT * FROM `t_order` WHERE NOT 1 = `t_order`.`order_id`" db-types="MySQL" sql-case-types="LITERAL" />
     <test-cases sql-case-id="select_where_with_expr_with_not" expected-sql="SELECT * FROM `t_order` WHERE NOT ? = `t_order`.`order_id`" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_expr_with_xor" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` = 1 XOR (2 = `t_order`.`order_id`)" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_expr_with_xor" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` = ? XOR (? = `t_order`.`order_id`)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_predicate_with_regexp" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` NOT REGEXP '[123]'" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_predicate_with_sounds_like" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`order_id` SOUNDS LIKE '1%'" db-types="" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_expr_with_and_sign" expected-sql="SELECT * FROM `t_order` WHERE (`t_order`.`order_id` = 1 &amp;&amp; 2 = `t_order`.`order_id`)" db-types="MySQL" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_expr_with_and_sign" expected-sql="SELECT * FROM `t_order` WHERE (`t_order`.`order_id` = ? &amp;&amp; ? = `t_order`.`order_id`)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_boolean_primary_with_null_safe" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`status` &lt;=&gt; `t_order`.`order_id`" db-types="MySQL" sql-case-types="LITERAL" />
 </sql-node-converter-test-cases>


### PR DESCRIPTION
Ref #24200

Changes proposed in this pull request:
Support for Operators :- XOR, LOGICAL AND, SOUNDS LIKE, NOT REGEXP & NULL SAFE 
1.select_where_with_expr_with_xor 
2.select_where_with_predicate_with_regexp 
3.select_where_with_predicate_with_sounds_like 
4.select_where_with_expr_with_and_sign 
5.select_where_with_boolean_primary_with_null_safe

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
