### PR TITLE
Fix java.sql.time convert failed when there are negative values

### DIFF
--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
@@ -110,6 +110,9 @@ public final class ColumnValueConvertUtils {
             Time time = (Time) object;
             long millis = (int) (time.getTime() % MILLISECONDS_PER_SECOND);
             int nanosOfSecond = (int) (millis * NANOSECONDS_PER_MILLISECOND);
+            if (nanosOfSecond < 0) {
+                nanosOfSecond = (int) (nanosOfSecond + TimeUnit.SECONDS.toNanos(1));
+            }
             LocalTime localTime = LocalTime.of(time.getHours(), time.getMinutes(), time.getSeconds(), nanosOfSecond);
             return Int64Value.of(localTime.toNanoOfDay());
         }

--- a/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
+++ b/kernel/data-pipeline/cdc/core/src/main/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtils.java
@@ -47,7 +47,6 @@ import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Column value convert utility class.
@@ -55,10 +54,6 @@ import java.util.concurrent.TimeUnit;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Slf4j
 public final class ColumnValueConvertUtils {
-    
-    private static final long MILLISECONDS_PER_SECOND = TimeUnit.SECONDS.toMillis(1);
-    
-    private static final long NANOSECONDS_PER_MILLISECOND = TimeUnit.MILLISECONDS.toNanos(1);
     
     /**
      * Convert java object to protobuf message.
@@ -108,12 +103,7 @@ public final class ColumnValueConvertUtils {
         }
         if (object instanceof Time) {
             Time time = (Time) object;
-            long millis = (int) (time.getTime() % MILLISECONDS_PER_SECOND);
-            int nanosOfSecond = (int) (millis * NANOSECONDS_PER_MILLISECOND);
-            if (nanosOfSecond < 0) {
-                nanosOfSecond = (int) (nanosOfSecond + TimeUnit.SECONDS.toNanos(1));
-            }
-            LocalTime localTime = LocalTime.of(time.getHours(), time.getMinutes(), time.getSeconds(), nanosOfSecond);
+            LocalTime localTime = LocalTime.of(time.getHours(), time.getMinutes(), time.getSeconds(), new Timestamp(time.getTime()).getNanos());
             return Int64Value.of(localTime.toNanoOfDay());
         }
         if (object instanceof java.sql.Date) {

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
@@ -110,7 +110,7 @@ class ColumnValueConvertUtilsTest {
     
     @Test
     void assertTimeConvert() {
-        Time time = new Time(-3600 * 1000);
+        Time time = new Time(-3612 * 1000);
         Int64Value actualMessage = (Int64Value) ColumnValueConvertUtils.convertToProtobufMessage(time);
         assertThat(LocalTime.ofNanoOfDay(actualMessage.getValue()), is(time.toLocalTime()));
     }

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
@@ -110,8 +110,9 @@ class ColumnValueConvertUtilsTest {
     
     @Test
     void assertTimeConvert() {
-        Time time = new Time(-3612 * 1000);
+        Time time = new Time(-3600 * 1000 - 1234);
+        int nanos = new Timestamp(time.getTime()).getNanos();
         Int64Value actualMessage = (Int64Value) ColumnValueConvertUtils.convertToProtobufMessage(time);
-        assertThat(LocalTime.ofNanoOfDay(actualMessage.getValue()), is(time.toLocalTime()));
+        assertThat(LocalTime.ofNanoOfDay(actualMessage.getValue()), is(time.toLocalTime().withNano(nanos)));
     }
 }

--- a/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
+++ b/kernel/data-pipeline/cdc/core/src/test/java/org/apache/shardingsphere/data/pipeline/cdc/util/ColumnValueConvertUtilsTest.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.Date;
@@ -104,5 +106,12 @@ class ColumnValueConvertUtilsTest {
         assertTrue(actualMessage instanceof com.google.protobuf.Timestamp);
         assertThat(((com.google.protobuf.Timestamp) actualMessage).getSeconds(), is(offsetDateTime.toEpochSecond()));
         assertThat(((com.google.protobuf.Timestamp) actualMessage).getNanos(), is(offsetDateTime.getNano()));
+    }
+    
+    @Test
+    void assertTimeConvert() {
+        Time time = new Time(-3600 * 1000);
+        Int64Value actualMessage = (Int64Value) ColumnValueConvertUtils.convertToProtobufMessage(time);
+        assertThat(LocalTime.ofNanoOfDay(actualMessage.getValue()), is(time.toLocalTime()));
     }
 }


### PR DESCRIPTION


Changes proposed in this pull request:
  - Fix java.sql.time convert failed when there are negative values

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
