### PR TITLE
Refactor : set skip javadoc and checkstyle as default

### DIFF
--- a/distribution/agent/pom.xml
+++ b/distribution/agent/pom.xml
@@ -53,6 +53,10 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+                <checkstyle.skip>false</checkstyle.skip>
+            </properties>
             <build>
                 <finalName>apache-shardingsphere-${project.version}</finalName>
                 <plugins>

--- a/distribution/jdbc/pom.xml
+++ b/distribution/jdbc/pom.xml
@@ -66,6 +66,10 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+                <checkstyle.skip>false</checkstyle.skip>
+            </properties>
             <build>
                 <finalName>apache-shardingsphere-${project.version}</finalName>
                 <plugins>

--- a/distribution/proxy/pom.xml
+++ b/distribution/proxy/pom.xml
@@ -67,6 +67,10 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+                <checkstyle.skip>false</checkstyle.skip>
+            </properties>
             <build>
                 <finalName>apache-shardingsphere-${project.version}</finalName>
                 <plugins>

--- a/distribution/src/pom.xml
+++ b/distribution/src/pom.xml
@@ -30,6 +30,10 @@
     <profiles>
         <profile>
             <id>release</id>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+                <checkstyle.skip>false</checkstyle.skip>
+            </properties>
             <build>
                 <finalName>apache-shardingsphere-${project.version}</finalName>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <maven.version.range>[3.0.4,)</maven.version.range>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <checkstyle.skip>true</checkstyle.skip>
         <shade.package>org.apache.shardingsphere.shade</shade.package>
         <antlr.output.directory>${basedir}/target/generated-sources/antlr4</antlr.output.directory>
         


### PR DESCRIPTION
Changes proposed in this pull request:
  - set skip javadoc and checkstyle as default

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
