### PR TITLE
Rename distinctExpression to distinctInnerExpression to keep same with AggregationDistinctProjection

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -139,7 +139,7 @@ public final class ProjectionEngine {
         IdentifierValue alias =
                 projectionSegment.getAlias().orElseGet(() -> new IdentifierValue(DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(aggregationDistinctDerivedColumnCount++)));
         AggregationDistinctProjection result = new AggregationDistinctProjection(
-                projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getType(), innerExpression, alias, projectionSegment.getDistinctExpression(), databaseType);
+                projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getType(), innerExpression, alias, projectionSegment.getDistinctInnerExpression(), databaseType);
         if (AggregationType.AVG == result.getType()) {
             appendAverageDistinctDerivedProjection(result);
         }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationDistinctProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationDistinctProjectionSegment.java
@@ -27,10 +27,10 @@ import org.apache.shardingsphere.sql.parser.sql.common.util.SQLUtils;
 @Getter
 public final class AggregationDistinctProjectionSegment extends AggregationProjectionSegment {
     
-    private final String distinctExpression;
+    private final String distinctInnerExpression;
     
     public AggregationDistinctProjectionSegment(final int startIndex, final int stopIndex, final AggregationType type, final String innerExpression, final String distinctExpression) {
         super(startIndex, stopIndex, type, innerExpression);
-        this.distinctExpression = SQLUtils.getExpressionWithoutOutsideParentheses(distinctExpression);
+        this.distinctInnerExpression = SQLUtils.getExpressionWithoutOutsideParentheses(distinctExpression);
     }
 }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
@@ -33,9 +33,9 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.pagination.to
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.SQLCaseAssertContext;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.SQLSegmentAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.expression.ExpressionAssert;
+import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.owner.OwnerAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.statement.dml.impl.SelectStatementAssert;
-import org.apache.shardingsphere.test.it.sql.parser.internal.asserts.segment.identifier.IdentifierValueAssert;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjection;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.ExpectedProjections;
 import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.segment.impl.projection.impl.aggregation.ExpectedAggregationDistinctProjection;
@@ -51,8 +51,8 @@ import java.util.List;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -146,8 +146,8 @@ public final class ProjectionAssert {
         assertThat(assertContext.getText("Aggregation projection alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         if (actual instanceof AggregationDistinctProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, instanceOf(ExpectedAggregationDistinctProjection.class));
-            assertThat(assertContext.getText("Aggregation projection alias assertion error: "),
-                    ((AggregationDistinctProjectionSegment) actual).getDistinctExpression(), is(((ExpectedAggregationDistinctProjection) expected).getDistinctExpression()));
+            assertThat(assertContext.getText("Aggregation projection distinct inner expression assertion error: "),
+                    ((AggregationDistinctProjectionSegment) actual).getDistinctInnerExpression(), is(((ExpectedAggregationDistinctProjection) expected).getDistinctInnerExpression()));
         }
     }
     

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/impl/aggregation/ExpectedAggregationDistinctProjection.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/impl/aggregation/ExpectedAggregationDistinctProjection.java
@@ -29,6 +29,6 @@ import javax.xml.bind.annotation.XmlAttribute;
 @Setter
 public final class ExpectedAggregationDistinctProjection extends ExpectedAggregationProjection {
     
-    @XmlAttribute(name = "distinct-expression")
-    private String distinctExpression;
+    @XmlAttribute(name = "distinct-inner-expression")
+    private String distinctInnerExpression;
 }

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -3068,7 +3068,7 @@
             <simple-table  name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="s" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="s" start-index="7" stop-index="28" />
         </projections>
         <where start-index="45" stop-index="65">
             <expr>
@@ -3090,7 +3090,7 @@
             <simple-table name="t_order" start-index="39" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="32">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
         </projections>
         <where start-index="47" stop-index="67">
             <expr>
@@ -3112,7 +3112,7 @@
             <simple-table name="t_order" start-index="35" stop-index="41" />
         </from>
         <projections start-index="7" stop-index="28">
-            <aggregation-distinct-projection type="AVG" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="AVG" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
         </projections>
         <where start-index="43" stop-index="63">
             <expr>
@@ -3134,8 +3134,8 @@
             <simple-table name="t_order" start-index="61" stop-index="67" />
         </from>
         <projections start-index="7" stop-index="54">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="30" />
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="33" stop-index="54" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="33" stop-index="54" />
         </projections>
         <where start-index="69" stop-index="89">
             <expr>
@@ -3158,7 +3158,7 @@
         </from>
         <projections start-index="7" stop-index="42">
             <column-projection name="order_id" start-index="7" stop-index="14" />
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="17" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="17" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3186,7 +3186,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
             <column-projection name="order_id" start-index="35" stop-index="42" />
         </projections>
         <group-by>
@@ -3226,7 +3226,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT user_id + order_id)" distinct-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT user_id + order_id)" distinct-inner-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3248,8 +3248,8 @@
             <simple-table  name="t_order" start-index="77" stop-index="83" />
         </from>
         <projections start-index="7" stop-index="69">
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-expression="order_id" start-index="30" stop-index="53" />
+            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="30" stop-index="53" />
             <aggregation-projection type="COUNT" inner-expression="(order_id)" start-index="55" stop-index="69" />
         </projections>
         <where start-index="85" stop-index="105">


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Rename distinctExpression to distinctInnerExpression to keep same with AggregationDistinctProjection
  - rename projection sql parse assert

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
