### PR TITLE
Add unit test for RuleNodePathProvider 's implements

### DIFF
--- a/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/metadata/nodepath/BroadcastRuleNodePathProviderTest.java
+++ b/features/broadcast/core/src/test/java/org/apache/shardingsphere/broadcast/metadata/nodepath/BroadcastRuleNodePathProviderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.broadcast.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BroadcastRuleNodePathProviderTest {
+    
+    @Test
+    void assertBroadcastRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new BroadcastRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertTrue(actualRuleNodePath.getNamedItems().isEmpty());
+        assertEquals(1, actualRuleNodePath.getUniqueItems().size());
+        assertTrue(actualRuleNodePath.getUniqueItems().containsKey(BroadcastRuleNodePathProvider.TABLES));
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(BroadcastRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/nodepath/CompatibleEncryptRuleNodePathProviderTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/nodepath/CompatibleEncryptRuleNodePathProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CompatibleEncryptRuleNodePathProviderTest {
+    
+    @Test
+    void assertCompatibleEncryptRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new CompatibleEncryptRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(2, actualRuleNodePath.getNamedItems().size());
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(CompatibleEncryptRuleNodePathProvider.ENCRYPTORS));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(CompatibleEncryptRuleNodePathProvider.TABLES));
+        assertTrue(actualRuleNodePath.getUniqueItems().isEmpty());
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(CompatibleEncryptRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/nodepath/EncryptRuleNodePathProviderTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/metadata/nodepath/EncryptRuleNodePathProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EncryptRuleNodePathProviderTest {
+    
+    @Test
+    void assertEncryptRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new EncryptRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(2, actualRuleNodePath.getNamedItems().size());
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(EncryptRuleNodePathProvider.ENCRYPTORS));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(EncryptRuleNodePathProvider.TABLES));
+        assertTrue(actualRuleNodePath.getUniqueItems().isEmpty());
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(EncryptRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/mask/core/src/test/java/org/apache/shardingsphere/mask/metadata/nodepath/MaskRuleNodePathProviderTest.java
+++ b/features/mask/core/src/test/java/org/apache/shardingsphere/mask/metadata/nodepath/MaskRuleNodePathProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.mask.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MaskRuleNodePathProviderTest {
+    
+    @Test
+    void assertMaskRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new MaskRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(2, actualRuleNodePath.getNamedItems().size());
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(MaskRuleNodePathProvider.ALGORITHMS));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(MaskRuleNodePathProvider.TABLES));
+        assertTrue(actualRuleNodePath.getUniqueItems().isEmpty());
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(MaskRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/metadata/nodepath/ReadwriteSplittingRuleNodePathProviderTest.java
+++ b/features/readwrite-splitting/core/src/test/java/org/apache/shardingsphere/readwritesplitting/metadata/nodepath/ReadwriteSplittingRuleNodePathProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.readwritesplitting.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ReadwriteSplittingRuleNodePathProviderTest {
+    
+    @Test
+    void assertReadwriteSplittingRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new ReadwriteSplittingRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(2, actualRuleNodePath.getNamedItems().size());
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(ReadwriteSplittingRuleNodePathProvider.DATA_SOURCES));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(ReadwriteSplittingRuleNodePathProvider.LOAD_BALANCERS));
+        assertTrue(actualRuleNodePath.getUniqueItems().isEmpty());
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(ReadwriteSplittingRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/metadata/nodepath/ShadowRuleNodePathProviderTest.java
+++ b/features/shadow/core/src/test/java/org/apache/shardingsphere/shadow/metadata/nodepath/ShadowRuleNodePathProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.shadow.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ShadowRuleNodePathProviderTest {
+    
+    @Test
+    void assertShadowRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new ShadowRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(3, actualRuleNodePath.getNamedItems().size());
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(ShadowRuleNodePathProvider.ALGORITHMS));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(ShadowRuleNodePathProvider.TABLES));
+        assertTrue(actualRuleNodePath.getNamedItems().containsKey(ShadowRuleNodePathProvider.DATA_SOURCES));
+        assertEquals(1, actualRuleNodePath.getUniqueItems().size());
+        assertTrue(actualRuleNodePath.getUniqueItems().containsKey(ShadowRuleNodePathProvider.DEFAULT_ALGORITHM));
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(ShadowRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/nodepath/ShardingRuleNodePathProviderTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/metadata/nodepath/ShardingRuleNodePathProviderTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sharding.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+public class ShardingRuleNodePathProviderTest {
+
+    @Test
+    void assertShardingRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new ShardingRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertEquals(6, actualRuleNodePath.getNamedItems().size());
+        List<String> namedRuleItems = Arrays.asList(ShardingRuleNodePathProvider.TABLES, ShardingRuleNodePathProvider.AUTO_TABLES, ShardingRuleNodePathProvider.BINDING_TABLES,
+                ShardingRuleNodePathProvider.ALGORITHMS, ShardingRuleNodePathProvider.KEY_GENERATORS, ShardingRuleNodePathProvider.AUDITORS);
+        assertThat("Named rule items equality without order", actualRuleNodePath.getNamedItems().keySet(), IsIterableContainingInAnyOrder.containsInAnyOrder(namedRuleItems.toArray()));
+        assertEquals(6, actualRuleNodePath.getUniqueItems().size());
+        List<String> uniqueRuleItems = Arrays.asList(ShardingRuleNodePathProvider.DEFAULT_DATABASE_STRATEGY, ShardingRuleNodePathProvider.DEFAULT_TABLE_STRATEGY,
+                ShardingRuleNodePathProvider.DEFAULT_KEY_GENERATE_STRATEGY, ShardingRuleNodePathProvider.DEFAULT_AUDIT_STRATEGY, ShardingRuleNodePathProvider.DEFAULT_SHARDING_COLUMN,
+                ShardingRuleNodePathProvider.SHARDING_CACHE);
+        assertThat("Unique rule items equality without order", actualRuleNodePath.getUniqueItems().keySet(), IsIterableContainingInAnyOrder.containsInAnyOrder(uniqueRuleItems.toArray()));
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(ShardingRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}

--- a/kernel/single/core/src/test/java/org/apache/shardingsphere/single/metadata/nodepath/SingleRuleNodePathProviderTest.java
+++ b/kernel/single/core/src/test/java/org/apache/shardingsphere/single/metadata/nodepath/SingleRuleNodePathProviderTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.single.metadata.nodepath;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.RuleNodePath;
+import org.apache.shardingsphere.mode.spi.RuleNodePathProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SingleRuleNodePathProviderTest {
+    
+    @Test
+    void assertSingleRuleNodePath() {
+        RuleNodePathProvider ruleNodePathProvider = new SingleRuleNodePathProvider();
+        RuleNodePath actualRuleNodePath = ruleNodePathProvider.getRuleNodePath();
+        assertTrue(actualRuleNodePath.getNamedItems().isEmpty());
+        assertEquals(1, actualRuleNodePath.getUniqueItems().size());
+        assertTrue(actualRuleNodePath.getUniqueItems().containsKey(SingleRuleNodePathProvider.TABLES));
+        assertNotNull(actualRuleNodePath.getRoot());
+        assertEquals(SingleRuleNodePathProvider.RULE_TYPE, actualRuleNodePath.getRoot().getRuleType());
+    }
+}


### PR DESCRIPTION
Fixes #26709.

Changes proposed in this pull request:Add unit test for RuleNodePathProvider 's implements
  -
Please add label "in:test" for this PR. I don't have access to add label.
---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [X] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
