### PR TITLE
Revise #26312, make executionPlanCache optional in DistSQL.

### DIFF
--- a/kernel/sql-federation/distsql/parser/src/main/antlr4/imports/sql-federation/RALStatement.g4
+++ b/kernel/sql-federation/distsql/parser/src/main/antlr4/imports/sql-federation/RALStatement.g4
@@ -28,7 +28,7 @@ alterSQLFederationRule
     ;
 
 sqlFederationRuleDefinition
-    : LP_ sqlFederationEnabled? COMMA_ executionPlanCache RP_
+    : LP_ sqlFederationEnabled? (COMMA_? executionPlanCache)? RP_
     ;
 
 sqlFederationEnabled


### PR DESCRIPTION
For #26312.

Changes proposed in this pull request:
  - Make `executionPlanCache` optional in DistSQL.

### Just modify sqlFederationEnabled
<img width="685" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/9d5b020e-b404-44f0-8dca-b47466dce5a9">



### Just modify executionPlanCache
<img width="669" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/02f51a28-d4e9-4997-96a2-a1dd9a88f9d0">
