### PR TITLE
Move optimizer context init logic to SQLFederationRule

### DIFF
--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/PreparedStatementAdapterTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/PreparedStatementAdapterTest.java
@@ -70,7 +70,7 @@ class PreparedStatementAdapterTest {
                 new ShardingSphereRuleMetaData(Arrays.asList(
                         new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()),
                         new TrafficRule(new DefaultTrafficRuleConfigurationBuilder().build()),
-                        new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build()))));
+                        new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build(), Collections.emptyMap(), mock(ConfigurationProperties.class)))));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getDatabase(connection.getDatabaseName()).getProtocolType()).thenReturn(new MySQLDatabaseType());
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getDatabase(connection.getDatabaseName()).getResourceMetaData().getStorageTypes())

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/adapter/StatementAdapterTest.java
@@ -236,7 +236,7 @@ class StatementAdapterTest {
         ShardingSphereConnection connection = mock(ShardingSphereConnection.class, RETURNS_DEEP_STUBS);
         ShardingSphereRuleMetaData globalRuleMetaData = new ShardingSphereRuleMetaData(Arrays.asList(
                 new TrafficRule(new DefaultTrafficRuleConfigurationBuilder().build()),
-                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build()),
+                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build(), Collections.emptyMap(), mock(ConfigurationProperties.class)),
                 new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build())));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData()).thenReturn(globalRuleMetaData);
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
@@ -254,7 +254,7 @@ class StatementAdapterTest {
         when(connection.getDatabaseName()).thenReturn("db");
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Arrays.asList(
                 new TrafficRule(new DefaultTrafficRuleConfigurationBuilder().build()),
-                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build()),
+                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build(), Collections.emptyMap(), mock(ConfigurationProperties.class)),
                 new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()))));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         ShardingSphereStatement result = new ShardingSphereStatement(connection);

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationPreparedStatementTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationPreparedStatementTest.java
@@ -37,6 +37,7 @@ import java.sql.NClob;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -55,7 +56,7 @@ class UnsupportedOperationPreparedStatementTest {
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(Arrays.asList(
                 new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()),
                 new TrafficRule(new DefaultTrafficRuleConfigurationBuilder().build()),
-                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build()))));
+                new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build(), Collections.emptyMap(), mock(ConfigurationProperties.class)))));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getDatabase(connection.getDatabaseName()).getProtocolType()).thenReturn(new MySQLDatabaseType());
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         shardingSpherePreparedStatement = new ShardingSpherePreparedStatement(connection, "SELECT 1");

--- a/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
+++ b/jdbc/core/src/test/java/org/apache/shardingsphere/driver/jdbc/unsupported/UnsupportedOperationStatementTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -49,7 +50,7 @@ class UnsupportedOperationStatementTest {
         when(connection.getDatabaseName()).thenReturn("db");
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getGlobalRuleMetaData()).thenReturn(new ShardingSphereRuleMetaData(
                 Arrays.asList(new TrafficRule(new DefaultTrafficRuleConfigurationBuilder().build()),
-                        new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build()),
+                        new SQLFederationRule(new DefaultSQLFederationRuleConfigurationBuilder().build(), Collections.emptyMap(), mock(ConfigurationProperties.class)),
                         new SQLParserRule(new DefaultSQLParserRuleConfigurationBuilder().build()))));
         when(connection.getContextManager().getMetaDataContexts().getMetaData().getProps()).thenReturn(new ConfigurationProperties(new Properties()));
         shardingSphereStatement = new ShardingSphereStatement(connection);

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/SQLFederationExecutor.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/SQLFederationExecutor.java
@@ -20,21 +20,15 @@ package org.apache.shardingsphere.sqlfederation.executor;
 import com.google.common.base.Preconditions;
 import org.apache.calcite.adapter.enumerable.EnumerableInterpretable;
 import org.apache.calcite.adapter.enumerable.EnumerableRel;
-import org.apache.calcite.adapter.java.JavaTypeFactory;
-import org.apache.calcite.config.CalciteConnectionConfig;
-import org.apache.calcite.config.CalciteConnectionConfigImpl;
-import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.linq4j.Enumerator;
-import org.apache.calcite.plan.RelOptPlanner;
-import org.apache.calcite.prepare.CalciteCatalogReader;
 import org.apache.calcite.runtime.Bindable;
-import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.Schema;
+import org.apache.calcite.schema.Table;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.shardingsphere.infra.binder.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
-import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutor;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutorCallback;
@@ -49,11 +43,10 @@ import org.apache.shardingsphere.sqlfederation.executor.resultset.SQLFederationR
 import org.apache.shardingsphere.sqlfederation.optimizer.SQLFederationCompiler;
 import org.apache.shardingsphere.sqlfederation.optimizer.SQLFederationExecutionPlan;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.OptimizerContext;
-import org.apache.shardingsphere.sqlfederation.optimizer.context.OptimizerContextFactory;
-import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.OptimizerParserContext;
+import org.apache.shardingsphere.sqlfederation.optimizer.context.planner.OptimizerPlannerContext;
 import org.apache.shardingsphere.sqlfederation.optimizer.executor.TableScanExecutor;
-import org.apache.shardingsphere.sqlfederation.optimizer.metadata.schema.SQLFederationSchema;
-import org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationPlannerUtils;
+import org.apache.shardingsphere.sqlfederation.optimizer.metadata.schema.SQLFederationTable;
+import org.apache.shardingsphere.sqlfederation.rule.SQLFederationRule;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -67,8 +60,6 @@ import java.util.Map;
  * SQL federation executor.
  */
 public final class SQLFederationExecutor implements AutoCloseable {
-    
-    private static final JavaTypeFactory JAVA_TYPE_FACTORY = new JavaTypeFactoryImpl();
     
     private String databaseName;
     
@@ -98,7 +89,7 @@ public final class SQLFederationExecutor implements AutoCloseable {
     public void init(final String databaseName, final String schemaName, final ShardingSphereMetaData metaData, final ShardingSphereData data, final JDBCExecutor jdbcExecutor) {
         this.databaseName = databaseName;
         this.schemaName = schemaName;
-        this.optimizerContext = OptimizerContextFactory.create(metaData.getDatabases(), metaData.getGlobalRuleMetaData());
+        this.optimizerContext = metaData.getDatabase(databaseName).getRuleMetaData().getSingleRule(SQLFederationRule.class).getOptimizerContext();
         this.globalRuleMetaData = metaData.getGlobalRuleMetaData();
         this.props = metaData.getProps();
         this.data = data;
@@ -119,7 +110,8 @@ public final class SQLFederationExecutor implements AutoCloseable {
         Preconditions.checkArgument(sqlStatementContext instanceof SelectStatementContext, "SQL statement context must be select statement context.");
         ShardingSphereDatabase database = federationContext.getMetaData().getDatabase(databaseName);
         ShardingSphereSchema schema = database.getSchema(schemaName);
-        AbstractSchema sqlFederationSchema = createSQLFederationSchema(prepareEngine, database.getProtocolType(), schema, callback, federationContext);
+        Schema sqlFederationSchema = optimizerContext.getPlannerContext(databaseName).getValidators().get(schemaName).getCatalogReader().getRootSchema().plus();
+        registerTableScanExecutor(sqlFederationSchema, prepareEngine, callback, federationContext);
         Map<String, Object> params = createParameters(federationContext.getQueryContext().getParameters());
         resultSet = execute((SelectStatementContext) sqlStatementContext, schema, sqlFederationSchema, params);
         return resultSet;
@@ -134,26 +126,26 @@ public final class SQLFederationExecutor implements AutoCloseable {
         return result;
     }
     
-    private AbstractSchema createSQLFederationSchema(final DriverExecutionPrepareEngine<JDBCExecutionUnit, Connection> prepareEngine, final DatabaseType protocolType,
-                                                     final ShardingSphereSchema schema,
-                                                     final JDBCExecutorCallback<? extends ExecuteResult> callback, final SQLFederationExecutorContext federationContext) {
+    private void registerTableScanExecutor(final Schema sqlFederationSchema, final DriverExecutionPrepareEngine<JDBCExecutionUnit, Connection> prepareEngine,
+                                           final JDBCExecutorCallback<? extends ExecuteResult> callback, final SQLFederationExecutorContext federationContext) {
         TableScanExecutorContext executorContext = new TableScanExecutorContext(databaseName, schemaName, props, federationContext);
         TableScanExecutor executor = new TranslatableTableScanExecutor(prepareEngine, jdbcExecutor, callback, optimizerContext, globalRuleMetaData, executorContext, data);
-        return new SQLFederationSchema(schemaName, schema, protocolType, JAVA_TYPE_FACTORY, executor);
+        for (String each : federationContext.getQueryContext().getSqlStatementContext().getTablesContext().getTableNames()) {
+            Table table = sqlFederationSchema.getTable(each);
+            if (table instanceof SQLFederationTable) {
+                ((SQLFederationTable) table).setExecutor(executor);
+            }
+        }
     }
     
     @SuppressWarnings("unchecked")
-    private ResultSet execute(final SelectStatementContext selectStatementContext, final ShardingSphereSchema schema, final AbstractSchema sqlFederationSchema, final Map<String, Object> params) {
-        OptimizerParserContext parserContext = optimizerContext.getParserContext(databaseName);
-        CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(parserContext.getDialectProps());
-        CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(schemaName, sqlFederationSchema, JAVA_TYPE_FACTORY, connectionConfig);
-        SqlValidator validator = SQLFederationPlannerUtils.createSqlValidator(catalogReader, JAVA_TYPE_FACTORY, parserContext.getDatabaseType(), connectionConfig);
-        SqlToRelConverter converter = SQLFederationPlannerUtils.createSqlToRelConverter(catalogReader, validator,
-                SQLFederationPlannerUtils.createRelOptCluster(JAVA_TYPE_FACTORY), optimizerContext.getSqlParserRule(), parserContext.getDatabaseType(), true);
-        RelOptPlanner hepPlanner = optimizerContext.getPlannerContext(databaseName).getHepPlanner();
-        SQLFederationExecutionPlan executionPlan = new SQLFederationCompiler(converter, hepPlanner).compile(selectStatementContext.getSqlStatement());
+    private ResultSet execute(final SelectStatementContext selectStatementContext, final ShardingSphereSchema schema, final Schema sqlFederationSchema, final Map<String, Object> params) {
+        OptimizerPlannerContext plannerContext = optimizerContext.getPlannerContext(databaseName);
+        SqlValidator sqlValidator = plannerContext.getValidators().get(schemaName);
+        SqlToRelConverter sqlToRelConverter = plannerContext.getConverters().get(schemaName);
+        SQLFederationExecutionPlan executionPlan = new SQLFederationCompiler(sqlToRelConverter, plannerContext.getHepPlanner()).compile(selectStatementContext.getSqlStatement());
         Bindable<Object> executablePlan = EnumerableInterpretable.toBindable(Collections.emptyMap(), null, (EnumerableRel) executionPlan.getPhysicalPlan(), EnumerableRel.Prefer.ARRAY);
-        Enumerator<Object> enumerator = executablePlan.bind(new SQLFederationDataContext(validator, converter, params)).enumerator();
+        Enumerator<Object> enumerator = executablePlan.bind(new SQLFederationDataContext(sqlValidator, sqlToRelConverter, params)).enumerator();
         return new SQLFederationResultSet(enumerator, schema, sqlFederationSchema, selectStatementContext, executionPlan.getResultColumnType());
     }
     

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/SQLFederationExecutor.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/SQLFederationExecutor.java
@@ -108,7 +108,7 @@ public final class SQLFederationExecutor implements AutoCloseable {
         ShardingSphereDatabase database = federationContext.getMetaData().getDatabase(databaseName);
         ShardingSphereSchema schema = database.getSchema(schemaName);
         OptimizerContext optimizerContext = globalRuleMetaData.getSingleRule(SQLFederationRule.class).getOptimizerContext();
-        Schema sqlFederationSchema = optimizerContext.getPlannerContext(databaseName).getValidators().get(schemaName).getCatalogReader().getRootSchema().plus();
+        Schema sqlFederationSchema = optimizerContext.getPlannerContext(databaseName).getValidators().get(schemaName).getCatalogReader().getRootSchema().plus().getSubSchema(schemaName);
         registerTableScanExecutor(sqlFederationSchema, prepareEngine, callback, federationContext, optimizerContext);
         Map<String, Object> params = createParameters(federationContext.getQueryContext().getParameters());
         resultSet = execute((SelectStatementContext) sqlStatementContext, schema, sqlFederationSchema, params, optimizerContext);

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TranslatableTableScanExecutor.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TranslatableTableScanExecutor.java
@@ -318,7 +318,7 @@ public final class TranslatableTableScanExecutor implements TableScanExecutor {
         CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(optimizerContext.getParserContext(databaseName).getDialectProps());
         ShardingSphereDatabase database = executorContext.getFederationContext().getMetaData().getDatabase(databaseName);
         CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(schemaName,
-                new SQLFederationSchema(schemaName, database.getSchema(schemaName), database.getProtocolType(), JAVA_TYPE_FACTORY, null), JAVA_TYPE_FACTORY, connectionConfig);
+                new SQLFederationSchema(schemaName, database.getSchema(schemaName), database.getProtocolType(), JAVA_TYPE_FACTORY), JAVA_TYPE_FACTORY, connectionConfig);
         RelOptCluster relOptCluster = RelOptCluster.create(SQLFederationPlannerUtils.createVolcanoPlanner(), new RexBuilder(JAVA_TYPE_FACTORY));
         RelBuilder builder = RelFactories.LOGICAL_BUILDER.create(relOptCluster, catalogReader).scan(table.getName());
         if (null != scanContext.getFilterValues()) {

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/resultset/SQLFederationResultSet.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/resultset/SQLFederationResultSet.java
@@ -19,7 +19,7 @@ package org.apache.shardingsphere.sqlfederation.executor.resultset;
 
 import org.apache.calcite.linq4j.Enumerator;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.Schema;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
@@ -78,13 +78,13 @@ public final class SQLFederationResultSet extends AbstractUnsupportedOperationRe
     
     private boolean closed;
     
-    public SQLFederationResultSet(final Enumerator<Object> enumerator, final ShardingSphereSchema schema, final AbstractSchema filterableSchema,
+    public SQLFederationResultSet(final Enumerator<Object> enumerator, final ShardingSphereSchema schema, final Schema sqlFederationSchema,
                                   final SelectStatementContext selectStatementContext, final RelDataType resultColumnType) {
         this.enumerator = enumerator;
         columnLabelAndIndexes = new HashMap<>(selectStatementContext.getProjectionsContext().getExpandProjections().size(), 1F);
         Map<Integer, String> indexAndColumnLabels = new HashMap<>(selectStatementContext.getProjectionsContext().getExpandProjections().size(), 1F);
         handleColumnLabelAndIndex(columnLabelAndIndexes, indexAndColumnLabels, selectStatementContext);
-        resultSetMetaData = new SQLFederationResultSetMetaData(schema, filterableSchema, selectStatementContext, resultColumnType, indexAndColumnLabels);
+        resultSetMetaData = new SQLFederationResultSetMetaData(schema, sqlFederationSchema, selectStatementContext, resultColumnType, indexAndColumnLabels);
     }
     
     private void handleColumnLabelAndIndex(final Map<String, Integer> columnLabelAndIndexes, final Map<Integer, String> indexAndColumnLabels, final SelectStatementContext selectStatementContext) {

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/resultset/SQLFederationResultSetMetaData.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/resultset/SQLFederationResultSetMetaData.java
@@ -20,8 +20,8 @@ package org.apache.shardingsphere.sqlfederation.executor.resultset;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.Schema;
 import org.apache.calcite.schema.Table;
-import org.apache.calcite.schema.impl.AbstractSchema;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.impl.ColumnProjection;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
@@ -40,7 +40,7 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     private final ShardingSphereSchema schema;
     
-    private final AbstractSchema filterableSchema;
+    private final Schema sqlFederationSchema;
     
     private final RelDataTypeFactory relDataTypeFactory;
     
@@ -50,10 +50,10 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     private final Map<Integer, String> indexAndColumnLabels;
     
-    public SQLFederationResultSetMetaData(final ShardingSphereSchema schema, final AbstractSchema filterableSchema,
+    public SQLFederationResultSetMetaData(final ShardingSphereSchema schema, final Schema sqlFederationSchema,
                                           final SelectStatementContext selectStatementContext, final RelDataType resultColumnType, final Map<Integer, String> indexAndColumnLabels) {
         this.schema = schema;
-        this.filterableSchema = filterableSchema;
+        this.sqlFederationSchema = sqlFederationSchema;
         this.relDataTypeFactory = new JavaTypeFactoryImpl();
         this.selectStatementContext = selectStatementContext;
         this.resultColumnType = resultColumnType;
@@ -87,7 +87,7 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     @Override
     public int isNullable(final int column) {
-        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(filterableSchema.getTable(optional)));
+        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(sqlFederationSchema.getTable(optional)));
         return !table.isPresent() || table.get().getRowType(relDataTypeFactory).isNullable() ? ResultSetMetaData.columnNullable : ResultSetMetaData.columnNoNulls;
     }
     
@@ -98,7 +98,7 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     @Override
     public int getColumnDisplaySize(final int column) {
-        return findTableName(column).flatMap(optional -> Optional.ofNullable(filterableSchema.getTable(optional))).map(optional -> optional.getRowType(relDataTypeFactory).getPrecision()).orElse(0);
+        return findTableName(column).flatMap(optional -> Optional.ofNullable(sqlFederationSchema.getTable(optional))).map(optional -> optional.getRowType(relDataTypeFactory).getPrecision()).orElse(0);
     }
     
     @Override
@@ -122,13 +122,13 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
     
     @Override
     public int getPrecision(final int column) {
-        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(filterableSchema.getTable(optional)));
+        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(sqlFederationSchema.getTable(optional)));
         return !table.isPresent() || RelDataType.PRECISION_NOT_SPECIFIED == table.get().getRowType(relDataTypeFactory).getPrecision() ? 0 : table.get().getRowType(relDataTypeFactory).getPrecision();
     }
     
     @Override
     public int getScale(final int column) {
-        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(filterableSchema.getTable(optional)));
+        Optional<Table> table = findTableName(column).flatMap(optional -> Optional.ofNullable(sqlFederationSchema.getTable(optional)));
         return !table.isPresent() || RelDataType.SCALE_NOT_SPECIFIED == table.get().getRowType(relDataTypeFactory).getScale() ? 0 : table.get().getRowType(relDataTypeFactory).getScale();
     }
     

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLFederationCompiler.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/SQLFederationCompiler.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.apache.calcite.adapter.enumerable.EnumerableConvention;
 import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.metadata.JaninoRelMetadataProvider;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
@@ -46,6 +48,7 @@ public final class SQLFederationCompiler {
      * @return sql federation execution plan
      */
     public SQLFederationExecutionPlan compile(final SQLStatement sqlStatement) {
+        RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.DEFAULT);
         SqlNode sqlNode = SQLNodeConverterEngine.convert(sqlStatement);
         RelNode logicPlan = converter.convertQuery(sqlNode, true, true).rel;
         RelDataType resultColumnType = Objects.requireNonNull(converter.validator).getValidatedNodeType(sqlNode);

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/OptimizerContextFactory.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/OptimizerContextFactory.java
@@ -19,13 +19,15 @@ package org.apache.shardingsphere.sqlfederation.optimizer.context;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.parser.rule.SQLParserRule;
+import org.apache.shardingsphere.parser.rule.builder.DefaultSQLParserRuleConfigurationBuilder;
+import org.apache.shardingsphere.parser.rule.builder.SQLParserRuleBuilder;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.OptimizerParserContext;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.OptimizerParserContextFactory;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.planner.OptimizerPlannerContext;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.planner.OptimizerPlannerContextFactory;
-import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
-import org.apache.shardingsphere.parser.rule.SQLParserRule;
 
 import java.util.Map;
 
@@ -39,13 +41,13 @@ public final class OptimizerContextFactory {
      * Create optimize context.
      *
      * @param databases databases
-     * @param globalRuleMetaData global rule meta data
+     * @param props props
      * @return created optimizer context
      */
-    public static OptimizerContext create(final Map<String, ShardingSphereDatabase> databases, final ShardingSphereRuleMetaData globalRuleMetaData) {
+    public static OptimizerContext create(final Map<String, ShardingSphereDatabase> databases, final ConfigurationProperties props) {
         Map<String, OptimizerParserContext> parserContexts = OptimizerParserContextFactory.create(databases);
-        Map<String, OptimizerPlannerContext> plannerContexts = OptimizerPlannerContextFactory.create(databases);
-        SQLParserRule sqlParserRule = globalRuleMetaData.getSingleRule(SQLParserRule.class);
+        SQLParserRule sqlParserRule = new SQLParserRuleBuilder().build(new DefaultSQLParserRuleConfigurationBuilder().build(), databases, props);
+        Map<String, OptimizerPlannerContext> plannerContexts = OptimizerPlannerContextFactory.create(databases, parserContexts, sqlParserRule);
         return new OptimizerContext(sqlParserRule, parserContexts, plannerContexts);
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContext.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContext.java
@@ -20,6 +20,10 @@ package org.apache.shardingsphere.sqlfederation.optimizer.context.planner;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+
+import java.util.Map;
 
 /**
  * Optimize planner context.
@@ -29,4 +33,8 @@ import org.apache.calcite.plan.RelOptPlanner;
 public final class OptimizerPlannerContext {
     
     private final RelOptPlanner hepPlanner;
+    
+    private final Map<String, SqlValidator> validators;
+    
+    private final Map<String, SqlToRelConverter> converters;
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContextFactory.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContextFactory.java
@@ -24,10 +24,9 @@ import org.apache.calcite.config.CalciteConnectionConfig;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
 import org.apache.calcite.prepare.CalciteCatalogReader;
-import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.schema.Schema;
 import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
-import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
@@ -78,7 +77,7 @@ public final class OptimizerPlannerContextFactory {
         Map<String, SqlToRelConverter> converters = new LinkedHashMap<>();
         for (Entry<String, ShardingSphereSchema> entry : database.getSchemas().entrySet()) {
             CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(parserContext.getDialectProps());
-            AbstractSchema sqlFederationSchema = createSQLFederationSchema(entry.getKey(), entry.getValue(), database.getProtocolType());
+            Schema sqlFederationSchema = new SQLFederationSchema(entry.getKey(), entry.getValue(), database.getProtocolType(), DEFAULT_DATA_TYPE_FACTORY);
             CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(entry.getKey(), sqlFederationSchema, DEFAULT_DATA_TYPE_FACTORY, connectionConfig);
             SqlValidator validator = SQLFederationPlannerUtils.createSqlValidator(catalogReader, DEFAULT_DATA_TYPE_FACTORY, parserContext.getDatabaseType(), connectionConfig);
             SqlToRelConverter converter = SQLFederationPlannerUtils.createSqlToRelConverter(catalogReader, validator, SQLFederationPlannerUtils.createRelOptCluster(DEFAULT_DATA_TYPE_FACTORY),
@@ -87,10 +86,5 @@ public final class OptimizerPlannerContextFactory {
             converters.put(entry.getKey(), converter);
         }
         return new OptimizerPlannerContext(SQLFederationPlannerUtils.createHepPlanner(), validators, converters);
-    }
-    
-    private static AbstractSchema createSQLFederationSchema(final String schemaName, final ShardingSphereSchema schema, final DatabaseType protocolType) {
-        // TODO register when execute sql
-        return new SQLFederationSchema(schemaName, schema, protocolType, DEFAULT_DATA_TYPE_FACTORY);
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContextFactory.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/context/planner/OptimizerPlannerContextFactory.java
@@ -19,9 +19,23 @@ package org.apache.shardingsphere.sqlfederation.optimizer.context.planner;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.calcite.adapter.java.JavaTypeFactory;
+import org.apache.calcite.config.CalciteConnectionConfig;
+import org.apache.calcite.config.CalciteConnectionConfigImpl;
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.prepare.CalciteCatalogReader;
+import org.apache.calcite.schema.impl.AbstractSchema;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.sql2rel.SqlToRelConverter;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
+import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
+import org.apache.shardingsphere.parser.rule.SQLParserRule;
+import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.OptimizerParserContext;
+import org.apache.shardingsphere.sqlfederation.optimizer.metadata.schema.SQLFederationSchema;
 import org.apache.shardingsphere.sqlfederation.optimizer.planner.util.SQLFederationPlannerUtils;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,17 +46,51 @@ import java.util.concurrent.ConcurrentHashMap;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class OptimizerPlannerContextFactory {
     
+    private static final JavaTypeFactory DEFAULT_DATA_TYPE_FACTORY = new JavaTypeFactoryImpl();
+    
     /**
      * Create optimizer planner context map.
      *
      * @param databases databases
+     * @param parserContexts parser contexts
+     * @param sqlParserRule sql parser rule
      * @return created optimizer planner context map
      */
-    public static Map<String, OptimizerPlannerContext> create(final Map<String, ShardingSphereDatabase> databases) {
+    public static Map<String, OptimizerPlannerContext> create(final Map<String, ShardingSphereDatabase> databases, final Map<String, OptimizerParserContext> parserContexts,
+                                                              final SQLParserRule sqlParserRule) {
         Map<String, OptimizerPlannerContext> result = new ConcurrentHashMap<>(databases.size(), 1F);
         for (Entry<String, ShardingSphereDatabase> entry : databases.entrySet()) {
-            result.put(entry.getKey(), new OptimizerPlannerContext(SQLFederationPlannerUtils.createHepPlanner()));
+            result.put(entry.getKey(), create(entry.getValue(), parserContexts.get(entry.getKey()), sqlParserRule));
         }
         return result;
+    }
+    
+    /**
+     * Create optimizer planner context.
+     *
+     * @param database database
+     * @param parserContext parser context
+     * @param sqlParserRule sql parser rule
+     * @return created optimizer planner context
+     */
+    public static OptimizerPlannerContext create(final ShardingSphereDatabase database, final OptimizerParserContext parserContext, final SQLParserRule sqlParserRule) {
+        Map<String, SqlValidator> validators = new LinkedHashMap<>();
+        Map<String, SqlToRelConverter> converters = new LinkedHashMap<>();
+        for (Entry<String, ShardingSphereSchema> entry : database.getSchemas().entrySet()) {
+            CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(parserContext.getDialectProps());
+            AbstractSchema sqlFederationSchema = createSQLFederationSchema(entry.getKey(), entry.getValue(), database.getProtocolType());
+            CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(entry.getKey(), sqlFederationSchema, DEFAULT_DATA_TYPE_FACTORY, connectionConfig);
+            SqlValidator validator = SQLFederationPlannerUtils.createSqlValidator(catalogReader, DEFAULT_DATA_TYPE_FACTORY, parserContext.getDatabaseType(), connectionConfig);
+            SqlToRelConverter converter = SQLFederationPlannerUtils.createSqlToRelConverter(catalogReader, validator, SQLFederationPlannerUtils.createRelOptCluster(DEFAULT_DATA_TYPE_FACTORY),
+                    sqlParserRule, parserContext.getDatabaseType(), true);
+            validators.put(entry.getKey(), validator);
+            converters.put(entry.getKey(), converter);
+        }
+        return new OptimizerPlannerContext(SQLFederationPlannerUtils.createHepPlanner(), validators, converters);
+    }
+    
+    private static AbstractSchema createSQLFederationSchema(final String schemaName, final ShardingSphereSchema schema, final DatabaseType protocolType) {
+        // TODO register when execute sql
+        return new SQLFederationSchema(schemaName, schema, protocolType, DEFAULT_DATA_TYPE_FACTORY);
     }
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationDatabase.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationDatabase.java
@@ -47,7 +47,7 @@ public final class SQLFederationDatabase extends AbstractSchema {
     private Map<String, Schema> createSubSchemaMap(final ShardingSphereDatabase database, final DatabaseType protocolType, final TableScanExecutor executor) {
         Map<String, Schema> result = new LinkedHashMap<>(database.getSchemas().size(), 1F);
         for (Entry<String, ShardingSphereSchema> entry : database.getSchemas().entrySet()) {
-            result.put(entry.getKey(), new SQLFederationSchema(entry.getKey(), entry.getValue(), protocolType, null, executor));
+            result.put(entry.getKey(), new SQLFederationSchema(entry.getKey(), entry.getValue(), protocolType, null));
         }
         return result;
     }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationSchema.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationSchema.java
@@ -28,9 +28,8 @@ import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereView;
-import org.apache.shardingsphere.sqlfederation.optimizer.executor.TableScanExecutor;
-import org.apache.shardingsphere.sqlfederation.optimizer.statistic.SQLFederationStatistic;
 import org.apache.shardingsphere.sqlfederation.optimizer.metadata.util.SQLFederationDataTypeUtils;
+import org.apache.shardingsphere.sqlfederation.optimizer.statistic.SQLFederationStatistic;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -46,19 +45,19 @@ public final class SQLFederationSchema extends AbstractSchema {
     
     private final Map<String, Table> tableMap;
     
-    public SQLFederationSchema(final String schemaName, final ShardingSphereSchema schema, final DatabaseType protocolType, final JavaTypeFactory javaTypeFactory, final TableScanExecutor executor) {
+    public SQLFederationSchema(final String schemaName, final ShardingSphereSchema schema, final DatabaseType protocolType, final JavaTypeFactory javaTypeFactory) {
         name = schemaName;
-        tableMap = createTableMap(schema, protocolType, javaTypeFactory, executor);
+        tableMap = createTableMap(schema, protocolType, javaTypeFactory);
     }
     
-    private Map<String, Table> createTableMap(final ShardingSphereSchema schema, final DatabaseType protocolType, final JavaTypeFactory javaTypeFactory, final TableScanExecutor executor) {
+    private Map<String, Table> createTableMap(final ShardingSphereSchema schema, final DatabaseType protocolType, final JavaTypeFactory javaTypeFactory) {
         Map<String, Table> result = new LinkedHashMap<>(schema.getTables().size(), 1F);
         for (ShardingSphereTable each : schema.getTables().values()) {
             if (schema.containsView(each.getName())) {
                 result.put(each.getName(), getViewTable(schema, each, protocolType, javaTypeFactory));
             } else {
                 // TODO implement table statistic logic after using custom operators
-                result.put(each.getName(), new SQLFederationTable(each, executor, new SQLFederationStatistic(), protocolType));
+                result.put(each.getName(), new SQLFederationTable(each, new SQLFederationStatistic(), protocolType));
             }
         }
         return result;

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationTable.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/optimizer/metadata/schema/SQLFederationTable.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.sqlfederation.optimizer.metadata.schema;
 
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.calcite.DataContext;
 import org.apache.calcite.linq4j.Enumerable;
 import org.apache.calcite.linq4j.QueryProvider;
@@ -39,8 +40,8 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.util.exception.external.sql.type.generic.UnsupportedSQLOperationException;
 import org.apache.shardingsphere.sqlfederation.optimizer.executor.TableScanExecutor;
 import org.apache.shardingsphere.sqlfederation.optimizer.executor.TranslatableScanNodeExecutorContext;
-import org.apache.shardingsphere.sqlfederation.optimizer.operator.physical.EnumerablePushDownTableScan;
 import org.apache.shardingsphere.sqlfederation.optimizer.metadata.util.SQLFederationDataTypeUtils;
+import org.apache.shardingsphere.sqlfederation.optimizer.operator.physical.EnumerablePushDownTableScan;
 import org.apache.shardingsphere.sqlfederation.optimizer.statistic.SQLFederationStatistic;
 
 import java.lang.reflect.Type;
@@ -53,11 +54,12 @@ public final class SQLFederationTable extends AbstractTable implements Queryable
     
     private final ShardingSphereTable table;
     
-    private final TableScanExecutor executor;
-    
     private final SQLFederationStatistic statistic;
     
     private final DatabaseType protocolType;
+    
+    @Setter
+    private TableScanExecutor executor;
     
     /**
      * Execute filter and project when query the federation translatable table.

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/SQLFederationRule.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/SQLFederationRule.java
@@ -18,12 +18,15 @@
 package org.apache.shardingsphere.sqlfederation.rule;
 
 import lombok.Getter;
-import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutor;
-import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
-import org.apache.shardingsphere.infra.metadata.data.ShardingSphereData;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
+import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.rule.identifier.scope.GlobalRule;
 import org.apache.shardingsphere.sqlfederation.api.config.SQLFederationRuleConfiguration;
 import org.apache.shardingsphere.sqlfederation.executor.SQLFederationExecutor;
+import org.apache.shardingsphere.sqlfederation.optimizer.context.OptimizerContext;
+import org.apache.shardingsphere.sqlfederation.optimizer.context.OptimizerContextFactory;
+
+import java.util.Map;
 
 /**
  * SQL federation rule.
@@ -35,23 +38,12 @@ public final class SQLFederationRule implements GlobalRule {
     
     private final SQLFederationExecutor sqlFederationExecutor;
     
-    public SQLFederationRule(final SQLFederationRuleConfiguration ruleConfig) {
+    private final OptimizerContext optimizerContext;
+    
+    public SQLFederationRule(final SQLFederationRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases, final ConfigurationProperties props) {
         configuration = ruleConfig;
         sqlFederationExecutor = new SQLFederationExecutor();
-    }
-    
-    /**
-     * Init SQL federation executor.
-     *
-     * @param databaseName database name
-     * @param schemaName schema name
-     * @param metaData ShardingSphere meta data
-     * @param shardingSphereData ShardingSphere data
-     * @param jdbcExecutor jdbc executor
-     */
-    public void init(final String databaseName, final String schemaName, final ShardingSphereMetaData metaData, final ShardingSphereData shardingSphereData,
-                     final JDBCExecutor jdbcExecutor) {
-        sqlFederationExecutor.init(databaseName, schemaName, metaData, shardingSphereData, jdbcExecutor);
+        optimizerContext = OptimizerContextFactory.create(databases, props);
     }
     
     @Override

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/builder/SQLFederationRuleBuilder.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/rule/builder/SQLFederationRuleBuilder.java
@@ -34,7 +34,7 @@ public final class SQLFederationRuleBuilder implements GlobalRuleBuilder<SQLFede
     
     @Override
     public GlobalRule build(final SQLFederationRuleConfiguration ruleConfig, final Map<String, ShardingSphereDatabase> databases, final ConfigurationProperties props) {
-        return new SQLFederationRule(ruleConfig);
+        return new SQLFederationRule(ruleConfig, databases, props);
     }
     
     @Override

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/decider/engine/SQLFederationDecideEngineTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/decider/engine/SQLFederationDecideEngineTest.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sqlfederation.decider.engine;
 
 import org.apache.shardingsphere.infra.binder.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementContext;
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.dialect.MySQLDatabaseType;
@@ -59,7 +60,8 @@ class SQLFederationDecideEngineTest {
     
     @Test
     void assertDecideWhenNotConfigSqlFederationEnabled() {
-        Collection<ShardingSphereRule> rules = Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, mock(CacheOption.class))));
+        Collection<ShardingSphereRule> rules =
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(false, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)));
         SQLFederationDecideEngine engine = new SQLFederationDecideEngine(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ShardingSphereResourceMetaData.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(rules), Collections.emptyMap());
@@ -69,7 +71,8 @@ class SQLFederationDecideEngineTest {
     
     @Test
     void assertDecideWhenExecuteNotSelectStatement() {
-        Collection<ShardingSphereRule> rules = Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class))));
+        Collection<ShardingSphereRule> rules =
+                Collections.singletonList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)));
         SQLFederationDecideEngine engine = new SQLFederationDecideEngine(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ShardingSphereResourceMetaData.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(rules), Collections.emptyMap());
@@ -79,7 +82,9 @@ class SQLFederationDecideEngineTest {
     
     @Test
     void assertDecideWhenConfigSingleMatchedRule() {
-        Collection<ShardingSphereRule> rules = Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class))), new SQLFederationDeciderRuleMatchFixture());
+        Collection<ShardingSphereRule> rules =
+                Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)),
+                        new SQLFederationDeciderRuleMatchFixture());
         SQLFederationDecideEngine engine = new SQLFederationDecideEngine(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ShardingSphereResourceMetaData.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(rules), Collections.emptyMap());
@@ -89,7 +94,9 @@ class SQLFederationDecideEngineTest {
     
     @Test
     void assertDecideWhenConfigSingleNotMatchedRule() {
-        Collection<ShardingSphereRule> rules = Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class))), new SQLFederationDeciderRuleNotMatchFixture());
+        Collection<ShardingSphereRule> rules =
+                Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)),
+                        new SQLFederationDeciderRuleNotMatchFixture());
         SQLFederationDecideEngine engine = new SQLFederationDecideEngine(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ShardingSphereResourceMetaData.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(rules), Collections.emptyMap());
@@ -99,8 +106,10 @@ class SQLFederationDecideEngineTest {
     
     @Test
     void assertDecideWhenConfigMultiRule() {
-        Collection<ShardingSphereRule> rules = Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class))), new SQLFederationDeciderRuleNotMatchFixture(),
-                new SQLFederationDeciderRuleMatchFixture());
+        Collection<ShardingSphereRule> rules =
+                Arrays.asList(new SQLFederationRule(new SQLFederationRuleConfiguration(true, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)),
+                        new SQLFederationDeciderRuleNotMatchFixture(),
+                        new SQLFederationDeciderRuleMatchFixture());
         SQLFederationDecideEngine engine = new SQLFederationDecideEngine(rules);
         ShardingSphereDatabase database = new ShardingSphereDatabase(DefaultDatabase.LOGIC_NAME,
                 mock(DatabaseType.class), mock(ShardingSphereResourceMetaData.class, RETURNS_DEEP_STUBS), new ShardingSphereRuleMetaData(rules), Collections.emptyMap());

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/context/OptimizerContextTest.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/context/OptimizerContextTest.java
@@ -17,12 +17,10 @@
 
 package org.apache.shardingsphere.sqlfederation.optimizer.context;
 
+import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.database.DefaultDatabase;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
-import org.apache.shardingsphere.parser.config.SQLParserRuleConfiguration;
 import org.apache.shardingsphere.parser.rule.SQLParserRule;
-import org.apache.shardingsphere.sql.parser.api.CacheOption;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.parser.OptimizerParserContext;
 import org.apache.shardingsphere.sqlfederation.optimizer.context.planner.OptimizerPlannerContext;
 import org.junit.jupiter.api.Test;
@@ -39,19 +37,19 @@ class OptimizerContextTest {
     
     @Test
     void assertGetSqlParserRule() {
-        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), createShardingSphereRuleMetaData());
+        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), mock(ConfigurationProperties.class));
         assertThat(actual.getSqlParserRule(), instanceOf(SQLParserRule.class));
     }
     
     @Test
     void assertGetParserContext() {
-        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), createShardingSphereRuleMetaData());
+        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), mock(ConfigurationProperties.class));
         assertThat(actual.getParserContext(DefaultDatabase.LOGIC_NAME.toLowerCase()), instanceOf(OptimizerParserContext.class));
     }
     
     @Test
     void assertGetPlannerContext() {
-        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), createShardingSphereRuleMetaData());
+        OptimizerContext actual = OptimizerContextFactory.create(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, createShardingSphereDatabase()), mock(ConfigurationProperties.class));
         assertThat(actual.getPlannerContext(DefaultDatabase.LOGIC_NAME.toLowerCase()), instanceOf(OptimizerPlannerContext.class));
     }
     
@@ -59,10 +57,5 @@ class OptimizerContextTest {
         ShardingSphereDatabase result = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(result.getProtocolType().getType()).thenReturn("MySQL");
         return result;
-    }
-    
-    private ShardingSphereRuleMetaData createShardingSphereRuleMetaData() {
-        CacheOption cacheOption = new CacheOption(10, 1000);
-        return new ShardingSphereRuleMetaData(Collections.singleton(new SQLParserRule(new SQLParserRuleConfiguration(true, cacheOption, cacheOption))));
     }
 }

--- a/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/SQLFederationCompilerIT.java
+++ b/kernel/sql-federation/core/src/test/java/org/apache/shardingsphere/sqlfederation/optimizer/it/SQLFederationCompilerIT.java
@@ -236,7 +236,7 @@ class SQLFederationCompilerIT {
         CalciteConnectionConfig connectionConfig = new CalciteConnectionConfigImpl(new Properties());
         RelDataTypeFactory relDataTypeFactory = new JavaTypeFactoryImpl();
         DatabaseType databaseType = DatabaseTypeEngine.getDatabaseType("H2");
-        SQLFederationSchema sqlFederationSchema = new SQLFederationSchema(SCHEMA_NAME, schema, databaseType, new JavaTypeFactoryImpl(), null);
+        SQLFederationSchema sqlFederationSchema = new SQLFederationSchema(SCHEMA_NAME, schema, databaseType, new JavaTypeFactoryImpl());
         CalciteCatalogReader catalogReader = SQLFederationPlannerUtils.createCatalogReader(SCHEMA_NAME, sqlFederationSchema, relDataTypeFactory, connectionConfig);
         SqlValidator validator = SQLFederationPlannerUtils.createSqlValidator(catalogReader, relDataTypeFactory, databaseType, connectionConfig);
         RelOptCluster cluster = RelOptCluster.create(SQLFederationPlannerUtils.createVolcanoPlanner(), new RexBuilder(relDataTypeFactory));

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/DatabaseConnector.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/DatabaseConnector.java
@@ -254,7 +254,7 @@ public final class DatabaseConnector implements DatabaseBackendHandler {
         String schemaName = queryContext.getSqlStatementContext().getTablesContext().getSchemaName().orElseGet(() -> DatabaseTypeEngine.getDefaultSchemaName(databaseType, databaseName));
         SQLFederationRule sqlFederationRule = metaDataContexts.getMetaData().getGlobalRuleMetaData().getSingleRule(SQLFederationRule.class);
         federationExecutor = sqlFederationRule.getSqlFederationExecutor();
-        sqlFederationRule.init(databaseName, schemaName, metaDataContexts.getMetaData(), metaDataContexts.getShardingSphereData(),
+        federationExecutor.init(databaseName, schemaName, metaDataContexts.getMetaData(), metaDataContexts.getShardingSphereData(),
                 new JDBCExecutor(BackendExecutorContext.getInstance().getExecutorEngine(), databaseConnectionManager.getConnectionSession().getConnectionContext()));
     }
     

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/sql/PreviewExecutor.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rul/sql/PreviewExecutor.java
@@ -140,7 +140,7 @@ public final class PreviewExecutor implements ConnectionSessionRequiredRULExecut
         String schemaName = queryContext.getSqlStatementContext().getTablesContext().getSchemaName().orElseGet(() -> DatabaseTypeEngine.getDefaultSchemaName(database.getProtocolType(), databaseName));
         SQLFederationRule sqlFederationRule = metaDataContexts.getMetaData().getGlobalRuleMetaData().getSingleRule(SQLFederationRule.class);
         SQLFederationExecutor sqlFederationExecutor = sqlFederationRule.getSqlFederationExecutor();
-        sqlFederationRule.init(databaseName, schemaName, metaDataContexts.getMetaData(), metaDataContexts.getShardingSphereData(),
+        sqlFederationExecutor.init(databaseName, schemaName, metaDataContexts.getMetaData(), metaDataContexts.getShardingSphereData(),
                 new JDBCExecutor(BackendExecutorContext.getInstance().getExecutorEngine(), connectionSession.getConnectionContext()));
         sqlFederationExecutor.executeQuery(prepareEngine, createPreviewFederationCallback(database.getProtocolType(), database.getResourceMetaData().getStorageTypes(), sqlStatement), context);
         return context.getExecutionUnits();

--- a/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewrite/engine/SQLRewriterIT.java
+++ b/test/it/rewriter/src/test/java/org/apache/shardingsphere/test/it/rewrite/engine/SQLRewriterIT.java
@@ -162,7 +162,7 @@ public abstract class SQLRewriterIT {
     private Collection<ShardingSphereRule> createGlobalRules() {
         Collection<ShardingSphereRule> result = new LinkedList<>();
         result.add(new SQLTranslatorRule(new SQLTranslatorRuleConfiguration()));
-        result.add(new SQLFederationRule(new SQLFederationRuleConfiguration(false, mock(CacheOption.class))));
+        result.add(new SQLFederationRule(new SQLFederationRuleConfiguration(false, mock(CacheOption.class)), Collections.emptyMap(), mock(ConfigurationProperties.class)));
         result.add(new TimestampServiceRule(mock(TimestampServiceRuleConfiguration.class)));
         return result;
     }


### PR DESCRIPTION
Ref #26011.

Changes proposed in this pull request:
  - Move optimizer context init logic to SQLFederationRule

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
