### PR TITLE
Disable indentSchemaLocation of spotless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -866,7 +866,7 @@
                                 <nrOfIndentSpace>4</nrOfIndentSpace>
                                 <keepBlankLines>true</keepBlankLines>
                                 <indentBlankLines>true</indentBlankLines>
-                                <indentSchemaLocation>true</indentSchemaLocation>
+                                <indentSchemaLocation>false</indentSchemaLocation>
                                 <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>
                                 <sortModules>false</sortModules>
                                 <sortExecutions>false</sortExecutions>


### PR DESCRIPTION
`maven-release-plugin` will modify pom.xml of projects. Spotless indentSchemaLocation sortPom will break the schema line.