### PR TITLE
Fix shorthand expand wrong column name when subquery projection contains alias

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/SubqueryTableSegmentBinder.java
@@ -17,6 +17,7 @@
 
 package org.apache.shardingsphere.infra.binder.segment.from.impl;
 
+import com.google.common.base.Strings;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.segment.from.TableSegmentBinderContext;
@@ -78,16 +79,17 @@ public final class SubqueryTableSegmentBinder {
         return result;
     }
     
-    private static ColumnProjectionSegment createColumnProjection(final ColumnProjectionSegment originalColumnProjection, final IdentifierValue subqueryTableName) {
-        ColumnSegment originalColumnSegment = originalColumnProjection.getColumn();
-        ColumnSegment newColumnSegment = new ColumnSegment(0, 0, originalColumnSegment.getIdentifier());
-        newColumnSegment.setOwner(new OwnerSegment(0, 0, subqueryTableName));
-        newColumnSegment.setOriginalColumn(originalColumnSegment.getOriginalColumn());
-        newColumnSegment.setOriginalTable(originalColumnSegment.getOriginalTable());
-        newColumnSegment.setOriginalSchema(originalColumnSegment.getOriginalSchema());
-        newColumnSegment.setOriginalDatabase(originalColumnSegment.getOriginalDatabase());
+    private static ColumnProjectionSegment createColumnProjection(final ColumnProjectionSegment originalColumn, final IdentifierValue subqueryTableName) {
+        ColumnSegment newColumnSegment = new ColumnSegment(0, 0, originalColumn.getAlias().orElseGet(() -> originalColumn.getColumn().getIdentifier()));
+        if (!Strings.isNullOrEmpty(subqueryTableName.getValue())) {
+            newColumnSegment.setOwner(new OwnerSegment(0, 0, subqueryTableName));
+        }
+        newColumnSegment.setOriginalColumn(originalColumn.getColumn().getOriginalColumn());
+        newColumnSegment.setOriginalTable(originalColumn.getColumn().getOriginalTable());
+        newColumnSegment.setOriginalSchema(originalColumn.getColumn().getOriginalSchema());
+        newColumnSegment.setOriginalDatabase(originalColumn.getColumn().getOriginalDatabase());
         ColumnProjectionSegment result = new ColumnProjectionSegment(newColumnSegment);
-        result.setVisible(originalColumnProjection.isVisible());
+        result.setVisible(originalColumn.isVisible());
         return result;
     }
 }


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Fix shorthand expand wrong column name when subquery projection contains alias
  - add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
