### PR TITLE
Support oracle SYS_XMLAGG/SYS_XMLGEN functions parsing

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -1853,6 +1853,7 @@ xmlFunction
     | xmlSerializeFunction
     | xmlTableFunction
     | xmlIsSchemaValidFunction
+    | specifiedFunctionName = (SYS_XMLGEN | SYS_XMLAGG) LP_ expr (COMMA_ expr)? RP_
     ;
 
 xmlAggFunction

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/OracleKeyword.g4
@@ -6659,6 +6659,10 @@ SYS_XMLEXNSURI
 SYS_XMLGEN
     :S Y S UL_ X M L G E N
     ;
+    
+SYS_XMLAGG
+    :S Y S UL_ X M L A G G
+    ;
 
 SYS_XMLI_LOC_ISNODE
     :S Y S UL_ X M L I UL_ L O C UL_ I S N O D E

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -593,7 +593,10 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         if (null != ctx.xmlIsSchemaValidFunction()) {
             return visit(ctx.xmlIsSchemaValidFunction());
         }
-        return visit(ctx.xmlTableFunction());
+        if (null != ctx.xmlTableFunction()) {
+            return visit(ctx.xmlTableFunction());
+        }
+        return new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.specifiedFunctionName.getText(), getOriginalText(ctx));
     }
     
     @Override

--- a/test/it/parser/src/main/resources/case/dml/select.xml
+++ b/test/it/parser/src/main/resources/case/dml/select.xml
@@ -5877,4 +5877,48 @@
             </column-item>
         </group-by>
     </select>
+
+    <select sql-case-id="select_with_sys_xmlagg_and_xmlgen">
+        <projections start-index="7" stop-index="54" literal-start-index="7" literal-stop-index="54">
+            <expression-projection text="SYS_XMLAGG(last_name)" alias="a" start-index="7" stop-index="29" literal-start-index="7" literal-stop-index="29">
+                <literalText>SYS_XMLAGG(last_name)</literalText>
+                <expr>
+                    <function function-name="SYS_XMLAGG" text="SYS_XMLAGG(last_name)" start-index="7" stop-index="27" literal-start-index="7" literal-stop-index="27">
+                        <literalText>SYS_XMLAGG(last_name)</literalText>
+                    </function>
+                </expr>
+            </expression-projection>
+            <expression-projection text="SYS_XMLGEN(last_name)" alias="b" start-index="32" stop-index="54" literal-start-index="32" literal-stop-index="54">
+                <literalText>SYS_XMLGEN(last_name)</literalText>
+                <expr>
+                    <function function-name="SYS_XMLGEN" text="SYS_XMLGEN(last_name)" start-index="32" stop-index="52" literal-start-index="32" literal-stop-index="52">
+                        <parameter>
+                            <column name="last_name" start-index="43" stop-index="51" literal-start-index="43" literal-stop-index="51" />
+                        </parameter>
+                        <literalText>SYS_XMLGEN(last_name)</literalText>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="employees" start-index="61" stop-index="69" literal-start-index="61" literal-stop-index="69" />
+        </from>
+        <where start-index="71" stop-index="95" literal-start-index="71" literal-stop-index="95">
+            <expr>
+                <binary-operation-expression start-index="77" stop-index="95" literal-start-index="77" literal-stop-index="95">
+                    <left>
+                        <column name="last_name" start-index="77" stop-index="85" literal-start-index="77" literal-stop-index="85" />
+                    </left>
+                    <operator>LIKE</operator>
+                    <right>
+                        <list-expression start-index="92" stop-index="95" literal-start-index="92" literal-stop-index="95">
+                            <items>
+                                <literal-expression value="R%" start-index="92" stop-index="95" literal-start-index="92" literal-stop-index="95" />
+                            </items>
+                        </list-expression>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select.xml
@@ -197,4 +197,5 @@
     <sql-case id="select_with_corr_function" value="SELECT employee_id, CORR(SYSDATE - hire_date, salary) FROM employees WHERE department_id in (50, 80) ORDER BY employee_id" db-types="Oracle" />
     <sql-case id="select_with_trim_function" value="select TRIM('  derby '), TRIM(BOTH ' ' FROM '  derby '), TRIM(TRAILING ' ' FROM '  derby '), TRIM(cast (null as char(1)) FROM '  derby '), TRIM(' ' FROM cast(null as varchar(30))), TRIM('y' FROM ' derby') FROM employees" db-types="Oracle" />
     <sql-case id="select_with_ratio_to_report_function" value="SELECT TO_CHAR(RATIO_TO_REPORT(amount_sold) OVER (), '9.999') AS RATIO_TO_REPORT FROM sales s GROUP BY s.channel_desc" db-types="Oracle" />
+    <sql-case id="select_with_sys_xmlagg_and_xmlgen" value="SELECT SYS_XMLAGG(last_name) a, SYS_XMLGEN(last_name) b FROM employees WHERE last_name LIKE 'R%' ORDER BY xmlagg;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Changes proposed in this pull request:
  - Support oracle SYS_XMLAGG/SYS_XMLGEN functions parsing

Refer to:
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SYS_XMLAGG.html#GUID-BEDD241D-360A-46A2-AEBF-C8B70E465D75
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SELECT.html#GUID-CFA006CA-6FF1-4972-821E-6996142A51C6
![image](https://github.com/apache/shardingsphere/assets/19788130/acd51bf2-5a07-45d7-911c-8ab01bf54e76)
![image](https://github.com/apache/shardingsphere/assets/19788130/d792e863-3be7-4891-899b-6f161ec42ba2)

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
