### PR TITLE
Support oracle LAST_VALUE function parsing

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -705,7 +705,19 @@ analyticFunction
     ;
 
 specialFunction
-    : castFunction  | charFunction | extractFunction | formatFunction
+    : castFunction  | charFunction | extractFunction | formatFunction | firstOrLastValueFunction
+    ;
+
+firstOrLastValueFunction
+    : (FIRST_VALUE | LAST_VALUE)  (LP_ expr respectOrIgnoreNulls? RP_ | LP_ expr RP_ respectOrIgnoreNulls?) overClause
+    ;
+
+respectOrIgnoreNulls
+    : (RESPECT | IGNORE) NULLS
+    ;
+
+overClause
+    : OVER analyticClause
     ;
 
 formatFunction

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -322,10 +322,6 @@ schemaName
     : identifier
     ;
 
-profileName
-    : identifier
-    ;
-
 tableName
     : (owner DOT_)? name
     ;
@@ -717,7 +713,7 @@ respectOrIgnoreNulls
     ;
 
 overClause
-    : OVER analyticClause
+    : OVER LP_ analyticClause RP_
     ;
 
 formatFunction

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -5556,4 +5556,17 @@
             </expression-projection>
         </projections>
     </select>
+    
+    <select sql-case-id="select_with_last_value_function">
+        <projections start-index="7" stop-index="71" literal-start-index="7" literal-stop-index="71">
+            <expression-projection text="LAST_VALUE(AGE IGNORE NULLS) OVER (PARTITION BY AGE ORDER BY AGE)" start-index="7" stop-index="71" literal-start-index="7" literal-stop-index="71">
+                <expr>
+                    <function function-name="LAST_VALUE" text="LAST_VALUE(AGE IGNORE NULLS) OVER (PARTITION BY AGE ORDER BY AGE)" start-index="7" stop-index="71" literal-start-index="7" literal-stop-index="71"/>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="TEST" start-index="78" stop-index="81" literal-start-index="78" literal-stop-index="81"/>
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -185,4 +185,5 @@
     <sql-case id="select_with_keyword_system" value="SELECT * FROM vtx_project WHERE system = ?" />
     <sql-case id="select_with_keyword_groups_and_rank" value="SELECT t.groups, t.rank FROM t_order t" db-types="MySQL" />
     <sql-case id="select_with_format_function" value="SELECT wi.code.format(null,'PURE_IDENTITY') as PURE_IDENTITY FROM warehouse_info wi;" db-types="Oracle" />
+    <sql-case id="select_with_last_value_function" value="SELECT LAST_VALUE(AGE IGNORE NULLS) OVER (PARTITION BY AGE ORDER BY AGE) from TEST;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support oracle LAST_VALUE function parsing

Refer to: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/LAST_VALUE.html#GUID-A646AF95-C8E9-4A67-87BA-87B11AEE7B79

![image](https://github.com/apache/shardingsphere/assets/19788130/b2358c0f-234e-407a-82e5-e7960712e152)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
