### PR TITLE
Remove useless timezone properties in OptimizerParserContextFactory

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/ShardingSphereStatisticsScheduleCollector.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/core/listener/ShardingSphereStatisticsScheduleCollector.java
@@ -104,8 +104,9 @@ public final class ShardingSphereStatisticsScheduleCollector {
         
         private void collectForTable(final String databaseName, final String schemaName, final ShardingSphereTable table,
                                      final Map<String, ShardingSphereDatabase> databases, final ShardingSphereStatistics statistics) {
-            String collectorType = SHARDING_SPHERE_SYSTEM_DATABASE_SCHEMA.equalsIgnoreCase(schemaName) 
-                    ? table.getName() : String.join(".", databases.get(databaseName).getProtocolType().getType(), schemaName, table.getName());
+            String collectorType = SHARDING_SPHERE_SYSTEM_DATABASE_SCHEMA.equalsIgnoreCase(schemaName)
+                    ? table.getName()
+                    : String.join(".", databases.get(databaseName).getProtocolType().getType(), schemaName, table.getName());
             Optional<ShardingSphereStatisticsCollector> dataCollector = TypedSPILoader.findService(ShardingSphereStatisticsCollector.class, collectorType);
             if (!dataCollector.isPresent()) {
                 return;

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/context/parser/OptimizerParserContextFactory.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/context/parser/OptimizerParserContextFactory.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.sqlfederation.compiler.context.parser;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.shardingsphere.infra.database.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.type.DatabaseTypeEngine;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
@@ -63,9 +62,6 @@ public final class OptimizerParserContextFactory {
     }
     
     private static Properties createSQLDialectProperties(final DatabaseType databaseType) {
-        Properties result = new Properties();
-        result.setProperty(CalciteConnectionProperty.TIME_ZONE.camelName(), "UTC");
-        result.putAll(TypedSPILoader.getService(OptimizerSQLDialectBuilder.class, null == databaseType ? null : databaseType.getType()).build());
-        return result;
+        return TypedSPILoader.getService(OptimizerSQLDialectBuilder.class, databaseType.getType()).build();
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Remove useless timezone properties in OptimizerParserContextFactory

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
