### PR TITLE
Enhance Oracle qualifiedTemplateClause and alterFlashbackArchive syntax

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -2420,7 +2420,7 @@ alterFlashbackArchive
     ( SET DEFAULT
     | (ADD | MODIFY) TABLESPACE tablespaceName flashbackArchiveQuota?
     | REMOVE TABLESPACE tablespaceName
-    | MODIFY RETENTION flashbackArchiveRetention
+    | MODIFY RETENTION? flashbackArchiveRetention
     | PURGE purgeClause
     | NO? OPTIMIZE DATA)
     ;

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -2888,7 +2888,7 @@ diskgroupTemplateClauses
     ;
 
 qualifiedTemplateClause
-    : ATTRIBUTE LP_ redundancyClause stripingClause diskRegionClause RP_
+    : (ATTRIBUTE | ATTRIBUTES) LP_ redundancyClause stripingClause diskRegionClause RP_
     ;
 
 redundancyClause

--- a/test/it/parser/src/main/resources/case/ddl/alter-diskgroup.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-diskgroup.xml
@@ -43,4 +43,5 @@
     <alter-diskgroup sql-case-id="alter_diskgroup_modify_drop_member" />
     <alter-diskgroup sql-case-id="alter_diskgroup_resize_disks_in_failgroup_size_g" />
     <alter-diskgroup sql-case-id="alter_diskgroup_add_template_attribute_unprotected_coarse" />
+    <alter-diskgroup sql-case-id="alter_diskgroup_modify_template_attribute_fine" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/alter-diskgroup.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-diskgroup.xml
@@ -42,4 +42,5 @@
     <alter-diskgroup sql-case-id="alter_diskgroup_add_template_attribute_hot_hirrorhot" />
     <alter-diskgroup sql-case-id="alter_diskgroup_modify_drop_member" />
     <alter-diskgroup sql-case-id="alter_diskgroup_resize_disks_in_failgroup_size_g" />
+    <alter-diskgroup sql-case-id="alter_diskgroup_add_template_attribute_unprotected_coarse" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/alter-flashback-archive.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-flashback-archive.xml
@@ -23,4 +23,5 @@
     <alter-flashback-archive sql-case-id="alter_flashback_archive_purge_all" />
     <alter-flashback-archive sql-case-id="alter_flashback_archive_purge_before" />
     <alter-flashback-archive sql-case-id="alter_flashback_archive_no_optimize_data" />
+    <alter-flashback-archive sql-case-id="alter_flashback_archive_modify_retention_month" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/alter-flashback-archive.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-flashback-archive.xml
@@ -24,4 +24,5 @@
     <alter-flashback-archive sql-case-id="alter_flashback_archive_purge_before" />
     <alter-flashback-archive sql-case-id="alter_flashback_archive_no_optimize_data" />
     <alter-flashback-archive sql-case-id="alter_flashback_archive_modify_retention_month" />
+    <alter-flashback-archive sql-case-id="alter_flashback_archive_modify_retention_year" />
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-diskgroup.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-diskgroup.xml
@@ -42,4 +42,5 @@
     <sql-case id="alter_diskgroup_add_template_attribute_hot_hirrorhot" value="ALTER DISKGROUP data ADD TEMPLATE datafile_hot ATTRIBUTE (HOT MIRRORHOT)" db-types="Oracle" />
     <sql-case id="alter_diskgroup_modify_drop_member" value="ALTER DISKGROUP data MODIFY USERGROUP 'test_grp2' DROP MEMBER 'oracle2'" db-types="Oracle" />
     <sql-case id="alter_diskgroup_resize_disks_in_failgroup_size_g" value="ALTER DISKGROUP data1 RESIZE DISKS IN FAILGROUP failgrp1 SIZE 100G" db-types="Oracle" />
+    <sql-case id="alter_diskgroup_add_template_attribute_unprotected_coarse" value="ALTER DISKGROUP dgroup_01 ADD TEMPLATE template_01 ATTRIBUTES (UNPROTECTED COARSE)" db-types="Oracle" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-diskgroup.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-diskgroup.xml
@@ -43,4 +43,5 @@
     <sql-case id="alter_diskgroup_modify_drop_member" value="ALTER DISKGROUP data MODIFY USERGROUP 'test_grp2' DROP MEMBER 'oracle2'" db-types="Oracle" />
     <sql-case id="alter_diskgroup_resize_disks_in_failgroup_size_g" value="ALTER DISKGROUP data1 RESIZE DISKS IN FAILGROUP failgrp1 SIZE 100G" db-types="Oracle" />
     <sql-case id="alter_diskgroup_add_template_attribute_unprotected_coarse" value="ALTER DISKGROUP dgroup_01 ADD TEMPLATE template_01 ATTRIBUTES (UNPROTECTED COARSE)" db-types="Oracle" />
+    <sql-case id="alter_diskgroup_modify_template_attribute_fine" value="ALTER DISKGROUP dgroup_01 MODIFY TEMPLATE template_01 ATTRIBUTES (FINE)" db-types="Oracle" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-flashback-archive.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-flashback-archive.xml
@@ -23,4 +23,5 @@
     <sql-case id="alter_flashback_archive_purge_all" value="ALTER FLASHBACK ARCHIVE test_archive PURGE ALL;" db-types="Oracle" />
     <sql-case id="alter_flashback_archive_purge_before" value="ALTER FLASHBACK ARCHIVE test_archive PURGE BEFORE TIMESTAMP 2649009;" db-types="Oracle" />
     <sql-case id="alter_flashback_archive_no_optimize_data" value="ALTER FLASHBACK ARCHIVE test_archive NO OPTIMIZE DATA;" db-types="Oracle" />
+    <sql-case id="alter_flashback_archive_modify_retention_month" value="ALTER FLASHBACK ARCHIVE test_archive1 MODIFY RETENTION 1 MONTH" db-types="Oracle" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-flashback-archive.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-flashback-archive.xml
@@ -24,4 +24,5 @@
     <sql-case id="alter_flashback_archive_purge_before" value="ALTER FLASHBACK ARCHIVE test_archive PURGE BEFORE TIMESTAMP 2649009;" db-types="Oracle" />
     <sql-case id="alter_flashback_archive_no_optimize_data" value="ALTER FLASHBACK ARCHIVE test_archive NO OPTIMIZE DATA;" db-types="Oracle" />
     <sql-case id="alter_flashback_archive_modify_retention_month" value="ALTER FLASHBACK ARCHIVE test_archive1 MODIFY RETENTION 1 MONTH" db-types="Oracle" />
+    <sql-case id="alter_flashback_archive_modify_retention_year" value="ALTER FLASHBACK ARCHIVE fla1 MODIFY RETENTION 2 YEAR" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #26962 #26963.

Changes proposed in this pull request:
  - Enhance Oracle qualifiedTemplateClause and alterFlashbackArchive syntax
  - Add test sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
