### PR TITLE
[Oracle SQL] Support HR-7-1 of Oracle SQL

### DIFF
--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -152,6 +152,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.Number
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.parametermarker.ParameterMarkerValue;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLSelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dml.OracleSelectStatement;
 
 import java.util.ArrayList;
@@ -405,8 +406,18 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
     
     private ASTNode createCompareSegment(final BooleanPrimaryContext ctx) {
         ExpressionSegment left = (ExpressionSegment) visit(ctx.booleanPrimary());
-        String operator = null == ctx.SAFE_EQ_() ? ctx.comparisonOperator().getText() : ctx.SAFE_EQ_().getText();
-        ExpressionSegment right = null != ctx.predicate() ? (ExpressionSegment) visit(ctx.predicate()) : (ExpressionSegment) visit(ctx.subquery());
+        ExpressionSegment right;
+        String operator;
+        if (null != ctx.ALL()) {
+            operator = null != ctx.SAFE_EQ_() ? ctx.SAFE_EQ_().getText() : ctx.comparisonOperator().getText() + " ALL";
+        } else {
+            operator = null != ctx.SAFE_EQ_() ? ctx.SAFE_EQ_().getText() : ctx.comparisonOperator().getText();
+        }
+        if (null != ctx.predicate()) {
+            right = (ExpressionSegment) visit(ctx.predicate());
+        } else {
+            right = new SubqueryExpressionSegment(new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), (OracleSelectStatement) visit(ctx.subquery())));
+        }
         String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
         return new BinaryOperationExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), left, right, operator, text);
     }

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -152,7 +152,6 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.Number
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.OtherLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.literal.impl.StringLiteralValue;
 import org.apache.shardingsphere.sql.parser.sql.common.value.parametermarker.ParameterMarkerValue;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLSelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dml.OracleSelectStatement;
 
 import java.util.ArrayList;

--- a/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-sub-query.xml
@@ -187,6 +187,53 @@
         </where>
     </select>
 
+    <select sql-case-id="select_with_any_subquery">
+        <from>
+            <simple-table name="employees" start-index="14" stop-index="22" />
+        </from>
+        <projections start-index="7" stop-index="7">
+            <shorthand-projection start-index="7" stop-index="7" />
+        </projections>
+        <where start-index="24" stop-index="97">
+            <expr>
+                <binary-operation-expression start-index="30" stop-index="97">
+                    <left>
+                        <column name="salary" start-index="30" stop-index="35" />
+                    </left>
+                    <operator>=</operator>
+                    <right>
+                        <subquery start-index="43" stop-index="97">
+                            <select>
+                                <from start-index="63" stop-index="71">
+                                    <simple-table name="employees" start-index="63" stop-index="71"/>
+                                </from>
+                                <projections start-index="51" stop-index="56">
+                                    <column-projection name="salary" start-index="51" stop-index="56"/>
+                                </projections>
+                                <where start-index="73" stop-index="96">
+                                    <expr>
+                                        <binary-operation-expression start-index="79" stop-index="96">
+                                            <left>
+                                                <column name="department_id" start-index="79" stop-index="91" />
+                                            </left>
+                                            <operator>=</operator>
+                                            <right>
+                                                <literal-expression value="30" start-index="95" stop-index="96" />
+                                            </right>
+                                        </binary-operation-expression>
+                                    </expr>
+                                </where>
+                            </select>
+                        </subquery>
+                    </right>
+                </binary-operation-expression>
+            </expr>
+        </where>
+        <order-by>
+            <column-item name="employee_id" order-direction="ASC" start-index="108" stop-index="118" />
+        </order-by>
+    </select>
+
     <select sql-case-id="select_with_in_subquery">
         <from>
             <simple-table name="t_order" start-index="14" stop-index="20" />

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-sub-query.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-sub-query.xml
@@ -21,6 +21,7 @@
     <sql-case id="select_sub_query_with_project" value="SELECT order_id, (SELECT 1) AS num FROM t_order" db-types="MySQL, PostgreSQL,openGauss, SQLServer" />
     <sql-case id="select_sub_query_with_table" value="SELECT t.* FROM (SELECT * FROM t_order WHERE order_id IN (?, ?)) t" />
     <sql-case id="select_with_equal_subquery" value="SELECT * FROM t_order WHERE user_id = (SELECT user_id FROM t_order_item WHERE id = 10)" db-types="MySQL, PostgreSQL,openGauss" />
+    <sql-case id="select_with_any_subquery" value="SELECT * FROM employees WHERE salary = ANY (SELECT salary FROM employees WHERE department_id = 30) ORDER BY employee_id;" db-types="Oracle" />
     <sql-case id="select_with_in_subquery" value="SELECT * FROM t_order WHERE user_id IN (SELECT user_id FROM t_order_item WHERE id IN (10, 11))" db-types="MySQL, PostgreSQL,openGauss" />
     <sql-case id="select_with_between_subquery" value="SELECT * FROM t_order WHERE user_id BETWEEN (SELECT user_id FROM t_order_item WHERE order_id = 10) AND ?" db-types="MySQL, PostgreSQL,openGauss" />
     <sql-case id="select_with_exists_sub_query_with_project" value="SELECT EXISTS (SELECT 1 FROM t_order)" db-types="MySQL, PostgreSQL,openGauss" />


### PR DESCRIPTION
The following SQL can not be parsed because createCompareSegment deals with Subquery wrongly.
```SELECT * FROM employees WHERE salary = ANY (SELECT salary FROM employees WHERE department_id = 30) ORDER BY employee_id;```
I referred to the createCompareSegment method of MySQLStatementVisitor and fixed the createCompareSegment of OracleStatementVisitor.
<img width="1030" alt="截屏2023-08-01 13 13 17" src="https://github.com/apache/shardingsphere/assets/108499334/24709dbd-a7c4-4d56-9d39-20313c0956c1">
