### PR TITLE
Fix the issue with e2e.

### DIFF
--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/framework/param/array/E2ETestParameterGenerator.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/framework/param/array/E2ETestParameterGenerator.java
@@ -105,7 +105,7 @@ public final class E2ETestParameterGenerator {
                                                                          final IntegrationTestCaseAssertion assertion, final SQLCommandType sqlCommandType) {
         Collection<AssertionTestParameter> result = new LinkedList<>();
         for (String each : getEnvAdapters(testCaseContext.getTestCase().getAdapters())) {
-            if (sqlCommandType.getRunningAdaptors().contains(each)) {
+            if (sqlCommandType.getRunningAdaptors().contains(each) && envAdapters.contains(each)) {
                 result.addAll(getAssertionTestParameter(testCaseContext, assertion, each, databaseType, sqlExecuteType, sqlCommandType));
             }
         }

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/framework/param/array/JdbcStandaloneTestParameterGenerator.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/framework/param/array/JdbcStandaloneTestParameterGenerator.java
@@ -19,8 +19,6 @@ package org.apache.shardingsphere.test.e2e.framework.param.array;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.shardingsphere.infra.database.type.DatabaseType;
-import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.cases.SQLCommandType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterMode;
@@ -39,8 +37,6 @@ public final class JdbcStandaloneTestParameterGenerator {
     
     private static final Collection<String> ADAPTERS = Collections.singleton(AdapterType.JDBC.getValue());
     
-    private static final Collection<DatabaseType> DATABASE_TYPES = Collections.singleton(TypedSPILoader.getService(DatabaseType.class, "H2"));
-    
     private static final IntegrationTestEnvironment ENV = IntegrationTestEnvironment.getInstance();
     
     /**
@@ -50,7 +46,7 @@ public final class JdbcStandaloneTestParameterGenerator {
      * @return assertion test parameter
      */
     public static Collection<AssertionTestParameter> getAssertionTestParameter(final SQLCommandType sqlCommandType) {
-        return new E2ETestParameterGenerator(ADAPTERS, ENV.getScenarios(), AdapterMode.STANDALONE.getValue(), DATABASE_TYPES).getAssertionTestParameter(sqlCommandType);
+        return new E2ETestParameterGenerator(ADAPTERS, ENV.getScenarios(), AdapterMode.STANDALONE.getValue(), ENV.getClusterEnvironment().getDatabaseTypes()).getAssertionTestParameter(sqlCommandType);
     }
     
     /**
@@ -60,6 +56,6 @@ public final class JdbcStandaloneTestParameterGenerator {
      * @return case test parameter
      */
     public static Collection<E2ETestParameter> getCaseTestParameter(final SQLCommandType sqlCommandType) {
-        return new E2ETestParameterGenerator(ADAPTERS, ENV.getScenarios(), AdapterMode.STANDALONE.getValue(), DATABASE_TYPES).getCaseTestParameter(sqlCommandType);
+        return new E2ETestParameterGenerator(ADAPTERS, ENV.getScenarios(), AdapterMode.STANDALONE.getValue(), ENV.getClusterEnvironment().getDatabaseTypes()).getCaseTestParameter(sqlCommandType);
     }
 }

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
@@ -111,4 +111,3 @@ rules:
   
 - !SQL_PARSER
   sqlCommentParseEnabled: true
-  

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
@@ -108,6 +108,6 @@ rules:
   tables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
-
-sqlParser:
+  
+- !SQL_PARSER
   sqlCommentParseEnabled: true

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
@@ -108,3 +108,6 @@ rules:
   tables:
     - t_broadcast_table
     - t_broadcast_table_for_ddl
+
+sqlParser:
+  sqlCommentParseEnabled: true

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/proxy/conf/mysql/config-tbl.yaml
@@ -111,3 +111,4 @@ rules:
   
 - !SQL_PARSER
   sqlCommentParseEnabled: true
+  

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
@@ -104,3 +104,4 @@ sqlFederation:
     
 sqlParser:
   sqlCommentParseEnabled: true
+  

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
@@ -101,3 +101,6 @@ sqlFederation:
   executionPlanCache:
     initialCapacity: 2000
     maximumSize: 65535
+    
+sqlParser:
+  sqlCommentParseEnabled: true

--- a/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
+++ b/test/e2e/sql/src/test/resources/env/scenario/tbl/rules.yaml
@@ -104,4 +104,4 @@ sqlFederation:
     
 sqlParser:
   sqlCommentParseEnabled: true
-  
+


### PR DESCRIPTION
- Fix the issue where JdbcStandaloneTestParameterGenerator always uses H2 as the database type.
- Fix e2e failure caused by sqlCommentParseEnabled not being enabled.
- Fix the problem of getAssertionTestParameter not filtering by env adapter.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
