### PR TITLE
Support sql federation stream query when not contains pipeline breaker

### DIFF
--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TableScanExecutorContext.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/TableScanExecutorContext.java
@@ -21,8 +21,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.config.props.ConfigurationProperties;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
- * Translatable table scan executor context.
+ * Table scan executor context.
  */
 @RequiredArgsConstructor
 @Getter
@@ -35,4 +38,6 @@ public final class TableScanExecutorContext {
     private final ConfigurationProperties props;
     
     private final SQLFederationExecutorContext federationContext;
+    
+    private final Map<String, Integer> connectionOffsets = new LinkedHashMap<>();
 }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/EnumerablePushDownTableScanExecutor.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/executor/enumerable/EnumerablePushDownTableScanExecutor.java
@@ -49,14 +49,13 @@ import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroup;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupContext;
 import org.apache.shardingsphere.infra.executor.kernel.model.ExecutionGroupReportContext;
 import org.apache.shardingsphere.infra.executor.sql.context.ExecutionContext;
+import org.apache.shardingsphere.infra.executor.sql.context.ExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutionUnit;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutor;
 import org.apache.shardingsphere.infra.executor.sql.execute.engine.driver.jdbc.JDBCExecutorCallback;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.ExecuteResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResult;
 import org.apache.shardingsphere.infra.executor.sql.execute.result.query.QueryResultMetaData;
-import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.memory.JDBCMemoryQueryResult;
-import org.apache.shardingsphere.infra.executor.sql.execute.result.query.impl.driver.jdbc.type.stream.JDBCStreamQueryResult;
 import org.apache.shardingsphere.infra.executor.sql.prepare.driver.DriverExecutionPrepareEngine;
 import org.apache.shardingsphere.infra.executor.sql.process.ProcessEngine;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
@@ -74,17 +73,17 @@ import org.apache.shardingsphere.infra.session.connection.ConnectionContext;
 import org.apache.shardingsphere.infra.session.query.QueryContext;
 import org.apache.shardingsphere.infra.util.exception.external.sql.type.wrapper.SQLWrapperException;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sqlfederation.compiler.context.OptimizerContext;
+import org.apache.shardingsphere.sqlfederation.compiler.metadata.schema.SQLFederationSchema;
+import org.apache.shardingsphere.sqlfederation.compiler.planner.util.SQLFederationPlannerUtils;
 import org.apache.shardingsphere.sqlfederation.executor.SQLDialectFactory;
 import org.apache.shardingsphere.sqlfederation.executor.SQLFederationDataContext;
 import org.apache.shardingsphere.sqlfederation.executor.SQLFederationExecutorContext;
 import org.apache.shardingsphere.sqlfederation.executor.TableScanExecutorContext;
-import org.apache.shardingsphere.sqlfederation.executor.util.StringToRexNodeUtils;
 import org.apache.shardingsphere.sqlfederation.executor.row.EmptyRowEnumerator;
 import org.apache.shardingsphere.sqlfederation.executor.row.MemoryEnumerator;
 import org.apache.shardingsphere.sqlfederation.executor.row.SQLFederationRowEnumerator;
-import org.apache.shardingsphere.sqlfederation.compiler.context.OptimizerContext;
-import org.apache.shardingsphere.sqlfederation.compiler.metadata.schema.SQLFederationSchema;
-import org.apache.shardingsphere.sqlfederation.compiler.planner.util.SQLFederationPlannerUtils;
+import org.apache.shardingsphere.sqlfederation.executor.util.StringToRexNodeUtils;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -150,7 +149,7 @@ public final class EnumerablePushDownTableScanExecutor {
             federationContext.getExecutionUnits().addAll(context.getExecutionUnits());
             return createEmptyScalarEnumerable();
         }
-        return executeScalarEnumerable(databaseType, queryContext, database, context);
+        return executeScalarEnumerable(queryContext, database, context);
     }
     
     private AbstractEnumerable<Object> createEmptyScalarEnumerable() {
@@ -179,18 +178,18 @@ public final class EnumerablePushDownTableScanExecutor {
         };
     }
     
-    private AbstractEnumerable<Object> executeScalarEnumerable(final DatabaseType databaseType, final QueryContext queryContext,
-                                                               final ShardingSphereDatabase database, final ExecutionContext context) {
+    private AbstractEnumerable<Object> executeScalarEnumerable(final QueryContext queryContext, final ShardingSphereDatabase database, final ExecutionContext context) {
         try {
+            computeConnectionOffsets(context);
             ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext =
-                    prepareEngine.prepare(context.getRouteContext(), context.getExecutionUnits(), new ExecutionGroupReportContext(database.getName()));
+                    prepareEngine.prepare(context.getRouteContext(), executorContext.getConnectionOffsets(), context.getExecutionUnits(), new ExecutionGroupReportContext(database.getName()));
             setParameters(executionGroupContext.getInputGroups());
             processEngine.executeSQL(executionGroupContext, context.getQueryContext());
-            List<QueryResult> queryResults = execute(executionGroupContext, databaseType);
+            List<QueryResult> queryResults = jdbcExecutor.execute(executionGroupContext, callback).stream().map(QueryResult.class::cast).collect(Collectors.toList());
             MergeEngine mergeEngine = new MergeEngine(database, executorContext.getProps(), new ConnectionContext());
             MergedResult mergedResult = mergeEngine.merge(queryResults, queryContext.getSqlStatementContext());
             Collection<Statement> statements = getStatements(executionGroupContext.getInputGroups());
-            return createScalarEnumerable(mergedResult, statements);
+            return createScalarEnumerable(mergedResult, queryResults.get(0).getMetaData(), statements);
         } catch (final SQLException ex) {
             throw new SQLWrapperException(ex);
         } finally {
@@ -198,25 +197,25 @@ public final class EnumerablePushDownTableScanExecutor {
         }
     }
     
-    private AbstractEnumerable<Object> createScalarEnumerable(final MergedResult mergedResult, final Collection<Statement> statements) throws SQLException {
-        // TODO remove getRows when mergedResult support JDBC first method
-        Collection<Object> rows = getScalarRows(mergedResult);
+    private void computeConnectionOffsets(final ExecutionContext context) {
+        for (ExecutionUnit each : context.getExecutionUnits()) {
+            if (executorContext.getConnectionOffsets().containsKey(each.getDataSourceName())) {
+                int connectionOffset = executorContext.getConnectionOffsets().get(each.getDataSourceName());
+                executorContext.getConnectionOffsets().put(each.getDataSourceName(), ++connectionOffset);
+            } else {
+                executorContext.getConnectionOffsets().put(each.getDataSourceName(), 0);
+            }
+        }
+    }
+    
+    private AbstractEnumerable<Object> createScalarEnumerable(final MergedResult mergedResult, final QueryResultMetaData metaData, final Collection<Statement> statements) {
         return new AbstractEnumerable<Object>() {
             
             @Override
             public Enumerator<Object> enumerator() {
-                return new SQLFederationRowEnumerator<>(rows, statements);
+                return new SQLFederationRowEnumerator<>(mergedResult, metaData, statements);
             }
         };
-    }
-    
-    private Collection<Object> getScalarRows(final MergedResult mergedResult) throws SQLException {
-        Collection<Object> result = new LinkedList<>();
-        while (mergedResult.next()) {
-            Object currentRow = mergedResult.getValue(1, Object.class);
-            result.add(currentRow);
-        }
-        return result;
     }
     
     /**
@@ -242,16 +241,17 @@ public final class EnumerablePushDownTableScanExecutor {
             federationContext.getExecutionUnits().addAll(context.getExecutionUnits());
             return createEmptyEnumerable();
         }
-        return execute(databaseType, queryContext, database, context);
+        return execute(queryContext, database, context);
     }
     
-    private AbstractEnumerable<Object[]> execute(final DatabaseType databaseType, final QueryContext queryContext, final ShardingSphereDatabase database, final ExecutionContext context) {
+    private AbstractEnumerable<Object[]> execute(final QueryContext queryContext, final ShardingSphereDatabase database, final ExecutionContext context) {
         try {
+            computeConnectionOffsets(context);
             ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext =
-                    prepareEngine.prepare(context.getRouteContext(), context.getExecutionUnits(), new ExecutionGroupReportContext(database.getName()));
+                    prepareEngine.prepare(context.getRouteContext(), executorContext.getConnectionOffsets(), context.getExecutionUnits(), new ExecutionGroupReportContext(database.getName()));
             setParameters(executionGroupContext.getInputGroups());
             processEngine.executeSQL(executionGroupContext, context.getQueryContext());
-            List<QueryResult> queryResults = execute(executionGroupContext, databaseType);
+            List<QueryResult> queryResults = jdbcExecutor.execute(executionGroupContext, callback).stream().map(QueryResult.class::cast).collect(Collectors.toList());
             MergeEngine mergeEngine = new MergeEngine(database, executorContext.getProps(), new ConnectionContext());
             MergedResult mergedResult = mergeEngine.merge(queryResults, queryContext.getSqlStatementContext());
             Collection<Statement> statements = getStatements(executionGroupContext.getInputGroups());
@@ -261,18 +261,6 @@ public final class EnumerablePushDownTableScanExecutor {
         } finally {
             processEngine.completeSQLExecution();
         }
-    }
-    
-    private List<QueryResult> execute(final ExecutionGroupContext<JDBCExecutionUnit> executionGroupContext, final DatabaseType databaseType) throws SQLException {
-        Collection<QueryResult> queryResults = jdbcExecutor.execute(executionGroupContext, callback).stream().map(QueryResult.class::cast).collect(Collectors.toList());
-        List<QueryResult> result = new LinkedList<>();
-        for (QueryResult each : queryResults) {
-            QueryResult queryResult = each instanceof JDBCStreamQueryResult
-                    ? new JDBCMemoryQueryResult(((JDBCStreamQueryResult) each).getResultSet(), databaseType)
-                    : each;
-            result.add(queryResult);
-        }
-        return result;
     }
     
     private Enumerable<Object[]> executeByShardingSphereData(final String databaseName, final String schemaName, final ShardingSphereTable table) {
@@ -378,28 +366,14 @@ public final class EnumerablePushDownTableScanExecutor {
         return result;
     }
     
-    private AbstractEnumerable<Object[]> createEnumerable(final MergedResult mergedResult, final QueryResultMetaData metaData, final Collection<Statement> statements) throws SQLException {
-        // TODO remove getRows when mergedResult support JDBC first method
-        Collection<Object[]> rows = getRows(mergedResult, metaData);
+    private AbstractEnumerable<Object[]> createEnumerable(final MergedResult mergedResult, final QueryResultMetaData metaData, final Collection<Statement> statements) {
         return new AbstractEnumerable<Object[]>() {
             
             @Override
             public Enumerator<Object[]> enumerator() {
-                return new SQLFederationRowEnumerator<>(rows, statements);
+                return new SQLFederationRowEnumerator<>(mergedResult, metaData, statements);
             }
         };
-    }
-    
-    private Collection<Object[]> getRows(final MergedResult mergedResult, final QueryResultMetaData metaData) throws SQLException {
-        Collection<Object[]> result = new LinkedList<>();
-        while (mergedResult.next()) {
-            Object[] currentRow = new Object[metaData.getColumnCount()];
-            for (int i = 0; i < metaData.getColumnCount(); i++) {
-                currentRow[i] = mergedResult.getValue(i + 1, Object.class);
-            }
-            result.add(currentRow);
-        }
-        return result;
     }
     
     private QueryContext createQueryContext(final ShardingSphereMetaData metaData, final SqlString sqlString, final DatabaseType databaseType, final boolean useCache) {


### PR DESCRIPTION
Fixes #26360.

Changes proposed in this pull request:
  - Support sql federation stream query when not contains pipeline breaker

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
