### PR TITLE
Move the DB init SQL script from DockerStorageContainer to StorageContainerConfiguration.

### DIFF
--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/DockerStorageContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/DockerStorageContainer.java
@@ -18,9 +18,7 @@
 package org.apache.shardingsphere.test.e2e.env.container.atomic.storage;
 
 import com.google.common.base.Strings;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.DockerITContainer;
@@ -28,18 +26,16 @@ import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.Storage
 import org.apache.shardingsphere.test.e2e.env.container.atomic.util.StorageContainerUtils;
 import org.apache.shardingsphere.test.e2e.env.container.wait.JdbcConnectionWaitStrategy;
 import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
-import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
-import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
-import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 import org.testcontainers.containers.BindMode;
 
 import javax.sql.DataSource;
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
 import java.sql.DriverManager;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Docker storage container.
@@ -54,17 +50,13 @@ public abstract class DockerStorageContainer extends DockerITContainer implement
     
     private final DatabaseType databaseType;
     
-    @Getter(AccessLevel.NONE)
-    private final String scenario;
-    
     private final Map<String, DataSource> actualDataSourceMap;
     
     private final Map<String, DataSource> expectedDataSourceMap;
     
-    protected DockerStorageContainer(final DatabaseType databaseType, final String containerImage, final String scenario) {
+    protected DockerStorageContainer(final DatabaseType databaseType, final String containerImage) {
         super(databaseType.getType().toLowerCase(), containerImage);
         this.databaseType = databaseType;
-        this.scenario = scenario;
         actualDataSourceMap = new LinkedHashMap<>();
         expectedDataSourceMap = new LinkedHashMap<>();
     }
@@ -72,14 +64,6 @@ public abstract class DockerStorageContainer extends DockerITContainer implement
     @Override
     protected void configure() {
         withClasspathResourceMapping("/container/init-sql/" + databaseType.getType().toLowerCase() + "/00-init-authority.sql", "/docker-entrypoint-initdb.d/00-init-authority.sql", BindMode.READ_ONLY);
-        if (Strings.isNullOrEmpty(scenario)) {
-            withClasspathResourceMapping("/env/" + databaseType.getType().toLowerCase() + "/01-initdb.sql", "/docker-entrypoint-initdb.d/01-initdb.sql", BindMode.READ_ONLY);
-        } else {
-            withClasspathResourceMapping(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, databaseType) + "/01-actual-init.sql", "/docker-entrypoint-initdb.d/01-actual-init.sql",
-                    BindMode.READ_ONLY);
-            withClasspathResourceMapping(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, databaseType) + "/01-expected-init.sql",
-                    "/docker-entrypoint-initdb.d/01-expected-init.sql", BindMode.READ_ONLY);
-        }
         withClasspathResourceMapping("/container/init-sql/" + databaseType.getType().toLowerCase() + "/99-be-ready.sql", "/docker-entrypoint-initdb.d/99-be-ready.sql", BindMode.READ_ONLY);
         withExposedPorts(getExposedPort());
         setWaitStrategy(new JdbcConnectionWaitStrategy(
@@ -104,13 +88,14 @@ public abstract class DockerStorageContainer extends DockerITContainer implement
     }
     
     @Override
-    @SneakyThrows({IOException.class, JAXBException.class})
     protected void postStart() {
-        if (!Strings.isNullOrEmpty(scenario)) {
-            DatabaseEnvironmentManager.getDatabaseNames(scenario).forEach(each -> actualDataSourceMap.put(each, createAccessDataSource(each)));
-            DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario).forEach(each -> expectedDataSourceMap.put(each, createAccessDataSource(each)));
-        }
+        actualDataSourceMap.putAll(createAccessDataSource(getDatabaseNames()));
+        expectedDataSourceMap.putAll(createAccessDataSource(getExpectedDatabaseNames()));
     }
+    
+    protected abstract Collection<String> getDatabaseNames();
+    
+    protected abstract Collection<String> getExpectedDatabaseNames();
     
     /**
      * Create access data source.
@@ -120,6 +105,16 @@ public abstract class DockerStorageContainer extends DockerITContainer implement
      */
     public DataSource createAccessDataSource(final String dataSourceName) {
         return StorageContainerUtils.generateDataSource(getJdbcUrl(dataSourceName), getUsername(), getPassword(), 4);
+    }
+    
+    /**
+     * Create access data source map.
+     *
+     * @param dataSourceNames data source name collection
+     * @return access data source map
+     */
+    public Map<String, DataSource> createAccessDataSource(final Collection<String> dataSourceNames) {
+        return dataSourceNames.stream().distinct().collect(Collectors.toMap(Function.identity(), this::createAccessDataSource));
     }
     
     /**

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/EmbeddedStorageContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/EmbeddedStorageContainer.java
@@ -18,7 +18,6 @@
 package org.apache.shardingsphere.test.e2e.env.container.atomic.storage;
 
 import lombok.Getter;
-import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.util.StorageContainerUtils;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.EmbeddedITContainer;
@@ -26,8 +25,6 @@ import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
 
 import javax.sql.DataSource;
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -53,7 +50,6 @@ public abstract class EmbeddedStorageContainer implements EmbeddedITContainer, S
         expectedDataSourceMap = createExpectedDataSourceMap();
     }
     
-    @SneakyThrows({IOException.class, JAXBException.class})
     private Map<String, DataSource> createActualDataSourceMap() {
         Collection<String> databaseNames = DatabaseEnvironmentManager.getDatabaseNames(scenario);
         Map<String, DataSource> result = new LinkedHashMap<>(databaseNames.size(), 1F);
@@ -62,7 +58,6 @@ public abstract class EmbeddedStorageContainer implements EmbeddedITContainer, S
         return result;
     }
     
-    @SneakyThrows({IOException.class, JAXBException.class})
     private Map<String, DataSource> createExpectedDataSourceMap() {
         Collection<String> databaseNames = DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario);
         Map<String, DataSource> result = new LinkedHashMap<>(databaseNames.size(), 1F);

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/StorageContainerFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/StorageContainerFactory.java
@@ -37,22 +37,21 @@ public final class StorageContainerFactory {
      *
      * @param databaseType database type
      * @param storageContainerImage storage container image
-     * @param scenario scenario
      * @param storageContainerConfiguration storage container configuration
      * @return created instance
      * @throws RuntimeException runtime exception
      */
-    public static StorageContainer newInstance(final DatabaseType databaseType, final String storageContainerImage, final String scenario,
+    public static StorageContainer newInstance(final DatabaseType databaseType, final String storageContainerImage,
                                                final StorageContainerConfiguration storageContainerConfiguration) {
         switch (databaseType.getType()) {
             case "MySQL":
-                return new MySQLContainer(storageContainerImage, scenario, storageContainerConfiguration);
+                return new MySQLContainer(storageContainerImage, storageContainerConfiguration);
             case "PostgreSQL":
-                return new PostgreSQLContainer(storageContainerImage, scenario, storageContainerConfiguration);
+                return new PostgreSQLContainer(storageContainerImage, storageContainerConfiguration);
             case "openGauss":
-                return new OpenGaussContainer(storageContainerImage, scenario, storageContainerConfiguration);
+                return new OpenGaussContainer(storageContainerImage, storageContainerConfiguration);
             case "H2":
-                return new H2Container(scenario);
+                return new H2Container(storageContainerConfiguration);
             default:
                 throw new RuntimeException(String.format("Database `%s` is unknown.", databaseType.getType()));
         }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/StorageContainerConfiguration.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/StorageContainerConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -29,9 +30,25 @@ import java.util.Map;
 @Getter
 public class StorageContainerConfiguration {
     
+    private final String scenario;
+    
     private final String containerCommand;
     
     private final Map<String, String> containerEnvironments;
     
     private final Map<String, String> mountedResources;
+    
+    private final Collection<String> databaseNames;
+    
+    private final Collection<String> expectedDatabaseNames;
+    
+    public StorageContainerConfiguration(final String containerCommand, final Map<String, String> containerEnvironments, final Map<String, String> mountedResources,
+                                         final Collection<String> databaseNames, final Collection<String> expectedDatabaseNames) {
+        this.databaseNames = databaseNames;
+        this.expectedDatabaseNames = expectedDatabaseNames;
+        this.scenario = null;
+        this.containerCommand = containerCommand;
+        this.containerEnvironments = containerEnvironments;
+        this.mountedResources = mountedResources;
+    }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/StorageContainerConfigurationFactory.java
@@ -36,13 +36,37 @@ public final class StorageContainerConfigurationFactory {
      * Create new instance of storage container configuration.
      *
      * @param databaseType database type
+     * @param scenario scenario
      * @return created instance
      * @throws RuntimeException runtime exception
      */
-    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType) {
+    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType, final String scenario) {
         switch (databaseType.getType()) {
             case "MySQL":
-                return MySQLContainerConfigurationFactory.newInstance();
+                return MySQLContainerConfigurationFactory.newInstance(scenario);
+            case "PostgreSQL":
+                return PostgreSQLContainerConfigurationFactory.newInstance(scenario);
+            case "openGauss":
+                return OpenGaussContainerConfigurationFactory.newInstance(scenario);
+            case "H2":
+                return H2ContainerConfigurationFactory.newInstance(scenario);
+            default:
+                throw new RuntimeException(String.format("Database `%s` is unknown.", databaseType.getType()));
+        }
+    }
+    
+    /**
+     * Create new instance of storage container configuration.
+     *
+     * @param databaseType database type
+     * @param majorVersion majorVersion
+     * @return created instance
+     * @throws RuntimeException runtime exception
+     */
+    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType, final int majorVersion) {
+        switch (databaseType.getType()) {
+            case "MySQL":
+                return MySQLContainerConfigurationFactory.newInstance(majorVersion);
             case "PostgreSQL":
                 return PostgreSQLContainerConfigurationFactory.newInstance();
             case "openGauss":

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/h2/H2ContainerConfigurationFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/h2/H2ContainerConfigurationFactory.java
@@ -19,9 +19,16 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.i
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.h2.H2DatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * H2 container configuration factory.
@@ -35,6 +42,23 @@ public final class H2ContainerConfigurationFactory {
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration("", Collections.emptyMap(), Collections.emptyMap());
+        Map<String, String> mountedResources = new HashMap<>(1, 1F);
+        mountedResources.put("/env/mysql/01-initdb.sql", "/docker-entrypoint-initdb.d/01-initdb.sql");
+        return new StorageContainerConfiguration("", Collections.emptyMap(), mountedResources, new ArrayList<>(), new ArrayList<>());
+    }
+    
+    /**
+     * Create new instance of h2 container configuration.
+     *
+     * @param scenario scenario
+     * @return created instance
+     */
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        Map<String, String> mountedResources = new HashMap<>(2, 1F);
+        mountedResources.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new H2DatabaseType()) + "/01-actual-init.sql", "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        mountedResources.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new H2DatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        return new StorageContainerConfiguration(scenario, "", Collections.emptyMap(), mountedResources, DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/mysql/MySQLContainerConfigurationFactory.java
@@ -19,14 +19,17 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.i
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.mysql.MySQLDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.MySQLContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.util.ContainerUtils;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * MySQL container configuration factory.
@@ -36,25 +39,23 @@ public final class MySQLContainerConfigurationFactory {
     
     /**
      * Create new instance of MySQL container configuration.
-     * 
+     *
+     * @param scenario scenario
      * @return created instance
      */
-    public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     /**
-     * Create new instance of MySQL container configuration with parameter.
+     * Create new instance of MySQL container configuration with major version.
      *
-     * @param command command
-     * @param containerEnvironments container environments
-     * @param mountedResources mounted resources
+     * @param majorVersion major version
      * @return created instance
      */
-    public static StorageContainerConfiguration newInstance(final String command, final Map<String, String> containerEnvironments, final Map<String, String> mountedResources) {
-        return new StorageContainerConfiguration(Optional.ofNullable(command).orElseGet(MySQLContainerConfigurationFactory::getCommand),
-                Optional.ofNullable(containerEnvironments).orElseGet(MySQLContainerConfigurationFactory::getContainerEnvironments),
-                Optional.ofNullable(mountedResources).orElseGet(MySQLContainerConfigurationFactory::getMountedResources));
+    public static StorageContainerConfiguration newInstance(final int majorVersion) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(majorVersion), new ArrayList<>(), new ArrayList<>());
     }
     
     private static String getCommand() {
@@ -68,7 +69,22 @@ public final class MySQLContainerConfigurationFactory {
         return result;
     }
     
-    private static Map<String, String> getMountedResources() {
-        return Collections.singletonMap("/env/mysql/my.cnf", MySQLContainer.MYSQL_CONF_IN_CONTAINER);
+    private static Map<String, String> getMountedResources(final int majorVersion) {
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put(String.format("/env/mysql/mysql%s/my.cnf", majorVersion), MySQLContainer.MYSQL_CONF_IN_CONTAINER);
+        result.put("/env/mysql/01-initdb.sql", "/docker-entrypoint-initdb.d/01-initdb.sql");
+        if (majorVersion > 5) {
+            result.put("/env/mysql/mysql8/02-initdb.sql", "/docker-entrypoint-initdb.d/02-initdb.sql");
+        }
+        return result;
+    }
+    
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new MySQLDatabaseType()) + "/01-actual-init.sql", "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new MySQLDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        result.put("/env/mysql/my.cnf", MySQLContainer.MYSQL_CONF_IN_CONTAINER);
+        return result;
     }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/opengauss/OpenGaussContainerConfigurationFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/opengauss/OpenGaussContainerConfigurationFactory.java
@@ -19,10 +19,15 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.i
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.opengauss.OpenGaussDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.OpenGaussContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,7 +44,18 @@ public final class OpenGaussContainerConfigurationFactory {
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(), new ArrayList<>(), new ArrayList<>());
+    }
+    
+    /**
+     * Create new instance of openGauss container configuration.
+     *
+     * @param scenario scenario
+     * @return created instance
+     */
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     private static String getCommand() {
@@ -51,7 +67,18 @@ public final class OpenGaussContainerConfigurationFactory {
     }
     
     private static Map<String, String> getMountedResources() {
-        Map<String, String> result = new HashMap<>(2, 1F);
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put("/env/opengauss/01-initdb.sql", "/docker-entrypoint-initdb.d/01-initdb.sql");
+        result.put("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
+        result.put("/env/opengauss/pg_hba.conf", OpenGaussContainer.OPENGAUSS_HBA_IN_CONF_CONTAINER);
+        return result;
+    }
+    
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>(4, 1F);
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new OpenGaussDatabaseType()) + "/01-actual-init.sql", "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new OpenGaussDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
         result.put("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
         result.put("/env/opengauss/pg_hba.conf", OpenGaussContainer.OPENGAUSS_HBA_IN_CONF_CONTAINER);
         return result;

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/postgresql/PostgreSQLContainerConfigurationFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/config/impl/postgresql/PostgreSQLContainerConfigurationFactory.java
@@ -19,11 +19,17 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.i
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.postgresql.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.PostgreSQLContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,7 +44,18 @@ public final class PostgreSQLContainerConfigurationFactory {
      * @return created instance
      */
     public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(), new ArrayList<>(), new ArrayList<>());
+    }
+    
+    /**
+     * Create new instance of PostgreSQL container configuration.
+     *
+     * @param scenario scenario
+     * @return created instance
+     */
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     private static String getCommand() {
@@ -50,6 +67,19 @@ public final class PostgreSQLContainerConfigurationFactory {
     }
     
     private static Map<String, String> getMountedResources() {
-        return Collections.singletonMap("/env/postgresql/postgresql.conf", PostgreSQLContainer.POSTGRESQL_CONF_IN_CONTAINER);
+        Map<String, String> result = new HashMap<>(2, 1F);
+        result.put("/env/postgresql/01-initdb.sql", "/docker-entrypoint-initdb.d/01-initdb.sql");
+        result.put("/env/postgresql/postgresql.conf", PostgreSQLContainer.POSTGRESQL_CONF_IN_CONTAINER);
+        return result;
+    }
+    
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new PostgreSQLDatabaseType()) + "/01-actual-init.sql",
+                "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new PostgreSQLDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        result.put("/env/postgresql/postgresql.conf", PostgreSQLContainer.POSTGRESQL_CONF_IN_CONTAINER);
+        return result;
     }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/H2Container.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/H2Container.java
@@ -21,6 +21,7 @@ import lombok.SneakyThrows;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.EmbeddedStorageContainer;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 import org.h2.tools.RunScript;
@@ -40,9 +41,9 @@ public final class H2Container extends EmbeddedStorageContainer {
     
     private final ScenarioDataPath scenarioDataPath;
     
-    public H2Container(final String scenario) {
-        super(TypedSPILoader.getService(DatabaseType.class, "H2"), scenario);
-        scenarioDataPath = new ScenarioDataPath(scenario);
+    public H2Container(final StorageContainerConfiguration storageContainerConfiguration) {
+        super(TypedSPILoader.getService(DatabaseType.class, "H2"), storageContainerConfiguration.getScenario());
+        scenarioDataPath = new ScenarioDataPath(storageContainerConfiguration.getScenario());
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/MySQLContainer.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -36,8 +37,8 @@ public final class MySQLContainer extends DockerStorageContainer {
     
     private final StorageContainerConfiguration storageContainerConfig;
     
-    public MySQLContainer(final String containerImage, final String scenario, final StorageContainerConfiguration storageContainerConfig) {
-        super(TypedSPILoader.getService(DatabaseType.class, "MySQL"), Strings.isNullOrEmpty(containerImage) ? "mysql:5.7" : containerImage, scenario);
+    public MySQLContainer(final String containerImage, final StorageContainerConfiguration storageContainerConfig) {
+        super(TypedSPILoader.getService(DatabaseType.class, "MySQL"), Strings.isNullOrEmpty(containerImage) ? "mysql:5.7" : containerImage);
         this.storageContainerConfig = storageContainerConfig;
     }
     
@@ -47,6 +48,16 @@ public final class MySQLContainer extends DockerStorageContainer {
         addEnvs(storageContainerConfig.getContainerEnvironments());
         mapResources(storageContainerConfig.getMountedResources());
         super.configure();
+    }
+    
+    @Override
+    protected Collection<String> getDatabaseNames() {
+        return storageContainerConfig.getDatabaseNames();
+    }
+    
+    @Override
+    protected Collection<String> getExpectedDatabaseNames() {
+        return storageContainerConfig.getExpectedDatabaseNames();
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/OpenGaussContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/OpenGaussContainer.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -42,8 +43,8 @@ public final class OpenGaussContainer extends DockerStorageContainer {
     
     private final StorageContainerConfiguration storageContainerConfig;
     
-    public OpenGaussContainer(final String containerImage, final String scenario, final StorageContainerConfiguration storageContainerConfig) {
-        super(TypedSPILoader.getService(DatabaseType.class, "openGauss"), Strings.isNullOrEmpty(containerImage) ? "enmotech/opengauss:3.0.0" : containerImage, scenario);
+    public OpenGaussContainer(final String containerImage, final StorageContainerConfiguration storageContainerConfig) {
+        super(TypedSPILoader.getService(DatabaseType.class, "openGauss"), Strings.isNullOrEmpty(containerImage) ? "enmotech/opengauss:3.0.0" : containerImage);
         this.storageContainerConfig = storageContainerConfig;
     }
     
@@ -55,6 +56,16 @@ public final class OpenGaussContainer extends DockerStorageContainer {
         withPrivilegedMode(true);
         super.configure();
         withStartupTimeout(Duration.of(120, ChronoUnit.SECONDS));
+    }
+    
+    @Override
+    protected Collection<String> getDatabaseNames() {
+        return storageContainerConfig.getDatabaseNames();
+    }
+    
+    @Override
+    protected Collection<String> getExpectedDatabaseNames() {
+        return storageContainerConfig.getExpectedDatabaseNames();
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/PostgreSQLContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/storage/impl/PostgreSQLContainer.java
@@ -23,6 +23,7 @@ import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 
+import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -36,8 +37,8 @@ public final class PostgreSQLContainer extends DockerStorageContainer {
     
     private final StorageContainerConfiguration storageContainerConfig;
     
-    public PostgreSQLContainer(final String containerImage, final String scenario, final StorageContainerConfiguration storageContainerConfig) {
-        super(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"), Strings.isNullOrEmpty(containerImage) ? "postgres:12-alpine" : containerImage, scenario);
+    public PostgreSQLContainer(final String containerImage, final StorageContainerConfiguration storageContainerConfig) {
+        super(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"), Strings.isNullOrEmpty(containerImage) ? "postgres:12-alpine" : containerImage);
         this.storageContainerConfig = storageContainerConfig;
     }
     
@@ -47,6 +48,16 @@ public final class PostgreSQLContainer extends DockerStorageContainer {
         addEnvs(storageContainerConfig.getContainerEnvironments());
         mapResources(storageContainerConfig.getMountedResources());
         super.configure();
+    }
+    
+    @Override
+    protected Collection<String> getDatabaseNames() {
+        return storageContainerConfig.getDatabaseNames();
+    }
+    
+    @Override
+    protected Collection<String> getExpectedDatabaseNames() {
+        return storageContainerConfig.getExpectedDatabaseNames();
     }
     
     @Override

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/database/DatabaseEnvironmentManager.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/database/DatabaseEnvironmentManager.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.test.e2e.env.runtime.scenario.database;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
 import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
@@ -39,10 +40,8 @@ public final class DatabaseEnvironmentManager {
      *
      * @param scenario scenario
      * @return database names
-     * @throws IOException IO exception
-     * @throws JAXBException JAXB exception
      */
-    public static Collection<String> getDatabaseNames(final String scenario) throws IOException, JAXBException {
+    public static Collection<String> getDatabaseNames(final String scenario) {
         return unmarshal(new ScenarioDataPath(scenario).getDatabasesFile(Type.ACTUAL)).getDatabases();
     }
     
@@ -51,14 +50,13 @@ public final class DatabaseEnvironmentManager {
      *
      * @param scenario scenario
      * @return expected database names
-     * @throws IOException IO exception
-     * @throws JAXBException JAXB exception
      */
-    public static Collection<String> getExpectedDatabaseNames(final String scenario) throws IOException, JAXBException {
+    public static Collection<String> getExpectedDatabaseNames(final String scenario) {
         return unmarshal(new ScenarioDataPath(scenario).getDatabasesFile(Type.EXPECTED)).getDatabases();
     }
     
-    private static DatabaseNameEnvironment unmarshal(final String databasesFile) throws IOException, JAXBException {
+    @SneakyThrows({IOException.class, JAXBException.class})
+    private static DatabaseNameEnvironment unmarshal(final String databasesFile) {
         try (FileReader reader = new FileReader(databasesFile)) {
             return (DatabaseNameEnvironment) JAXBContext.newInstance(DatabaseNameEnvironment.class).createUnmarshaller().unmarshal(reader);
         }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/createtable/CreateTableSQLGeneratorIT.java
@@ -36,8 +36,6 @@ import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerSto
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageContainerFactory;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.mysql.MySQLContainerConfigurationFactory;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.MySQLContainer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,10 +47,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
-import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
@@ -101,17 +97,13 @@ class CreateTableSQLGeneratorIT {
     
     private void startStorageContainer(final DatabaseType databaseType, final String storageContainerImage) {
         StorageContainerConfiguration storageContainerConfig = createStorageContainerConfiguration(databaseType, storageContainerImage);
-        storageContainer = (DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage, "", storageContainerConfig);
+        storageContainer = (DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage, storageContainerConfig);
         storageContainer.start();
     }
     
     private StorageContainerConfiguration createStorageContainerConfiguration(final DatabaseType databaseType, final String storageContainerImage) {
-        if (databaseType instanceof MySQLDatabaseType) {
-            int majorVersion = new DockerImageVersion(storageContainerImage).getMajorVersion();
-            Map<String, String> mountedResources = Collections.singletonMap(String.format("/env/mysql/mysql%s/my.cnf", majorVersion), MySQLContainer.MYSQL_CONF_IN_CONTAINER);
-            return MySQLContainerConfigurationFactory.newInstance(null, null, mountedResources);
-        }
-        return StorageContainerConfigurationFactory.newInstance(databaseType);
+        int majorVersion = new DockerImageVersion(storageContainerImage).getMajorVersion();
+        return StorageContainerConfigurationFactory.newInstance(databaseType, majorVersion);
     }
     
     private void assertSQL(final Collection<String> actualSQL, final Collection<String> expectedSQL) {

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/framework/container/compose/DockerContainerComposer.java
@@ -19,7 +19,6 @@ package org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.com
 
 import lombok.Getter;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
-import org.apache.shardingsphere.infra.database.mysql.MySQLDatabaseType;
 import org.apache.shardingsphere.test.e2e.data.pipeline.framework.container.config.proxy.PipelineProxyClusterContainerConfigurationFactory;
 import org.apache.shardingsphere.test.e2e.data.pipeline.util.DockerImageVersion;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.AdapterContainerFactory;
@@ -33,16 +32,12 @@ import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerSto
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.StorageContainerFactory;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.StorageContainerConfigurationFactory;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.mysql.MySQLContainerConfigurationFactory;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.MySQLContainer;
 import org.apache.shardingsphere.test.e2e.env.runtime.DataSourceEnvironment;
 
 import java.security.InvalidParameterException;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Composed container, include governance container and database container.
@@ -67,18 +62,9 @@ public final class DockerContainerComposer extends BaseContainerComposer {
         }
         for (int i = 0; i < storageContainerCount; i++) {
             StorageContainerConfiguration storageContainerConfig;
-            if (databaseType instanceof MySQLDatabaseType) {
-                int majorVersion = new DockerImageVersion(storageContainerImage).getMajorVersion();
-                Map<String, String> mountedResources = new HashMap<>();
-                mountedResources.put(String.format("/env/mysql/mysql%s/my.cnf", majorVersion), MySQLContainer.MYSQL_CONF_IN_CONTAINER);
-                if (majorVersion > 5) {
-                    mountedResources.put("/env/mysql/mysql8/02-initdb.sql", "/docker-entrypoint-initdb.d/02-initdb.sql");
-                }
-                storageContainerConfig = MySQLContainerConfigurationFactory.newInstance(null, null, mountedResources);
-            } else {
-                storageContainerConfig = StorageContainerConfigurationFactory.newInstance(databaseType);
-            }
-            DockerStorageContainer storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage, null,
+            int majorVersion = new DockerImageVersion(storageContainerImage).getMajorVersion();
+            storageContainerConfig = StorageContainerConfigurationFactory.newInstance(databaseType, majorVersion);
+            DockerStorageContainer storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, storageContainerImage,
                     storageContainerConfig));
             storageContainer.setNetworkAliases(Collections.singletonList(String.join(".", databaseType.getType().toLowerCase() + "_" + i, "host")));
             storageContainers.add(storageContainer);

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/util/DockerImageVersion.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/util/DockerImageVersion.java
@@ -17,6 +17,8 @@
 
 package org.apache.shardingsphere.test.e2e.data.pipeline.util;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Docker image version.
  */
@@ -36,7 +38,7 @@ public final class DockerImageVersion {
      * @return major version
      */
     public int getMajorVersion() {
-        String[] split = version.split("\\.");
+        String[] split = StringUtils.substringBefore(version, "-").split("\\.");
         return Integer.parseInt(split[0]);
     }
 }

--- a/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
+++ b/test/e2e/operation/showprocesslist/src/test/java/org/apache/shardingsphere/test/e2e/showprocesslist/container/composer/ClusterShowProcessListContainerComposer.java
@@ -54,8 +54,8 @@ public final class ClusterShowProcessListContainerComposer implements AutoClosea
     public ClusterShowProcessListContainerComposer(final ShowProcessListTestParameter testParam) {
         containers = new ITContainers(testParam.getScenario());
         governanceContainer = isClusterMode(testParam.getRunMode()) ? containers.registerContainer(GovernanceContainerFactory.newInstance("ZooKeeper")) : null;
-        StorageContainer storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "", testParam.getScenario(),
-                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType())));
+        StorageContainer storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "",
+                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType(), testParam.getScenario())));
         AdaptorContainerConfiguration containerConfig = new AdaptorContainerConfiguration(testParam.getScenario(),
                 getMountedResources(testParam.getScenario(), testParam.getDatabaseType(), testParam.getRunMode(), testParam.getGovernanceCenter()), AdapterContainerUtils.getAdapterContainerImage());
         jdbcContainer = AdapterContainerFactory.newInstance(

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/compose/DockerContainerComposer.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/compose/DockerContainerComposer.java
@@ -23,8 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.AdapterContainerFactory;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl.ShardingSphereProxyClusterContainer;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterMode;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.enums.AdapterType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.GovernanceContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.governance.impl.ZookeeperContainer;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.DockerStorageContainer;
@@ -59,8 +59,8 @@ public final class DockerContainerComposer extends BaseContainerComposer {
         super(testParam.getScenario());
         this.databaseType = testParam.getDatabaseType();
         governanceContainer = getContainers().registerContainer(new ZookeeperContainer());
-        storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, testParam.getStorageContainerImage(), testParam.getScenario(),
-                StorageContainerConfigurationFactory.newInstance(databaseType)));
+        storageContainer = getContainers().registerContainer((DockerStorageContainer) StorageContainerFactory.newInstance(databaseType, testParam.getStorageContainerImage(),
+                StorageContainerConfigurationFactory.newInstance(databaseType, testParam.getScenario())));
         if (AdapterType.PROXY.getValue().equalsIgnoreCase(testParam.getAdapter())) {
             jdbcContainer = null;
             proxyContainer = (ShardingSphereProxyClusterContainer) AdapterContainerFactory.newInstance(AdapterMode.CLUSTER, AdapterType.PROXY,

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/StorageContainerConfigurationFactory.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/StorageContainerConfigurationFactory.java
@@ -20,11 +20,11 @@ package org.apache.shardingsphere.test.e2e.transaction.framework.container.confi
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
+import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.h2.H2ContainerConfigurationFactory;
 import org.apache.shardingsphere.test.e2e.transaction.framework.container.config.mysql.MySQLContainerConfigurationFactory;
 import org.apache.shardingsphere.test.e2e.transaction.framework.container.config.opengauss.OpenGaussContainerConfigurationFactory;
 import org.apache.shardingsphere.test.e2e.transaction.framework.container.config.postgresql.PostgreSQLContainerConfigurationFactory;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
-import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.impl.h2.H2ContainerConfigurationFactory;
 
 /**
  * Storage container configuration factory.
@@ -34,21 +34,22 @@ public final class StorageContainerConfigurationFactory {
     
     /**
      * Create new instance of storage container configuration.
-     * 
+     *
      * @param databaseType database type
+     * @param scenario scenario
      * @return created instance
      * @throws RuntimeException runtime exception
      */
-    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType) {
+    public static StorageContainerConfiguration newInstance(final DatabaseType databaseType, final String scenario) {
         switch (databaseType.getType()) {
             case "MySQL":
-                return MySQLContainerConfigurationFactory.newInstance();
+                return MySQLContainerConfigurationFactory.newInstance(scenario);
             case "PostgreSQL":
-                return PostgreSQLContainerConfigurationFactory.newInstance();
+                return PostgreSQLContainerConfigurationFactory.newInstance(scenario);
             case "openGauss":
-                return OpenGaussContainerConfigurationFactory.newInstance();
+                return OpenGaussContainerConfigurationFactory.newInstance(scenario);
             case "H2":
-                return H2ContainerConfigurationFactory.newInstance();
+                return H2ContainerConfigurationFactory.newInstance(scenario);
             default:
                 throw new RuntimeException(String.format("Database `%s` is unknown.", databaseType.getType()));
         }

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/mysql/MySQLContainerConfigurationFactory.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/mysql/MySQLContainerConfigurationFactory.java
@@ -19,10 +19,13 @@ package org.apache.shardingsphere.test.e2e.transaction.framework.container.confi
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.mysql.MySQLDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.MySQLContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,10 +38,12 @@ public final class MySQLContainerConfigurationFactory {
     /**
      * Create new instance of MySQL container configuration.
      *
+     * @param scenario scenario
      * @return created instance
      */
-    public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     private static String getCommand() {
@@ -53,7 +58,12 @@ public final class MySQLContainerConfigurationFactory {
         return result;
     }
     
-    private static Map<String, String> getMountedResources() {
-        return Collections.singletonMap("/env/mysql/my.cnf", MySQLContainer.MYSQL_CONF_IN_CONTAINER);
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>();
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new MySQLDatabaseType()) + "/01-actual-init.sql", "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new MySQLDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        result.put("/env/mysql/my.cnf", MySQLContainer.MYSQL_CONF_IN_CONTAINER);
+        return result;
     }
 }

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/opengauss/OpenGaussContainerConfigurationFactory.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/opengauss/OpenGaussContainerConfigurationFactory.java
@@ -19,11 +19,16 @@ package org.apache.shardingsphere.test.e2e.transaction.framework.container.confi
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.opengauss.OpenGaussDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.OpenGaussContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -35,10 +40,12 @@ public final class OpenGaussContainerConfigurationFactory {
     /**
      * Create new instance of openGauss container configuration.
      *
+     * @param scenario scenario
      * @return created instance
      */
-    public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     private static String getCommand() {
@@ -49,7 +56,13 @@ public final class OpenGaussContainerConfigurationFactory {
         return Collections.singletonMap("GS_PASSWORD", StorageContainerConstants.PASSWORD);
     }
     
-    private static Map<String, String> getMountedResources() {
-        return Collections.singletonMap("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new OpenGaussDatabaseType()) + "/01-actual-init.sql",
+                "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new OpenGaussDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        result.put("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
+        return result;
     }
 }

--- a/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/postgresql/PostgreSQLContainerConfigurationFactory.java
+++ b/test/e2e/operation/transaction/src/test/java/org/apache/shardingsphere/test/e2e/transaction/framework/container/config/postgresql/PostgreSQLContainerConfigurationFactory.java
@@ -19,11 +19,14 @@ package org.apache.shardingsphere.test.e2e.transaction.framework.container.confi
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.database.postgresql.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.constants.StorageContainerConstants;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.config.StorageContainerConfiguration;
 import org.apache.shardingsphere.test.e2e.env.container.atomic.storage.impl.OpenGaussContainer;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.database.DatabaseEnvironmentManager;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath;
+import org.apache.shardingsphere.test.e2e.env.runtime.scenario.path.ScenarioDataPath.Type;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,10 +39,12 @@ public final class PostgreSQLContainerConfigurationFactory {
     /**
      * Create new instance of PostgreSQL container configuration.
      *
+     * @param scenario scenario
      * @return created instance
      */
-    public static StorageContainerConfiguration newInstance() {
-        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources());
+    public static StorageContainerConfiguration newInstance(final String scenario) {
+        return new StorageContainerConfiguration(getCommand(), getContainerEnvironments(), getMountedResources(scenario), DatabaseEnvironmentManager.getDatabaseNames(scenario),
+                DatabaseEnvironmentManager.getExpectedDatabaseNames(scenario));
     }
     
     private static String getCommand() {
@@ -53,7 +58,13 @@ public final class PostgreSQLContainerConfigurationFactory {
         return result;
     }
     
-    private static Map<String, String> getMountedResources() {
-        return Collections.singletonMap("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
+    private static Map<String, String> getMountedResources(final String scenario) {
+        Map<String, String> result = new HashMap<>(3, 1F);
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.ACTUAL, new PostgreSQLDatabaseType()) + "/01-actual-init.sql",
+                "/docker-entrypoint-initdb.d/01-actual-init.sql");
+        result.put(new ScenarioDataPath(scenario).getInitSQLResourcePath(Type.EXPECTED, new PostgreSQLDatabaseType()) + "/01-expected-init.sql",
+                "/docker-entrypoint-initdb.d/01-expected-init.sql");
+        result.put("/env/postgresql/postgresql.conf", OpenGaussContainer.OPENGAUSS_CONF_IN_CONTAINER);
+        return result;
     }
 }

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/container/compose/mode/ClusterContainerComposer.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/container/compose/mode/ClusterContainerComposer.java
@@ -56,8 +56,8 @@ public final class ClusterContainerComposer implements ContainerComposer {
         // TODO support other types of governance
         governanceContainer = containers.registerContainer(GovernanceContainerFactory.newInstance("ZooKeeper"));
         // TODO add more version of databases
-        storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "", scenario,
-                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType())));
+        storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "",
+                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType(), scenario)));
         AdaptorContainerConfiguration containerConfig = ProxyClusterContainerConfigurationFactory.newInstance(
                 scenario, testParam.getDatabaseType(), AdapterContainerUtils.getAdapterContainerImage());
         AdapterContainer adapterContainer = AdapterContainerFactory.newInstance(AdapterMode.valueOf(testParam.getMode().toUpperCase()),

--- a/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/container/compose/mode/StandaloneContainerComposer.java
+++ b/test/e2e/sql/src/test/java/org/apache/shardingsphere/test/e2e/container/compose/mode/StandaloneContainerComposer.java
@@ -48,8 +48,8 @@ public final class StandaloneContainerComposer implements ContainerComposer {
         String scenario = testParam.getScenario();
         containers = new ITContainers(scenario);
         // TODO add more version of databases
-        storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "", scenario,
-                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType())));
+        storageContainer = containers.registerContainer(StorageContainerFactory.newInstance(testParam.getDatabaseType(), "",
+                StorageContainerConfigurationFactory.newInstance(testParam.getDatabaseType(), scenario)));
         adapterContainer = containers.registerContainer(AdapterContainerFactory.newInstance(AdapterMode.valueOf(testParam.getMode().toUpperCase()),
                 AdapterType.valueOf(testParam.getAdapter().toUpperCase()),
                 testParam.getDatabaseType(), storageContainer, scenario, ProxyStandaloneContainerConfigurationFactory.newInstance(scenario, testParam.getDatabaseType())));


### PR DESCRIPTION
Changes proposed in this pull request:
  - Move the DB init SQL script from DockerStorageContainer to StorageContainerConfiguration. 
  
---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
