### PR TITLE
Fix creating transaction hook when global clock is not enabled

### DIFF
--- a/kernel/global-clock/core/src/main/java/org/apache/shardingsphere/globalclock/core/rule/GlobalClockRule.java
+++ b/kernel/global-clock/core/src/main/java/org/apache/shardingsphere/globalclock/core/rule/GlobalClockRule.java
@@ -44,8 +44,8 @@ public final class GlobalClockRule implements GlobalRule {
         configuration = ruleConfig;
         if (ruleConfig.isEnabled()) {
             TypedSPILoader.getService(GlobalClockProvider.class, getGlobalClockProviderType(), configuration.getProps());
+            TypedSPILoader.getService(TransactionHook.class, "GLOBAL_CLOCK", getProps(databases));
         }
-        TypedSPILoader.getService(TransactionHook.class, "GLOBAL_CLOCK", getProps(databases));
     }
     
     private Properties getProps(final Map<String, ShardingSphereDatabase> databases) {


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix creating transaction hook when global clock is not enabled

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
