### PR TITLE
Optimize performance of single table ddl refresher

### DIFF
--- a/infra/context/pom.xml
+++ b/infra/context/pom.xml
@@ -55,6 +55,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
+            <artifactId>shardingsphere-single-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.shardingsphere</groupId>
             <artifactId>shardingsphere-transaction-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/infra/context/pom.xml
+++ b/infra/context/pom.xml
@@ -55,7 +55,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.shardingsphere</groupId>
-            <artifactId>shardingsphere-single-core</artifactId>
+            <artifactId>shardingsphere-single-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/CreateTableStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/CreateTableStatementSchemaRefresher.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.connection.refresher.type.table;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.connection.refresher.MetaDataRefresher;
+import org.apache.shardingsphere.infra.connection.refresher.util.TableRefreshUtils;
 import org.apache.shardingsphere.infra.instance.mode.ModeContextManager;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -60,7 +61,7 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
             AlterSchemaMetaDataPOJO alterSchemaMetaDataPOJO = new AlterSchemaMetaDataPOJO(database.getName(), schemaName, logicDataSourceNames);
             alterSchemaMetaDataPOJO.getAlteredTables().add(actualTableMetaData.get());
             modeContextManager.alterSchemaMetaData(alterSchemaMetaDataPOJO);
-            if (isSingleTable) {
+            if (isSingleTable && TableRefreshUtils.isRuleRefreshRequired(database.getName(), database.getProtocolType(), ruleMetaData, schemaName, tableName)) {
                 modeContextManager.alterRuleConfiguration(database.getName(), ruleMetaData.getConfigurations());
             }
         }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/CreateTableStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/CreateTableStatementSchemaRefresher.java
@@ -61,7 +61,7 @@ public final class CreateTableStatementSchemaRefresher implements MetaDataRefres
             AlterSchemaMetaDataPOJO alterSchemaMetaDataPOJO = new AlterSchemaMetaDataPOJO(database.getName(), schemaName, logicDataSourceNames);
             alterSchemaMetaDataPOJO.getAlteredTables().add(actualTableMetaData.get());
             modeContextManager.alterSchemaMetaData(alterSchemaMetaDataPOJO);
-            if (isSingleTable && TableRefreshUtils.isRuleRefreshRequired(database.getName(), database.getProtocolType(), ruleMetaData, schemaName, tableName)) {
+            if (isSingleTable && TableRefreshUtils.isRuleRefreshRequired(ruleMetaData, schemaName, tableName)) {
                 modeContextManager.alterRuleConfiguration(database.getName(), ruleMetaData.getConfigurations());
             }
         }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/DropTableStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/DropTableStatementSchemaRefresher.java
@@ -45,7 +45,7 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
         for (SimpleTableSegment each : sqlStatement.getTables()) {
             String tableName = each.getTableName().getIdentifier().getValue();
             if (isSingleTable(tableName, ruleMetaData)
-                    && TableRefreshUtils.isRuleRefreshRequired(database.getName(), database.getProtocolType(), ruleMetaData, schemaName, tableName)) {
+                    && TableRefreshUtils.isRuleRefreshRequired(ruleMetaData, schemaName, tableName)) {
                 modeContextManager.alterRuleConfiguration(database.getName(), ruleMetaData.getConfigurations());
                 break;
             }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/DropTableStatementSchemaRefresher.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/type/table/DropTableStatementSchemaRefresher.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.infra.connection.refresher.type.table;
 
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 import org.apache.shardingsphere.infra.connection.refresher.MetaDataRefresher;
+import org.apache.shardingsphere.infra.connection.refresher.util.TableRefreshUtils;
 import org.apache.shardingsphere.infra.instance.mode.ModeContextManager;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
@@ -42,7 +43,9 @@ public final class DropTableStatementSchemaRefresher implements MetaDataRefreshe
         modeContextManager.alterSchemaMetaData(alterSchemaMetaDataPOJO);
         ShardingSphereRuleMetaData ruleMetaData = database.getRuleMetaData();
         for (SimpleTableSegment each : sqlStatement.getTables()) {
-            if (isSingleTable(each.getTableName().getIdentifier().getValue(), ruleMetaData)) {
+            String tableName = each.getTableName().getIdentifier().getValue();
+            if (isSingleTable(tableName, ruleMetaData)
+                    && TableRefreshUtils.isRuleRefreshRequired(database.getName(), database.getProtocolType(), ruleMetaData, schemaName, tableName)) {
                 modeContextManager.alterRuleConfiguration(database.getName(), ruleMetaData.getConfigurations());
                 break;
             }

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
@@ -37,12 +37,12 @@ import java.util.Optional;
 public final class TableRefreshUtils {
     
     /**
-     * Get aggregated data source map.
+     * Judge whether the rule need to be refreshed.
      * 
      * @param ruleMetaData rule meta data
      * @param schemaName schema name
      * @param tableName table name
-     * @return aggregated data source map
+     * @return whether the rule need to be refreshed
      */
     public static boolean isRuleRefreshRequired(final ShardingSphereRuleMetaData ruleMetaData, final String schemaName, final String tableName) {
         Optional<MutableDataNodeRule> singleRule = ruleMetaData.findSingleRule(MutableDataNodeRule.class);

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.connection.refresher.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.type.DatabaseType;
+import org.apache.shardingsphere.infra.datanode.DataNode;
+import org.apache.shardingsphere.infra.metadata.database.rule.ShardingSphereRuleMetaData;
+import org.apache.shardingsphere.single.constant.SingleTableConstants;
+import org.apache.shardingsphere.single.rule.SingleRule;
+import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Table refresh utils.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TableRefreshUtils {
+    
+    /**
+     * Get aggregated data source map.
+     * 
+     * @param databaseName database name
+     * @param databaseType database type
+     * @param ruleMetaData rule meta data
+     * @param schemaName schema name
+     * @param tableName table name
+     * @return aggregated data source map
+     */
+    public static boolean isRuleRefreshRequired(final String databaseName, final DatabaseType databaseType, final ShardingSphereRuleMetaData ruleMetaData,
+                                                final String schemaName, final String tableName) {
+        Optional<SingleRule> singleRule = ruleMetaData.findSingleRule(SingleRule.class);
+        if (!singleRule.isPresent()) {
+            return false;
+        }
+        Optional<DataNode> dataNode = singleRule.get().findTableDataNode(schemaName, tableName);
+        if (!dataNode.isPresent()) {
+            return false;
+        }
+        DataNode actualNode = dataNode.get();
+        Collection<String> tablesConfig = SingleTableLoadUtils.splitTableLines(singleRule.get().getConfiguration().getTables());
+        if (tablesConfig.contains(SingleTableConstants.ALL_TABLES) || tablesConfig.contains(SingleTableConstants.ALL_SCHEMA_TABLES)) {
+            return false;
+        }
+        Collection<DataNode> dataNods = SingleTableLoadUtils.convertToDataNodes(databaseName, databaseType, tablesConfig);
+        for (DataNode each : dataNods) {
+            if (each.equals(actualNode) || SingleTableConstants.ASTERISK.equals(each.getSchemaName())
+                    || each.getDataSourceName().equals(actualNode.getDataSourceName()) && SingleTableConstants.ASTERISK.equals(each.getTableName())) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
+++ b/infra/context/src/main/java/org/apache/shardingsphere/infra/connection/refresher/util/TableRefreshUtils.java
@@ -62,9 +62,7 @@ public final class TableRefreshUtils {
             return false;
         }
         DataNode actualNode = dataNode.get();
-        return !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), actualNode.getSchemaName(), actualNode.getTableName()))
-                && !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), SingleTableConstants.ASTERISK))
-                && !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), actualNode.getTableName()))
+        return !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), SingleTableConstants.ASTERISK))
                 && !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), SingleTableConstants.ASTERISK, SingleTableConstants.ASTERISK))
                 && !tablesConfig.contains(joinDataNodeSegments(actualNode.getDataSourceName(), actualNode.getSchemaName(), SingleTableConstants.ASTERISK));
     }

--- a/kernel/single/api/src/main/java/org/apache/shardingsphere/single/api/constant/SingleTableConstants.java
+++ b/kernel/single/api/src/main/java/org/apache/shardingsphere/single/api/constant/SingleTableConstants.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.shardingsphere.single.constant;
+package org.apache.shardingsphere.single.api.constant;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -23,7 +23,7 @@ import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.metadata.database.schema.loader.common.SchemaMetaDataLoader;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
-import org.apache.shardingsphere.single.constant.SingleTableConstants;
+import org.apache.shardingsphere.single.api.constant.SingleTableConstants;
 import org.apache.shardingsphere.single.exception.SingleTablesLoadingException;
 import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
 

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/util/SingleTableLoadUtils.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/util/SingleTableLoadUtils.java
@@ -26,7 +26,7 @@ import org.apache.shardingsphere.infra.datanode.DataNode;
 import org.apache.shardingsphere.infra.rule.ShardingSphereRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
-import org.apache.shardingsphere.single.constant.SingleTableConstants;
+import org.apache.shardingsphere.single.api.constant.SingleTableConstants;
 
 import javax.sql.DataSource;
 import java.util.Collection;

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableStatementUpdater.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableStatementUpdater.java
@@ -29,7 +29,7 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.single.api.config.SingleRuleConfiguration;
-import org.apache.shardingsphere.single.constant.SingleTableConstants;
+import org.apache.shardingsphere.single.api.constant.SingleTableConstants;
 import org.apache.shardingsphere.single.datanode.SingleTableDataNodeLoader;
 import org.apache.shardingsphere.single.distsql.handler.exception.MissingRequiredSingleTableException;
 import org.apache.shardingsphere.single.distsql.segment.SingleTableSegment;

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableStatementUpdater.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/UnloadSingleTableStatementUpdater.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereTable;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.single.api.config.SingleRuleConfiguration;
-import org.apache.shardingsphere.single.constant.SingleTableConstants;
+import org.apache.shardingsphere.single.api.constant.SingleTableConstants;
 import org.apache.shardingsphere.single.distsql.statement.rdl.UnloadSingleTableStatement;
 import org.apache.shardingsphere.single.exception.SingleTableNotFoundException;
 import org.apache.shardingsphere.single.rule.SingleRule;


### PR DESCRIPTION
For #26334

Changes proposed in this pull request:
  - Do not call `alterRuleConfiguration` when refresh is not required

