### PR TITLE
Modify innerExpression to expression in AggregationProjectionSegment to support MySQL column label

### DIFF
--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/ShardingDQLResultMergerTest.java
@@ -407,7 +407,7 @@ class ShardingDQLResultMergerTest {
         when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(mock(ShardingSphereSchema.class));
         MySQLSelectStatement selectStatement = (MySQLSelectStatement) buildSelectStatement(new MySQLSelectStatement());
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
         selectStatement.setProjections(projectionsSegment);
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
                 selectStatement, DefaultDatabase.LOGIC_NAME);
@@ -420,7 +420,7 @@ class ShardingDQLResultMergerTest {
         when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(mock(ShardingSphereSchema.class));
         MySQLSelectStatement selectStatement = (MySQLSelectStatement) buildSelectStatement(new MySQLSelectStatement());
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
         selectStatement.setProjections(projectionsSegment);
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralLimitValueSegment(0, 0, 1), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),
@@ -453,7 +453,7 @@ class ShardingDQLResultMergerTest {
         when(subquerySegment.getSelect()).thenReturn(subSelectStatement);
         when(subqueryTableSegment.getSubquery()).thenReturn(subquerySegment);
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
         OracleSelectStatement selectStatement = (OracleSelectStatement) buildSelectStatement(new OracleSelectStatement());
         selectStatement.setProjections(projectionsSegment);
         selectStatement.setFrom(subqueryTableSegment);
@@ -472,7 +472,7 @@ class ShardingDQLResultMergerTest {
         when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(mock(ShardingSphereSchema.class));
         SQLServerSelectStatement selectStatement = (SQLServerSelectStatement) buildSelectStatement(new SQLServerSelectStatement());
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
         selectStatement.setProjections(projectionsSegment);
         selectStatement.setLimit(new LimitSegment(0, 0, new NumberLiteralRowNumberValueSegment(0, 0, 1, true), null));
         SelectStatementContext selectStatementContext = new SelectStatementContext(createShardingSphereMetaData(database), Collections.emptyList(),

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByMemoryMergedResultTest.java
@@ -124,8 +124,8 @@ class GroupByMemoryMergedResultTest {
     private SelectStatementContext createSelectStatementContext() {
         SelectStatement selectStatement = new MySQLSelectStatement();
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.AVG, "(num)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.AVG, "AVG(num)"));
         selectStatement.setProjections(projectionsSegment);
         selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.ASC, NullsOrderType.FIRST))));
         selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.DESC, NullsOrderType.FIRST))));

--- a/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
+++ b/features/sharding/core/src/test/java/org/apache/shardingsphere/sharding/merge/dql/groupby/GroupByStreamMergedResultTest.java
@@ -169,8 +169,8 @@ class GroupByStreamMergedResultTest {
         ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         when(database.getSchema(DefaultDatabase.LOGIC_NAME)).thenReturn(mock(ShardingSphereSchema.class));
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.AVG, "(num)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.AVG, "AVG(num)"));
         selectStatement.setProjections(projectionsSegment);
         selectStatement.setGroupBy(new GroupBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.ASC, NullsOrderType.FIRST))));
         selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(new IndexOrderByItemSegment(0, 0, 3, OrderDirection.ASC, NullsOrderType.FIRST))));

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -135,11 +135,11 @@ public final class ProjectionEngine {
     }
     
     private AggregationDistinctProjection createProjection(final AggregationDistinctProjectionSegment projectionSegment) {
-        String innerExpression = projectionSegment.getInnerExpression();
         IdentifierValue alias =
                 projectionSegment.getAlias().orElseGet(() -> new IdentifierValue(DerivedColumn.AGGREGATION_DISTINCT_DERIVED.getDerivedColumnAlias(aggregationDistinctDerivedColumnCount++)));
         AggregationDistinctProjection result = new AggregationDistinctProjection(
-                projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getType(), innerExpression, alias, projectionSegment.getDistinctInnerExpression(), databaseType);
+                projectionSegment.getStartIndex(), projectionSegment.getStopIndex(), projectionSegment.getType(), projectionSegment.getExpression(), alias,
+                projectionSegment.getDistinctInnerExpression(), databaseType);
         if (AggregationType.AVG == result.getType()) {
             appendAverageDistinctDerivedProjection(result);
         }
@@ -147,8 +147,7 @@ public final class ProjectionEngine {
     }
     
     private AggregationProjection createProjection(final AggregationProjectionSegment projectionSegment) {
-        String innerExpression = projectionSegment.getInnerExpression();
-        AggregationProjection result = new AggregationProjection(projectionSegment.getType(), innerExpression, projectionSegment.getAlias().orElse(null), databaseType);
+        AggregationProjection result = new AggregationProjection(projectionSegment.getType(), projectionSegment.getExpression(), projectionSegment.getAlias().orElse(null), databaseType);
         if (AggregationType.AVG == result.getType()) {
             appendAverageDerivedProjection(result);
             // TODO replace avg to constant, avoid calculate useless avg
@@ -292,25 +291,23 @@ public final class ProjectionEngine {
     }
     
     private void appendAverageDistinctDerivedProjection(final AggregationDistinctProjection averageDistinctProjection) {
-        String innerExpression = averageDistinctProjection.getInnerExpression();
         String distinctInnerExpression = averageDistinctProjection.getDistinctInnerExpression();
         String countAlias = DerivedColumn.AVG_COUNT_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
         AggregationDistinctProjection countDistinctProjection = new AggregationDistinctProjection(
-                0, 0, AggregationType.COUNT, innerExpression, new IdentifierValue(countAlias), distinctInnerExpression, databaseType);
+                0, 0, AggregationType.COUNT, averageDistinctProjection.getExpression(), new IdentifierValue(countAlias), distinctInnerExpression, databaseType);
         String sumAlias = DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
         AggregationDistinctProjection sumDistinctProjection = new AggregationDistinctProjection(
-                0, 0, AggregationType.SUM, innerExpression, new IdentifierValue(sumAlias), distinctInnerExpression, databaseType);
+                0, 0, AggregationType.SUM, averageDistinctProjection.getExpression(), new IdentifierValue(sumAlias), distinctInnerExpression, databaseType);
         averageDistinctProjection.getDerivedAggregationProjections().add(countDistinctProjection);
         averageDistinctProjection.getDerivedAggregationProjections().add(sumDistinctProjection);
         aggregationAverageDerivedColumnCount++;
     }
     
     private void appendAverageDerivedProjection(final AggregationProjection averageProjection) {
-        String innerExpression = averageProjection.getInnerExpression();
         String countAlias = DerivedColumn.AVG_COUNT_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationProjection countProjection = new AggregationProjection(AggregationType.COUNT, innerExpression, new IdentifierValue(countAlias), databaseType);
+        AggregationProjection countProjection = new AggregationProjection(AggregationType.COUNT, averageProjection.getExpression(), new IdentifierValue(countAlias), databaseType);
         String sumAlias = DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationProjection sumProjection = new AggregationProjection(AggregationType.SUM, innerExpression, new IdentifierValue(sumAlias), databaseType);
+        AggregationProjection sumProjection = new AggregationProjection(AggregationType.SUM, averageProjection.getExpression(), new IdentifierValue(sumAlias), databaseType);
         averageProjection.getDerivedAggregationProjections().add(countProjection);
         averageProjection.getDerivedAggregationProjections().add(sumProjection);
         aggregationAverageDerivedColumnCount++;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngine.java
@@ -36,6 +36,7 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
+import org.apache.shardingsphere.sql.parser.sql.common.enums.Paren;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationDistinctProjectionSegment;
@@ -293,11 +294,12 @@ public final class ProjectionEngine {
     private void appendAverageDistinctDerivedProjection(final AggregationDistinctProjection averageDistinctProjection) {
         String distinctInnerExpression = averageDistinctProjection.getDistinctInnerExpression();
         String countAlias = DerivedColumn.AVG_COUNT_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationDistinctProjection countDistinctProjection = new AggregationDistinctProjection(
-                0, 0, AggregationType.COUNT, averageDistinctProjection.getExpression(), new IdentifierValue(countAlias), distinctInnerExpression, databaseType);
+        String innerExpression = averageDistinctProjection.getExpression().substring(averageDistinctProjection.getExpression().indexOf(Paren.PARENTHESES.getLeftParen()));;
+        AggregationDistinctProjection countDistinctProjection =
+                new AggregationDistinctProjection(0, 0, AggregationType.COUNT, AggregationType.COUNT.name() + innerExpression, new IdentifierValue(countAlias), distinctInnerExpression, databaseType);
         String sumAlias = DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationDistinctProjection sumDistinctProjection = new AggregationDistinctProjection(
-                0, 0, AggregationType.SUM, averageDistinctProjection.getExpression(), new IdentifierValue(sumAlias), distinctInnerExpression, databaseType);
+        AggregationDistinctProjection sumDistinctProjection =
+                new AggregationDistinctProjection(0, 0, AggregationType.SUM, AggregationType.SUM.name() + innerExpression, new IdentifierValue(sumAlias), distinctInnerExpression, databaseType);
         averageDistinctProjection.getDerivedAggregationProjections().add(countDistinctProjection);
         averageDistinctProjection.getDerivedAggregationProjections().add(sumDistinctProjection);
         aggregationAverageDerivedColumnCount++;
@@ -305,9 +307,10 @@ public final class ProjectionEngine {
     
     private void appendAverageDerivedProjection(final AggregationProjection averageProjection) {
         String countAlias = DerivedColumn.AVG_COUNT_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationProjection countProjection = new AggregationProjection(AggregationType.COUNT, averageProjection.getExpression(), new IdentifierValue(countAlias), databaseType);
+        String innerExpression = averageProjection.getExpression().substring(averageProjection.getExpression().indexOf(Paren.PARENTHESES.getLeftParen()));
+        AggregationProjection countProjection = new AggregationProjection(AggregationType.COUNT, AggregationType.COUNT.name() + innerExpression, new IdentifierValue(countAlias), databaseType);
         String sumAlias = DerivedColumn.AVG_SUM_ALIAS.getDerivedColumnAlias(aggregationAverageDerivedColumnCount);
-        AggregationProjection sumProjection = new AggregationProjection(AggregationType.SUM, averageProjection.getExpression(), new IdentifierValue(sumAlias), databaseType);
+        AggregationProjection sumProjection = new AggregationProjection(AggregationType.SUM, AggregationType.SUM.name() + innerExpression, new IdentifierValue(sumAlias), databaseType);
         averageProjection.getDerivedAggregationProjections().add(countProjection);
         averageProjection.getDerivedAggregationProjections().add(sumProjection);
         aggregationAverageDerivedColumnCount++;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationDistinctProjection.java
@@ -36,9 +36,9 @@ public final class AggregationDistinctProjection extends AggregationProjection {
     
     private final String distinctInnerExpression;
     
-    public AggregationDistinctProjection(final int startIndex, final int stopIndex, final AggregationType type, final String innerExpression,
+    public AggregationDistinctProjection(final int startIndex, final int stopIndex, final AggregationType type, final String expression,
                                          final IdentifierValue alias, final String distinctInnerExpression, final DatabaseType databaseType) {
-        super(type, innerExpression, alias, databaseType);
+        super(type, expression, alias, databaseType);
         this.startIndex = startIndex;
         this.stopIndex = stopIndex;
         this.distinctInnerExpression = distinctInnerExpression;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjection.java
@@ -43,7 +43,7 @@ public class AggregationProjection implements Projection {
     
     private final AggregationType type;
     
-    private final String innerExpression;
+    private final String expression;
     
     private final IdentifierValue alias;
     
@@ -56,7 +56,7 @@ public class AggregationProjection implements Projection {
     
     @Override
     public String getColumnName() {
-        return ProjectionUtils.getColumnNameFromFunction(type.name(), type.name() + innerExpression, databaseType);
+        return ProjectionUtils.getColumnNameFromFunction(type.name(), expression, databaseType);
     }
     
     @Override
@@ -66,7 +66,7 @@ public class AggregationProjection implements Projection {
     
     @Override
     public String getExpression() {
-        return type.name() + innerExpression;
+        return expression;
     }
     
     @Override

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/engine/ProjectionEngineTest.java
@@ -141,7 +141,7 @@ class ProjectionEngineTest {
     
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationProjectionSegment() {
-        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.COUNT, "(1)");
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.COUNT, "COUNT(1)");
         Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
                 Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
         assertTrue(actual.isPresent());
@@ -159,7 +159,7 @@ class ProjectionEngineTest {
     
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationProjectionSegmentAndAggregationTypeIsAvg() {
-        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.AVG, "(1)");
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.AVG, "AVG(1)");
         Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
                 Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
         assertTrue(actual.isPresent());

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/impl/AggregationProjectionTest.java
@@ -36,62 +36,62 @@ class AggregationProjectionTest {
     
     @Test
     void assertGetColumnName() {
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )",
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )",
                 null, TypedSPILoader.getService(DatabaseType.class, "MySQL")).getColumnName(), is("COUNT( A.\"DIRECTION\" )"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )",
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )",
                 null, TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).getColumnName(), is("count"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null,
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", null,
                 TypedSPILoader.getService(DatabaseType.class, "openGauss")).getColumnName(), is("count"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( a.\"direction\" )", null,
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( a.\"direction\" )", null,
                 TypedSPILoader.getService(DatabaseType.class, "Oracle")).getColumnName(), is("COUNT(A.\"DIRECTION\")"));
     }
     
     @Test
     void assertGetColumnLabelWithAliasNoQuote() {
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
                 TypedSPILoader.getService(DatabaseType.class, "MySQL")).getColumnLabel(),
                 is("AVG_DERIVED_COUNT_0"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
                 TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).getColumnLabel(),
                 is("avg_derived_count_0"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"),
                 TypedSPILoader.getService(DatabaseType.class, "openGauss")).getColumnLabel(),
                 is("avg_derived_count_0"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("avg_derived_count_0"),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("avg_derived_count_0"),
                 TypedSPILoader.getService(DatabaseType.class, "Oracle")).getColumnLabel(),
                 is("AVG_DERIVED_COUNT_0"));
     }
     
     @Test
     void assertGetColumnLabelWithAliasAndQuote() {
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.BACK_QUOTE),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.BACK_QUOTE),
                 TypedSPILoader.getService(DatabaseType.class, "MySQL")).getColumnLabel(), is("AVG_DERIVED_COUNT_0"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.QUOTE),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.QUOTE),
                 TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).getColumnLabel(), is("AVG_DERIVED_COUNT_0"));
         assertThat(
-                new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.QUOTE),
+                new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0", QuoteCharacter.QUOTE),
                         TypedSPILoader.getService(DatabaseType.class, "openGauss")).getColumnLabel(),
                 is("AVG_DERIVED_COUNT_0"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("avg_derived_count_0", QuoteCharacter.QUOTE),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("avg_derived_count_0", QuoteCharacter.QUOTE),
                 TypedSPILoader.getService(DatabaseType.class, "Oracle")).getColumnLabel(),
                 is("avg_derived_count_0"));
     }
     
     @Test
     void assertGetColumnLabelWithoutAlias() {
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "MySQL")).getColumnLabel(),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "MySQL")).getColumnLabel(),
                 is("COUNT( A.\"DIRECTION\" )"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).getColumnLabel(),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).getColumnLabel(),
                 is("count"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "openGauss")).getColumnLabel(),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", null, TypedSPILoader.getService(DatabaseType.class, "openGauss")).getColumnLabel(),
                 is("count"));
-        assertThat(new AggregationProjection(AggregationType.COUNT, "( a.\"direction\" )", null, TypedSPILoader.getService(DatabaseType.class, "Oracle")).getColumnLabel(),
+        assertThat(new AggregationProjection(AggregationType.COUNT, "COUNT( a.\"direction\" )", null, TypedSPILoader.getService(DatabaseType.class, "Oracle")).getColumnLabel(),
                 is("COUNT(A.\"DIRECTION\")"));
     }
     
     @Test
     void assertGetAlias() {
-        Projection projection = new AggregationProjection(AggregationType.COUNT, "( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"), mock(DatabaseType.class));
+        Projection projection = new AggregationProjection(AggregationType.COUNT, "COUNT( A.\"DIRECTION\" )", new IdentifierValue("AVG_DERIVED_COUNT_0"), mock(DatabaseType.class));
         Optional<IdentifierValue> actual = projection.getAlias();
         assertTrue(actual.isPresent());
         assertThat(actual.get().getValue(), is("AVG_DERIVED_COUNT_0"));

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContextTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementContextTest.java
@@ -361,7 +361,7 @@ class SelectStatementContextTest {
     private void assertSetIndexWhenAggregationProjectionsPresent(final SelectStatement selectStatement) {
         selectStatement.setOrderBy(new OrderBySegment(0, 0, Collections.singletonList(createOrderByItemSegment(COLUMN_ORDER_BY_WITHOUT_OWNER_ALIAS))));
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 0, AggregationType.MAX, "");
+        AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 0, AggregationType.MAX, "MAX(id)");
         aggregationProjectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("id", QuoteCharacter.QUOTE)));
         projectionsSegment.getProjections().add(aggregationProjectionSegment);
         selectStatement.setProjections(projectionsSegment);
@@ -564,8 +564,8 @@ class SelectStatementContextTest {
     
     private void assertContainsPartialDistinctAggregation(final SelectStatement selectStatement) {
         ProjectionsSegment projectionsSegment = new ProjectionsSegment(0, 0);
-        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "(*)"));
-        projectionsSegment.getProjections().add(new AggregationDistinctProjectionSegment(0, 10, AggregationType.COUNT, "(1)", "distinctExpression"));
+        projectionsSegment.getProjections().add(new AggregationProjectionSegment(0, 0, AggregationType.COUNT, "COUNT(*)"));
+        projectionsSegment.getProjections().add(new AggregationDistinctProjectionSegment(0, 10, AggregationType.COUNT, "COUNT(1)", "distinctExpression"));
         selectStatement.setProjections(projectionsSegment);
         ShardingSphereMetaData metaData = new ShardingSphereMetaData(Collections.singletonMap(DefaultDatabase.LOGIC_NAME, mockDatabase()), mock(ShardingSphereResourceMetaData.class),
                 mock(ShardingSphereRuleMetaData.class), mock(ConfigurationProperties.class));

--- a/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/converter/segment/projection/impl/AggregationProjectionConverter.java
+++ b/kernel/sql-federation/core/src/main/java/org/apache/shardingsphere/sqlfederation/compiler/converter/segment/projection/impl/AggregationProjectionConverter.java
@@ -68,7 +68,7 @@ public final class AggregationProjectionConverter implements SQLSegmentConverter
         }
         SqlLiteral functionQuantifier = segment instanceof AggregationDistinctProjectionSegment ? SqlLiteral.createSymbol(SqlSelectKeyword.DISTINCT, SqlParserPos.ZERO) : null;
         SqlAggFunction operator = convertOperator(segment.getType().name());
-        List<SqlNode> params = convertParameters(segment.getParameters(), segment.getInnerExpression());
+        List<SqlNode> params = convertParameters(segment.getParameters(), segment.getExpression());
         SqlBasicCall sqlBasicCall = new SqlBasicCall(operator, params, SqlParserPos.ZERO, functionQuantifier);
         if (segment.getAliasName().isPresent()) {
             return Optional.of(new SqlBasicCall(SqlStdOperatorTable.AS, Arrays.asList(sqlBasicCall,
@@ -82,8 +82,8 @@ public final class AggregationProjectionConverter implements SQLSegmentConverter
         return REGISTRY.get(operator);
     }
     
-    private List<SqlNode> convertParameters(final Collection<ExpressionSegment> params, final String innerExpression) {
-        if (innerExpression.contains("*")) {
+    private List<SqlNode> convertParameters(final Collection<ExpressionSegment> params, final String expression) {
+        if (expression.contains("*")) {
             return Collections.singletonList(SqlIdentifier.star(SqlParserPos.ZERO));
         }
         List<SqlNode> result = new LinkedList<>();

--- a/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
+++ b/parser/sql/dialect/mysql/src/main/java/org/apache/shardingsphere/sql/parser/mysql/visitor/statement/MySQLStatementVisitor.java
@@ -911,14 +911,13 @@ public abstract class MySQLStatementVisitor extends MySQLStatementBaseVisitor<AS
     
     private ASTNode createAggregationSegment(final AggregationFunctionContext ctx, final String aggregationType) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null != ctx.distinct()) {
-            AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                    type, innerExpression, getDistinctExpression(ctx));
+            AggregationDistinctProjectionSegment result =
+                    new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
             result.getParameters().addAll(getExpressions(ctx));
             return result;
         }
-        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
         result.getParameters().addAll(getExpressions(ctx));
         return result;
     }

--- a/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
+++ b/parser/sql/dialect/opengauss/src/main/java/org/apache/shardingsphere/sql/parser/opengauss/visitor/statement/OpenGaussStatementVisitor.java
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementBaseVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.AExprContext;
@@ -113,7 +114,6 @@ import org.apache.shardingsphere.sql.parser.autogen.OpenGaussStatementParser.Win
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.CombineType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
-import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.OrderDirection;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.ParameterMarkerType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintSegment;
@@ -585,14 +585,13 @@ public abstract class OpenGaussStatementVisitor extends OpenGaussStatementBaseVi
     
     private ProjectionSegment createAggregationSegment(final FuncApplicationContext ctx, final String aggregationType, final Collection<ExpressionSegment> expressionSegments) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null == ctx.DISTINCT()) {
-            AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+            AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
             result.getParameters().addAll(expressionSegments);
             return result;
         }
         AggregationDistinctProjectionSegment result =
-                new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression, getDistinctExpression(ctx));
+                new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
         result.getParameters().addAll(expressionSegments);
         return result;
     }

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -22,6 +22,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementBaseVisitor;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser;
@@ -83,7 +84,6 @@ import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTab
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableFunctionContext;
 import org.apache.shardingsphere.sql.parser.autogen.OracleStatementParser.XmlTableOptionsContext;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
-import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.OrderDirection;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.ParameterMarkerType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintSegment;
@@ -550,14 +550,13 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
     
     private ASTNode createAggregationSegment(final AggregationFunctionContext ctx, final String aggregationType) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().get(0).getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null != ctx.DISTINCT()) {
-            AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                    type, innerExpression, getDistinctExpression(ctx));
+            AggregationDistinctProjectionSegment result =
+                    new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
             result.getParameters().addAll(getExpressions(ctx));
             return result;
         }
-        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
         result.getParameters().addAll(getExpressions(ctx));
         return result;
     }

--- a/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
+++ b/parser/sql/dialect/postgresql/src/main/java/org/apache/shardingsphere/sql/parser/postgresql/visitor/statement/PostgreSQLStatementVisitor.java
@@ -23,6 +23,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.misc.Interval;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.api.ASTNode;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AExprContext;
 import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParser.AexprConstContext;
@@ -113,7 +114,6 @@ import org.apache.shardingsphere.sql.parser.autogen.PostgreSQLStatementParserBas
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.CombineType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
-import org.apache.shardingsphere.infra.database.enums.NullsOrderType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.OrderDirection;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.ParameterMarkerType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.constraint.ConstraintSegment;
@@ -582,14 +582,13 @@ public abstract class PostgreSQLStatementVisitor extends PostgreSQLStatementPars
     
     private ProjectionSegment createAggregationSegment(final FuncApplicationContext ctx, final String aggregationType, final Collection<ExpressionSegment> expressionSegments) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null == ctx.DISTINCT()) {
-            AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+            AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
             result.getParameters().addAll(expressionSegments);
             return result;
         }
         AggregationDistinctProjectionSegment result =
-                new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression, getDistinctExpression(ctx));
+                new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
         result.getParameters().addAll(expressionSegments);
         return result;
     }

--- a/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/SQL92StatementVisitor.java
+++ b/parser/sql/dialect/sql92/src/main/java/org/apache/shardingsphere/sql/parser/sql92/visitor/statement/SQL92StatementVisitor.java
@@ -437,14 +437,13 @@ public abstract class SQL92StatementVisitor extends SQL92StatementBaseVisitor<AS
     
     private ASTNode createAggregationSegment(final AggregationFunctionContext ctx, final String aggregationType) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null != ctx.distinct()) {
-            AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                    type, innerExpression, getDistinctExpression(ctx));
+            AggregationDistinctProjectionSegment result =
+                    new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
             result.getParameters().addAll(getExpressions(ctx));
             return result;
         }
-        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
         result.getParameters().addAll(getExpressions(ctx));
         return result;
     }

--- a/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
+++ b/parser/sql/dialect/sqlserver/src/main/java/org/apache/shardingsphere/sql/parser/sqlserver/visitor/statement/SQLServerStatementVisitor.java
@@ -562,14 +562,13 @@ public abstract class SQLServerStatementVisitor extends SQLServerStatementBaseVi
     
     private ASTNode createAggregationSegment(final AggregationFunctionContext ctx, final String aggregationType) {
         AggregationType type = AggregationType.valueOf(aggregationType.toUpperCase());
-        String innerExpression = ctx.start.getInputStream().getText(new Interval(ctx.LP_().getSymbol().getStartIndex(), ctx.stop.getStopIndex()));
         if (null != ctx.distinct()) {
-            AggregationDistinctProjectionSegment result = new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(),
-                    type, innerExpression, getDistinctExpression(ctx));
+            AggregationDistinctProjectionSegment result =
+                    new AggregationDistinctProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx), getDistinctExpression(ctx));
             result.getParameters().addAll(getExpressions(ctx));
             return result;
         }
-        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, innerExpression);
+        AggregationProjectionSegment result = new AggregationProjectionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), type, getOriginalText(ctx));
         result.getParameters().addAll(getExpressions(ctx));
         return result;
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationDistinctProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationDistinctProjectionSegment.java
@@ -29,8 +29,8 @@ public final class AggregationDistinctProjectionSegment extends AggregationProje
     
     private final String distinctInnerExpression;
     
-    public AggregationDistinctProjectionSegment(final int startIndex, final int stopIndex, final AggregationType type, final String innerExpression, final String distinctExpression) {
-        super(startIndex, stopIndex, type, innerExpression);
+    public AggregationDistinctProjectionSegment(final int startIndex, final int stopIndex, final AggregationType type, final String expression, final String distinctExpression) {
+        super(startIndex, stopIndex, type, expression);
         this.distinctInnerExpression = SQLUtils.getExpressionWithoutOutsideParentheses(distinctExpression);
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationProjectionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/dml/item/AggregationProjectionSegment.java
@@ -41,18 +41,18 @@ public class AggregationProjectionSegment implements ProjectionSegment, AliasAva
     
     private final AggregationType type;
     
-    private final String innerExpression;
+    private final String expression;
     
     private final Collection<ExpressionSegment> parameters = new LinkedList<>();
     
     @Setter
     private AliasSegment alias;
     
-    public AggregationProjectionSegment(final int startIndex, final int stopIndex, final AggregationType type, final String innerExpression) {
+    public AggregationProjectionSegment(final int startIndex, final int stopIndex, final AggregationType type, final String expression) {
         this.startIndex = startIndex;
         this.stopIndex = stopIndex;
         this.type = type;
-        this.innerExpression = innerExpression;
+        this.expression = expression;
     }
     
     @Override
@@ -67,6 +67,6 @@ public class AggregationProjectionSegment implements ProjectionSegment, AliasAva
     
     @Override
     public String getText() {
-        return innerExpression;
+        return expression;
     }
 }

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractorTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/extractor/TableExtractorTest.java
@@ -62,7 +62,7 @@ class TableExtractorTest {
     
     @Test
     void assertExtractTablesFromSelectProjects() {
-        AggregationProjectionSegment aggregationProjection = new AggregationProjectionSegment(10, 20, AggregationType.SUM, "t_order.id");
+        AggregationProjectionSegment aggregationProjection = new AggregationProjectionSegment(10, 20, AggregationType.SUM, "SUM(t_order.id)");
         ColumnSegment columnSegment = new ColumnSegment(133, 136, new IdentifierValue("id"));
         columnSegment.setOwner(new OwnerSegment(130, 132, new IdentifierValue("t_order")));
         aggregationProjection.getParameters().add(columnSegment);

--- a/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
+++ b/parser/sql/statement/src/test/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtilsTest.java
@@ -118,7 +118,7 @@ class SubqueryExtractUtilsTest {
         subqueryLeftSelectStatement.setWhere(new WhereSegment(73, 91, leftStatusCondition));
         subqueryLeftSelectStatement.setProjections(new ProjectionsSegment(34, 58));
         subqueryLeftSelectStatement.getProjections().getProjections().add(new ColumnProjectionSegment(new ColumnSegment(34, 41, new IdentifierValue("order_id"))));
-        subqueryLeftSelectStatement.getProjections().getProjections().add(new AggregationProjectionSegment(44, 51, AggregationType.COUNT, "(*)"));
+        subqueryLeftSelectStatement.getProjections().getProjections().add(new AggregationProjectionSegment(44, 51, AggregationType.COUNT, "COUNT(*)"));
         MySQLSelectStatement subqueryRightSelectStatement = new MySQLSelectStatement();
         subqueryRightSelectStatement.setFrom(new SimpleTableSegment(new TableNameSegment(143, 154, new IdentifierValue("t_order_item"))));
         ColumnSegment rightColumnSegment = new ColumnSegment(162, 167, new IdentifierValue("status"));
@@ -127,7 +127,7 @@ class SubqueryExtractUtilsTest {
         subqueryRightSelectStatement.setWhere(new WhereSegment(156, 174, rightStatusCondition));
         subqueryRightSelectStatement.setProjections(new ProjectionsSegment(112, 136));
         subqueryRightSelectStatement.getProjections().getProjections().add(new ColumnProjectionSegment(new ColumnSegment(112, 119, new IdentifierValue("order_id"))));
-        subqueryRightSelectStatement.getProjections().getProjections().add(new AggregationProjectionSegment(122, 129, AggregationType.COUNT, "(*)"));
+        subqueryRightSelectStatement.getProjections().getProjections().add(new AggregationProjectionSegment(122, 129, AggregationType.COUNT, "COUNT(*)"));
         MySQLSelectStatement selectStatement = new MySQLSelectStatement();
         selectStatement.setProjections(new ProjectionsSegment(7, 19));
         selectStatement.getProjections().getProjections().add(new ColumnProjectionSegment(new ColumnSegment(7, 11, new IdentifierValue("cnt"))));

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/projection/ProjectionAssert.java
@@ -142,7 +142,7 @@ public final class ProjectionAssert {
     
     private static void assertAggregationProjection(final SQLCaseAssertContext assertContext, final AggregationProjectionSegment actual, final ExpectedAggregationProjection expected) {
         assertThat(assertContext.getText("Aggregation projection type assertion error: "), actual.getType().name(), is(expected.getType()));
-        assertThat(assertContext.getText("Aggregation projection inner expression assertion error: "), actual.getInnerExpression(), is(expected.getInnerExpression()));
+        assertThat(assertContext.getText("Aggregation projection inner expression assertion error: "), actual.getExpression(), is(expected.getExpression()));
         assertThat(assertContext.getText("Aggregation projection alias assertion error: "), actual.getAliasName().orElse(null), is(expected.getAlias()));
         if (actual instanceof AggregationDistinctProjectionSegment) {
             assertThat(assertContext.getText("Projection type assertion error: "), expected, instanceOf(ExpectedAggregationDistinctProjection.class));

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/impl/aggregation/ExpectedAggregationProjection.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/parser/jaxb/segment/impl/projection/impl/aggregation/ExpectedAggregationProjection.java
@@ -38,8 +38,8 @@ public class ExpectedAggregationProjection extends AbstractExpectedSQLSegment im
     @XmlAttribute
     private String type;
     
-    @XmlAttribute(name = "inner-expression")
-    private String innerExpression;
+    @XmlAttribute
+    private String expression;
     
     @XmlAttribute
     private String alias;

--- a/test/it/parser/src/main/resources/case/dml/delete.xml
+++ b/test/it/parser/src/main/resources/case/dml/delete.xml
@@ -140,7 +140,7 @@
                                 <projections start-index="98" stop-index="148">
                                     <column-projection name="product_id" start-index="98" stop-index="107" />
                                     <column-projection name="currency_code" start-index="110" stop-index="122" />
-                                    <aggregation-projection type="MAX" inner-expression="(effective_from_date)" start-index="125" stop-index="148" />
+                                    <aggregation-projection type="MAX" expression="MAX(effective_from_date)" start-index="125" stop-index="148" />
                                 </projections>
                                 <group-by>
                                     <column-item name="product_id" start-index="186" stop-index="195" />

--- a/test/it/parser/src/main/resources/case/dml/select-aggregate.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-aggregate.xml
@@ -22,7 +22,7 @@
             <simple-table name="t_order" start-index="40" stop-index="46" />
         </from>
         <projections start-index="7" stop-index="33">
-            <aggregation-projection type="SUM" inner-expression="(user_id)" alias="user_id_sum" start-index="7" stop-index="18" />
+            <aggregation-projection type="SUM" expression="SUM(user_id)" alias="user_id_sum" start-index="7" stop-index="18" />
         </projections>
     </select>
 
@@ -31,7 +31,7 @@
             <simple-table name="t_order" start-index="48" stop-index="54" />
         </from>
         <projections start-index="7" stop-index="41">
-            <aggregation-projection type="SUM" inner-expression="(t_order.user_id)" alias="user_id_sum" start-index="7" stop-index="26">
+            <aggregation-projection type="SUM" expression="SUM(t_order.user_id)" alias="user_id_sum" start-index="7" stop-index="26">
                 <paramters>
                     <column name="user_id" start-index="17" stop-index="25">
                         <owner name="t_order" start-index="8" stop-index="16" />
@@ -46,7 +46,7 @@
             <simple-table name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
     </select>
 
@@ -55,7 +55,7 @@
             <simple-table name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="45" stop-index="64">
             <expr>
@@ -85,7 +85,7 @@
             <simple-table name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="45" stop-index="66">
             <expr>
@@ -116,7 +116,7 @@
             <simple-table name="t_order" start-index="40" stop-index="46" />
         </from>
         <projections start-index="7" stop-index="33">
-            <aggregation-projection type="MAX" inner-expression="(user_id)" alias="max_user_id" start-index="7" stop-index="18" />
+            <aggregation-projection type="MAX" expression="MAX(user_id)" alias="max_user_id" start-index="7" stop-index="18" />
         </projections>
     </select>
 
@@ -125,7 +125,7 @@
             <simple-table name="t_order" start-index="40" stop-index="46" />
         </from>
         <projections start-index="7" stop-index="33">
-            <aggregation-projection type="MIN" inner-expression="(user_id)" alias="min_user_id" start-index="7" stop-index="18" />
+            <aggregation-projection type="MIN" expression="MIN(user_id)" alias="min_user_id" start-index="7" stop-index="18" />
         </projections>
     </select>
 
@@ -134,7 +134,7 @@
             <simple-table name="t_order" start-index="40" stop-index="46" />
         </from>
         <projections start-index="7" stop-index="33">
-            <aggregation-projection type="AVG" inner-expression="(user_id)" alias="user_id_avg" start-index="7" stop-index="18" />
+            <aggregation-projection type="AVG" expression="AVG(user_id)" alias="user_id_avg" start-index="7" stop-index="18" />
         </projections>
     </select>
 
@@ -150,7 +150,7 @@
             </join-table>
         </from>
         <projections start-index="7" stop-index="29">
-            <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="62" stop-index="171" literal-stop-index="172">
             <expr>
@@ -288,7 +288,7 @@
             </join-table>
         </from>
         <projections start-index="7" stop-index="29">
-            <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="119" stop-index="174" literal-stop-index="175">
             <expr>
@@ -344,7 +344,7 @@
             <simple-table name="t_order" start-index="46" stop-index="52" />
         </from>
         <projections start-index="7" stop-index="39">
-            <aggregation-projection type="COUNT" inner-expression="(`order_id`)" alias="orders_count" start-index="7" stop-index="23" />
+            <aggregation-projection type="COUNT" expression="COUNT(`order_id`)" alias="orders_count" start-index="7" stop-index="23" />
         </projections>
     </select>
 
@@ -371,7 +371,7 @@
             <simple-table name="t_order" start-index="21" stop-index="27" />
         </from>
         <projections start-index="7" stop-index="14">
-            <aggregation-projection type="COUNT" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="29" stop-index="54">
             <expr>
@@ -402,7 +402,7 @@
             <simple-table name="t_order" start-index="21" stop-index="27" />
         </from>
         <projections start-index="7" stop-index="14">
-            <aggregation-projection type="COUNT" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="29" stop-index="81">
             <expr>
@@ -458,7 +458,7 @@
             <simple-table name="t_order" start-index="29" stop-index="35" />
         </from>
         <projections start-index="7" stop-index="22">
-            <aggregation-projection type="BIT_XOR" inner-expression="(user_id)" start-index="7" stop-index="22" />
+            <aggregation-projection type="BIT_XOR" expression="BIT_XOR(user_id)" start-index="7" stop-index="22" />
         </projections>
     </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/dml/select-group-by.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-group-by.xml
@@ -160,7 +160,7 @@
             </join-table>
         </from>
         <projections start-index="7" stop-index="29">
-            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="items_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="count(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="119" stop-index="174" literal-stop-index="175">
             <expr>
@@ -291,7 +291,7 @@
                     </function>
                 </expr>
             </expression-projection>
-            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="c_number" start-index="65" stop-index="72" />
+            <aggregation-projection type="COUNT" expression="count(*)" alias="c_number" start-index="65" stop-index="72" />
         </projections>
         <where start-index="106" stop-index="129" literal-stop-index="135">
             <expr>

--- a/test/it/parser/src/main/resources/case/dml/select-group-by.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-group-by.xml
@@ -22,7 +22,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-projection type="SUM" alias="orders_sum" inner-expression="(order_id)" start-index="7" stop-index="19" />
+            <aggregation-projection type="SUM" alias="orders_sum" expression="SUM(order_id)" start-index="7" stop-index="19" />
             <column-projection name="user_id" start-index="36" stop-index="42" />
         </projections>
         <group-by>
@@ -38,7 +38,7 @@
             <simple-table name="t_order" start-index="53" stop-index="59" />
         </from>
         <projections start-index="7" stop-index="46">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(order_id)" start-index="7" stop-index="21" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(order_id)" start-index="7" stop-index="21" />
             <column-projection name="user_id" start-index="40" stop-index="46" />
         </projections>
         <group-by>
@@ -54,7 +54,7 @@
             <simple-table name="t_order" start-index="51" stop-index="57" />
         </from>
         <projections start-index="7" stop-index="44">
-            <aggregation-projection type="MAX" alias="max_order_id" inner-expression="(order_id)" start-index="7" stop-index="19" />
+            <aggregation-projection type="MAX" alias="max_order_id" expression="MAX(order_id)" start-index="7" stop-index="19" />
             <column-projection name="user_id" start-index="38" stop-index="44" />
         </projections>
         <group-by>
@@ -70,7 +70,7 @@
             <simple-table name="t_order" start-index="51" stop-index="57" />
         </from>
         <projections start-index="7" stop-index="44">
-            <aggregation-projection type="MIN" alias="min_order_id" inner-expression="(order_id)" start-index="7" stop-index="19" />
+            <aggregation-projection type="MIN" alias="min_order_id" expression="MIN(order_id)" start-index="7" stop-index="19" />
             <column-projection name="user_id" start-index="38" stop-index="44" />
         </projections>
         <group-by>
@@ -86,7 +86,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-projection type="AVG" alias="orders_avg" inner-expression="(order_id)" start-index="7" stop-index="19" />
+            <aggregation-projection type="AVG" alias="orders_avg" expression="AVG(order_id)" start-index="7" stop-index="19" />
             <column-projection name="user_id" start-index="36" stop-index="42" />
         </projections>
         <group-by>
@@ -102,7 +102,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-projection type="SUM" inner-expression="(order_id)" alias="orders_sum" start-index="7" stop-index="19" />
+            <aggregation-projection type="SUM" expression="SUM(order_id)" alias="orders_sum" start-index="7" stop-index="19" />
             <column-projection name="user_id" start-index="36" stop-index="42" />
         </projections>
         <group-by>
@@ -160,7 +160,7 @@
             </join-table>
         </from>
         <projections start-index="7" stop-index="29">
-            <aggregation-projection type="COUNT" inner-expression="(*)" alias="items_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="items_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="119" stop-index="174" literal-stop-index="175">
             <expr>
@@ -240,7 +240,7 @@
         </from>
         <projections start-index="7" stop-index="42">
             <column-projection name="user_id" start-index="7" stop-index="13" />
-            <aggregation-projection type="SUM"  inner-expression="(order_id)" alias="orders_sum" start-index="16" stop-index="28" />
+            <aggregation-projection type="SUM"  expression="SUM(order_id)" alias="orders_sum" start-index="16" stop-index="28" />
         </projections>
         <group-by>
             <column-item name="user_id" start-index="66" stop-index="72" />
@@ -291,7 +291,7 @@
                     </function>
                 </expr>
             </expression-projection>
-            <aggregation-projection type="COUNT" inner-expression="(*)" alias="c_number" start-index="65" stop-index="72" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" alias="c_number" start-index="65" stop-index="72" />
         </projections>
         <where start-index="106" stop-index="129" literal-stop-index="135">
             <expr>
@@ -325,7 +325,7 @@
             <simple-table name="t_order" start-index="58" stop-index="64" />
         </from>
         <projections start-index="7" stop-index="51">
-            <aggregation-projection type="SUM" inner-expression="(order_id)" alias="orders_sum" start-index="7" stop-index="19" />
+            <aggregation-projection type="SUM" expression="SUM(order_id)" alias="orders_sum" start-index="7" stop-index="19" />
             <column-projection name="user_id" alias="key" start-index="36" stop-index="51" />
         </projections>
         <group-by>
@@ -338,7 +338,7 @@
             <simple-table name="t_order" start-index="53" stop-index="59" />
         </from>
         <projections start-index="7" stop-index="46">
-            <aggregation-projection inner-expression="(order_id)" type="COUNT" alias="orders_count" start-index="7" stop-index="21" />
+            <aggregation-projection expression="COUNT(order_id)" type="COUNT" alias="orders_count" start-index="7" stop-index="21" />
             <column-projection name="user_id" start-index="40" stop-index="46" />
         </projections>
         <group-by>
@@ -354,7 +354,7 @@
             <simple-table name="t_order" start-index="53" stop-index="59" />
         </from>
         <projections start-index="7" stop-index="46">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(order_id)" start-index="7" stop-index="21" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(order_id)" start-index="7" stop-index="21" />
             <column-projection name="user_id" start-index="40" stop-index="46" />
         </projections>
         <group-by>
@@ -380,7 +380,7 @@
             <simple-table name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" inner-expression="(order_id)" start-index="7" stop-index="21" />
+            <aggregation-projection type="COUNT" expression="COUNT(order_id)" start-index="7" stop-index="21" />
             <column-projection name="user_id" start-index="24" stop-index="30" />
         </projections>
         <group-by>
@@ -390,7 +390,7 @@
             <expr>
                 <binary-operation-expression start-index="69" stop-index="87">
                     <left>
-                        <aggregation-projection type="COUNT" inner-expression="(order_id)" start-index="69" stop-index="83" />
+                        <aggregation-projection type="COUNT" expression="COUNT(order_id)" start-index="69" stop-index="83" />
                     </left>
                     <operator>&gt;</operator>
                     <right>
@@ -406,7 +406,7 @@
             <simple-table name="t_order" start-index="53" stop-index="59" />
         </from>
         <projections start-index="7" stop-index="46">
-            <aggregation-projection type="COUNT" alias="orders_count" inner-expression="(order_id)" start-index="7" stop-index="21" />
+            <aggregation-projection type="COUNT" alias="orders_count" expression="COUNT(order_id)" start-index="7" stop-index="21" />
             <column-projection name="user_id" start-index="40" stop-index="46" />
         </projections>
         <group-by>
@@ -442,7 +442,7 @@
         <projections start-index="7" stop-index="211">
             <expression-projection text="DECODE(GROUPING(department_name), 1, 'All Departments', department_name)" alias="department_name" start-index="7" stop-index="97" />
             <expression-projection text="DECODE(GROUPING(job_id), 1, 'All Jobs', job_id)" alias="job_id" start-index="100" stop-index="156" />
-            <aggregation-projection type="COUNT" alias="Total Empl" inner-expression="(*)" start-index="159" stop-index="166" />
+            <aggregation-projection type="COUNT" alias="Total Empl" expression="COUNT(*)" start-index="159" stop-index="166" />
             <expression-projection text="AVG(salary) * 12" alias="Average Sal" start-index="182" stop-index="211" />
         </projections>
         <where start-index="245" stop-index="283">
@@ -542,8 +542,8 @@
         </from>
         <projections start-index="7" stop-index="45">
             <column-projection name="department_id" start-index="7" stop-index="19" />
-            <aggregation-projection type="MIN" inner-expression="(salary)" start-index="22" stop-index="32" />
-            <aggregation-projection type="MAX" inner-expression="(salary)" start-index="35" stop-index="45" />
+            <aggregation-projection type="MIN" expression="MIN(salary)" start-index="22" stop-index="32" />
+            <aggregation-projection type="MAX" expression="MAX(salary)" start-index="35" stop-index="45" />
         </projections>
         <group-by>
             <column-item name="department_id" start-index="71" stop-index="83" />
@@ -552,7 +552,7 @@
             <expr>
                 <binary-operation-expression start-index="92" stop-index="109">
                     <left>
-                        <aggregation-projection type="MIN" inner-expression="(salary)" start-index="92" stop-index="102" />
+                        <aggregation-projection type="MIN" expression="MIN(salary)" start-index="92" stop-index="102" />
                     </left>
                     <operator>&lt;</operator>
                     <right>

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -22,7 +22,7 @@
             <simple-table name="t_order" start-index="33" stop-index="39" />
         </from>
         <projections start-index="7" stop-index="26">
-            <aggregation-projection type="GROUP_CONCAT" inner-expression="(status)" text="GROUP_CONCAT(status)" start-index="7" stop-index="26">
+            <aggregation-projection type="GROUP_CONCAT" expression="GROUP_CONCAT(status)" text="GROUP_CONCAT(status)" start-index="7" stop-index="26">
                 <expr>
                     <function function-name="GROUP_CONCAT" start-index="7" stop-index="26" text="GROUP_CONCAT(status)">
                         <parameter>

--- a/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
@@ -367,7 +367,7 @@
                 <subquery>
                     <select>
                         <projections start-index="68" stop-index="81">
-                            <aggregation-projection type="COUNT" inner-expression="(user_id)" start-index="68" stop-index="81" />
+                            <aggregation-projection type="COUNT" expression="COUNT(user_id)" start-index="68" stop-index="81" />
                         </projections>
                         <from start-index="83" stop-index="98">
                             <simple-table name="t_user_info" start-index="88" stop-index="98" />

--- a/test/it/parser/src/main/resources/case/dml/select-with.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-with.xml
@@ -27,7 +27,7 @@
                         </from>
                         <projections start-index="27" stop-index="65">
                             <column-projection name="department_name" start-index="27" stop-index="41" />
-                            <aggregation-projection type="SUM" alias="dept_total" inner-expression="(salary)" start-index="44" stop-index="54" />
+                            <aggregation-projection type="SUM" alias="dept_total" expression="SUM(salary)" start-index="44" stop-index="54" />
                         </projections>
                         <group-by>
                             <column-item name="department_name" start-index="95" stop-index="109" />
@@ -77,7 +77,7 @@
                         </from>
                         <projections start-index="27" stop-index="65">
                             <column-projection name="department_name" start-index="27" stop-index="41" />
-                            <aggregation-projection type="SUM" alias="dept_total" inner-expression="(salary)" start-index="44" stop-index="54" />
+                            <aggregation-projection type="SUM" alias="dept_total" expression="SUM(salary)" start-index="44" stop-index="54" />
                         </projections>
                         <where start-index="99" stop-index="137">
                             <expr>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -1456,7 +1456,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="count(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
@@ -1546,7 +1546,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="count(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
@@ -1661,7 +1661,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="count(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="140" literal-stop-index="146">
             <expr>
@@ -3068,7 +3068,7 @@
             <simple-table  name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" alias="s" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-inner-expression="order_id" alias="s" start-index="7" stop-index="28" />
         </projections>
         <where start-index="45" stop-index="65">
             <expr>
@@ -3090,7 +3090,7 @@
             <simple-table name="t_order" start-index="39" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="32">
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
         </projections>
         <where start-index="47" stop-index="67">
             <expr>
@@ -3112,7 +3112,7 @@
             <simple-table name="t_order" start-index="35" stop-index="41" />
         </from>
         <projections start-index="7" stop-index="28">
-            <aggregation-distinct-projection type="AVG" expression="AVG(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="AVG" expression="AVG(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
         </projections>
         <where start-index="43" stop-index="63">
             <expr>
@@ -3134,8 +3134,8 @@
             <simple-table name="t_order" start-index="61" stop-index="67" />
         </from>
         <projections start-index="7" stop-index="54">
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="30" />
-            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" start-index="33" stop-index="54" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="33" stop-index="54" />
         </projections>
         <where start-index="69" stop-index="89">
             <expr>
@@ -3158,7 +3158,7 @@
         </from>
         <projections start-index="7" stop-index="42">
             <column-projection name="order_id" start-index="7" stop-index="14" />
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="17" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="17" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3186,7 +3186,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
             <column-projection name="order_id" start-index="35" stop-index="42" />
         </projections>
         <group-by>
@@ -3226,7 +3226,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT user_id + order_id)" distinct-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT user_id + order_id)" distinct-inner-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3248,9 +3248,9 @@
             <simple-table  name="t_order" start-index="77" stop-index="83" />
         </from>
         <projections start-index="7" stop-index="69">
-            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
-            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" start-index="30" stop-index="53" />
-            <aggregation-projection type="COUNT" expression="COUNT(order_id)" start-index="55" stop-index="69" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="COUNT" expression="count(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="30" stop-index="53" />
+            <aggregation-projection type="COUNT" expression="count(order_id)" start-index="55" stop-index="69" />
         </projections>
         <where start-index="85" stop-index="105">
             <expr>
@@ -3427,7 +3427,7 @@
             <simple-table name="t_order" start-index="48" stop-index="54" />
         </from>
         <projections start-index="7" stop-index="41">
-            <aggregation-projection type="SUM" expression="SUM(if(status=0, 1, 0))" alias="func_status" start-index="7" stop-index="29" />
+            <aggregation-projection type="SUM" expression="sum(if(status=0, 1, 0))" alias="func_status" start-index="7" stop-index="29" />
         </projections>
         <where start-index="56" stop-index="89" literal-stop-index="93">
             <expr>

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -1378,7 +1378,7 @@
             <simple-table name="t_order" start-index="21" stop-index="27" />
         </from>
         <projections start-index="7" stop-index="14">
-            <aggregation-projection type="COUNT" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="29" stop-index="65" literal-stop-index="70">
             <expr>
@@ -1422,7 +1422,7 @@
             <simple-table name="t_order" start-index="21" stop-index="27" />
         </from>
         <projections start-index="7" stop-index="14">
-            <aggregation-projection type="COUNT" inner-expression="(*)" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(*)" start-index="7" stop-index="14" />
         </projections>
         <where start-index="29" stop-index="58" literal-stop-index="60">
             <expr>
@@ -1456,7 +1456,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
@@ -1546,7 +1546,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="142" literal-stop-index="148">
             <expr>
@@ -1661,7 +1661,7 @@
             <simple-table name="t_order" alias="o" start-index="37" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-projection type="COUNT" inner-expression="(0)" alias="orders_count" start-index="7" stop-index="14" />
+            <aggregation-projection type="COUNT" expression="COUNT(0)" alias="orders_count" start-index="7" stop-index="14" />
         </projections>
         <where start-index="47" stop-index="140" literal-stop-index="146">
             <expr>
@@ -3068,7 +3068,7 @@
             <simple-table  name="t_order" start-index="37" stop-index="43" />
         </from>
         <projections start-index="7" stop-index="30">
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="s" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" alias="s" start-index="7" stop-index="28" />
         </projections>
         <where start-index="45" stop-index="65">
             <expr>
@@ -3090,7 +3090,7 @@
             <simple-table name="t_order" start-index="39" stop-index="45" />
         </from>
         <projections start-index="7" stop-index="32">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
         </projections>
         <where start-index="47" stop-index="67">
             <expr>
@@ -3112,7 +3112,7 @@
             <simple-table name="t_order" start-index="35" stop-index="41" />
         </from>
         <projections start-index="7" stop-index="28">
-            <aggregation-distinct-projection type="AVG" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="AVG" expression="AVG(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
         </projections>
         <where start-index="43" stop-index="63">
             <expr>
@@ -3134,8 +3134,8 @@
             <simple-table name="t_order" start-index="61" stop-index="67" />
         </from>
         <projections start-index="7" stop-index="54">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="30" />
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="33" stop-index="54" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" start-index="33" stop-index="54" />
         </projections>
         <where start-index="69" stop-index="89">
             <expr>
@@ -3158,7 +3158,7 @@
         </from>
         <projections start-index="7" stop-index="42">
             <column-projection name="order_id" start-index="7" stop-index="14" />
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="17" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="17" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3186,7 +3186,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" alias="c" start-index="7" stop-index="30" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" alias="c" start-index="7" stop-index="30" />
             <column-projection name="order_id" start-index="35" stop-index="42" />
         </projections>
         <group-by>
@@ -3226,7 +3226,7 @@
             <simple-table name="t_order" start-index="49" stop-index="55" />
         </from>
         <projections start-index="7" stop-index="42">
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT user_id + order_id)" distinct-inner-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT user_id + order_id)" distinct-expression="user_id+order_id" alias="c" start-index="7" stop-index="40" />
         </projections>
         <where start-index="57" stop-index="77">
             <expr>
@@ -3248,9 +3248,9 @@
             <simple-table  name="t_order" start-index="77" stop-index="83" />
         </from>
         <projections start-index="7" stop-index="69">
-            <aggregation-distinct-projection type="SUM" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="7" stop-index="28" />
-            <aggregation-distinct-projection type="COUNT" inner-expression="(DISTINCT order_id)" distinct-inner-expression="order_id" start-index="30" stop-index="53" />
-            <aggregation-projection type="COUNT" inner-expression="(order_id)" start-index="55" stop-index="69" />
+            <aggregation-distinct-projection type="SUM" expression="SUM(DISTINCT order_id)" distinct-expression="order_id" start-index="7" stop-index="28" />
+            <aggregation-distinct-projection type="COUNT" expression="COUNT(DISTINCT order_id)" distinct-expression="order_id" start-index="30" stop-index="53" />
+            <aggregation-projection type="COUNT" expression="COUNT(order_id)" start-index="55" stop-index="69" />
         </projections>
         <where start-index="85" stop-index="105">
             <expr>
@@ -3427,7 +3427,7 @@
             <simple-table name="t_order" start-index="48" stop-index="54" />
         </from>
         <projections start-index="7" stop-index="41">
-            <aggregation-projection type="SUM" inner-expression="(if(status=0, 1, 0))" alias="func_status" start-index="7" stop-index="29" />
+            <aggregation-projection type="SUM" expression="SUM(if(status=0, 1, 0))" alias="func_status" start-index="7" stop-index="29" />
         </projections>
         <where start-index="56" stop-index="89" literal-stop-index="93">
             <expr>
@@ -4131,8 +4131,8 @@
                             <select>
                                 <projections start-index="127" stop-index="178">
                                     <column-projection name="department_id" start-index="127" stop-index="139" />
-                                    <aggregation-projection type="COUNT" alias="num_emp" inner-expression="(*)" start-index="142" stop-index="149" />
-                                    <aggregation-projection type="SUM" alias="sal_sum" inner-expression="(salary)" start-index="160" stop-index="170" />
+                                    <aggregation-projection type="COUNT" alias="num_emp" expression="COUNT(*)" start-index="142" stop-index="149" />
+                                    <aggregation-projection type="SUM" alias="sal_sum" expression="SUM(salary)" start-index="160" stop-index="170" />
                                 </projections>
                                 <from>
                                     <simple-table name="employees" start-index="185" stop-index="193" />
@@ -4149,8 +4149,8 @@
                         <subquery>
                             <select>
                                 <projections start-index="230" stop-index="272">
-                                    <aggregation-projection type="COUNT" alias="total_count" inner-expression="(*)" start-index="230" stop-index="237" />
-                                    <aggregation-projection type="SUM" alias="total_sal" inner-expression="(salary)" start-index="252" stop-index="262" />
+                                    <aggregation-projection type="COUNT" alias="total_count" expression="COUNT(*)" start-index="230" stop-index="237" />
+                                    <aggregation-projection type="SUM" alias="total_sal" expression="SUM(salary)" start-index="252" stop-index="262" />
                                 </projections>
                                 <from>
                                     <simple-table name="employees" start-index="279" stop-index="287" />
@@ -4433,7 +4433,7 @@
                         <projections start-index="46" stop-index="74">
                             <column-projection name="country" start-index="46" stop-index="52" />
                             <column-projection name="year" start-index="55" stop-index="58" />
-                            <aggregation-projection type="SUM" alias="sale" inner-expression="(sale)" start-index="61" stop-index="69" />
+                            <aggregation-projection type="SUM" alias="sale" expression="SUM(sale)" start-index="61" stop-index="69" />
                         </projections>
                         <group-by>
                             <column-item name="country" start-index="105" stop-index="111" />


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Modify innerExpression to expression in AggregationProjectionSegment to support MySQL column label
  - modify unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
