### PR TITLE
Support PostgreSQL pg_catalog.pg_range table empty query

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRule.java
@@ -77,7 +77,7 @@ public enum SystemSchemaBuilderRule {
     POSTGRESQL_INFORMATION_SCHEMA("PostgreSQL", "information_schema", new HashSet<>(Arrays.asList("columns", "tables", "views"))),
     
     POSTGRESQL_PG_CATALOG("PostgreSQL", "pg_catalog", new HashSet<>(Arrays.asList("pg_aggregate", "pg_am", "pg_amop", "pg_amproc", "pg_attrdef", "pg_class", "pg_database", "pg_tables", "pg_inherits",
-            "pg_tablespace", "pg_trigger", "pg_namespace", "pg_roles", "pg_user_mapping"))),
+            "pg_tablespace", "pg_trigger", "pg_namespace", "pg_range", "pg_replication_origin", "pg_rewrite", "pg_seclabel", "pg_sequence", "pg_roles", "pg_user_mapping"))),
     
     POSTGRESQL_SHARDING_SPHERE("PostgreSQL", "shardingsphere", new HashSet<>(Arrays.asList("sharding_table_statistics", "cluster_information"))),
     

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_range.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_range.yaml
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_range
+columns:
+  rngtypid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: rngtypid
+    primaryKey: false
+    visible: true
+  rngsubtype:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: rngsubtype
+    primaryKey: false
+    visible: true
+  rngmultitypid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: rngmultitypid
+    primaryKey: false
+    visible: true
+  rngcollation:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: rngcollation
+    primaryKey: false
+    visible: true
+  rngsubopc:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: rngsubopc
+    primaryKey: false
+    visible: true
+  rngcanonical:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: rngcanonical
+    primaryKey: false
+    visible: true
+  rngsubdiff:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: rngsubdiff
+    primaryKey: false
+    visible: true
+indexes:
+  pg_range_rngmultitypid_index:
+    name: pg_range_rngmultitypid_index
+  pg_range_rngtypid_index:
+    name: pg_range_rngtypid_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_replication_origin.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_replication_origin.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_replication_origin
+columns:
+  roident:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: roident
+    primaryKey: false
+    visible: true
+  roname:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: roname
+    primaryKey: false
+    visible: true
+indexes:
+  pg_replication_origin_roiident_index:
+    name: pg_replication_origin_roiident_index
+  pg_replication_origin_roname_index:
+    name: pg_replication_origin_roname_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_rewrite.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_rewrite.yaml
@@ -1,0 +1,80 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_rewrite
+columns:
+  oid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: oid
+    primaryKey: false
+    visible: true
+  rulename:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: rulename
+    primaryKey: false
+    visible: true
+  ev_class:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: ev_class
+    primaryKey: false
+    visible: true
+  ev_type:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: ev_type
+    primaryKey: false
+    visible: true
+  ev_enabled:
+    caseSensitive: true
+    dataType: 1
+    generated: false
+    name: ev_enabled
+    primaryKey: false
+    visible: true
+  is_instead:
+    caseSensitive: true
+    dataType: 16
+    generated: false
+    name: is_instead
+    primaryKey: false
+    visible: true
+  ev_qual:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: ev_qual
+    primaryKey: false
+    visible: true
+  ev_action:
+    caseSensitive: true
+    dataType: 1111
+    generated: false
+    name: ev_action
+    primaryKey: false
+    visible: true
+indexes:
+  pg_rewrite_oid_index:
+    name: pg_rewrite_oid_index
+  pg_rewrite_rel_rulename_index:
+    name: pg_rewrite_rel_rulename_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_seclabel.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_seclabel.yaml
@@ -1,0 +1,57 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_seclabel
+columns:
+  objoid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: objoid
+    primaryKey: false
+    visible: true
+  classoid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: classoid
+    primaryKey: false
+    visible: true
+  objsubid:
+    caseSensitive: true
+    dataType: 4
+    generated: false
+    name: objsubid
+    primaryKey: false
+    visible: true
+  provider:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: provider
+    primaryKey: false
+    visible: true
+  label:
+    caseSensitive: true
+    dataType: 12
+    generated: false
+    name: label
+    primaryKey: false
+    visible: true
+indexes:
+  pg_seclabel_object_index:
+    name: pg_seclabel_object_index

--- a/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_sequence.yaml
+++ b/infra/common/src/main/resources/schema/postgresql/pg_catalog/pg_sequence.yaml
@@ -1,0 +1,78 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: pg_sequence
+columns:
+  seqrelid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqrelid
+    primaryKey: false
+    visible: true
+  seqtypid:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqtypid
+    primaryKey: false
+    visible: true
+  seqstart:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqstart
+    primaryKey: false
+    visible: true
+  seqincrement:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqincrement
+    primaryKey: false
+    visible: true
+  seqmax:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqmax
+    primaryKey: false
+    visible: true
+  seqmin:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqmin
+    primaryKey: false
+    visible: true
+  seqcache:
+    caseSensitive: true
+    dataType: -5
+    generated: false
+    name: seqcache
+    primaryKey: false
+    visible: true
+  seqcycle:
+    caseSensitive: true
+    dataType: 16
+    generated: false
+    name: seqcycle
+    primaryKey: false
+    visible: true
+indexes:
+  pg_sequence_seqrelid_index:
+    name: pg_sequence_seqrelid_index

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderRuleTest.java
@@ -42,7 +42,7 @@ class SystemSchemaBuilderRuleTest {
         assertThat(actualPerformanceSchema.getTables().size(), is(87));
         SystemSchemaBuilderRule actualPgCatalog = SystemSchemaBuilderRule.valueOf(new PostgreSQLDatabaseType().getType(), "pg_catalog");
         assertThat(actualPgCatalog, is(SystemSchemaBuilderRule.POSTGRESQL_PG_CATALOG));
-        assertThat(actualPgCatalog.getTables().size(), is(14));
+        assertThat(actualPgCatalog.getTables().size(), is(19));
     }
     
     @Test
@@ -60,6 +60,11 @@ class SystemSchemaBuilderRuleTest {
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_amop"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_amproc"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_attrdef"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_range"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_replication_origin"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_rewrite"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_seclabel"));
+        assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_sequence"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_roles"));
         assertTrue(SystemSchemaBuilderRule.isSystemTable("pg_catalog", "pg_user_mapping"));
         assertFalse(SystemSchemaBuilderRule.isSystemTable("sharding_db", "t_order"));

--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/database/schema/builder/SystemSchemaBuilderTest.java
@@ -55,7 +55,7 @@ class SystemSchemaBuilderTest {
         assertTrue(actual.containsKey("pg_catalog"));
         assertTrue(actual.containsKey("shardingsphere"));
         assertThat(actual.get("information_schema").getTables().size(), is(3));
-        assertThat(actual.get("pg_catalog").getTables().size(), is(14));
+        assertThat(actual.get("pg_catalog").getTables().size(), is(19));
         assertThat(actual.get("shardingsphere").getTables().size(), is(2));
     }
     

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_range.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_range.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="rngtypid" />
+        <column name="rngsubtype" />
+        <column name="rngmultitypid" />
+        <column name="rngcollation" />
+        <column name="rngsubopc" />
+        <column name="rngcanonical" />
+        <column name="rngsubdiff" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_replication_origin.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_replication_origin.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="roident" />
+        <column name="roname" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_rewrite.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_rewrite.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="oid" />
+        <column name="rulename" />
+        <column name="ev_class" />
+        <column name="ev_type" />
+        <column name="ev_enabled" />
+        <column name="is_instead" />
+        <column name="ev_qual" />
+        <column name="ev_action" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_seclabel.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_seclabel.xml
@@ -1,0 +1,26 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="objoid" />
+        <column name="classoid" />
+        <column name="objsubid" />
+        <column name="provider" />
+        <column name="label" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_sequence.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dataset/db/select_postgresql_pg_catalog_pg_sequence.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<dataset>
+    <metadata>
+        <column name="seqrelid" />
+        <column name="seqtypid" />
+        <column name="seqstart" />
+        <column name="seqincrement" />
+        <column name="seqmax" />
+        <column name="seqmin" />
+        <column name="seqcache" />
+        <column name="seqcycle" />
+    </metadata>
+</dataset>

--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-system-schema.xml
@@ -737,6 +737,26 @@
     <test-case sql="SELECT * FROM pg_catalog.pg_attrdef" db-types="PostgreSQL" scenario-types="db">
         <assertion expected-data-file="select_postgresql_pg_catalog_pg_attrdef.xml" />
     </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_range" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_range.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_replication_origin" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_replication_origin.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_rewrite" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_rewrite.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_seclabel" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_seclabel.xml" />
+    </test-case>
+
+    <test-case sql="SELECT * FROM pg_catalog.pg_sequence" db-types="PostgreSQL" scenario-types="db">
+        <assertion expected-data-file="select_postgresql_pg_catalog_pg_sequence.xml" />
+    </test-case>
   
     <test-case sql="SELECT * FROM pg_catalog.pg_user_mapping" db-types="PostgreSQL" scenario-types="db">
         <assertion expected-data-file="select_postgresql_pg_catalog_pg_user_mapping.xml" />


### PR DESCRIPTION
For #26150.

Changes proposed in this pull request:
  -add  pg_range, pg_replication_origin, pg_rewrite, pg_seclabel, pg_sequence table in pg_catalog for PostgreSQL
  -add test cases

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
