### PR TITLE
Refactor : remove skywalking eye from nightly ci

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
-      max-parallel: 1
+      max-parallel: 20
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
@@ -55,9 +55,9 @@ jobs:
             ${{ env.REPOSITORY_NAME }}-maven-third-party-cache-
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
       - name: Build Project with Maven
-        run: ./mvnw -T1C -B -ntp clean install
+        run: ./mvnw clean install -B -ntp -T1C
       - name: Build Examples with Maven
-        run: ./mvnw -T1C -B -f examples/pom.xml clean package
+        run: ./mvnw clean package -B -f -T1C examples/pom.xml
   
   ci-jdk8:
     if: github.repository == 'apache/shardingsphere'
@@ -65,12 +65,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
-      max-parallel: 1
+      max-parallel: 20
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
     steps:
-      - name: Support long paths in Windows
+      - name: Support Long Paths in Windows
         if: matrix.os == 'windows-latest'
         run: git config --global core.longpaths true
       - uses: actions/checkout@v3
@@ -86,19 +86,11 @@ jobs:
             ${{ env.REPOSITORY_NAME }}-maven-third-party-cache-
             ${{ env.REPOSITORY_NAME }}-maven-third-party-
       - name: Build prod with Maven
-        run: ./mvnw -T1C -B -ntp clean install -DskipTests
+        run: ./mvnw clean install -DskipTests -B -ntp -T1C
       - name: Setup JDK 8 for Test
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 8
       - name: Run Tests with JDK 8
-        run: ./mvnw -T1C -B -ntp -fae test
-  
-  check-license:
-    name: Check - License with SkyWalking Eyes
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: apache/skywalking-eyes@v0.4.0
+        run: ./mvnw test -B -ntp -fae -T1C


### PR DESCRIPTION
Changes proposed in this pull request:
  - remove skywalking eye from nightly ci

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
