### PR TITLE
Refactor : leavel a message when set the issue/pr as stale

### DIFF
--- a/.github/workflows/nightly-check.yml
+++ b/.github/workflows/nightly-check.yml
@@ -183,3 +183,9 @@ jobs:
           stale-pr-label: "stale"
           operations-per-run: 1000
           remove-stale-when-updated: true
+          stale-issue-message: >
+            There hasn't been any activity on this issue recently, and in order to prioritize active issues, it will be
+            marked as stale.
+          stale-pr-message: >
+            There hasn't been any activity on this pull request recently, and in order to prioritize active work, it has
+            been marked as stale.


### PR DESCRIPTION
Changes proposed in this pull request:
  - leavel a message when set the issue/pr as stale

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
