### PR TITLE
Support cache index default parse

### DIFF
--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/type/MySQLDALStatementVisitor.java
@@ -415,7 +415,11 @@ public final class MySQLDALStatementVisitor extends MySQLStatementVisitor implem
             segment.getPartitions().addAll(((CollectionValue<PartitionSegment>) visit(ctx.partitionList())).getValue());
             result.setPartitionDefinition(segment);
         }
-        result.setName((IdentifierValue) visit(ctx.identifier()));
+        if (null != ctx.DEFAULT()) {
+            result.setName(new IdentifierValue(ctx.DEFAULT().getText()));
+        } else {
+            result.setName((IdentifierValue) visit(ctx.identifier()));
+        }
         return result;
     }
     

--- a/test/it/parser/src/main/resources/case/dal/cache-index.xml
+++ b/test/it/parser/src/main/resources/case/dal/cache-index.xml
@@ -17,6 +17,14 @@
   -->
 
 <sql-parser-test-cases>
+    <cache-index sql-case-id="cache_index_with_in" name="default">
+        <table-index start-index="12" stop-index="13">
+            <table name="t1" start-index="12" stop-index="13" />
+        </table-index>
+        <table-index start-index="15" stop-index="16">
+            <table name="t2" start-index="15" stop-index="16" />
+        </table-index>
+    </cache-index>
     <cache-index sql-case-id="cache_index_single_table" name="hot_cache_index">
         <table-index start-index="12" stop-index="18">
             <table name="t_order" start-index="12" stop-index="18" />

--- a/test/it/parser/src/main/resources/sql/supported/dal/cache-index.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dal/cache-index.xml
@@ -17,6 +17,7 @@
   -->
 
 <sql-cases>
+    <sql-case id="cache_index_with_in" value="cache index t1,t2 in default" db-types="MySQL" />
     <sql-case id="cache_index_single_table" value="CACHE INDEX t_order IN hot_cache_index" db-types="MySQL" />
     <sql-case id="cache_index_multiple_table" value="CACHE INDEX t_order, t_user IN hot_cache_index" db-types="MySQL" />
     <sql-case id="cache_index_single_table_multiple_index" value="CACHE INDEX t_order INDEX (idx_a, idx_b) IN hot_cache_index" db-types="MySQL" />


### PR DESCRIPTION
Refer #25535.

Changes proposed in this pull request:
  - cache index t1,t2 in default;
  - Add test sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
