### PR TITLE
[Documentation] Altered English Rules for Identifier

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/_index.en.md
+++ b/docs/document/content/user-manual/shardingsphere-proxy/distsql/syntax/_index.en.md
@@ -22,7 +22,7 @@ In DistSQL statement, except for keywords, the input format of other elements sh
 - rule name
 - algorithm name
 
-2. The allowed characters in the identifier are: [`A-Z, A-Z, 0-9, _`] (letters, numbers, underscores) and should start with a letter.
+2. The allowed characters in the identifier are: [`a-z, A-Z, 0-9, _`] (letters, numbers, underscores) and should start with a letter.
 3. When keywords or special characters appear in the identifier, use the backticks (`).
 
 ### Literal


### PR DESCRIPTION
The English manual had Capitalized A-Z twice. I changed one to lowercase values a-z as I assume that was the intent.

I believe many of the following check list is not applicable, because this is a simple documentation change and not a code change.

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
