### PR TITLE
Implement shorthand expand when contains join tables

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/TableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/TableSegmentBinder.java
@@ -47,8 +47,8 @@ public final class TableSegmentBinder {
      * @param tableBinderContexts table binder contexts
      * @return bounded table segment
      */
-    public static TableSegment bind(final TableSegment segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName, final DatabaseType databaseType,
-                                    final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+    public static TableSegment bind(final TableSegment segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName,
+                                    final DatabaseType databaseType, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
         if (segment instanceof SimpleTableSegment) {
             return SimpleTableSegmentBinder.bind((SimpleTableSegment) segment, metaData, defaultDatabaseName, databaseType, tableBinderContexts);
         }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
@@ -22,9 +22,21 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinder;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import org.apache.shardingsphere.infra.database.mysql.MySQLDatabaseType;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.infra.util.exception.ShardingSpherePreconditions;
+import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.Map;
 
 /**
@@ -43,11 +55,111 @@ public final class JoinTableSegmentBinder {
      * @param tableBinderContexts table binder contexts
      * @return bounded join table segment
      */
-    public static JoinTableSegment bind(final JoinTableSegment segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName, final DatabaseType databaseType,
-                                        final Map<String, TableSegmentBinderContext> tableBinderContexts) {
-        segment.setLeft(TableSegmentBinder.bind(segment.getLeft(), metaData, defaultDatabaseName, databaseType, tableBinderContexts));
-        segment.setRight(TableSegmentBinder.bind(segment.getRight(), metaData, defaultDatabaseName, databaseType, tableBinderContexts));
+    public static JoinTableSegment bind(final JoinTableSegment segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName,
+                                        final DatabaseType databaseType, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+        JoinTableSegment result = new JoinTableSegment();
+        result.setStartIndex(segment.getStartIndex());
+        result.setStopIndex(segment.getStopIndex());
+        segment.getAliasSegment().ifPresent(result::setAlias);
+        result.setLeft(TableSegmentBinder.bind(segment.getLeft(), metaData, defaultDatabaseName, databaseType, tableBinderContexts));
+        result.setNatural(segment.isNatural());
+        result.setJoinType(segment.getJoinType());
+        result.setRight(TableSegmentBinder.bind(segment.getRight(), metaData, defaultDatabaseName, databaseType, tableBinderContexts));
+        result.setCondition(segment.getCondition());
+        result.getJoinTableProjectionSegments().addAll(getJoinTableProjectionSegments(segment, databaseType, tableBinderContexts));
         // TODO bind condition and using column in join table segment
-        return segment;
+        return result;
+    }
+    
+    private static Collection<ProjectionSegment> getJoinTableProjectionSegments(final JoinTableSegment segment, final DatabaseType databaseType,
+                                                                                final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+        Collection<ProjectionSegment> projectionSegments = getProjectionSegments(segment, databaseType, tableBinderContexts);
+        if (segment.getUsing().isEmpty() && !segment.isNatural()) {
+            return projectionSegments;
+        }
+        Collection<ProjectionSegment> result = new LinkedList<>();
+        Map<String, ProjectionSegment> originalUsingColumns = segment.getUsing().isEmpty() ? getUsingColumnsByNaturalJoin(segment, tableBinderContexts) : getUsingColumns(segment.getUsing());
+        Collection<ProjectionSegment> orderedUsingColumns =
+                databaseType instanceof MySQLDatabaseType ? getJoinUsingColumnsByProjectionOrder(projectionSegments, originalUsingColumns) : originalUsingColumns.values();
+        result.addAll(orderedUsingColumns);
+        result.addAll(getJoinRemainingColumns(projectionSegments, originalUsingColumns));
+        return result;
+    }
+    
+    private static Collection<ProjectionSegment> getProjectionSegments(final JoinTableSegment segment, final DatabaseType databaseType,
+                                                                       final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+        Collection<ProjectionSegment> result = new LinkedList<>();
+        if (databaseType instanceof MySQLDatabaseType && JoinType.RIGHT.name().equalsIgnoreCase(segment.getJoinType()) && (!segment.getUsing().isEmpty() || segment.isNatural())) {
+            result.addAll(getProjectionSegments(segment.getRight(), tableBinderContexts));
+            result.addAll(getProjectionSegments(segment.getLeft(), tableBinderContexts));
+        } else {
+            result.addAll(getProjectionSegments(segment.getLeft(), tableBinderContexts));
+            result.addAll(getProjectionSegments(segment.getRight(), tableBinderContexts));
+        }
+        return result;
+    }
+    
+    private static Collection<ProjectionSegment> getProjectionSegments(final TableSegment tableSegment, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+        Collection<ProjectionSegment> result = new LinkedList<>();
+        if (tableSegment instanceof SimpleTableSegment) {
+            String tableAliasOrName = tableSegment.getAliasName().orElseGet(() -> ((SimpleTableSegment) tableSegment).getTableName().getIdentifier().getValue());
+            result.addAll(getProjectionSegmentsByTableAliasOrName(tableBinderContexts, tableAliasOrName));
+        } else if (tableSegment instanceof JoinTableSegment) {
+            result.addAll(((JoinTableSegment) tableSegment).getJoinTableProjectionSegments());
+        } else if (tableSegment instanceof SubqueryTableSegment) {
+            result.addAll(getProjectionSegmentsByTableAliasOrName(tableBinderContexts, tableSegment.getAliasName().orElse("")));
+        }
+        return result;
+    }
+    
+    private static Collection<ProjectionSegment> getProjectionSegmentsByTableAliasOrName(final Map<String, TableSegmentBinderContext> tableBinderContexts, final String tableAliasOrName) {
+        ShardingSpherePreconditions.checkState(tableBinderContexts.containsKey(tableAliasOrName),
+                () -> new IllegalStateException(String.format("Can not find table binder context by table alias or name %s.", tableAliasOrName)));
+        return tableBinderContexts.get(tableAliasOrName).getProjectionSegments();
+    }
+    
+    private static Map<String, ProjectionSegment> getUsingColumnsByNaturalJoin(final JoinTableSegment segment, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+        Map<String, ProjectionSegment> result = new LinkedHashMap<>();
+        Collection<ProjectionSegment> leftProjections = getProjectionSegments(segment.getLeft(), tableBinderContexts);
+        Map<String, ProjectionSegment> rightProjections = new LinkedHashMap<>();
+        getProjectionSegments(segment.getRight(), tableBinderContexts).forEach(each -> rightProjections.put(each.getColumnLabel().toLowerCase(), each));
+        for (ProjectionSegment each : leftProjections) {
+            String columnLabel = each.getColumnLabel().toLowerCase();
+            if (rightProjections.containsKey(columnLabel)) {
+                result.put(columnLabel, each);
+            }
+        }
+        return result;
+    }
+    
+    private static Map<String, ProjectionSegment> getUsingColumns(final Collection<ColumnSegment> usingColumns) {
+        Map<String, ProjectionSegment> result = new LinkedHashMap<>();
+        for (ColumnSegment each : usingColumns) {
+            ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment(each);
+            result.put(columnProjectionSegment.getColumnLabel().toLowerCase(), columnProjectionSegment);
+        }
+        return result;
+    }
+    
+    private static Collection<ProjectionSegment> getJoinUsingColumnsByProjectionOrder(final Collection<ProjectionSegment> projectionSegments,
+                                                                                      final Map<String, ProjectionSegment> usingColumns) {
+        Map<String, ProjectionSegment> result = new LinkedHashMap<>(usingColumns.size(), 1F);
+        for (ProjectionSegment each : projectionSegments) {
+            String columnLabel = each.getColumnLabel().toLowerCase();
+            if (!result.containsKey(columnLabel) && usingColumns.containsKey(columnLabel)) {
+                result.put(columnLabel, each);
+            }
+        }
+        return result.values();
+    }
+    
+    private static Collection<ProjectionSegment> getJoinRemainingColumns(final Collection<ProjectionSegment> projectionSegments, final Map<String, ProjectionSegment> usingColumns) {
+        Collection<ProjectionSegment> result = new LinkedList<>();
+        for (ProjectionSegment each : projectionSegments) {
+            if (!usingColumns.containsKey(each.getColumnLabel().toLowerCase())) {
+                result.add(each);
+            }
+        }
+        return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/projection/ProjectionsSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/projection/ProjectionsSegmentBinder.java
@@ -22,10 +22,12 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
 import org.apache.shardingsphere.infra.binder.segment.projection.impl.ColumnProjectionSegmentBinder;
 import org.apache.shardingsphere.infra.binder.segment.projection.impl.ShorthandProjectionSegmentBinder;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionsSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 
 import java.util.Map;
 
@@ -39,22 +41,26 @@ public final class ProjectionsSegmentBinder {
      * Bind projections segment with metadata.
      *
      * @param segment table segment
+     * @param boundedTableSegment bounded table segment
+     * @param databaseType database type
      * @param tableBinderContexts table binder contexts
      * @return bounded projections segment
      */
-    public static ProjectionsSegment bind(final ProjectionsSegment segment, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+    public static ProjectionsSegment bind(final ProjectionsSegment segment, final TableSegment boundedTableSegment,
+                                          final DatabaseType databaseType, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
         ProjectionsSegment result = new ProjectionsSegment(segment.getStartIndex(), segment.getStopIndex());
         result.setDistinctRow(segment.isDistinctRow());
-        segment.getProjections().forEach(each -> result.getProjections().add(bind(each, tableBinderContexts)));
+        segment.getProjections().forEach(each -> result.getProjections().add(bind(each, boundedTableSegment, databaseType, tableBinderContexts)));
         return result;
     }
     
-    private static ProjectionSegment bind(final ProjectionSegment projectionSegment, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
+    private static ProjectionSegment bind(final ProjectionSegment projectionSegment, final TableSegment boundedTableSegment,
+                                          final DatabaseType databaseType, final Map<String, TableSegmentBinderContext> tableBinderContexts) {
         if (projectionSegment instanceof ColumnProjectionSegment) {
             return ColumnProjectionSegmentBinder.bind((ColumnProjectionSegment) projectionSegment, tableBinderContexts);
         }
         if (projectionSegment instanceof ShorthandProjectionSegment) {
-            return ShorthandProjectionSegmentBinder.bind((ShorthandProjectionSegment) projectionSegment, tableBinderContexts);
+            return ShorthandProjectionSegmentBinder.bind((ShorthandProjectionSegment) projectionSegment, boundedTableSegment, tableBinderContexts);
         }
         // TODO support more ProjectionSegment bind
         return projectionSegment;

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/projection/impl/ShorthandProjectionSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/projection/impl/ShorthandProjectionSegmentBinderTest.java
@@ -20,19 +20,29 @@ package org.apache.shardingsphere.infra.binder.segment.projection.impl;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SubqueryTableSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableNameSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLSelectStatement;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 class ShorthandProjectionSegmentBinderTest {
     
@@ -44,7 +54,49 @@ class ShorthandProjectionSegmentBinderTest {
         ColumnProjectionSegment invisibleColumn = new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("status")));
         invisibleColumn.setVisible(false);
         tableBinderContexts.put("o", new TableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
-        ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(shorthandProjectionSegment, tableBinderContexts);
+        ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(shorthandProjectionSegment, mock(TableSegment.class), tableBinderContexts);
+        assertThat(actual.getActualProjectionSegments().size(), is(1));
+        ProjectionSegment visibleColumn = actual.getActualProjectionSegments().iterator().next();
+        assertThat(visibleColumn.getColumnLabel(), is("order_id"));
+        assertTrue(visibleColumn.isVisible());
+    }
+    
+    @Test
+    void assertBindWithoutOwnerForSimpleTableSegment() {
+        Map<String, TableSegmentBinderContext> tableBinderContexts = new CaseInsensitiveMap<>();
+        ColumnProjectionSegment invisibleColumn = new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("status")));
+        invisibleColumn.setVisible(false);
+        tableBinderContexts.put("o", new TableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
+        SimpleTableSegment boundedTableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
+        boundedTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
+        ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(new ShorthandProjectionSegment(0, 0), boundedTableSegment, tableBinderContexts);
+        assertThat(actual.getActualProjectionSegments().size(), is(1));
+        ProjectionSegment visibleColumn = actual.getActualProjectionSegments().iterator().next();
+        assertThat(visibleColumn.getColumnLabel(), is("order_id"));
+        assertTrue(visibleColumn.isVisible());
+    }
+    
+    @Test
+    void assertBindWithoutOwnerForSubqueryTableSegment() {
+        Map<String, TableSegmentBinderContext> tableBinderContexts = new CaseInsensitiveMap<>();
+        ColumnProjectionSegment invisibleColumn = new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("status")));
+        invisibleColumn.setVisible(false);
+        tableBinderContexts.put("o", new TableSegmentBinderContext(Arrays.asList(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))), invisibleColumn)));
+        SubqueryTableSegment boundedTableSegment = new SubqueryTableSegment(new SubquerySegment(0, 0, mock(MySQLSelectStatement.class)));
+        boundedTableSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
+        ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(new ShorthandProjectionSegment(0, 0), boundedTableSegment, tableBinderContexts);
+        assertThat(actual.getActualProjectionSegments().size(), is(1));
+        ProjectionSegment visibleColumn = actual.getActualProjectionSegments().iterator().next();
+        assertThat(visibleColumn.getColumnLabel(), is("order_id"));
+        assertTrue(visibleColumn.isVisible());
+    }
+    
+    @Test
+    void assertBindWithoutOwnerForJoinTableSegment() {
+        ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 0);
+        JoinTableSegment boundedTableSegment = new JoinTableSegment();
+        boundedTableSegment.getJoinTableProjectionSegments().add(new ColumnProjectionSegment(new ColumnSegment(0, 0, new IdentifierValue("order_id"))));
+        ShorthandProjectionSegment actual = ShorthandProjectionSegmentBinder.bind(shorthandProjectionSegment, boundedTableSegment, Collections.emptyMap());
         assertThat(actual.getActualProjectionSegments().size(), is(1));
         ProjectionSegment visibleColumn = actual.getActualProjectionSegments().iterator().next();
         assertThat(visibleColumn.getColumnLabel(), is("order_id"));

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/JoinTableSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/generic/table/JoinTableSegment.java
@@ -21,10 +21,13 @@ import lombok.Getter;
 import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -50,6 +53,8 @@ public final class JoinTableSegment implements TableSegment {
     
     private List<ColumnSegment> using = Collections.emptyList();
     
+    private Collection<ProjectionSegment> joinTableProjectionSegments = new LinkedList<>();
+    
     @Override
     public Optional<String> getAliasName() {
         return null == alias ? Optional.empty() : Optional.ofNullable(alias.getIdentifier().getValue());
@@ -58,5 +63,14 @@ public final class JoinTableSegment implements TableSegment {
     @Override
     public Optional<IdentifierValue> getAlias() {
         return Optional.ofNullable(alias).map(AliasSegment::getIdentifier);
+    }
+    
+    /**
+     * Get alias segment.
+     * 
+     * @return alias segment
+     */
+    public Optional<AliasSegment> getAliasSegment() {
+        return Optional.ofNullable(alias);
     }
 }


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Implement shorthand expand when contains join tables
  - add more unit test for JoinTableSegmentBinder and ShorthandProjectionSegmentBinder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
