### PR TITLE
Disable system-schema-metadata-enabled in pipeline

### DIFF
--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/data/pipeline/datasource/creator/ShardingSpherePipelineDataSourceCreator.java
@@ -21,6 +21,7 @@ import org.apache.shardingsphere.data.pipeline.api.datasource.config.impl.Shardi
 import org.apache.shardingsphere.data.pipeline.spi.datasource.creator.PipelineDataSourceCreator;
 import org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory;
 import org.apache.shardingsphere.infra.config.props.ConfigurationPropertyKey;
+import org.apache.shardingsphere.infra.config.props.temporary.TemporaryConfigurationPropertyKey;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.algorithm.YamlAlgorithmConfiguration;
@@ -46,6 +47,7 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
     @Override
     public DataSource createPipelineDataSource(final Object dataSourceConfig) throws SQLException {
         YamlRootConfiguration rootConfig = YamlEngine.unmarshal(YamlEngine.marshal(dataSourceConfig), YamlRootConfiguration.class);
+        disableSystemSchemaMetadata(rootConfig);
         enableStreamingQuery(rootConfig);
         updateSingleRuleConfiguration(rootConfig);
         Optional<YamlShardingRuleConfiguration> yamlShardingRuleConfig = ShardingRuleConfigurationConverter.findYamlShardingRuleConfiguration(rootConfig.getRules());
@@ -64,6 +66,10 @@ public final class ShardingSpherePipelineDataSourceCreator implements PipelineDa
         YamlSingleRuleConfiguration singleRuleConfig = new YamlSingleRuleConfiguration();
         singleRuleConfig.setTables(Collections.singletonList(SingleTableConstants.ALL_TABLES));
         rootConfig.getRules().add(singleRuleConfig);
+    }
+    
+    private void disableSystemSchemaMetadata(final YamlRootConfiguration rootConfig) {
+        rootConfig.getProps().put(TemporaryConfigurationPropertyKey.SYSTEM_SCHEMA_METADATA_ENABLED.getKey(), String.valueOf(Boolean.FALSE));
     }
     
     // TODO Another way is improving ExecuteQueryCallback.executeSQL to enable streaming query, then remove it

--- a/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_source.yaml
+++ b/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_source.yaml
@@ -38,20 +38,20 @@ dataSources:
 
 rules:
 - !SHARDING
-  defaultDatabaseStrategy:
-    standard:
-      shardingAlgorithmName: default_db_inline
-      shardingColumn: user_id
+#  defaultDatabaseStrategy:
+#    standard:
+#      shardingAlgorithmName: default_db_inline
+#      shardingColumn: user_id
   tables:
     t_order:
       actualDataNodes: ds_0.t_order
       keyGenerateStrategy:
         column: order_id
         keyGeneratorName: snowflake
-      tableStrategy:
-        standard:
-          shardingAlgorithmName: t_order_tbl_inline
-          shardingColumn: order_id
+#      tableStrategy:
+#        standard:
+#          shardingAlgorithmName: t_order_tbl_inline
+#          shardingColumn: order_id
   shardingAlgorithms:
     default_db_inline:
       type: INLINE

--- a/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_source.yaml
+++ b/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_source.yaml
@@ -29,6 +29,9 @@ mode:
       maxRetries: 3
       operationTimeoutMilliseconds: 500
 
+props:
+  system-schema-metadata-enabled: false
+
 dataSources:
   ds_0:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource

--- a/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_target.yaml
+++ b/test/it/pipeline/src/test/resources/config_sharding_sphere_jdbc_target.yaml
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+props:
+  system-schema-metadata-enabled: false
+
 dataSources:
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
@@ -26,6 +29,7 @@ dataSources:
     url: jdbc:h2:mem:test_ds_2;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL
     username: root
     password: root
+
 rules:
 - !SHARDING
   defaultDatabaseStrategy:

--- a/test/it/pipeline/src/test/resources/migration_sharding_sphere_jdbc_target.yaml
+++ b/test/it/pipeline/src/test/resources/migration_sharding_sphere_jdbc_target.yaml
@@ -15,6 +15,9 @@
 # limitations under the License.
 #
 
+props:
+  system-schema-metadata-enabled: false
+
 dataSources:
   ds_1:
     dataSourceClassName: com.zaxxer.hikari.HikariDataSource
@@ -26,6 +29,7 @@ dataSources:
     url: jdbc:h2:mem:test_ds_2_${databaseNameSuffix};DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false;MODE=MySQL
     username: root
     password: root
+
 rules:
   - !SHARDING
     defaultDatabaseStrategy:


### PR DESCRIPTION

Changes proposed in this pull request:
  - Disable system-schema-metadata-enabled in ShardingSpherePipelineDataSourceCreator. Else consistency check might be very slow.
  - Disable system-schema-metadata-enabled in yaml config

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
