### PR TITLE
Support PostgreSQL pg_catalog.pg_am/pg_amop/pg_ampro/pg_attrdef table empty query

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -76,7 +76,7 @@ public enum SystemSchemaBuilderRule {
     
     POSTGRESQL_INFORMATION_SCHEMA("PostgreSQL", "information_schema", new HashSet<>(Arrays.asList("columns", "tables", "views"))),
     
-    POSTGRESQL_PG_CATALOG("PostgreSQL", "pg_catalog", new HashSet<>(Arrays.asList("pg_aggregate", "pg_class", "pg_database", "pg_tables", "pg_inherits",
+    POSTGRESQL_PG_CATALOG("PostgreSQL", "pg_catalog", new HashSet<>(Arrays.asList("pg_aggregate", "pg_am", "pg_amop", "pg_amproc", "pg_attrdef", "pg_class", "pg_database", "pg_tables", "pg_inherits",
             "pg_tablespace", "pg_trigger", "pg_namespace", "pg_roles"))),
     
     POSTGRESQL_SHARDING_SPHERE("PostgreSQL", "shardingsphere", new HashSet<>(Arrays.asList("sharding_table_statistics", "cluster_information"))),

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_am.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_am.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_am
+columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    visible: true
+  amname:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: amname
+    primaryKey: false
+    visible: true
+  amhandler:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: amhandler
+    primaryKey: false
+    visible: true
+  amtype:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: amtype
+    primaryKey: false
+    visible: true
+indexes:
+  pg_am_name_index:
+    name: pg_am_name_index
+  pg_am_oid_index:
+    name: pg_am_oid_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_amop.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_amop.yaml
@@ -1,0 +1,89 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_amop
+columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    visible: true
+  amopfamily:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amopfamily
+    primaryKey: false
+    visible: true
+  amoplefttype:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amoplefttype
+    primaryKey: false
+    visible: true
+  amoprighttype:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amoprighttype
+    primaryKey: false
+    visible: true
+  amopstrategy:
+    caseSensitive: true
+    dataType: 5
+    generated: false
+    name: amopstrategy
+    primaryKey: false
+    visible: true
+  amoppurpose:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: amoppurpose
+    primaryKey: false
+    visible: true
+  amopopr:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amopopr
+    primaryKey: false
+    visible: true
+  amopmethod:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amopmethod
+    primaryKey: false
+    visible: true
+  amopsortfamily:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amopsortfamily
+    primaryKey: false
+    visible: true
+indexes:
+  pg_amop_fam_strat_index:
+    name: pg_amop_fam_strat_index
+  pg_amop_oid_index:
+    name: pg_amop_oid_index
+  pg_amop_opr_fam_index:
+    name: pg_amop_opr_fam_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_amproc.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_amproc.yaml
@@ -1,0 +1,66 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_amproc
+columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    visible: true
+  amprocfamily:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amprocfamily
+    primaryKey: false
+    visible: true
+  amproclefttype:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amproclefttype
+    primaryKey: false
+    visible: true
+  amprocrighttype:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: amprocrighttype
+    primaryKey: false
+    visible: true
+  amprocnum:
+    caseSensitive: true
+    dataType: 5
+    generated: false
+    name: amprocnum
+    primaryKey: false
+    visible: true
+  amproc:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: amproc
+    primaryKey: false
+    visible: true
+indexes:
+  pg_amproc_fam_proc_index:
+    name: pg_amproc_fam_proc_index
+  pg_amproc_oid_index:
+    name: pg_amproc_oid_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_attrdef.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_attrdef.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_attrdef
+columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    visible: true
+  adrelid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: adrelid
+    primaryKey: false
+    visible: true
+  adnum:
+    caseSensitive: true
+    dataType: 5
+    generated: false
+    name: adnum
+    primaryKey: false
+    visible: true
+  adbin:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: adbin
+    primaryKey: false
+    visible: true
+indexes:
+  pg_attrdef_adrelid_adnum_index:
+    name: pg_attrdef_adrelid_adnum_index
+  pg_attrdef_oid_index:
+    name: pg_attrdef_oid_index

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -42,7 +42,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualPerformanceSchema.getTables().size(), is(87));
         SystemSchemaBuilderRule actualPgCatalog = SystemSchemaBuilderRule.valueOf(new PostgreSQLDatabaseType().getType(), "pg_catalog");
         assertThat(actualPgCatalog, is(SystemSchemaBuilderRule.POSTGRESQL_PG_CATALOG));
-        assertThat(actualPgCatalog.getTables().size(), is(9));
+        assertThat(actualPgCatalog.getTables().size(), is(13));
     }
     
     @Test
@@ -56,6 +56,10 @@ class SystemSchemaBuilderRuleTest {
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_database"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_tables"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_aggregate"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_am"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_amop"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_amproc"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_attrdef"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_roles"));
         assertFalse(SystemSchemaBuilderRule.isSystemTable("sharding_db", "t_order"));
     }

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -55,7 +55,7 @@ class SystemSchemaBuilderTest {
         assertTrue(actual.containsKey("pg_catalog"));
         assertTrue(actual.containsKey("shardingsphere"));
         assertThat(actual.get("information_schema").getTables().size(), is(3));
-        assertThat(actual.get("pg_catalog").getTables().size(), is(9));
+        assertThat(actual.get("pg_catalog").getTables().size(), is(13));
         assertThat(actual.get("shardingsphere").getTables().size(), is(2));
     }
     

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_am.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_am.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="oid" />
+        <column name="amname" />
+        <column name="amhandler" />
+        <column name="amtype" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_amop.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_amop.xml
@@ -1,0 +1,30 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="oid" />
+        <column name="amopfamily" />
+        <column name="amoplefttype" />
+        <column name="amoprighttype" />
+        <column name="amopstrategy" />
+        <column name="amoppurpose" />
+        <column name="amopopr" />
+        <column name="amopmethod" />
+        <column name="amopsortfamily" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_amproc.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_amproc.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="oid" />
+        <column name="amprocfamily" />
+        <column name="amproclefttype" />
+        <column name="amprocrighttype" />
+        <column name="amprocnum" />
+        <column name="amproc" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_attrdef.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_attrdef.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="oid" />
+        <column name="adrelid" />
+        <column name="adnum" />
+        <column name="adbin" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -721,4 +721,20 @@
     <test-case sql="SELECT * FROM pg_catalog.pg_aggregate" db-types="PostgreSQL" scenario-types="db">
         <assertion expected-data-file="select_postgresql_pg_catalog_pg_aggregate.xml" />
     </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_am" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_am.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_amop" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_amop.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_amproc" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_amproc.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_attrdef" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_attrdef.xml" />
+    </test-case>
 </integration-test-cases>


### PR DESCRIPTION
For #26143.

Changes proposed in this pull request:
  -add pg_am/pg_amop/pg_ampro/pg_attrdef table in pg_catalog for PostgreSQL
  -add test cases
  -pg_aggregate was finished in #25752 
- [x] pg_aggregate
- [x] pg_am
- [x] pg_amop
- [x] pg_amproc
- [x] pg_attrdef


---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
