### PR TITLE
Rename getExpression to getColumnName in Projection interface

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -78,7 +78,7 @@ public final class EncryptMergedResult implements MergedResult {
     }
     
     private Optional<String> findTableName(final ColumnProjection columnProjection, final Map<String, String> columnTableNames) {
-        String tableName = columnTableNames.get(columnProjection.getExpression());
+        String tableName = columnTableNames.get(columnProjection.getColumnName());
         if (null != tableName) {
             return Optional.of(tableName);
         }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
@@ -91,7 +91,7 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
             if (each instanceof ColumnProjectionSegment) {
                 ColumnProjectionSegment columnSegment = (ColumnProjectionSegment) each;
                 ColumnProjection columnProjection = buildColumnProjection(columnSegment);
-                String tableName = columnTableNames.get(columnProjection.getExpression());
+                String tableName = columnTableNames.get(columnProjection.getColumnName());
                 if (null == tableName) {
                     continue;
                 }
@@ -122,7 +122,7 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
                                                           final SelectStatementContext selectStatementContext, final SubqueryType subqueryType, final Map<String, String> columnTableNames) {
         List<Projection> projections = new LinkedList<>();
         for (Projection each : actualColumns) {
-            String tableName = columnTableNames.get(each.getExpression());
+            String tableName = columnTableNames.get(each.getColumnName());
             Optional<EncryptTable> encryptTable = null == tableName ? Optional.empty() : encryptRule.findEncryptTable(tableName);
             if (!encryptTable.isPresent() || !encryptTable.get().isEncryptColumn(each.getColumnLabel()) || containsTableSubquery(selectStatementContext)) {
                 projections.add(each.getAlias().map(optional -> (Projection) new ColumnProjection(null, optional, null)).orElse(each));

--- a/features/mask/core/src/main/java/org/apache/shardingsphere/mask/merge/dql/MaskAlgorithmMetaData.java
+++ b/features/mask/core/src/main/java/org/apache/shardingsphere/mask/merge/dql/MaskAlgorithmMetaData.java
@@ -73,7 +73,7 @@ public final class MaskAlgorithmMetaData {
     }
     
     private Optional<String> findTableName(final ColumnProjection columnProjection, final Map<String, String> columnTableNames) {
-        String tableName = columnTableNames.get(columnProjection.getExpression());
+        String tableName = columnTableNames.get(columnProjection.getColumnName());
         if (null != tableName) {
             return Optional.of(tableName);
         }

--- a/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ProjectionsTokenGenerator.java
+++ b/features/sharding/core/src/main/java/org/apache/shardingsphere/sharding/rewrite/token/generator/impl/ProjectionsTokenGenerator.java
@@ -100,7 +100,7 @@ public final class ProjectionsTokenGenerator implements OptionalSQLTokenGenerato
         if (projection instanceof AggregationDistinctProjection) {
             return ((AggregationDistinctProjection) projection).getDistinctInnerExpression() + " AS " + projection.getAlias().get().getValue() + " ";
         }
-        return projection.getExpression() + " AS " + projection.getAlias().get().getValue() + " ";
+        return projection.getColumnName() + " AS " + projection.getAlias().get().getValue() + " ";
     }
     
     private String getDerivedProjectionTextFromColumnOrderByItemSegment(final DerivedProjection projection, final TableExtractor tableExtractor, final RouteUnit routeUnit,

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/ProjectionsTokenGeneratorTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/rewrite/token/ProjectionsTokenGeneratorTest.java
@@ -151,7 +151,7 @@ class ProjectionsTokenGeneratorTest {
         DerivedProjection result = mock(DerivedProjection.class);
         when(result.getDerivedProjectionSegment()).thenReturn(null);
         when(result.getAlias()).thenReturn(Optional.of(new IdentifierValue(TEST_OTHER_DERIVED_PROJECTION_ALIAS)));
-        when(result.getExpression()).thenReturn(TEST_OTHER_DERIVED_PROJECTION_EXPRESSION);
+        when(result.getColumnName()).thenReturn(TEST_OTHER_DERIVED_PROJECTION_EXPRESSION);
         return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/Projection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/Projection.java
@@ -27,25 +27,25 @@ import java.util.Optional;
 public interface Projection {
     
     /**
-     * Get expression.
+     * Get column name.
      * 
-     * @return expression
+     * @return column name
      */
-    String getExpression();
+    String getColumnName();
+    
+    /**
+     * Get column label.
+     *
+     * @return column label
+     */
+    String getColumnLabel();
     
     /**
      * Get alias.
-     * 
+     *
      * @return alias
      */
     Optional<IdentifierValue> getAlias();
-    
-    /**
-     * Get columnLabel.
-     *
-     * @return columnLabel
-     */
-    String getColumnLabel();
     
     /**
      * Transform subquery projection.

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContext.java
@@ -113,10 +113,10 @@ public final class ProjectionsContext {
                 Optional<Projection> projection =
                         ((ShorthandProjection) each).getActualColumns().stream().filter(optional -> projectionName.equalsIgnoreCase(getOriginalColumnName(optional))).findFirst();
                 if (projection.isPresent()) {
-                    return projection.map(Projection::getExpression);
+                    return projection.map(Projection::getColumnName);
                 }
             }
-            if (projectionName.equalsIgnoreCase(SQLUtils.getExactlyValue(each.getExpression()))) {
+            if (projectionName.equalsIgnoreCase(SQLUtils.getExactlyValue(each.getColumnName()))) {
                 return each.getAlias().map(IdentifierValue::getValue);
             }
         }
@@ -124,7 +124,7 @@ public final class ProjectionsContext {
     }
     
     private String getOriginalColumnName(final Projection projection) {
-        return projection instanceof ColumnProjection ? ((ColumnProjection) projection).getOriginalName().getValue() : projection.getExpression();
+        return projection instanceof ColumnProjection ? ((ColumnProjection) projection).getOriginalName().getValue() : projection.getColumnName();
     }
     
     /**
@@ -136,7 +136,7 @@ public final class ProjectionsContext {
     public Optional<Integer> findProjectionIndex(final String projectionName) {
         int result = 1;
         for (Projection each : projections) {
-            if (projectionName.equalsIgnoreCase(SQLUtils.getExactlyValue(each.getExpression()))) {
+            if (projectionName.equalsIgnoreCase(SQLUtils.getExactlyValue(each.getColumnName()))) {
                 return Optional.of(result);
             }
             result++;
@@ -163,7 +163,7 @@ public final class ProjectionsContext {
     
     private boolean isContainsLastInsertIdProjection(final Collection<Projection> projections) {
         for (Projection each : projections) {
-            if (LAST_INSERT_ID_FUNCTION_EXPRESSION.equalsIgnoreCase(SQLUtils.getExactlyExpression(each.getExpression()))) {
+            if (LAST_INSERT_ID_FUNCTION_EXPRESSION.equalsIgnoreCase(SQLUtils.getExactlyExpression(each.getColumnName()))) {
                 return true;
             }
         }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -219,7 +219,7 @@ public final class ProjectionEngine {
         Collection<Projection> remainingProjections = new LinkedList<>();
         for (Projection each : getOriginalProjections(joinTable, projectionSegment)) {
             Collection<Projection> actualProjections = getActualProjections(Collections.singletonList(each));
-            if (joinTable.getUsing().isEmpty() && !joinTable.isNatural() || null != owner && each.getExpression().contains(owner.getValue())) {
+            if (joinTable.getUsing().isEmpty() && !joinTable.isNatural() || null != owner && each.getColumnName().contains(owner.getValue())) {
                 result.addAll(actualProjections);
             } else {
                 remainingProjections.addAll(actualProjections);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionsContextEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionsContextEngine.java
@@ -150,6 +150,6 @@ public final class ProjectionsContextEngine {
     }
     
     private boolean isSameQualifiedName(final Projection projection, final String text) {
-        return SQLUtils.getExactlyValue(text).equalsIgnoreCase(SQLUtils.getExactlyValue(projection.getExpression()));
+        return SQLUtils.getExactlyValue(text).equalsIgnoreCase(SQLUtils.getExactlyValue(projection.getColumnName()));
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.segment.select.projection.impl;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.shardingsphere.infra.binder.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.database.spi.DatabaseType;
@@ -26,6 +27,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.Identifi
 /**
  * Aggregation distinct projection.
  */
+@EqualsAndHashCode(callSuper = true)
 @Getter
 public final class AggregationDistinctProjection extends AggregationProjection {
     
@@ -54,9 +56,7 @@ public final class AggregationDistinctProjection extends AggregationProjection {
     
     @Override
     public Projection transformSubqueryProjection(final IdentifierValue subqueryTableAlias, final IdentifierValue originalOwner, final IdentifierValue originalName) {
-        if (getAlias().isPresent()) {
-            return new ColumnProjection(subqueryTableAlias, getAlias().get(), null);
-        }
-        return new AggregationDistinctProjection(startIndex, stopIndex, getType(), getInnerExpression(), null, distinctInnerExpression, getDatabaseType());
+        return getAlias().isPresent() ? new ColumnProjection(subqueryTableAlias, getAlias().get(), null)
+                : new AggregationDistinctProjection(startIndex, stopIndex, getType(), getInnerExpression(), null, distinctInnerExpression, getDatabaseType());
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -54,23 +54,18 @@ public class AggregationProjection implements Projection {
     private int index = -1;
     
     @Override
-    public final String getExpression() {
+    public final String getColumnName() {
         return type.name() + innerExpression;
+    }
+    
+    @Override
+    public String getColumnLabel() {
+        return getAlias().map(IdentifierValue::getValue).orElseGet(() -> databaseType.getDefaultSchema().isPresent() ? type.name().toLowerCase() : getColumnName());
     }
     
     @Override
     public final Optional<IdentifierValue> getAlias() {
         return Optional.ofNullable(alias);
-    }
-    
-    /**
-     * Get column label.
-     *
-     * @return column label
-     */
-    @Override
-    public String getColumnLabel() {
-        return getAlias().map(IdentifierValue::getValue).orElseGet(() -> databaseType.getDefaultSchema().isPresent() ? type.name().toLowerCase() : getExpression());
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ColumnProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ColumnProjection.java
@@ -72,7 +72,7 @@ public final class ColumnProjection implements Projection {
     }
     
     @Override
-    public String getExpression() {
+    public String getColumnName() {
         return null == owner ? name.getValue() : owner.getValue() + "." + name.getValue();
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/DerivedProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/DerivedProjection.java
@@ -43,13 +43,18 @@ public final class DerivedProjection implements Projection {
     private final SQLSegment derivedProjectionSegment;
     
     @Override
-    public Optional<IdentifierValue> getAlias() {
-        return Optional.ofNullable(alias);
+    public String getColumnName() {
+        return expression;
     }
     
     @Override
     public String getColumnLabel() {
         return getAlias().map(IdentifierValue::getValue).orElse(expression);
+    }
+    
+    @Override
+    public Optional<IdentifierValue> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ExpressionProjection.java
@@ -40,13 +40,18 @@ public final class ExpressionProjection implements Projection {
     private final IdentifierValue alias;
     
     @Override
-    public Optional<IdentifierValue> getAlias() {
-        return Optional.ofNullable(alias);
+    public String getColumnName() {
+        return expression;
     }
     
     @Override
     public String getColumnLabel() {
         return getAlias().map(IdentifierValue::getValue).orElse(expression);
+    }
+    
+    @Override
+    public Optional<IdentifierValue> getAlias() {
+        return Optional.ofNullable(alias);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ParameterMarkerProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ParameterMarkerProjection.java
@@ -43,7 +43,7 @@ public final class ParameterMarkerProjection implements Projection {
     private final IdentifierValue alias;
     
     @Override
-    public String getExpression() {
+    public String getColumnName() {
         return String.valueOf(parameterMarkerIndex);
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjection.java
@@ -42,18 +42,18 @@ public final class ShorthandProjection implements Projection {
     private final Collection<Projection> actualColumns;
     
     @Override
-    public String getExpression() {
+    public String getColumnName() {
         return null == owner ? "*" : owner.getValue() + ".*";
-    }
-    
-    @Override
-    public Optional<IdentifierValue> getAlias() {
-        return Optional.empty();
     }
     
     @Override
     public String getColumnLabel() {
         return "*";
+    }
+    
+    @Override
+    public Optional<IdentifierValue> getAlias() {
+        return Optional.empty();
     }
     
     /**

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/SubqueryProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/SubqueryProjection.java
@@ -46,6 +46,16 @@ public final class SubqueryProjection implements Projection {
     private final DatabaseType databaseType;
     
     @Override
+    public String getColumnLabel() {
+        return getAlias().map(IdentifierValue::getValue).orElse(expression);
+    }
+    
+    @Override
+    public String getColumnName() {
+        return expression;
+    }
+    
+    @Override
     public Optional<IdentifierValue> getAlias() {
         return null == alias ? buildDefaultAlias(databaseType) : Optional.of(alias);
     }
@@ -55,11 +65,6 @@ public final class SubqueryProjection implements Projection {
             return Optional.of(new IdentifierValue(expression.replace(" ", "").toUpperCase()));
         }
         return Optional.of(new IdentifierValue(expression));
-    }
-    
-    @Override
-    public String getColumnLabel() {
-        return getAlias().map(IdentifierValue::getValue).orElse(expression);
     }
     
     @Override

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/table/TablesContext.java
@@ -181,13 +181,13 @@ public final class TablesContext {
         }
         Map<String, String> result = new LinkedHashMap<>(columns.size(), 1F);
         for (ColumnProjection each : columns) {
-            if (ownerTableNames.containsKey(each.getExpression())) {
+            if (ownerTableNames.containsKey(each.getColumnName())) {
                 continue;
             }
-            Collection<SubqueryTableContext> subqueryTableContexts = subqueryTables.getOrDefault(each.getOwner(), Collections.emptyList());
+            Collection<SubqueryTableContext> subqueryTableContexts = each.getOwner().map(optional -> subqueryTables.get(each.getOwner().get().getValue())).orElseGet(Collections::emptyList);
             for (SubqueryTableContext subqueryTableContext : subqueryTableContexts) {
-                if (subqueryTableContext.getColumnNames().contains(each.getName())) {
-                    result.put(each.getExpression(), subqueryTableContext.getTableName());
+                if (subqueryTableContext.getColumnNames().contains(each.getName().getValue())) {
+                    result.put(each.getColumnName(), subqueryTableContext.getTableName());
                 }
             }
         }
@@ -207,7 +207,7 @@ public final class TablesContext {
         String tableName = simpleTableSegments.iterator().next().getTableName().getIdentifier().getValue();
         Map<String, String> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (ColumnProjection each : columns) {
-            result.putIfAbsent(each.getExpression(), tableName);
+            result.putIfAbsent(each.getColumnName(), tableName);
         }
         return result;
     }
@@ -227,7 +227,7 @@ public final class TablesContext {
         Map<String, Collection<String>> result = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         for (ColumnProjection each : columns) {
             if (each.getOwner().isPresent()) {
-                result.computeIfAbsent(each.getOwner().get().getValue(), unused -> new LinkedList<>()).add(each.getExpression());
+                result.computeIfAbsent(each.getOwner().get().getValue(), unused -> new LinkedList<>()).add(each.getColumnName());
             }
         }
         return result;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContext.java
@@ -293,7 +293,7 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
         String rawName = SQLUtils.getExactlyValue(((TextOrderByItemSegment) orderByItem).getText());
         for (Projection each : projectionsContext.getProjections()) {
             Optional<String> result = each.getAlias().map(IdentifierValue::getValue);
-            if (SQLUtils.getExactlyExpression(rawName).equalsIgnoreCase(SQLUtils.getExactlyExpression(SQLUtils.getExactlyValue(each.getExpression())))) {
+            if (SQLUtils.getExactlyExpression(rawName).equalsIgnoreCase(SQLUtils.getExactlyExpression(SQLUtils.getExactlyValue(each.getColumnName())))) {
                 return result;
             }
             if (rawName.equalsIgnoreCase(result.orElse(null))) {

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/ProjectionsContextTest.java
@@ -77,14 +77,14 @@ class ProjectionsContextTest {
     void assertFindAlias() {
         Projection projection = getColumnProjectionWithAlias();
         ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(projection));
-        assertTrue(projectionsContext.findAlias(projection.getExpression()).isPresent());
+        assertTrue(projectionsContext.findAlias(projection.getColumnName()).isPresent());
     }
     
     @Test
     void assertFindProjectionIndex() {
         Projection projection = getColumnProjection();
         ProjectionsContext projectionsContext = new ProjectionsContext(0, 0, true, Collections.singleton(projection));
-        Optional<Integer> actual = projectionsContext.findProjectionIndex(projection.getExpression());
+        Optional<Integer> actual = projectionsContext.findProjectionIndex(projection.getColumnName());
         assertTrue(actual.isPresent());
         assertThat(actual.get(), is(1));
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
@@ -36,7 +36,7 @@ class AggregationProjectionTest {
     @Test
     void assertGetExpression() {
         Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, mock(DatabaseType.class));
-        assertThat(projection.getExpression(), is("COUNT( A.\"DIRECTION\" )"));
+        assertThat(projection.getColumnName(), is("COUNT( A.\"DIRECTION\" )"));
     }
     
     @Test

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjectionTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/ShorthandProjectionTest.java
@@ -31,7 +31,7 @@ class ShorthandProjectionTest {
     
     @Test
     void assertGetExpression() {
-        assertThat(new ShorthandProjection(new IdentifierValue("owner"), Collections.emptyList()).getExpression(), is("owner.*"));
+        assertThat(new ShorthandProjection(new IdentifierValue("owner"), Collections.emptyList()).getColumnName(), is("owner.*"));
     }
     
     @Test

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetMetaData.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetMetaData.java
@@ -102,7 +102,7 @@ public final class ShardingSphereResultSetMetaData extends WrapperAdapter implem
             checkColumnIndex(column);
             Projection projection = ((SelectStatementContext) sqlStatementContext).getProjectionsContext().getExpandProjections().get(column - 1);
             if (projection instanceof AggregationDistinctProjection) {
-                return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : projection.getColumnLabel();
+                return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getColumnName() : projection.getColumnLabel();
             }
         }
         return resultSetMetaData.getColumnLabel(column);
@@ -117,7 +117,7 @@ public final class ShardingSphereResultSetMetaData extends WrapperAdapter implem
                 return ((ColumnProjection) projection).getName().getValue();
             }
             if (projection instanceof AggregationDistinctProjection) {
-                return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : projection.getColumnLabel();
+                return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getColumnName() : projection.getColumnLabel();
             }
         }
         return resultSetMetaData.getColumnName(column);

--- a/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtils.java
+++ b/jdbc/core/src/main/java/org/apache/shardingsphere/driver/jdbc/core/resultset/ShardingSphereResultSetUtils.java
@@ -62,7 +62,7 @@ public final class ShardingSphereResultSetUtils {
         Map<String, Integer> result = new CaseInsensitiveMap<>(actualProjections.size(), 1F);
         for (int columnIndex = actualProjections.size(); columnIndex > 0; columnIndex--) {
             Projection projection = actualProjections.get(columnIndex - 1);
-            result.put(DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : projection.getColumnLabel(), columnIndex);
+            result.put(DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getColumnName() : projection.getColumnLabel(), columnIndex);
         }
         return result;
     }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSet.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSet.java
@@ -98,7 +98,7 @@ public final class SQLFederationResultSet extends AbstractUnsupportedOperationRe
     
     private String getColumnLabel(final Projection projection, final DatabaseType databaseType) {
         if (projection instanceof AggregationDistinctProjection) {
-            return databaseType.getDefaultSchema().isPresent() ? ((AggregationDistinctProjection) projection).getType().name().toLowerCase() : projection.getExpression();
+            return databaseType.getDefaultSchema().isPresent() ? ((AggregationDistinctProjection) projection).getType().name().toLowerCase() : projection.getColumnName();
         }
         return projection.getColumnLabel();
     }

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/resultset/SQLFederationResultSetMetaData.java
@@ -186,7 +186,7 @@ public final class SQLFederationResultSetMetaData extends WrapperAdapter impleme
         if (projection instanceof ColumnProjection) {
             Map<String, String> tableNamesByColumnProjection =
                     selectStatementContext.getTablesContext().findTableNamesByColumnProjection(Collections.singletonList((ColumnProjection) projection), schema);
-            return Optional.of(tableNamesByColumnProjection.get(projection.getExpression()));
+            return Optional.of(tableNamesByColumnProjection.get(projection.getColumnName()));
         }
         return Optional.empty();
     }

--- a/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/QueryHeaderBuilderEngine.java
+++ b/proxy/backend/core/src/main/java/org/apache/shardingsphere/proxy/backend/response/header/query/QueryHeaderBuilderEngine.java
@@ -71,7 +71,7 @@ public final class QueryHeaderBuilderEngine {
     
     private String getColumnLabel(final ProjectionsContext projectionsContext, final QueryResultMetaData queryResultMetaData, final int columnIndex) throws SQLException {
         Projection projection = projectionsContext.getExpandProjections().get(columnIndex - 1);
-        return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getExpression() : queryResultMetaData.getColumnLabel(columnIndex);
+        return DerivedColumn.isDerivedColumnName(projection.getColumnLabel()) ? projection.getColumnName() : queryResultMetaData.getColumnLabel(columnIndex);
     }
     
     private String getColumnName(final ProjectionsContext projectionsContext, final QueryResultMetaData queryResultMetaData, final int columnIndex) throws SQLException {

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/NoResourceShowExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/NoResourceShowExecutor.java
@@ -61,7 +61,7 @@ public final class NoResourceShowExecutor implements DatabaseAdminQueryExecutor 
         TableSegment tableSegment = sqlStatement.getFrom();
         expressions = sqlStatement.getProjections().getProjections().stream().filter(each -> !(each instanceof ShorthandProjectionSegment))
                 .map(each -> new ProjectionEngine(null, Collections.emptyMap(), null).createProjection(tableSegment, each))
-                .filter(Optional::isPresent).map(each -> each.get().getAlias().isPresent() ? each.get().getAlias().get() : each.get().getExpression()).collect(Collectors.toList());
+                .filter(Optional::isPresent).map(each -> each.get().getAlias().isPresent() ? each.get().getAlias().get() : each.get().getColumnName()).collect(Collectors.toList());
         mergedResult = new TransparentMergedResult(getQueryResult());
     }
     

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -149,7 +149,7 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         for (Projection each : projections) {
             // TODO Calculate column definition flag for other projection types
             if (each instanceof ColumnProjection && null != ((ColumnProjection) each).getOriginalName()) {
-                result.add(Optional.ofNullable(columnToTableMap.get(each.getExpression())).map(schema::getTable)
+                result.add(Optional.ofNullable(columnToTableMap.get(each.getColumnName())).map(schema::getTable)
                         .map(table -> table.getColumns().get(((ColumnProjection) each).getOriginalName().getValue()))
                         .map(column -> createMySQLColumnDefinition41Packet(characterSet, calculateColumnDefinitionFlag(column), MySQLBinaryColumnType.valueOfJDBCType(column.getDataType())))
                         .orElseGet(() -> createMySQLColumnDefinition41Packet(characterSet, 0, MySQLBinaryColumnType.VAR_STRING)));


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Rename getExpression to getColumnName in Projection interface

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
