### PR TITLE
Support oracle RATIO_TO_REPORT function parsing

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -719,6 +719,7 @@ analyticFunction
     | specifiedAnalyticFunctionName = NTILE LP_ expr RP_ overClause
     | specifiedAnalyticFunctionName = (PERCENTILE_CONT | PERCENTILE_DISC) LP_ expr RP_ WITHIN GROUP LP_ orderByClause RP_ overClause
     | specifiedAnalyticFunctionName = CORR LP_ expr COMMA_ expr RP_ overClause
+    | specifiedAnalyticFunctionName = RATIO_TO_REPORT LP_ expr RP_ overClause
     | analyticFunctionName LP_ dataType* RP_ overClause
     ;
 

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -5848,4 +5848,33 @@
             <simple-table name="employees" start-index="210" stop-index="218" literal-start-index="210" literal-stop-index="218" />
         </from>
     </select>
+
+    <select sql-case-id="select_with_ratio_to_report_function">
+        <projections start-index="7" stop-index="79" literal-start-index="7" literal-stop-index="79">
+            <expression-projection text="TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999')" alias="RATIO_TO_REPORT" start-index="7" stop-index="79" literal-start-index="7" literal-stop-index="79">
+                <literalText>TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999')</literalText>
+                <expr>
+                    <function function-name="TO_CHAR" text="TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999')" start-index="7" stop-index="60" literal-start-index="7" literal-stop-index="60">
+                        <parameter>
+                            <function function-name="RATIO_TO_REPORT" text="RATIO_TO_REPORT(amount_sold) OVER ()" start-index="15" stop-index="50" literal-start-index="15" literal-stop-index="50">
+                                <literalText>RATIO_TO_REPORT(amount_sold) OVER ()</literalText>
+                            </function>
+                        </parameter>
+                        <parameter>
+                            <literal-expression value="9.999" start-index="53" stop-index="59" literal-start-index="53" literal-stop-index="59" />
+                        </parameter>
+                        <literalText>TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999')</literalText>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table alias="s" name="sales" start-index="86" stop-index="92" literal-start-index="86" literal-stop-index="92" />
+        </from>
+        <group-by>
+            <column-item name="channel_desc" order-direction="ASC" start-index="103" stop-index="116" literal-start-index="103" literal-stop-index="116">
+                <owner name="s" start-index="103" stop-index="103" literal-start-index="103" literal-stop-index="103" />
+            </column-item>
+        </group-by>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -196,4 +196,5 @@
     <sql-case id="select_with_keep_clause" value="SELECT salary,MIN(salary) KEEP (DENSE_RANK FIRST ORDER BY commission_pct) OVER (PARTITION BY department_id) 'Worst', MAX(salary) KEEP (DENSE_RANK LAST ORDER BY commission_pct) OVER (PARTITION BY department_id) 'Best' FROM employees ORDER BY department_id" db-types="Oracle" />
     <sql-case id="select_with_corr_function" value="SELECT employee_id, CORR(SYSDATE - hire_date, salary) FROM employees WHERE department_id in (50, 80) ORDER BY employee_id" db-types="Oracle" />
     <sql-case id="select_with_trim_function" value="select TRIM('  derby '), TRIM(BOTH ' ' FROM '  derby '), TRIM(TRAILING ' ' FROM '  derby '), TRIM(cast (null as char(1)) FROM '  derby '), TRIM(' ' FROM cast(null as varchar(30))), TRIM('y' FROM ' derby') FROM employees" db-types="Oracle" />
+    <sql-case id="select_with_ratio_to_report_function" value="SELECT TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999') AS RATIO_TO_REPORT FROM sales s GROUP BY s.channel_desc" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support oracle RATIO_TO_REPORT function parsing

Refer to:
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/RATIO_TO_REPORT.html#GUID-9D10C275-4341-435F-ACF4-767B9CCB7390

![image](https://github.com/apache/shardingsphere/assets/19788130/124bd451-f97b-4eac-afae-5219acadfd6c)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
