### PR TITLE
Fix mysql groups and rank keywords

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -232,6 +232,7 @@ identifierKeywordsUnambiguous
     | GET_MASTER_PUBLIC_KEY
     | GRANTS
     | GROUP_REPLICATION
+    | GROUPS
     | HASH
     | HISTOGRAM
     | HISTORY
@@ -371,6 +372,7 @@ identifierKeywordsUnambiguous
     | QUERY
     | QUICK
     | RANDOM
+    | RANK
     | READ_ONLY
     | REBUILD
     | RECOVER

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -5068,4 +5068,18 @@
             </expr>
         </where>
     </select>
+
+    <select sql-case-id="select_with_keyword_groups_and_rank">
+        <from>
+            <simple-table alias="t" name="t_order" start-index="29" stop-index="37" literal-start-index="29" literal-stop-index="37"/>
+        </from>
+        <projections distinct-row="false" start-index="7" stop-index="22" literal-start-index="7" literal-stop-index="22">
+            <column-projection name="groups" start-index="7" stop-index="14" literal-start-index="7" literal-stop-index="14">
+                <owner name="t" start-index="7" stop-index="7" literal-start-index="7" literal-stop-index="7"/>
+            </column-projection>
+            <column-projection name="rank" start-index="17" stop-index="22" literal-start-index="17" literal-stop-index="22">
+                <owner name="t" start-index="17" stop-index="17" literal-start-index="17" literal-stop-index="17"/>
+            </column-projection>
+        </projections>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -166,4 +166,5 @@
     <sql-case id="select_projection_with_parameter" value="SELECT 1 AS id, ? AS status, SYSDATE AS create_time, TRUNC(SYSDATE) AS create_date FROM DUAL" db-types="Oracle"  />
     <sql-case id="select_with_chinese_comma" value="SELECT 1， 2，3 FROM DUAL" db-types="Oracle"  />
     <sql-case id="select_with_keyword_system" value="SELECT * FROM vtx_project WHERE system = ?" />
+    <sql-case id="select_with_keyword_groups_and_rank" value="SELECT t.groups, t.rank FROM t_order t" db-types="MySQL" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Fix mysql groups and rank keywords

```sql
-- supported
select t1.groups,t1.rank from t1;

-- not supported
select groups,rank from t1;

-- supported
select `groups`,`rank` from t1;
```
---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
