### PR TITLE
Support oracle interval literals parsing

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -35,7 +35,11 @@ literals
     ;
 
 intervalLiterals
-    : INTERVAL stringLiterals intervalUnit (LP_ INTEGER_ RP_)? (TO intervalUnit)?
+    : INTERVAL stringLiterals intervalUnit (intervalPrecision)? (TO intervalUnit (intervalPrecision)?)?
+    ;
+
+intervalPrecision
+    : LP_ INTEGER_ RP_
     ;
 
 intervalUnit

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -31,6 +31,15 @@ literals
     | bitValueLiterals
     | booleanLiterals
     | nullValueLiterals
+    | intervalLiterals
+    ;
+
+intervalLiterals
+    : INTERVAL stringLiterals intervalUnit (LP_ INTEGER_ RP_)? (TO intervalUnit)?
+    ;
+
+intervalUnit
+    : SECOND | MINUTE | HOUR | DAY | MONTH | YEAR
     ;
 
 stringLiterals
@@ -100,7 +109,7 @@ unreservedWord1
     | BECOME | CHANGE | NOTIFICATION | PRIVILEGE | PURGE | RESUMABLE
     | SYSGUID | SYSBACKUP | SYSDBA | SYSDG | SYSKM | SYSOPER | DBA_RECYCLEBIN |SCHEMA
     | DO | DEFINER | CURRENT_USER | CASCADED | CLOSE | OPEN | NEXT | NAME | NAMES
-    | COLLATION | REAL | TYPE | FIRST | RANK | SAMPLE | SYSTIMESTAMP | INTERVAL | MINUTE | ANY 
+    | COLLATION | REAL | TYPE | FIRST | RANK | SAMPLE | SYSTIMESTAMP | MINUTE | ANY 
     | LENGTH | SINGLE_C | capacityUnit | TARGET | PUBLIC | ID | STATE | PRIORITY
     | CONSTRAINT | PRIMARY | FOREIGN | KEY | POSITION | PRECISION | FUNCTION | PROCEDURE | SPECIFICATION | CASE
     | WHEN | CAST | TRIM | SUBSTRING | FULL | INNER | OUTER | LEFT | RIGHT | CROSS

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -183,7 +183,10 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         if (null != ctx.dateTimeLiterals()) {
             return visit(ctx.dateTimeLiterals());
         }
-        throw new IllegalStateException("Literals must have string, number, dateTime, hex, bit, boolean or null.");
+        if (null != ctx.intervalLiterals()) {
+            return visit(ctx.intervalLiterals());
+        }
+        throw new IllegalStateException("Literals must have string, number, dateTime, hex, bit, interval, boolean or null.");
     }
     
     @Override

--- a/test/it/parser/src/main/resources/case/dml/insert.xml
+++ b/test/it/parser/src/main/resources/case/dml/insert.xml
@@ -2340,4 +2340,34 @@
             </where>
         </select-subquery>
     </insert>
+    
+    <insert sql-case-id="insert_with_interval">
+        <table name="test" start-index="12" stop-index="15" literal-start-index="12" literal-stop-index="15" />
+        <columns start-index="16" stop-index="16" literal-start-index="16" literal-stop-index="16" />
+        <values>
+            <value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '123-2' YEAR(3) TO MONTH" text="INTERVAL '123-2' YEAR(3) TO MONTH" start-index="25" stop-index="57" literal-start-index="25" literal-stop-index="57" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '123' YEAR(3)" text="INTERVAL '123' YEAR(3)" start-index="60" stop-index="81" literal-start-index="60" literal-stop-index="81" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '300' MONTH(3)" text="INTERVAL '300' MONTH(3)" start-index="84" stop-index="106" literal-start-index="84" literal-stop-index="106" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '4' YEAR" text="INTERVAL '4' YEAR" start-index="109" stop-index="125" literal-start-index="109" literal-stop-index="125" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '50' MONTH" text="INTERVAL '50' MONTH" start-index="128" stop-index="146" literal-start-index="128" literal-stop-index="146" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '4 5:12:10.222' DAY TO SECOND(3)" text="INTERVAL '4 5:12:10.222' DAY TO SECOND(3)" start-index="149" stop-index="189" literal-start-index="149" literal-stop-index="189" />
+                </assignment-value>
+                <assignment-value>
+                    <common-expression literal-text="INTERVAL '4 5:12' DAY TO MINUTE" text="INTERVAL '4 5:12' DAY TO MINUTE" start-index="192" stop-index="222" literal-start-index="192" literal-stop-index="222" />
+                </assignment-value>
+            </value>
+        </values>
+    </insert>
 </sql-parser-test-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support oracle interval literals parsing

Refer to: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/Literals.html#GUID-DC8D1DAD-7D04-45EA-9546-82810CD09A1B

![image](https://github.com/apache/shardingsphere/assets/19788130/79f31722-37ea-4f6b-bb76-0693340742c3)
![image](https://github.com/apache/shardingsphere/assets/19788130/ce1fe630-db42-446d-9638-5cc2e767c77b)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
