### PR TITLE
Fix pipeline buildUpdateSQL cache

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/sqlbuilder/PipelineImportSQLBuilder.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/sqlbuilder/PipelineImportSQLBuilder.java
@@ -85,16 +85,12 @@ public final class PipelineImportSQLBuilder {
     public String buildUpdateSQL(final String schemaName, final DataRecord dataRecord, final Collection<Column> conditionColumns) {
         String sqlCacheKey = UPDATE_SQL_CACHE_KEY_PREFIX + dataRecord.getTableName();
         if (!sqlCacheMap.containsKey(sqlCacheKey)) {
-            String updateMainClause = buildUpdateMainClause(schemaName, dataRecord);
+            String updateMainClause = String.format("UPDATE %s SET %%s", sqlSegmentBuilder.getQualifiedTableName(schemaName, dataRecord.getTableName()));
             sqlCacheMap.put(sqlCacheKey, buildWhereClause(conditionColumns).map(optional -> updateMainClause + optional).orElse(updateMainClause));
         }
-        return sqlCacheMap.get(sqlCacheKey);
-    }
-    
-    private String buildUpdateMainClause(final String schemaName, final DataRecord dataRecord) {
         Collection<Column> setColumns = dataRecord.getColumns().stream().filter(Column::isUpdated).collect(Collectors.toList());
         String updateSetClause = setColumns.stream().map(each -> sqlSegmentBuilder.getEscapedIdentifier(each.getName()) + " = ?").collect(Collectors.joining(","));
-        return String.format("UPDATE %s SET %s", sqlSegmentBuilder.getQualifiedTableName(schemaName, dataRecord.getTableName()), updateSetClause);
+        return String.format(sqlCacheMap.get(sqlCacheKey), updateSetClause);
     }
     
     /**

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/sqlbuilder/PipelineImportSQLBuilderTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/sqlbuilder/PipelineImportSQLBuilderTest.java
@@ -38,32 +38,37 @@ class PipelineImportSQLBuilderTest {
     
     @Test
     void assertBuildInsertSQL() {
-        String actual = importSQLBuilder.buildInsertSQL(null, mockDataRecord("t2"));
+        String actual = importSQLBuilder.buildInsertSQL(null, mockDataRecord("t2", 3));
         assertThat(actual, is("INSERT INTO t2(id,sc,c1,c2,c3) VALUES(?,?,?,?,?)"));
     }
     
     @Test
     void assertBuildUpdateSQLWithPrimaryKey() {
-        String actual = importSQLBuilder.buildUpdateSQL(null, mockDataRecord("t2"), RecordUtils.extractPrimaryColumns(mockDataRecord("t2")));
-        assertThat(actual, is("UPDATE t2 SET c1 = ?,c2 = ?,c3 = ? WHERE id = ?"));
+        DataRecord dataRecord = mockDataRecord("t1", 3);
+        String actual = importSQLBuilder.buildUpdateSQL(null, dataRecord, RecordUtils.extractPrimaryColumns(dataRecord));
+        assertThat(actual, is("UPDATE t1 SET c1 = ?,c2 = ?,c3 = ? WHERE id = ?"));
     }
     
     @Test
     void assertBuildUpdateSQLWithShardingColumns() {
-        DataRecord dataRecord = mockDataRecord("t2");
+        DataRecord dataRecord = mockDataRecord("t2", 3);
         String actual = importSQLBuilder.buildUpdateSQL(null, dataRecord, mockConditionColumns(dataRecord));
         assertThat(actual, is("UPDATE t2 SET c1 = ?,c2 = ?,c3 = ? WHERE id = ? AND sc = ?"));
+        dataRecord = mockDataRecord("t2", 2);
+        actual = importSQLBuilder.buildUpdateSQL(null, dataRecord, mockConditionColumns(dataRecord));
+        assertThat(actual, is("UPDATE t2 SET c1 = ?,c2 = ? WHERE id = ? AND sc = ?"));
     }
     
     @Test
     void assertBuildDeleteSQLWithPrimaryKey() {
-        String actual = importSQLBuilder.buildDeleteSQL(null, mockDataRecord("t3"), RecordUtils.extractPrimaryColumns(mockDataRecord("t3")));
+        DataRecord dataRecord = mockDataRecord("t3", 3);
+        String actual = importSQLBuilder.buildDeleteSQL(null, dataRecord, RecordUtils.extractPrimaryColumns(dataRecord));
         assertThat(actual, is("DELETE FROM t3 WHERE id = ?"));
     }
     
     @Test
     void assertBuildDeleteSQLWithConditionColumns() {
-        DataRecord dataRecord = mockDataRecord("t3");
+        DataRecord dataRecord = mockDataRecord("t3", 3);
         String actual = importSQLBuilder.buildDeleteSQL(null, dataRecord, mockConditionColumns(dataRecord));
         assertThat(actual, is("DELETE FROM t3 WHERE id = ? AND sc = ?"));
     }
@@ -72,13 +77,13 @@ class PipelineImportSQLBuilderTest {
         return RecordUtils.extractConditionColumns(dataRecord, Collections.singleton("sc"));
     }
     
-    private DataRecord mockDataRecord(final String tableName) {
+    private DataRecord mockDataRecord(final String tableName, final int extraColumnCount) {
         DataRecord result = new DataRecord(IngestDataChangeType.INSERT, tableName, new PlaceholderPosition(), 4);
         result.addColumn(new Column("id", "", false, true));
         result.addColumn(new Column("sc", "", false, false));
-        result.addColumn(new Column("c1", "", true, false));
-        result.addColumn(new Column("c2", "", true, false));
-        result.addColumn(new Column("c3", "", true, false));
+        for (int i = 1; i <= extraColumnCount; i++) {
+            result.addColumn(new Column("c" + i, "", true, false));
+        }
         return result;
     }
     


### PR DESCRIPTION

Changes proposed in this pull request:
  - Fix pipeline buildUpdateSQL cache. Add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
