### PR TITLE
Add spotless:check to avoid unformatted code in PR

### DIFF
--- a/.github/workflows/required-check.yml
+++ b/.github/workflows/required-check.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
       - name: Run CheckStyle
-        run: ./mvnw checkstyle:check -T1C
+        run: ./mvnw checkstyle:check spotless:check -T1C
   
   check-license:
     name: Check - License


### PR DESCRIPTION
Spotless check can fail the PR with unformatted code.

```
The following files had format violations:
    src/main/java/org/apache/shardingsphere/mode/manager/ContextManager.java
        @@ -83,7 +83,7 @@
         ·*/
         @Getter
         @Slf4j
        -public·final·class·ContextManager·implements·AutoCloseable·{····
        +public·final·class·ContextManager·implements·AutoCloseable·{
         ····
         ····private·final·AtomicReference<MetaDataContexts>·metaDataContexts;
         ····
Run 'mvn spotless:apply' to fix these violations.
```