### PR TITLE
add Oracle Join Operator SQL Parse

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -674,7 +674,7 @@ simpleExpr
     | EXISTS? subquery
     | LBE_ identifier expr RBE_
     | caseExpression
-    | columnName
+    | columnName joinOperator?
     | privateExprOfDb
     | PRIOR identifier
     ;
@@ -756,6 +756,10 @@ regularFunction
 
 regularFunctionName
     : identifier | IF | LOCALTIME | LOCALTIMESTAMP | INTERVAL | DECODE
+    ;
+
+joinOperator
+    : LP_ PLUS_  RP_
     ;
 
 caseExpression

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -17,7 +17,6 @@
 
 package org.apache.shardingsphere.sql.parser.oracle.visitor.statement;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
@@ -111,6 +110,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTable
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTableFunctionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.XmlTableOptionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ColumnWithJoinOperatorSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
@@ -504,7 +504,8 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
             return visit(ctx.functionCall());
         }
         if (null != ctx.columnName()) {
-            return visit(ctx.columnName());
+            return null == ctx.joinOperator() ? visit(ctx.columnName())
+                    : new ColumnWithJoinOperatorSegment(startIndex, stopIndex, (ColumnSegment) visitColumnName(ctx.columnName()), ctx.joinOperator().getText());
         }
         return new CommonExpressionSegment(startIndex, stopIndex, ctx.getText());
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/simple/ColumnWithJoinOperatorSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/expr/simple/ColumnWithJoinOperatorSegment.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+
+/**
+ * Column with join operator segment.
+ */
+@RequiredArgsConstructor
+@Getter
+public class ColumnWithJoinOperatorSegment implements SimpleExpressionSegment {
+    
+    private final int startIndex;
+    
+    private final int stopIndex;
+    
+    private final ColumnSegment columnName;
+    
+    private final String joinOperator;
+    
+    @Override
+    public String getText() {
+        return getColumnName().toString();
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/columnWithJoinOperator/ColumnWithJoinOperatorAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/columnWithJoinOperator/ColumnWithJoinOperatorAssert.java
@@ -28,8 +28,9 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
- * Column assert.
+ * Column with join operator assert.
  */
+
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ColumnWithJoinOperatorAssert {
     
@@ -40,8 +41,8 @@ public final class ColumnWithJoinOperatorAssert {
      * @param actual actual column with join operator segment
      * @param expected expected column with join operator segment
      */
-    public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnWithJoinOperatorSegment actual, final ExpectedColumnWithJoinOperatorSegment expected) {
     
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnWithJoinOperatorSegment actual, final ExpectedColumnWithJoinOperatorSegment expected) {
         ColumnAssert.assertIs(assertContext, actual.getColumnName(), expected.getColumn());
         assertEquals(actual.getJoinOperator(), expected.getJoinOperator());
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/columnWithJoinOperator/ColumnWithJoinOperatorAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/columnWithJoinOperator/ColumnWithJoinOperatorAssert.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.columnWithJoinOperator;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ColumnWithJoinOperatorSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.column.ColumnAssert;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr.ExpectedColumnWithJoinOperatorSegment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Column assert.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ColumnWithJoinOperatorAssert {
+    
+    /**
+     * Assert actual column segment is correct with expected column.
+     *
+     * @param assertContext assert context
+     * @param actual actual column with join operator segment
+     * @param expected expected column with join operator segment
+     */
+    public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnWithJoinOperatorSegment actual, final ExpectedColumnWithJoinOperatorSegment expected) {
+    
+        ColumnAssert.assertIs(assertContext, actual.getColumnName(), expected.getColumn());
+        assertEquals(actual.getJoinOperator(), expected.getJoinOperator());
+    }
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/expression/ExpressionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/expression/ExpressionAssert.java
@@ -37,6 +37,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.TypeCast
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ValuesExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.ComplexExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ColumnWithJoinOperatorSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.LiteralExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
@@ -47,6 +48,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DataTypeS
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.column.ColumnAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.columnWithJoinOperator.ColumnWithJoinOperatorAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.generic.DataTypeAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.insert.InsertValuesClauseAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.owner.OwnerAssert;
@@ -478,6 +480,8 @@ public final class ExpressionAssert {
             assertExtractArgExpression(assertContext, (ExtractArgExpression) actual, expected.getExtractArgExpression());
         } else if (actual instanceof MatchAgainstExpression) {
             assertMatchSegment(assertContext, (MatchAgainstExpression) actual, expected.getMatchExpression());
+        } else if (actual instanceof ColumnWithJoinOperatorSegment) {
+            ColumnWithJoinOperatorAssert.assertIs(assertContext, (ColumnWithJoinOperatorSegment) actual, expected.getColumnWithJoinOperatorSegment());
         } else {
             throw new UnsupportedOperationException(String.format("Unsupported expression: %s", actual.getClass().getName()));
         }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedColumnWithJoinOperatorSegment.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedColumnWithJoinOperatorSegment.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.expr;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.AbstractExpectedSQLSegment;
+import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.column.ExpectedColumn;
+
+import javax.xml.bind.annotation.XmlElement;
+
+/**
+ * Expected column with join operator segment.
+ */
+@Getter
+@Setter
+public final class ExpectedColumnWithJoinOperatorSegment extends AbstractExpectedSQLSegment implements ExpectedExpressionSegment {
+    
+    @XmlElement
+    private ExpectedColumn column;
+    
+    @XmlElement(name = "join-operator")
+    private String joinOperator;
+    
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedExpression.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/expr/ExpectedExpression.java
@@ -104,4 +104,7 @@ public final class ExpectedExpression extends AbstractExpectedSQLSegment {
     
     @XmlElement(name = "match-expression")
     private ExpectedMatchExpression matchExpression;
+    
+    @XmlElement(name = "colum-with-join-operator-segment")
+    private ExpectedColumnWithJoinOperatorSegment columnWithJoinOperatorSegment;
 }

--- a/test/it/parser/src/main/resources/case/dml/select-join.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-join.xml
@@ -555,4 +555,40 @@
             </expr>
         </where>
     </select>
+    
+    <select sql-case-id="select_with_join_operator">
+        <projections start-index="7" stop-index="7">
+        <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <from>
+            <join-table join-type="COMMA">
+                <left>
+                    <simple-table name="t_order" start-index="14" stop-index="22" alias="o"/>
+                </left>
+                <right>
+                    <simple-table name="t_order_item" start-index="26" stop-index="39" alias="i" />
+                </right>
+            </join-table>
+        </from>
+        <where start-index="41" stop-index="72">
+            <expr>
+                <binary-operation-expression start-index="47" stop-index="72">
+                    <left>
+                        <colum-with-join-operator-segment start-index="47" stop-index="48">
+                            <column name="order_id" start-index="47" stop-index="56">
+                                <owner name="o" start-index="47" stop-index="47" />
+                            </column>
+                            <join-operator>(+)</join-operator>
+                        </colum-with-join-operator-segment>
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <column name="order_id" start-index="63" stop-index="72">
+                            <owner name="i" start-index="63" stop-index="63" />
+                        </column>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-join.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-join.xml
@@ -30,4 +30,5 @@
     <sql-case id="select_natural_left_join" value="SELECT * FROM t_order o NATURAL LEFT JOIN t_order_item i WHERE o.order_id = ?" db-types="MySQL,PostgreSQL,openGauss" />
     <sql-case id="select_natural_right_join" value="SELECT * FROM t_order o NATURAL RIGHT JOIN t_order_item i WHERE o.order_id = ?" db-types="MySQL,PostgreSQL,openGauss" />
     <sql-case id="select_natural_full_join" value="SELECT * FROM t_order o NATURAL FULL JOIN t_order_item i WHERE o.order_id = ?" db-types="PostgreSQL,openGauss" />
+    <sql-case id="select_with_join_operator" value="SELECT * FROM t_order o , t_order_item i WHERE o.order_id(+) = i.order_id" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION

Changes proposed in this pull request:
  - add Oracle Join Operator Parse
  ref:  https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Joins.html#GUID-29A4584C-0741-4E6A-A89B-DCFAA222994A

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
