### PR TITLE
Support oracle select into clause parsing

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DMLStatement.g4
@@ -148,7 +148,19 @@ parenthesisSelectSubquery
     ;
 
 queryBlock
-    : withClause? SELECT hint? duplicateSpecification? selectList selectFromClause whereClause? hierarchicalQueryClause? groupByClause? modelClause?
+    : withClause? SELECT hint? duplicateSpecification? selectList selectIntoClause? selectFromClause whereClause? hierarchicalQueryClause? groupByClause? modelClause?
+    ;
+
+selectIntoClause
+    : (BULK COLLECT)? INTO variableNames
+    ;
+
+variableNames
+    : variableName (COMMA_ variableName)*
+    ;
+
+variableName
+    : identifier | stringLiterals
     ;
 
 withClause

--- a/test/it/parser/src/main/resources/case/dml/select-into.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-into.xml
@@ -201,4 +201,13 @@
             <expression-projection text="1" start-index="7" stop-index="7" />
         </projections>
     </select>
+
+    <select sql-case-id="select_into_with_variable">
+        <projections start-index="7" stop-index="17" literal-start-index="7" literal-stop-index="17">
+            <column-projection name="select_list" start-index="7" stop-index="17" literal-start-index="7" literal-stop-index="17" />
+        </projections>
+        <from>
+            <simple-table name="table_or_view_name" start-index="50" stop-index="67" literal-start-index="50" literal-stop-index="67" />
+        </from>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-into.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-into.xml
@@ -28,4 +28,5 @@
     <sql-case id="select_into_with_lock_after_into" value="SELECT status FROM t_order WHERE order_id = ? INTO @var1 FOR UPDATE " db-types="MySQL" />
     <sql-case id="select_into_with_lock_before_into" value="SELECT status FROM t_order WHERE order_id = ? FOR UPDATE INTO @var1" db-types="MySQL" />
     <sql-case id="select_into_param_without_at" value="SELECT 1 INTO a" db-types="MySQL" />
+    <sql-case id="select_into_with_variable" value="SELECT select_list INTO record_variable_name FROM table_or_view_name" db-types="Oracle" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
+++ b/test/it/parser/src/main/resources/sql/unsupported/unsupported.xml
@@ -17,7 +17,6 @@
   -->
 
 <sql-cases>
-    <sql-case id="assert_select_into_SQL" value="SELECT * INTO t_order_new FROM t_order" db-types="Oracle" />
     <sql-case id="assert_select_with_json_extract_sign_with_parameter_marker" value="SELECT * FROM t_order WHERE order_id -&gt; ?" db-types="MySQL" />
     <sql-case id="assert_select_with_json_unquote_extract_sign_with_parameter_marker" value="SELECT * FROM t_order WHERE order_id -&gt;&gt; ?" db-types="MySQL" />
     <sql-case id="assert_insert_with_first" value="INSERT FIRST INTO TABLE_XXX (field1) VALUES (field1) SELECT field1 FROM TABLE_XXX2" db-types="Oracle" />


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support oracle select into clause parsing
Refer to: https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/SELECT-INTO-statement.html#GUID-6E14E04D-4344-45F3-BE80-979DD26C7A90

![image](https://github.com/apache/shardingsphere/assets/19788130/53e65098-3d81-42f7-a683-11147c746203)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
