### PR TITLE
Update exception type for register/alter storage unit.

### DIFF
--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/storage/unit/AlterStorageUnitBackendHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/storage/unit/AlterStorageUnitBackendHandler.java
@@ -33,7 +33,7 @@ import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.datasource.props.DataSourcePropertiesCreator;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
-import org.apache.shardingsphere.infra.util.exception.external.server.ShardingSphereServerException;
+import org.apache.shardingsphere.infra.util.exception.external.ShardingSphereExternalException;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
@@ -71,7 +71,7 @@ public final class AlterStorageUnitBackendHandler extends StorageUnitDefinitionB
         validateHandler.validate(dataSourcePropsMap);
         try {
             ProxyContext.getInstance().getContextManager().getInstanceContext().getModeContextManager().alterStorageUnits(databaseName, dataSourcePropsMap);
-        } catch (final SQLException | ShardingSphereServerException ex) {
+        } catch (final SQLException | ShardingSphereExternalException ex) {
             log.error("Alter storage unit failed", ex);
             throw new InvalidStorageUnitsException(Collections.singleton(ex.getMessage()));
         }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/storage/unit/RegisterStorageUnitBackendHandler.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/handler/distsql/rdl/storage/unit/RegisterStorageUnitBackendHandler.java
@@ -28,7 +28,7 @@ import org.apache.shardingsphere.infra.database.spi.DatabaseType;
 import org.apache.shardingsphere.infra.datasource.props.DataSourceProperties;
 import org.apache.shardingsphere.infra.rule.identifier.type.DataSourceContainedRule;
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
-import org.apache.shardingsphere.infra.util.exception.external.server.ShardingSphereServerException;
+import org.apache.shardingsphere.infra.util.exception.external.ShardingSphereExternalException;
 import org.apache.shardingsphere.proxy.backend.context.ProxyContext;
 import org.apache.shardingsphere.proxy.backend.response.header.ResponseHeader;
 import org.apache.shardingsphere.proxy.backend.response.header.update.UpdateResponseHeader;
@@ -74,7 +74,7 @@ public final class RegisterStorageUnitBackendHandler extends StorageUnitDefiniti
         validateHandler.validate(dataSourcePropsMap);
         try {
             ProxyContext.getInstance().getContextManager().getInstanceContext().getModeContextManager().registerStorageUnits(databaseName, dataSourcePropsMap);
-        } catch (final SQLException | ShardingSphereServerException ex) {
+        } catch (final SQLException | ShardingSphereExternalException ex) {
             log.error("Register storage unit failed", ex);
             throw new InvalidStorageUnitsException(Collections.singleton(ex.getMessage()));
         }


### PR DESCRIPTION
During the execution of `ModeContextManager#registerStorageUnits`, two exceptions are known to occur:
1. SQLWrapperException
<img width="787" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/72bb8370-254c-4086-8b2c-579939569a17">

2. ServiceProviderNotFoundServerException
<img width="1485" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/70f31f28-5603-4cf0-bdb4-0da12c477e0c">


#### They all belong to `ShardingSphereExternalException`
![image](https://github.com/apache/shardingsphere/assets/5668787/141aaccb-f955-459c-a492-bbfa9ee4e0e5)


#### So now change exception type from `ShardingSphereServerException` to `ShardingSphereExternalException`

<img width="1644" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/8716942e-8858-4a39-86b0-58e5dc65202e">


