### PR TITLE
Remove useless projection logic in ProjectionContext and use bounded sql statement

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
@@ -17,28 +17,19 @@
 
 package org.apache.shardingsphere.infra.binder.context.segment.select.projection.engine;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.DerivedColumn;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationDistinctProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.AggregationProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.DerivedProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ParameterMarkerProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ShorthandProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.SubqueryProjection;
-import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
-import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseTypeRegistry;
-import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.exception.SchemaNotFoundException;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
-import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
-import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.Paren;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationDistinctProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationProjectionSegment;
@@ -48,42 +39,24 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.Projecti
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.SubqueryProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.Map;
 import java.util.Optional;
 
 /**
  * Projection engine.
  */
+@RequiredArgsConstructor
 public final class ProjectionEngine {
     
-    private final String databaseName;
-    
-    private final Map<String, ShardingSphereSchema> schemas;
-    
     private final DatabaseType databaseType;
-    
-    private final DialectDatabaseMetaData dialectDatabaseMetaData;
     
     private int aggregationAverageDerivedColumnCount;
     
     private int aggregationDistinctDerivedColumnCount;
-    
-    public ProjectionEngine(final String databaseName, final Map<String, ShardingSphereSchema> schemas, final DatabaseType databaseType) {
-        this.databaseName = databaseName;
-        this.schemas = schemas;
-        this.databaseType = databaseType;
-        dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType);
-    }
     
     /**
      * Create projection.
@@ -130,8 +103,7 @@ public final class ProjectionEngine {
     private ShorthandProjection createProjection(final TableSegment table, final ShorthandProjectionSegment projectionSegment) {
         IdentifierValue owner = projectionSegment.getOwner().map(OwnerSegment::getIdentifier).orElse(null);
         Collection<Projection> projections = new LinkedHashSet<>();
-        projections.addAll(getShorthandColumnsFromSimpleTableSegment(table, owner));
-        projections.addAll(getShorthandColumnsFromJoinTableSegment(table, owner, projectionSegment));
+        projectionSegment.getActualProjectionSegments().forEach(each -> createProjection(table, each).ifPresent(projections::add));
         return new ShorthandProjection(owner, projections);
     }
     
@@ -162,142 +134,6 @@ public final class ProjectionEngine {
         if (AggregationType.AVG == result.getType()) {
             appendAverageDerivedProjection(result);
             // TODO replace avg to constant, avoid calculate useless avg
-        }
-        return result;
-    }
-    
-    private Collection<ColumnProjection> getShorthandColumnsFromSimpleTableSegment(final TableSegment table, final IdentifierValue owner) {
-        if (!(table instanceof SimpleTableSegment)) {
-            return Collections.emptyList();
-        }
-        String tableName = ((SimpleTableSegment) table).getTableName().getIdentifier().getValue();
-        String tableAlias = table.getAliasName().orElse(tableName);
-        String schemaName = ((SimpleTableSegment) table).getOwner().map(optional -> optional.getIdentifier().getValue())
-                .orElseGet(() -> new DatabaseTypeRegistry(databaseType).getDefaultSchemaName(databaseName)).toLowerCase();
-        ShardingSphereSchema schema = schemas.get(schemaName);
-        ShardingSpherePreconditions.checkNotNull(schema, () -> new SchemaNotFoundException(schemaName));
-        Collection<ColumnProjection> result = new LinkedList<>();
-        if (null == owner) {
-            schema.getVisibleColumnNames(tableName).stream().map(each -> new ColumnProjection(table.getAlias().orElse(((SimpleTableSegment) table).getTableName().getIdentifier()),
-                    new IdentifierValue(each, dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType)).forEach(result::add);
-        } else if (owner.getValue().equalsIgnoreCase(tableAlias)) {
-            schema.getVisibleColumnNames(tableName).stream().map(each -> new ColumnProjection(owner, new IdentifierValue(each, dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType))
-                    .forEach(result::add);
-        }
-        return result;
-    }
-    
-    private Collection<Projection> getShorthandColumnsFromJoinTableSegment(final TableSegment table, final IdentifierValue owner, final ProjectionSegment projectionSegment) {
-        if (!(table instanceof JoinTableSegment)) {
-            return Collections.emptyList();
-        }
-        JoinTableSegment joinTable = (JoinTableSegment) table;
-        Collection<Projection> result = new LinkedList<>();
-        Collection<Projection> remainingProjections = new LinkedList<>();
-        for (Projection each : getOriginalProjections(joinTable, projectionSegment)) {
-            Collection<Projection> actualProjections = getActualProjections(Collections.singletonList(each));
-            if (joinTable.getUsing().isEmpty() && !joinTable.isNatural() || null != owner && each.getExpression().contains(owner.getValue())) {
-                result.addAll(actualProjections);
-            } else {
-                remainingProjections.addAll(actualProjections);
-            }
-        }
-        result.addAll(getUsingActualProjections(remainingProjections, joinTable.getUsing(), joinTable.isNatural()));
-        return result;
-    }
-    
-    private Collection<Projection> getOriginalProjections(final JoinTableSegment joinTable, final ProjectionSegment projectionSegment) {
-        Collection<Projection> result = new LinkedList<>();
-        if (databaseType instanceof MySQLDatabaseType && (!joinTable.getUsing().isEmpty() || joinTable.isNatural()) && JoinType.RIGHT.name().equalsIgnoreCase(joinTable.getJoinType())) {
-            createProjection(joinTable.getRight(), projectionSegment).ifPresent(result::add);
-            createProjection(joinTable.getLeft(), projectionSegment).ifPresent(result::add);
-            return result;
-        }
-        createProjection(joinTable.getLeft(), projectionSegment).ifPresent(result::add);
-        createProjection(joinTable.getRight(), projectionSegment).ifPresent(result::add);
-        return result;
-    }
-    
-    private Collection<Projection> getActualProjections(final Collection<Projection> projections) {
-        Collection<Projection> result = new LinkedList<>();
-        for (Projection each : projections) {
-            if (each instanceof ShorthandProjection) {
-                result.addAll(((ShorthandProjection) each).getActualColumns());
-            } else if (!(each instanceof DerivedProjection)) {
-                result.add(each);
-            }
-        }
-        return result;
-    }
-    
-    private Collection<Projection> getUsingActualProjections(final Collection<Projection> actualProjections, final Collection<ColumnSegment> usingColumns, final boolean natural) {
-        if (usingColumns.isEmpty() && !natural) {
-            return Collections.emptyList();
-        }
-        Collection<String> usingColumnNames = usingColumns.isEmpty() ? getUsingColumnNamesByNaturalJoin(actualProjections) : getUsingColumnNames(usingColumns);
-        Collection<Projection> result = new LinkedList<>();
-        if (databaseType instanceof MySQLDatabaseType) {
-            result.addAll(getJoinUsingColumnsByOriginalColumnSequence(actualProjections, usingColumnNames));
-        } else {
-            result.addAll(getJoinUsingColumnsByUsingColumnSequence(actualProjections, usingColumnNames));
-        }
-        result.addAll(getRemainingColumns(actualProjections, usingColumnNames));
-        return result;
-    }
-    
-    private Collection<String> getUsingColumnNamesByNaturalJoin(final Collection<Projection> actualProjections) {
-        Collection<String> result = new LinkedHashSet<>();
-        Map<String, Projection> uniqueProjections = new LinkedHashMap<>(actualProjections.size(), 1F);
-        for (Projection each : actualProjections) {
-            Projection previousProjection = uniqueProjections.put(each.getColumnLabel().toLowerCase(), each);
-            if (null != previousProjection) {
-                result.add(previousProjection.getColumnLabel().toLowerCase());
-            }
-        }
-        return result;
-    }
-    
-    private Collection<String> getUsingColumnNames(final Collection<ColumnSegment> usingColumns) {
-        Collection<String> result = new LinkedHashSet<>();
-        for (ColumnSegment each : usingColumns) {
-            result.add(each.getIdentifier().getValue().toLowerCase());
-        }
-        return result;
-    }
-    
-    private Collection<Projection> getJoinUsingColumnsByOriginalColumnSequence(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
-        Collection<Projection> result = new LinkedList<>();
-        for (Projection each : actualProjections) {
-            if (result.size() == usingColumnNames.size()) {
-                return result;
-            }
-            if (usingColumnNames.contains(each.getColumnLabel().toLowerCase())) {
-                result.add(each);
-            }
-        }
-        return result;
-    }
-    
-    private Collection<Projection> getJoinUsingColumnsByUsingColumnSequence(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
-        Collection<Projection> result = new LinkedList<>();
-        for (String each : usingColumnNames) {
-            for (Projection projection : actualProjections) {
-                if (each.equalsIgnoreCase(projection.getColumnLabel())) {
-                    result.add(projection);
-                    break;
-                }
-            }
-        }
-        return result;
-    }
-    
-    private Collection<Projection> getRemainingColumns(final Collection<Projection> actualProjections, final Collection<String> usingColumnNames) {
-        Collection<Projection> result = new LinkedList<>();
-        for (Projection each : actualProjections) {
-            if (usingColumnNames.contains(each.getColumnLabel().toLowerCase())) {
-                continue;
-            }
-            result.add(each);
         }
         return result;
     }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionsContextEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionsContextEngine.java
@@ -27,7 +27,6 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.DerivedProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ShorthandProjection;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionsSegment;
@@ -41,7 +40,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.Identifi
 
 import java.util.Collection;
 import java.util.LinkedList;
-import java.util.Map;
 
 /**
  * Projections context engine.
@@ -50,8 +48,8 @@ public final class ProjectionsContextEngine {
     
     private final ProjectionEngine projectionEngine;
     
-    public ProjectionsContextEngine(final String databaseName, final Map<String, ShardingSphereSchema> schemas, final DatabaseType databaseType) {
-        projectionEngine = new ProjectionEngine(databaseName, schemas, databaseType);
+    public ProjectionsContextEngine(final DatabaseType databaseType) {
+        projectionEngine = new ProjectionEngine(databaseType);
     }
     
     /**

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/statement/dml/SelectStatementContext.java
@@ -20,10 +20,7 @@ package org.apache.shardingsphere.infra.binder.context.statement.dml;
 import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
-import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.NoDatabaseSelectedException;
-import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.binder.context.aware.ParameterAware;
-import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.groupby.GroupByContext;
 import org.apache.shardingsphere.infra.binder.context.segment.select.groupby.engine.GroupByContextEngine;
 import org.apache.shardingsphere.infra.binder.context.segment.select.orderby.OrderByContext;
@@ -40,13 +37,15 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ParameterMarkerProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.SubqueryProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.table.TablesContext;
+import org.apache.shardingsphere.infra.binder.context.statement.CommonSQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.type.TableAvailable;
 import org.apache.shardingsphere.infra.binder.context.type.WhereAvailable;
+import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.NoDatabaseSelectedException;
+import org.apache.shardingsphere.infra.exception.dialect.exception.syntax.database.UnknownDatabaseException;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.metadata.database.ShardingSphereDatabase;
-import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.rule.identifier.type.TableContainedRule;
-import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.ParameterMarkerType;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.SubqueryType;
 import org.apache.shardingsphere.sql.parser.sql.common.extractor.TableExtractor;
@@ -116,12 +115,12 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
         ColumnExtractor.extractColumnSegments(columnSegments, whereSegments);
         subqueryContexts = createSubqueryContexts(metaData, params, defaultDatabaseName);
         tablesContext = new TablesContext(getAllTableSegments(), subqueryContexts, getDatabaseType());
-        String databaseName = tablesContext.getDatabaseName().orElse(defaultDatabaseName);
         groupByContext = new GroupByContextEngine().createGroupByContext(sqlStatement);
         orderByContext = new OrderByContextEngine().createOrderBy(sqlStatement, groupByContext);
-        projectionsContext = new ProjectionsContextEngine(databaseName, getSchemas(metaData, databaseName), getDatabaseType())
+        projectionsContext = new ProjectionsContextEngine(getDatabaseType())
                 .createProjectionsContext(getSqlStatement().getFrom(), getSqlStatement().getProjections(), groupByContext, orderByContext);
         paginationContext = new PaginationContextEngine().createPaginationContext(sqlStatement, projectionsContext, params, whereSegments);
+        String databaseName = tablesContext.getDatabaseName().orElse(defaultDatabaseName);
         containsEnhancedTable = isContainsEnhancedTable(metaData, databaseName, getTablesContext().getTableNames());
     }
     
@@ -155,16 +154,6 @@ public final class SelectStatementContext extends CommonSQLStatementContext impl
             result.put(each.getStartIndex(), subqueryContext);
         }
         return result;
-    }
-    
-    private Map<String, ShardingSphereSchema> getSchemas(final ShardingSphereMetaData metaData, final String databaseName) {
-        if (null == databaseName) {
-            ShardingSpherePreconditions.checkState(tablesContext.getSimpleTableSegments().isEmpty(), NoDatabaseSelectedException::new);
-            return Collections.emptyMap();
-        }
-        ShardingSphereDatabase database = metaData.getDatabase(databaseName);
-        ShardingSpherePreconditions.checkNotNull(database, () -> new UnknownDatabaseException(databaseName));
-        return database.getSchemas();
     }
     
     /**

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
@@ -23,11 +23,10 @@ import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinder;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.infra.exception.core.ShardingSpherePreconditions;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
@@ -78,7 +77,8 @@ public final class JoinTableSegmentBinder {
             return projectionSegments;
         }
         Collection<ProjectionSegment> result = new LinkedList<>();
-        Map<String, ProjectionSegment> originalUsingColumns = segment.getUsing().isEmpty() ? getUsingColumnsByNaturalJoin(segment, tableBinderContexts) : getUsingColumns(segment.getUsing());
+        Map<String, ProjectionSegment> originalUsingColumns =
+                segment.getUsing().isEmpty() ? getUsingColumnsByNaturalJoin(segment, tableBinderContexts) : getUsingColumns(projectionSegments, segment.getUsing());
         Collection<ProjectionSegment> orderedUsingColumns =
                 databaseType instanceof MySQLDatabaseType ? getJoinUsingColumnsByProjectionOrder(projectionSegments, originalUsingColumns) : originalUsingColumns.values();
         result.addAll(orderedUsingColumns);
@@ -132,11 +132,15 @@ public final class JoinTableSegmentBinder {
         return result;
     }
     
-    private static Map<String, ProjectionSegment> getUsingColumns(final Collection<ColumnSegment> usingColumns) {
+    private static Map<String, ProjectionSegment> getUsingColumns(final Collection<ProjectionSegment> projectionSegments, final Collection<ColumnSegment> usingColumns) {
+        Map<String, ProjectionSegment> columnLabelProjectionSegments = new LinkedHashMap<>(projectionSegments.size(), 1F);
+        projectionSegments.forEach(each -> columnLabelProjectionSegments.putIfAbsent(each.getColumnLabel().toLowerCase(), each));
         Map<String, ProjectionSegment> result = new LinkedHashMap<>();
         for (ColumnSegment each : usingColumns) {
-            ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment(each);
-            result.put(columnProjectionSegment.getColumnLabel().toLowerCase(), columnProjectionSegment);
+            ProjectionSegment projectionSegment = columnLabelProjectionSegments.get(each.getIdentifier().getValue().toLowerCase());
+            if (null != projectionSegment) {
+                result.put(projectionSegment.getColumnLabel().toLowerCase(), projectionSegment);
+            }
         }
         return result;
     }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngineTest.java
@@ -24,17 +24,11 @@ import org.apache.shardingsphere.infra.binder.context.segment.select.projection.
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ExpressionProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ParameterMarkerProjection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ShorthandProjection;
-import org.apache.shardingsphere.infra.database.core.DefaultDatabase;
-import org.apache.shardingsphere.infra.database.core.metadata.database.DialectDatabaseMetaData;
-import org.apache.shardingsphere.infra.database.core.spi.DatabaseTypedSPILoader;
 import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
-import org.apache.shardingsphere.infra.exception.SchemaNotFoundException;
 import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSphereSchema;
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.AggregationType;
-import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.complex.CommonExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.simple.ParameterMarkerExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationDistinctProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.AggregationProjectionSegment;
@@ -43,9 +37,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.Expressi
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ShorthandProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OwnerSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableNameSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
@@ -53,23 +44,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class ProjectionEngineTest {
@@ -81,41 +63,26 @@ class ProjectionEngineTest {
     
     @Test
     void assertCreateProjectionWhenProjectionSegmentNotMatched() {
-        assertFalse(new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), null).isPresent());
+        assertFalse(new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), null).isPresent());
     }
     
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfShorthandProjectionSegment() {
         ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 0);
         shorthandProjectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("tbl")));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), shorthandProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), shorthandProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenProjectionSegmentInstanceOfShorthandProjectionSegmentAndDuplicateTableSegment() {
-        SimpleTableSegment table = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "content"));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(table, new ShorthandProjectionSegment(0, 0));
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getColumnProjections().size(), is(2));
-        Collection<ColumnProjection> columnProjections = new LinkedList<>();
-        columnProjections.add(new ColumnProjection("t_order", "order_id", null, databaseType));
-        columnProjections.add(new ColumnProjection("t_order", "content", null, databaseType));
-        assertThat(((ShorthandProjection) actual.get()).getColumnProjections(), is(columnProjections));
     }
     
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfColumnProjectionSegment() {
         ColumnProjectionSegment columnProjectionSegment = new ColumnProjectionSegment(new ColumnSegment(0, 10, new IdentifierValue("name")));
         columnProjectionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("alias")));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), columnProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), columnProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ColumnProjection.class));
     }
@@ -123,8 +90,8 @@ class ProjectionEngineTest {
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfExpressionProjectionSegment() {
         ExpressionProjectionSegment expressionProjectionSegment = new ExpressionProjectionSegment(0, 10, "text");
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), expressionProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), expressionProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ExpressionProjection.class));
     }
@@ -132,8 +99,8 @@ class ProjectionEngineTest {
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationDistinctProjectionSegment() {
         AggregationDistinctProjectionSegment aggregationDistinctProjectionSegment = new AggregationDistinctProjectionSegment(0, 10, AggregationType.COUNT, "(1)", "distinctExpression");
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationDistinctProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), aggregationDistinctProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(AggregationDistinctProjection.class));
     }
@@ -141,8 +108,8 @@ class ProjectionEngineTest {
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationProjectionSegment() {
         AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.COUNT, "COUNT(1)");
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(AggregationProjection.class));
     }
@@ -150,8 +117,8 @@ class ProjectionEngineTest {
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationDistinctProjectionSegmentAndAggregationTypeIsAvg() {
         AggregationDistinctProjectionSegment aggregationDistinctProjectionSegment = new AggregationDistinctProjectionSegment(0, 10, AggregationType.AVG, "(1)", "distinctExpression");
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationDistinctProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), aggregationDistinctProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(AggregationDistinctProjection.class));
     }
@@ -159,8 +126,8 @@ class ProjectionEngineTest {
     @Test
     void assertCreateProjectionWhenProjectionSegmentInstanceOfAggregationProjectionSegmentAndAggregationTypeIsAvg() {
         AggregationProjectionSegment aggregationProjectionSegment = new AggregationProjectionSegment(0, 10, AggregationType.AVG, "AVG(1)");
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), aggregationProjectionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(AggregationProjection.class));
     }
@@ -169,218 +136,10 @@ class ProjectionEngineTest {
     void assertCreateProjectionWhenProjectionSegmentInstanceOfParameterMarkerExpressionSegment() {
         ParameterMarkerExpressionSegment parameterMarkerExpressionSegment = new ParameterMarkerExpressionSegment(7, 7, 0);
         parameterMarkerExpressionSegment.setAlias(new AliasSegment(0, 0, new IdentifierValue("alias")));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(mock(TableSegment.class), parameterMarkerExpressionSegment);
+        Optional<Projection> actual = new ProjectionEngine(
+                databaseType).createProjection(mock(TableSegment.class), parameterMarkerExpressionSegment);
         assertTrue(actual.isPresent());
         assertThat(actual.get(), instanceOf(ParameterMarkerProjection.class));
         assertThat(actual.get().getAlias().map(IdentifierValue::getValue).orElse(null), is("alias"));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenProjectionSegmentInstanceOfShorthandProjectionSegmentAndJoinTableSegment() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "customer_id"));
-        SimpleTableSegment customersTableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_customer")));
-        when(schema.getVisibleColumnNames("t_customer")).thenReturn(Collections.singletonList("customer_id"));
-        JoinTableSegment table = new JoinTableSegment();
-        SimpleTableSegment ordersTableSegment = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
-        table.setLeft(ordersTableSegment);
-        table.setRight(customersTableSegment);
-        table.setCondition(new CommonExpressionSegment(0, 0, "t_order.customer_id=t_customer.customer_id"));
-        ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 10);
-        Optional<Projection> actual = new ProjectionEngine(
-                DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(table, shorthandProjectionSegment);
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        Collection<ColumnProjection> columnProjections = ((ShorthandProjection) actual.get()).getColumnProjections();
-        assertThat(columnProjections.size(), is(3));
-        Iterator<ColumnProjection> iterator = columnProjections.iterator();
-        assertThat(iterator.next(), is(new ColumnProjection("t_order", "order_id", null, databaseType)));
-        assertThat(iterator.next(), is(new ColumnProjection("t_order", "customer_id", null, databaseType)));
-        assertThat(iterator.next(), is(new ColumnProjection("t_customer", "customer_id", null, databaseType)));
-    }
-    
-    @Test
-    void assertCreateProjectionWithNotExistedSchema() {
-        SimpleTableSegment tableSegment = mock(SimpleTableSegment.class, RETURNS_DEEP_STUBS);
-        OwnerSegment ownerSegment = mock(OwnerSegment.class, RETURNS_DEEP_STUBS);
-        when(tableSegment.getOwner()).thenReturn(Optional.of(ownerSegment));
-        when(ownerSegment.getIdentifier().getValue()).thenReturn("public");
-        ShorthandProjectionSegment shorthandProjectionSegment = new ShorthandProjectionSegment(0, 0);
-        assertThrows(SchemaNotFoundException.class, () -> new ProjectionEngine(
-                DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema), databaseType).createProjection(tableSegment, shorthandProjectionSegment));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsJoinUsingColumnForPostgreSQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        when(schema.getVisibleColumnNames("t_order_item")).thenReturn(Arrays.asList("item_id", "order_id", "user_id", "product_id", "quantity", "creation_date"));
-        Optional<Projection> actual = new ProjectionEngine("public", Collections.singletonMap("public", schema), TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"))
-                .createProjection(createJoinTableSegmentWithUsingColumn(), new ShorthandProjectionSegment(0, 0));
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(9));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithoutOwnerForPostgreSQL()));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsJoinUsingColumnForMySQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        when(schema.getVisibleColumnNames("t_order_item")).thenReturn(Arrays.asList("item_id", "order_id", "user_id", "product_id", "quantity", "creation_date"));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME,
-                Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema),
-                TypedSPILoader.getService(DatabaseType.class, "MySQL")).createProjection(createJoinTableSegmentWithUsingColumn(), new ShorthandProjectionSegment(0, 0));
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(9));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithoutOwnerForMySQL()));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsJoinUsingColumnAndOwnerForPostgreSQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        ShorthandProjectionSegment projectionSegment = new ShorthandProjectionSegment(0, 0);
-        projectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("o")));
-        Optional<Projection> actual =
-                new ProjectionEngine("public", Collections.singletonMap("public", schema),
-                        TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).createProjection(createJoinTableSegmentWithUsingColumn(), projectionSegment);
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(6));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithOwner(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"))));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsJoinUsingColumnAndOwnerForMySQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        ShorthandProjectionSegment projectionSegment = new ShorthandProjectionSegment(0, 0);
-        projectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("o")));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema),
-                TypedSPILoader.getService(DatabaseType.class, "MySQL")).createProjection(createJoinTableSegmentWithUsingColumn(), projectionSegment);
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(6));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithOwner(TypedSPILoader.getService(DatabaseType.class, "MySQL"))));
-    }
-    
-    private JoinTableSegment createJoinTableSegmentWithUsingColumn() {
-        SimpleTableSegment left = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
-        left.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
-        SimpleTableSegment right = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_item")));
-        right.setAlias(new AliasSegment(0, 0, new IdentifierValue("i")));
-        JoinTableSegment result = new JoinTableSegment();
-        result.setLeft(left);
-        result.setRight(right);
-        result.setJoinType(JoinType.RIGHT.name());
-        result.setUsing(Arrays.asList(new ColumnSegment(0, 0, new IdentifierValue("user_id")), new ColumnSegment(0, 0, new IdentifierValue("order_id")),
-                new ColumnSegment(0, 0, new IdentifierValue("creation_date"))));
-        return result;
-    }
-    
-    private Collection<Projection> crateExpectedColumnsWithoutOwnerForPostgreSQL() {
-        Collection<Projection> result = new LinkedHashSet<>();
-        DatabaseType postgresDatabaseType = TypedSPILoader.getService(DatabaseType.class, "PostgreSQL");
-        DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, postgresDatabaseType);
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("user_id", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("order_id", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("creation_date", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("status", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("merchant_id", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("remark", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("item_id", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("product_id", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("quantity", dialectDatabaseMetaData.getQuoteCharacter()), null, postgresDatabaseType));
-        return result;
-    }
-    
-    private Collection<Projection> crateExpectedColumnsWithoutOwnerForMySQL() {
-        Collection<Projection> result = new LinkedHashSet<>();
-        DatabaseType mysqlDatabaseType = TypedSPILoader.getService(DatabaseType.class, "MySQL");
-        DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, mysqlDatabaseType);
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("order_id", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("user_id", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("creation_date", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("item_id", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("product_id", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("i"), new IdentifierValue("quantity", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("status", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("merchant_id", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("remark", dialectDatabaseMetaData.getQuoteCharacter()), null, mysqlDatabaseType));
-        return result;
-    }
-    
-    private Collection<Projection> crateExpectedColumnsWithOwner(final DatabaseType databaseType) {
-        Collection<Projection> result = new LinkedHashSet<>();
-        DialectDatabaseMetaData dialectDatabaseMetaData = DatabaseTypedSPILoader.getService(DialectDatabaseMetaData.class, databaseType);
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("order_id", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("user_id", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("status", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("merchant_id", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("remark", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        result.add(new ColumnProjection(new IdentifierValue("o"), new IdentifierValue("creation_date", dialectDatabaseMetaData.getQuoteCharacter()), null, databaseType));
-        return result;
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsNaturalJoinForPostgreSQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        when(schema.getVisibleColumnNames("t_order_item")).thenReturn(Arrays.asList("item_id", "order_id", "user_id", "product_id", "quantity", "creation_date"));
-        Optional<Projection> actual = new ProjectionEngine("public", Collections.singletonMap("public", schema), TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"))
-                .createProjection(createJoinTableSegmentWithNaturalJoin(), new ShorthandProjectionSegment(0, 0));
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(9));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithoutOwnerForPostgreSQL()));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsNaturalJoinForMySQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        when(schema.getVisibleColumnNames("t_order_item")).thenReturn(Arrays.asList("item_id", "order_id", "user_id", "product_id", "quantity", "creation_date"));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema),
-                TypedSPILoader.getService(DatabaseType.class, "MySQL")).createProjection(createJoinTableSegmentWithNaturalJoin(), new ShorthandProjectionSegment(0, 0));
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(9));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithoutOwnerForMySQL()));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsNaturalJoinAndOwnerForPostgreSQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        ShorthandProjectionSegment projectionSegment = new ShorthandProjectionSegment(0, 0);
-        projectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("o")));
-        Optional<Projection> actual =
-                new ProjectionEngine("public", Collections.singletonMap("public", schema),
-                        TypedSPILoader.getService(DatabaseType.class, "PostgreSQL")).createProjection(createJoinTableSegmentWithNaturalJoin(), projectionSegment);
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(6));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithOwner(TypedSPILoader.getService(DatabaseType.class, "PostgreSQL"))));
-    }
-    
-    @Test
-    void assertCreateProjectionWhenShorthandProjectionContainsNaturalJoinAndOwnerForMySQL() {
-        when(schema.getVisibleColumnNames("t_order")).thenReturn(Arrays.asList("order_id", "user_id", "status", "merchant_id", "remark", "creation_date"));
-        ShorthandProjectionSegment projectionSegment = new ShorthandProjectionSegment(0, 0);
-        projectionSegment.setOwner(new OwnerSegment(0, 0, new IdentifierValue("o")));
-        Optional<Projection> actual = new ProjectionEngine(DefaultDatabase.LOGIC_NAME, Collections.singletonMap(DefaultDatabase.LOGIC_NAME, schema),
-                TypedSPILoader.getService(DatabaseType.class, "MySQL")).createProjection(createJoinTableSegmentWithNaturalJoin(), projectionSegment);
-        assertTrue(actual.isPresent());
-        assertThat(actual.get(), instanceOf(ShorthandProjection.class));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns().size(), is(6));
-        assertThat(((ShorthandProjection) actual.get()).getActualColumns(), is(crateExpectedColumnsWithOwner(TypedSPILoader.getService(DatabaseType.class, "MySQL"))));
-    }
-    
-    private JoinTableSegment createJoinTableSegmentWithNaturalJoin() {
-        SimpleTableSegment left = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order")));
-        left.setAlias(new AliasSegment(0, 0, new IdentifierValue("o")));
-        SimpleTableSegment right = new SimpleTableSegment(new TableNameSegment(0, 0, new IdentifierValue("t_order_item")));
-        right.setAlias(new AliasSegment(0, 0, new IdentifierValue("i")));
-        JoinTableSegment result = new JoinTableSegment();
-        result.setLeft(left);
-        result.setRight(right);
-        result.setNatural(true);
-        result.setJoinType(JoinType.RIGHT.name());
-        return result;
     }
 }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinderTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinderTest.java
@@ -27,6 +27,8 @@ import org.apache.shardingsphere.infra.metadata.database.schema.model.ShardingSp
 import org.apache.shardingsphere.infra.util.spi.type.typed.TypedSPILoader;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ColumnProjectionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.JoinTableSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.SimpleTableSegment;
@@ -35,7 +37,10 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.Identifi
 import org.junit.jupiter.api.Test;
 
 import java.sql.Types;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -67,9 +72,29 @@ class JoinTableSegmentBinderTest {
         assertTrue(actual.getRight() instanceof SimpleTableSegment);
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalDatabase().getValue(), is(DefaultDatabase.LOGIC_NAME));
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalSchema().getValue(), is(DefaultDatabase.LOGIC_NAME));
-        assertThat(actual.getJoinTableProjectionSegments().size(), is(7));
+        assertJoinTableProjectionSegments(actual.getJoinTableProjectionSegments());
         assertTrue(tableBinderContexts.containsKey("o"));
         assertTrue(tableBinderContexts.containsKey("i"));
+    }
+    
+    private void assertJoinTableProjectionSegments(final Collection<ProjectionSegment> joinTableProjectionSegments) {
+        List<ProjectionSegment> actual = new ArrayList<>(joinTableProjectionSegments);
+        assertThat(actual.size(), is(7));
+        assertTrue(actual.get(0) instanceof ColumnProjectionSegment);
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalColumn().getValue(), is("order_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalColumn().getValue(), is("user_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalColumn().getValue(), is("status"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalColumn().getValue(), is("item_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
+        assertThat(((ColumnProjectionSegment) actual.get(4)).getColumn().getOriginalColumn().getValue(), is("order_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(4)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
+        assertThat(((ColumnProjectionSegment) actual.get(5)).getColumn().getOriginalColumn().getValue(), is("user_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(5)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
+        assertThat(((ColumnProjectionSegment) actual.get(6)).getColumn().getOriginalColumn().getValue(), is("status"));
+        assertThat(((ColumnProjectionSegment) actual.get(6)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
     }
     
     @Test
@@ -88,7 +113,7 @@ class JoinTableSegmentBinderTest {
         assertTrue(actual.getRight() instanceof SimpleTableSegment);
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalDatabase().getValue(), is(DefaultDatabase.LOGIC_NAME));
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalSchema().getValue(), is(DefaultDatabase.LOGIC_NAME));
-        assertThat(actual.getJoinTableProjectionSegments().size(), is(7));
+        assertJoinTableProjectionSegments(actual.getJoinTableProjectionSegments());
         assertTrue(tableBinderContexts.containsKey("t_order"));
         assertTrue(tableBinderContexts.containsKey("t_order_item"));
     }
@@ -113,9 +138,23 @@ class JoinTableSegmentBinderTest {
         assertTrue(actual.getRight() instanceof SimpleTableSegment);
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalDatabase().getValue(), is(DefaultDatabase.LOGIC_NAME));
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalSchema().getValue(), is(DefaultDatabase.LOGIC_NAME));
-        assertThat(actual.getJoinTableProjectionSegments().size(), is(4));
+        assertJoinTableProjectionSegmentsWithNaturalJoin(actual.getJoinTableProjectionSegments());
         assertTrue(tableBinderContexts.containsKey("o"));
         assertTrue(tableBinderContexts.containsKey("i"));
+    }
+    
+    private void assertJoinTableProjectionSegmentsWithNaturalJoin(final Collection<ProjectionSegment> joinTableProjectionSegments) {
+        List<ProjectionSegment> actual = new ArrayList<>(joinTableProjectionSegments);
+        assertThat(actual.size(), is(4));
+        assertTrue(actual.get(0) instanceof ColumnProjectionSegment);
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalColumn().getValue(), is("order_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalColumn().getValue(), is("user_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalColumn().getValue(), is("status"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalColumn().getValue(), is("item_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
     }
     
     @Test
@@ -138,9 +177,25 @@ class JoinTableSegmentBinderTest {
         assertTrue(actual.getRight() instanceof SimpleTableSegment);
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalDatabase().getValue(), is(DefaultDatabase.LOGIC_NAME));
         assertThat(((SimpleTableSegment) actual.getRight()).getTableName().getOriginalSchema().getValue(), is(DefaultDatabase.LOGIC_NAME));
-        assertThat(actual.getJoinTableProjectionSegments().size(), is(5));
+        assertJoinTableProjectionSegmentsWithUsing(actual.getJoinTableProjectionSegments());
         assertTrue(tableBinderContexts.containsKey("o"));
         assertTrue(tableBinderContexts.containsKey("i"));
+    }
+    
+    private void assertJoinTableProjectionSegmentsWithUsing(final Collection<ProjectionSegment> joinTableProjectionSegments) {
+        List<ProjectionSegment> actual = new ArrayList<>(joinTableProjectionSegments);
+        assertThat(actual.size(), is(5));
+        assertTrue(actual.get(0) instanceof ColumnProjectionSegment);
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalColumn().getValue(), is("status"));
+        assertThat(((ColumnProjectionSegment) actual.get(0)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalColumn().getValue(), is("order_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(1)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalColumn().getValue(), is("user_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(2)).getColumn().getOriginalTable().getValue(), is("t_order"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalColumn().getValue(), is("item_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(3)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
+        assertThat(((ColumnProjectionSegment) actual.get(4)).getColumn().getOriginalColumn().getValue(), is("user_id"));
+        assertThat(((ColumnProjectionSegment) actual.get(4)).getColumn().getOriginalTable().getValue(), is("t_order_item"));
     }
     
     private ShardingSphereMetaData createMetaData() {

--- a/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/NoResourceShowExecutor.java
+++ b/proxy/backend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/backend/mysql/handler/admin/executor/NoResourceShowExecutor.java
@@ -60,7 +60,7 @@ public final class NoResourceShowExecutor implements DatabaseAdminQueryExecutor 
     public void execute(final ConnectionSession connectionSession) {
         TableSegment tableSegment = sqlStatement.getFrom();
         expressions = sqlStatement.getProjections().getProjections().stream().filter(each -> !(each instanceof ShorthandProjectionSegment))
-                .map(each -> new ProjectionEngine(null, Collections.emptyMap(), null).createProjection(tableSegment, each))
+                .map(each -> new ProjectionEngine(null).createProjection(tableSegment, each))
                 .filter(Optional::isPresent).map(each -> each.get().getAlias().isPresent() ? each.get().getAlias().get() : each.get().getExpression()).collect(Collectors.toList());
         mergedResult = new TransparentMergedResult(getQueryResult());
     }

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -44,7 +44,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`assisted_query_certificate_number`, a.`cipher_password` AS `password`, a.`assisted_query_password`, a.`cipher_amount` AS `amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password` AS `password`, `a`.`assisted_query_password`, `a`.`cipher_amount` AS `amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project" db-types="MySQL">


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Remove useless projection logic in ProjectionContext and use bounded sql statement
  - add unit test for JoinTableSegmentBinder

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
