### PR TITLE
Support filter loading when there are single tables with the same name

### DIFF
--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -126,7 +126,7 @@ public final class SingleTableDataNodeLoader {
     }
     
     private static Collection<DataNode> loadSpecifiedDataNode(final Collection<DataNode> dataNodes, final Collection<String> featureRequiredSingleTables,
-                                              final Map<String, Map<String, Collection<String>>> configuredTableMap) {
+                                                              final Map<String, Map<String, Collection<String>>> configuredTableMap) {
         for (final DataNode each : dataNodes) {
             if (featureRequiredSingleTables.contains(each.getTableName())) {
                 return Collections.singletonList(each);

--- a/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
+++ b/kernel/single/core/src/main/java/org/apache/shardingsphere/single/datanode/SingleTableDataNodeLoader.java
@@ -129,24 +129,30 @@ public final class SingleTableDataNodeLoader {
                                                               final Map<String, Map<String, Collection<String>>> configuredTableMap) {
         for (final DataNode each : dataNodes) {
             if (featureRequiredSingleTables.contains(each.getTableName())) {
-                return Collections.singletonList(each);
+                return getSingleDataNodeCollection(each);
             }
             Map<String, Collection<String>> configuredTablesForDataSource = configuredTableMap.get(each.getDataSourceName());
             if (null == configuredTablesForDataSource || configuredTablesForDataSource.isEmpty()) {
                 continue;
             }
             if (configuredTablesForDataSource.containsKey(SingleTableConstants.ASTERISK)) {
-                return Collections.singletonList(each);
+                return getSingleDataNodeCollection(each);
             }
             Collection<String> configuredTablesForSchema = configuredTablesForDataSource.get(each.getSchemaName());
             if (null == configuredTablesForSchema || configuredTablesForSchema.isEmpty()) {
                 continue;
             }
             if (configuredTablesForSchema.contains(SingleTableConstants.ASTERISK) || configuredTablesForSchema.contains(each.getTableName())) {
-                return Collections.singletonList(each);
+                return getSingleDataNodeCollection(each);
             }
         }
         return Collections.emptyList();
+    }
+    
+    private static Collection<DataNode> getSingleDataNodeCollection(final DataNode dataNode) {
+        Collection<DataNode> result = new LinkedList<>();
+        result.add(dataNode);
+        return result;
     }
     
     private static Map<String, Map<String, Collection<String>>> getConfiguredTableMap(final String databaseName, final DatabaseType databaseType, final Collection<String> configuredTables) {


### PR DESCRIPTION
Fixes #27290, 
Support filter loading when there are single tables with the same name
