### PR TITLE
Add test cases for UniqueRuleItemNodePath

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/nodepath/item/UniqueRuleItemNodePathTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/nodepath/item/UniqueRuleItemNodePathTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.metadata.nodepath.item;
+
+import org.apache.shardingsphere.infra.metadata.nodepath.root.RuleRootNodePath;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class UniqueRuleItemNodePathTest {
+    
+    @Test
+    void assertPathWithNullParentNode() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_path");
+        assertThat(uniqueRuleItemNodePath.getPath(), is("test_path"));
+    }
+    
+    @Test
+    void assertGetPathWithParentNode() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_parent", "test_path");
+        assertThat(uniqueRuleItemNodePath.getPath(), is("test_parent/test_path"));
+    }
+    
+    @Test
+    void assertIsValidPathWithNullParentNode() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_path");
+        assertTrue(uniqueRuleItemNodePath.isValidatedPath("/word1/word2-/rules/foo/test_path/versions/1234"));
+    }
+    
+    @Test
+    void assertIsNotValidPathWithNullParentNode() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_path");
+        assertFalse(uniqueRuleItemNodePath.isValidatedPath("/word1/word2/rules/test_foo/test_path/versions/1234"));
+        assertFalse(uniqueRuleItemNodePath.isValidatedPath("/rules/test_foo/test/versions/1234"));
+        assertFalse(uniqueRuleItemNodePath.isValidatedPath("/word1/word2/rules/foo/test_path/versions/"));
+    }
+    
+    @Test
+    void assertIsActiveVersionPath() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_path");
+        assertTrue(uniqueRuleItemNodePath.isActiveVersionPath("/word1-/word2/rules/foo/test_path/active_version"));
+    }
+    
+    @Test
+    void assertIsNotActiveVersionPath() {
+        UniqueRuleItemNodePath uniqueRuleItemNodePath = new UniqueRuleItemNodePath(new RuleRootNodePath("foo"), "test_path");
+        assertFalse(uniqueRuleItemNodePath.isActiveVersionPath("/word1/word2/rules/foo/test_path/active_version1"));
+        assertFalse(uniqueRuleItemNodePath.isActiveVersionPath("/rules/foo/test_path/active_version"));
+    }
+}


### PR DESCRIPTION
Fixes #26598.

Changes proposed in this pull request:Add test cases for UniqueRuleItemNodePath
  -
Please add label "in:test" for this PR. I don't have access to add label.
---

Before committing this PR, I'm sure that I have checked the following options:
- [X] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [X] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
