### PR TITLE
Support mysql GROUP_CONCAT function parsing

### DIFF
--- a/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
+++ b/parser/sql/dialect/mysql/src/main/antlr4/imports/mysql/BaseRule.g4
@@ -972,7 +972,7 @@ jsonFunctionName
     ;
 
 aggregationFunctionName
-    : MAX | MIN | SUM | COUNT | AVG | BIT_XOR
+    : MAX | MIN | SUM | COUNT | AVG | BIT_XOR | GROUP_CONCAT
     ;
     
 distinct

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/enums/AggregationType.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/enums/AggregationType.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
  */
 public enum AggregationType {
     
-    MAX, MIN, SUM, COUNT, AVG, BIT_XOR;
+    MAX, MIN, SUM, COUNT, AVG, BIT_XOR, GROUP_CONCAT;
     
     /**
      * Is aggregation type.

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -22,7 +22,7 @@
             <simple-table name="t_order" start-index="33" stop-index="39" />
         </from>
         <projections start-index="7" stop-index="26">
-            <expression-projection text="GROUP_CONCAT(status)" start-index="7" stop-index="26">
+            <aggregation-projection type="GROUP_CONCAT" inner-expression="(status)" text="GROUP_CONCAT(status)" start-index="7" stop-index="26">
                 <expr>
                     <function function-name="GROUP_CONCAT" start-index="7" stop-index="26" text="GROUP_CONCAT(status)">
                         <parameter>
@@ -30,7 +30,7 @@
                         </parameter>
                     </function>
                 </expr>
-            </expression-projection>
+            </aggregation-projection>
         </projections>
     </select>
     <select sql-case-id="select_window_function">


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support mysql GROUP_CONCAT function parsing

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
