### PR TITLE
Make Proxy default config path configurable

### DIFF
--- a/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/arguments/BootstrapArguments.java
+++ b/proxy/bootstrap/src/main/java/org/apache/shardingsphere/proxy/arguments/BootstrapArguments.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public final class BootstrapArguments {
     
-    private static final String DEFAULT_CONFIG_PATH = "/conf/";
+    private static final String DEFAULT_CONFIG_PATH = System.getenv().getOrDefault("PROXY_DEFAULT_CONFIG_PATH", "/conf/");
     
     private static final String DEFAULT_BIND_ADDRESS = "0.0.0.0";
     


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS1075&id=apache_shardingsphere&open=AYePECdUmlEb3_Pqvlm5
