### PR TITLE
Handle SQLFeatureNotSupportedException when some db not implement jdbc interface

### DIFF
--- a/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/metadata/JDBCQueryResultMetaData.java
+++ b/infra/executor/src/main/java/org/apache/shardingsphere/infra/executor/sql/execute/result/query/impl/driver/jdbc/metadata/JDBCQueryResultMetaData.java
@@ -39,7 +39,11 @@ public final class JDBCQueryResultMetaData implements QueryResultMetaData {
     
     @Override
     public String getTableName(final int columnIndex) throws SQLException {
-        return resultSetMetaData.getTableName(columnIndex);
+        try {
+            return resultSetMetaData.getTableName(columnIndex);
+        } catch (final SQLFeatureNotSupportedException ignore) {
+            return "";
+        }
     }
     
     @Override

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/executor/callback/ProxyJDBCExecutorCallback.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/executor/callback/ProxyJDBCExecutorCallback.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.Optional;
@@ -71,7 +72,7 @@ public abstract class ProxyJDBCExecutorCallback extends JDBCExecutorCallback<Exe
             databaseConnector.add(resultSet);
             return createQueryResult(resultSet, connectionMode, storageType);
         }
-        return new UpdateResult(statement.getUpdateCount(), isReturnGeneratedKeys ? getGeneratedKey(statement) : 0L);
+        return new UpdateResult(Math.max(statement.getUpdateCount(), 0), isReturnGeneratedKeys ? getGeneratedKey(statement) : 0L);
     }
     
     protected abstract boolean execute(String sql, Statement statement, boolean isReturnGeneratedKeys) throws SQLException;
@@ -81,8 +82,12 @@ public abstract class ProxyJDBCExecutorCallback extends JDBCExecutorCallback<Exe
     }
     
     private long getGeneratedKey(final Statement statement) throws SQLException {
-        ResultSet resultSet = statement.getGeneratedKeys();
-        return resultSet.next() ? getGeneratedKeyIfInteger(resultSet) : 0L;
+        try {
+            ResultSet resultSet = statement.getGeneratedKeys();
+            return resultSet.next() ? getGeneratedKeyIfInteger(resultSet) : 0L;
+        } catch (final SQLFeatureNotSupportedException ignore) {
+            return 0L;
+        }
     }
     
     private long getGeneratedKeyIfInteger(final ResultSet resultSet) throws SQLException {

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/executor/callback/impl/ProxyStatementExecutorCallback.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/connector/jdbc/executor/callback/impl/ProxyStatementExecutorCallback.java
@@ -24,6 +24,7 @@ import org.apache.shardingsphere.proxy.backend.connector.jdbc.executor.callback.
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
 
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Statement;
 
 /**
@@ -39,6 +40,10 @@ public final class ProxyStatementExecutorCallback extends ProxyJDBCExecutorCallb
     
     @Override
     protected boolean execute(final String sql, final Statement statement, final boolean isReturnGeneratedKeys) throws SQLException {
-        return statement.execute(sql, isReturnGeneratedKeys ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS);
+        try {
+            return statement.execute(sql, isReturnGeneratedKeys ? Statement.RETURN_GENERATED_KEYS : Statement.NO_GENERATED_KEYS);
+        } catch (final SQLFeatureNotSupportedException ignore) {
+            return statement.execute(sql);
+        }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Handle SQLFeatureNotSupportedException when some db not implement jdbc interface

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
