### PR TITLE
Check single table exists when build single rule.

### DIFF
--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -74,25 +74,6 @@ public final class SingleTableDataNodeLoader {
         return loadSpecifiedDataNodes(actualDataNodes, featureRequiredSingleTables, expectedTableMap);
     }
     
-    private static void checkExpectedTablesExist(final Map<String, Collection<DataNode>> actualDataNodes, final Collection<DataNode> expectedDataNodes) {
-        for (final DataNode each : expectedDataNodes) {
-            if (SingleTableConstants.ASTERISK.equals(each.getTableName())) {
-                continue;
-            }
-            ShardingSpherePreconditions.checkState(actualDataNodes.containsKey(each.getTableName()), () -> new SingleTableNotFoundException(each.getTableName()));
-            checkExpectedTableExists(actualDataNodes.get(each.getTableName()), each);
-        }
-    }
-    
-    private static void checkExpectedTableExists(final Collection<DataNode> actualDataNodes, final DataNode expectedDataNode) {
-        for (final DataNode each : actualDataNodes) {
-            if (each.getDataSourceName().equals(expectedDataNode.getDataSourceName())) {
-                return;
-            }
-        }
-        throw new SingleTableNotFoundException(expectedDataNode.getDataSourceName(), expectedDataNode.getTableName());
-    }
-    
     /**
      * Load single table data nodes.
      *
@@ -134,6 +115,25 @@ public final class SingleTableDataNodeLoader {
             }
         }
         return result;
+    }
+    
+    private static void checkExpectedTablesExist(final Map<String, Collection<DataNode>> actualDataNodes, final Collection<DataNode> expectedDataNodes) {
+        for (final DataNode each : expectedDataNodes) {
+            if (SingleTableConstants.ASTERISK.equals(each.getTableName())) {
+                continue;
+            }
+            ShardingSpherePreconditions.checkState(actualDataNodes.containsKey(each.getTableName()), () -> new SingleTableNotFoundException(each.getTableName()));
+            checkExpectedTableExists(actualDataNodes.get(each.getTableName()), each);
+        }
+    }
+    
+    private static void checkExpectedTableExists(final Collection<DataNode> actualDataNodes, final DataNode expectedDataNode) {
+        for (final DataNode each : actualDataNodes) {
+            if (each.getDataSourceName().equals(expectedDataNode.getDataSourceName())) {
+                return;
+            }
+        }
+        throw new SingleTableNotFoundException(expectedDataNode.getDataSourceName(), expectedDataNode.getTableName());
     }
     
     private static Map<String, Collection<DataNode>> loadSpecifiedDataNodes(final Map<String, Collection<DataNode>> actualDataNodes, final Collection<String> featureRequiredSingleTables,

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -32,7 +32,6 @@ import org.apache.shardingsphere.single.util.SingleTableLoadUtils;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -61,7 +60,7 @@ public final class SingleTableDataNodeLoader {
         Collection<String> excludedTables = SingleTableLoadUtils.getExcludedTables(builtRules);
         Collection<String> featureRequiredSingleTables = SingleTableLoadUtils.getFeatureRequiredSingleTables(builtRules);
         if (expectedSingleTables.isEmpty() && featureRequiredSingleTables.isEmpty()) {
-            return Collections.emptyMap();
+            return new LinkedHashMap<>();
         }
         Map<String, Collection<DataNode>> actualDataNodes = load(databaseName, databaseType, dataSourceMap, excludedTables);
         Collection<String> splitTables = SingleTableLoadUtils.splitTableLines(expectedSingleTables);

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/exception/SingleTableNotFoundException.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/exception/SingleTableNotFoundException.java
@@ -30,4 +30,8 @@ public final class SingleTableNotFoundException extends MetaDataSQLException {
     public SingleTableNotFoundException(final String tableName) {
         super(XOpenSQLState.NOT_FOUND, 21, "Single table `%s` does not exist.", tableName);
     }
+    
+    public SingleTableNotFoundException(final String dataSourceName, final String tableName) {
+        super(XOpenSQLState.NOT_FOUND, 21, "Single table `%s` does not exist in data source `%s`.", tableName, dataSourceName);
+    }
 }

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/rule/SingleRuleTest.java
@@ -72,8 +72,8 @@ class SingleRuleTest {
         dataSourceMap = new LinkedHashMap<>(2, 1F);
         dataSourceMap.put("foo_ds", mockDataSource("foo_ds", Arrays.asList("employee", "t_order_0")));
         dataSourceMap.put("bar_ds", mockDataSource("bar_ds", Arrays.asList("student", "t_order_1")));
-        Collection<String> configuredTables = new LinkedList<>(Arrays.asList("foo_ds.employee", "foo_ds.t_order_0", "bar_ds.student", "bar_ds.t_order_1"));
-        ruleConfig = new SingleRuleConfiguration(configuredTables, null);
+        ruleConfig = mock(SingleRuleConfiguration.class);
+        when(ruleConfig.getTables()).thenReturn(new LinkedList<>(Arrays.asList("foo_ds.employee", "bar_ds.student")));
     }
     
     private DataSource mockDataSource(final String dataSourceName, final List<String> tableNames) throws SQLException {
@@ -185,6 +185,7 @@ class SingleRuleTest {
     
     @Test
     void assertPut() {
+        when(ruleConfig.getTables()).thenReturn(new LinkedList<>(Arrays.asList("foo_ds.employee", "bar_ds.student", "foo_ds.t_order_0", "bar_ds.t_order_1")));
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         SingleRule singleRule = new SingleRule(ruleConfig, DefaultDatabase.LOGIC_NAME, dataSourceMap, Collections.singleton(dataNodeContainedRule));
         String tableName = "teacher";
@@ -203,6 +204,7 @@ class SingleRuleTest {
     
     @Test
     void assertRemove() {
+        when(ruleConfig.getTables()).thenReturn(new LinkedList<>(Arrays.asList("foo_ds.employee", "bar_ds.student", "foo_ds.t_order_0", "bar_ds.t_order_1")));
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         SingleRule singleRule = new SingleRule(ruleConfig, DefaultDatabase.LOGIC_NAME, dataSourceMap, Collections.singleton(dataNodeContainedRule));
         String tableName = "employee";
@@ -217,6 +219,7 @@ class SingleRuleTest {
     
     @Test
     void assertGetAllDataNodes() {
+        when(ruleConfig.getTables()).thenReturn(new LinkedList<>(Arrays.asList("foo_ds.employee", "bar_ds.student", "foo_ds.t_order_0", "bar_ds.t_order_1")));
         DataNodeContainedRule dataNodeContainedRule = mock(DataNodeContainedRule.class);
         SingleRule singleRule = new SingleRule(ruleConfig, DefaultDatabase.LOGIC_NAME, dataSourceMap, Collections.singleton(dataNodeContainedRule));
         assertTrue(singleRule.getAllDataNodes().containsKey("employee"));

--- a/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableStatementUpdater.java
+++ b/kernel/single/distsql/handler/src/main/java/org/apache/shardingsphere/single/distsql/handler/update/LoadSingleTableStatementUpdater.java
@@ -54,12 +54,12 @@ public final class LoadSingleTableStatementUpdater implements RuleDefinitionCrea
     @Override
     public void checkSQLStatement(final ShardingSphereDatabase database, final LoadSingleTableStatement sqlStatement, final SingleRuleConfiguration currentRuleConfig) {
         String defaultSchemaName = DatabaseTypeEngine.getDefaultSchemaName(database.getProtocolType(), database.getName());
-        checkTables(database, sqlStatement, currentRuleConfig, defaultSchemaName);
+        checkTables(database, sqlStatement, defaultSchemaName);
         checkStorageUnits(database, sqlStatement);
         checkActualTableExist(database, sqlStatement, defaultSchemaName);
     }
     
-    private void checkTables(final ShardingSphereDatabase database, final LoadSingleTableStatement sqlStatement, final SingleRuleConfiguration currentRuleConfig, final String defaultSchemaName) {
+    private void checkTables(final ShardingSphereDatabase database, final LoadSingleTableStatement sqlStatement, final String defaultSchemaName) {
         Optional<SingleRule> currentSingleRule = database.getRuleMetaData().findSingleRule(SingleRule.class);
         Collection<String> currentSingleTables = currentSingleRule.isPresent() ? currentSingleRule.get().getSingleTableDataNodes().keySet() : Collections.emptyList();
         Collection<SingleTableSegment> tableSegments = sqlStatement.getTables();


### PR DESCRIPTION
For single table #26582.

Changes proposed in this pull request:
  - Check single table exists when build single rule.

### No such single table
<img width="1281" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/6d7d5bd5-7e84-4128-82f5-c130e52f9de8">

### Single table exists but data source mismatch
<img width="1469" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/84f371aa-b4ba-499e-a1ac-3bbb15bec914">
