### PR TITLE
Refactor : refactor the max parall to 20 in code of conduct

### DIFF
--- a/docs/community/content/involved/conduct/code.cn.md
+++ b/docs/community/content/involved/conduct/code.cn.md
@@ -118,5 +118,5 @@ chapter = true
 - Workflow 文件内的 `name` 属性命名与文件名一致，单词以 `-` 作为分隔符，分隔符两侧要加空格，每个单词首字母大写。例如：`Nightly - Check`。
 - Step 下的 `name` 属性应该描述 step 的功能，每个单词首字母大写，介词小写。例如：`Build Project with Maven`。
 - Workflow 中的 `job` 属性命名，须在 Workflow 中保持唯一。
-- 使用 `matrix` 的时候，必须添加作业并行度限制为 5。例如：`max-parallel: 5`。
+- 使用 `matrix` 的时候，必须添加作业并行度限制为 20。例如：`max-parallel: 20`。
 - 必须为作业设置超时时间，最大不超过 1 小时。例如：`timeout-minutes: 10`。

--- a/docs/community/content/involved/conduct/code.en.md
+++ b/docs/community/content/involved/conduct/code.en.md
@@ -118,5 +118,5 @@ The following code of conduct is based on full compliance with [ASF CODE OF COND
 - `name` property in workflow file should be same with file name, Words separated by `-`, add space between `-` and words, first letter of every word should be capital. For example: `Nightly - Check`.
 - `name` property in step should describe the usage of step, first letter of every word should be capital, preposition should be lowercase. For example: `Build Project with Maven`.
 - `job` property in workflow should be unique in that workflow file.
-- When using `matrix` property, must add job parallelism limit to 5. For example: `max-parallel: 5`.
+- When using `matrix` property, must add job parallelism limit to 20. For example: `max-parallel: 20`.
 - Must set timeout for job, max timeout is 1 hour. For example: `timeout-minutes: 10`.


### PR DESCRIPTION
Changes proposed in this pull request:
  - refactor the max parall to 20 in code of conduc

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
