### PR TITLE
Remove query consistent routing from doc

### DIFF
--- a/docs/document/content/user-manual/shardingsphere-jdbc/java-api/rules/readwrite-splitting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/java-api/rules/readwrite-splitting.cn.md
@@ -35,7 +35,6 @@ Java API 形式配置的读写分离可以方便的适用于各种场景，不�
 | loadBalancerName (?)               | String                         | 读库负载均衡算法名称                                                                  | 轮询负载均衡算法 |
 
 算法类型的详情，请参见[内置负载均衡算法列表](/cn/user-manual/common-config/builtin-algorithm/load-balance)。
-查询一致性路由的详情，请参见[核心特性：读写分离](/cn/features/readwrite-splitting/)。
 
 ## 操作步骤
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/java-api/rules/readwrite-splitting.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/java-api/rules/readwrite-splitting.en.md
@@ -35,7 +35,6 @@ Configurable Properties:
 | loadBalancerName (?)               | String                         | Load balance algorithm name of replica sources                                                                                                         | Round robin load balance algorithm |
 
 Please refer to [Built-in Load Balance Algorithm List](/en/user-manual/common-config/builtin-algorithm/load-balance) for details on algorithm types.
-Please refer to [Read-write splitting-Core features](/en/features/readwrite-splitting/) for more details about query consistent routing.
 
 ## Operating Procedures
 

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.cn.md
@@ -30,7 +30,6 @@ rules:
 ```
 
 算法类型的详情，请参见[内置负载均衡算法列表](/cn/user-manual/common-config/builtin-algorithm/load-balance)。
-查询一致性路由的详情，请参见[核心特性：读写分离](/cn/features/readwrite-splitting/)。
 
 ## 操作步骤
 1. 添加读写分离数据源

--- a/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.en.md
+++ b/docs/document/content/user-manual/shardingsphere-jdbc/yaml-config/rules/readwrite-splitting.en.md
@@ -29,7 +29,6 @@ rules:
 ```
 
 Please refer to [Built-in Load Balance Algorithm List](/en/user-manual/common-config/builtin-algorithm/load-balance) for more details about type of algorithm.
-Please refer to [Read-write splitting-Core features](/en/features/readwrite-splitting/) for more details about query consistent routing.
 
 ## Procedure
 1. Add read/write splitting data source.


### PR DESCRIPTION
Changes proposed in this pull request:
  - Remove query consistent routing from doc

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
