### PR TITLE
Improve Standalone mode JDBC type impl reset data on initialization

### DIFF
--- a/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepository.java
+++ b/mode/type/standalone/repository/provider/jdbc/src/main/java/org/apache/shardingsphere/mode/repository/standalone/jdbc/JDBCRepository.java
@@ -67,7 +67,10 @@ public final class JDBCRepository implements StandalonePersistRepository {
                 Statement statement = connection.createStatement()) {
             // TODO remove it later. Add for reset standalone test e2e's env. Need to close DataSource to release H2's memory data
             if (jdbcRepositoryProps.<String>getValue(JDBCRepositoryPropertyKey.JDBC_URL).contains("h2:mem:")) {
-                statement.execute("DROP TABLE IF EXISTS `repository`");
+                try {
+                    statement.execute("TRUNCATE TABLE `repository`");
+                } catch (final SQLException ignored) {
+                }
             }
             // Finish TODO
             statement.execute(repositorySQL.getCreateTableSQL());


### PR DESCRIPTION

Changes proposed in this pull request:
  - Update `JDBCRepository.init`, replace `DROP TABLE` to `TRUNCATE TABLE`. To avoid possible `org.h2.jdbc.JdbcSQLSyntaxErrorException: Table "repository" not found (this database is empty); SQL statement:
SELECT value FROM repository WHERE key = ? [42104-214]` error, if several `ShardingSphereDataSource` use default mode.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
