### PR TITLE
Update Atomikos to 6.0.0 on javax classifier

### DIFF
--- a/distribution/proxy-native/src/main/release-docs/LICENSE
+++ b/distribution/proxy-native/src/main/release-docs/LICENSE
@@ -302,11 +302,11 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    atomikos-util 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-api 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-jdbc 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-jta 5.0.9: https://www.atomikos.com, Apache 2.0
+    atomikos-util 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-api 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-jdbc 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-jta 6.0.0: https://www.atomikos.com, Apache 2.0
     
 ========================================================================
 BSD licenses

--- a/distribution/proxy/src/main/release-docs/LICENSE
+++ b/distribution/proxy/src/main/release-docs/LICENSE
@@ -308,11 +308,11 @@ Apache 2.0 licenses
 The following components are provided under the Apache License. See project link for details.
 The text of each license is also included at licenses/LICENSE-[project].txt.
 
-    atomikos-util 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-api 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-jdbc 5.0.9: https://www.atomikos.com, Apache 2.0
-    transactions-jta 5.0.9: https://www.atomikos.com, Apache 2.0
+    atomikos-util 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-api 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-jdbc 6.0.0: https://www.atomikos.com, Apache 2.0
+    transactions-jta 6.0.0: https://www.atomikos.com, Apache 2.0
 
 ========================================================================
 BSD licenses

--- a/kernel/transaction/type/xa/provider/atomikos/pom.xml
+++ b/kernel/transaction/type/xa/provider/atomikos/pom.xml
@@ -27,7 +27,7 @@
     <name>${project.artifactId}</name>
     
     <properties>
-        <atomikos.version>5.0.9</atomikos.version>
+        <atomikos.version>6.0.0</atomikos.version>
     </properties>
     
     <dependencies>

--- a/test/e2e/operation/transaction/pom.xml
+++ b/test/e2e/operation/transaction/pom.xml
@@ -29,7 +29,7 @@
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         
-        <atomikos.version>5.0.9</atomikos.version>
+        <atomikos.version>6.0.0</atomikos.version>
         <narayana.version>5.12.4.Final</narayana.version>
         <jboss-transaction-spi.version>7.6.0.Final</jboss-transaction-spi.version>
         <jboss-logging.version>3.2.1.Final</jboss-logging.version>


### PR DESCRIPTION
For #26041, #26275 and #26274.

Changes proposed in this pull request:
  - Update Atomikos to 6.0.0 on javax classifier.

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
