### PR TITLE
Enhance SQLNodeConverterEngine to support ''select_where_with_predicate_with_in_subquery

### DIFF
--- a/test/it/optimizer/src/test/resources/converter/select-expression.xml
+++ b/test/it/optimizer/src/test/resources/converter/select-expression.xml
@@ -46,4 +46,6 @@
     <test-cases sql-case-id="select_where_with_boolean_primary_with_null_safe" expected-sql="SELECT * FROM `t_order` WHERE `t_order`.`status` &lt;=&gt; `t_order`.`order_id`" db-types="MySQL" sql-case-types="LITERAL" />
     <test-cases sql-case-id="select_where_with_simple_expr_with_match" expected-sql="SELECT * FROM `t_order` WHERE MATCH (`order_id`) AGAINST ('keyword' IN NATURAL LANGUAGE MODE)" db-types="MySQL" sql-case-types="LITERAL" />
     <test-cases sql-case-id="select_where_with_simple_expr_with_match" expected-sql="SELECT * FROM `t_order` WHERE MATCH (`order_id`) AGAINST (? IN NATURAL LANGUAGE MODE)" db-types="MySQL" sql-case-types="PLACEHOLDER" />
+    <test-cases sql-case-id="select_where_with_predicate_with_in_subquery" expected-sql="SELECT * FROM &quot;t_order&quot; WHERE &quot;t_order&quot;.&quot;order_id&quot; NOT IN (SELECT &quot;order_id&quot; FROM &quot;t_order_item&quot; WHERE &quot;status&quot; &gt; 1)" db-types="PostgreSQL, openGauss" sql-case-types="LITERAL" />
+    <test-cases sql-case-id="select_where_with_predicate_with_in_subquery" expected-sql="SELECT * FROM &quot;t_order&quot; WHERE &quot;t_order&quot;.&quot;order_id&quot; NOT IN (SELECT &quot;order_id&quot; FROM &quot;t_order_item&quot; WHERE &quot;status&quot; &gt; ?)" db-types="PostgreSQL, openGauss" sql-case-types="PLACEHOLDER" />
 </sql-node-converter-test-cases>


### PR DESCRIPTION
Fixes #26871 .

Changes proposed in this pull request:
  - Finish task6: select_where_with_predicate_with_in_subquery
  - dbtypes: PostgreSQL, openGauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
