### PR TITLE
Add default data type `VARCHAR(4000)` for encrypt columns.

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptColumnDataType.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/constant/EncryptColumnDataType.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.constant;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Encrypt column data type.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class EncryptColumnDataType {
+    
+    public static final String DEFAULT_DATA_TYPE = "VARCHAR(4000)";
+}

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGenerator.java
@@ -19,9 +19,11 @@ package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
 import lombok.Setter;
 import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.constant.EncryptColumnDataType;
 import org.apache.shardingsphere.encrypt.exception.metadata.EncryptColumnAlterException;
 import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
 import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptAlterTableToken;
+import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptColumnToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
@@ -104,13 +106,13 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     private Collection<SQLToken> getAddColumnTokens(final EncryptColumn encryptColumn,
                                                     final AddColumnDefinitionSegment addColumnDefinitionSegment, final ColumnDefinitionSegment columnDefinitionSegment) {
         Collection<SQLToken> result = new LinkedList<>();
-        result.add(new RemoveToken(columnDefinitionSegment.getStartIndex(), columnDefinitionSegment.getColumnName().getStopIndex()));
-        result.add(new EncryptAlterTableToken(columnDefinitionSegment.getColumnName().getStopIndex() + 1, columnDefinitionSegment.getColumnName().getStopIndex(),
-                encryptColumn.getCipher().getName(), null));
-        encryptColumn.getAssistedQuery().map(optional -> new EncryptAlterTableToken(
-                addColumnDefinitionSegment.getStopIndex() + 1, columnDefinitionSegment.getColumnName().getStopIndex(), optional.getName(), ", ADD COLUMN")).ifPresent(result::add);
-        encryptColumn.getLikeQuery().map(optional -> new EncryptAlterTableToken(
-                addColumnDefinitionSegment.getStopIndex() + 1, columnDefinitionSegment.getColumnName().getStopIndex(), optional.getName(), ", ADD COLUMN")).ifPresent(result::add);
+        result.add(new RemoveToken(columnDefinitionSegment.getStartIndex(), columnDefinitionSegment.getStopIndex()));
+        result.add(new EncryptColumnToken(columnDefinitionSegment.getStopIndex() + 1, columnDefinitionSegment.getStopIndex(),
+                encryptColumn.getCipher().getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE));
+        encryptColumn.getAssistedQuery().map(optional -> new EncryptColumnToken(addColumnDefinitionSegment.getStopIndex() + 1,
+                addColumnDefinitionSegment.getStopIndex(), ", ADD COLUMN " + optional.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE)).ifPresent(result::add);
+        encryptColumn.getLikeQuery().map(optional -> new EncryptColumnToken(addColumnDefinitionSegment.getStopIndex() + 1,
+                addColumnDefinitionSegment.getStopIndex(), ", ADD COLUMN " + optional.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE)).ifPresent(result::add);
         return result;
     }
     
@@ -204,13 +206,15 @@ public final class EncryptAlterTableTokenGenerator implements CollectionSQLToken
     
     private Collection<SQLToken> getColumnTokens(final EncryptColumn previousEncryptColumn, final EncryptColumn encryptColumn, final ChangeColumnDefinitionSegment segment) {
         Collection<SQLToken> result = new LinkedList<>();
-        result.add(new RemoveToken(segment.getColumnDefinition().getColumnName().getStartIndex(), segment.getColumnDefinition().getColumnName().getStopIndex()));
-        result.add(new EncryptAlterTableToken(segment.getColumnDefinition().getColumnName().getStopIndex() + 1, segment.getColumnDefinition().getColumnName().getStopIndex(),
-                encryptColumn.getCipher().getName(), null));
-        previousEncryptColumn.getAssistedQuery().map(optional -> new EncryptAlterTableToken(segment.getStopIndex() + 1, segment.getColumnDefinition().getColumnName().getStopIndex(),
-                encryptColumn.getAssistedQuery().map(AssistedQueryColumnItem::getName).orElse(""), ", CHANGE COLUMN " + optional.getName())).ifPresent(result::add);
-        previousEncryptColumn.getLikeQuery().map(optional -> new EncryptAlterTableToken(segment.getStopIndex() + 1, segment.getColumnDefinition().getColumnName().getStopIndex(),
-                encryptColumn.getLikeQuery().map(LikeQueryColumnItem::getName).orElse(""), ", CHANGE COLUMN " + optional.getName())).ifPresent(result::add);
+        result.add(new RemoveToken(segment.getColumnDefinition().getColumnName().getStartIndex(), segment.getColumnDefinition().getStopIndex()));
+        result.add(new EncryptColumnToken(segment.getColumnDefinition().getStopIndex() + 1, segment.getColumnDefinition().getStopIndex(),
+                encryptColumn.getCipher().getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE));
+        previousEncryptColumn.getAssistedQuery().map(optional -> new EncryptColumnToken(segment.getStopIndex() + 1, segment.getStopIndex(),
+                ", CHANGE COLUMN " + optional.getName() + " " + encryptColumn.getAssistedQuery().map(AssistedQueryColumnItem::getName).orElse(""),
+                EncryptColumnDataType.DEFAULT_DATA_TYPE)).ifPresent(result::add);
+        previousEncryptColumn.getLikeQuery().map(optional -> new EncryptColumnToken(segment.getStopIndex() + 1, segment.getStopIndex(),
+                ", CHANGE COLUMN " + optional.getName() + " " + encryptColumn.getLikeQuery().map(LikeQueryColumnItem::getName).orElse(""),
+                EncryptColumnDataType.DEFAULT_DATA_TYPE)).ifPresent(result::add);
         return result;
     }
     

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGenerator.java
@@ -18,26 +18,22 @@
 package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 
 import lombok.Setter;
-import org.apache.shardingsphere.encrypt.rewrite.aware.DatabaseTypeAware;
+import org.apache.shardingsphere.encrypt.constant.EncryptColumnDataType;
 import org.apache.shardingsphere.encrypt.rewrite.aware.EncryptRuleAware;
+import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptColumnToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
-import org.apache.shardingsphere.infra.binder.context.segment.select.projection.impl.ColumnProjection;
+import org.apache.shardingsphere.encrypt.rule.column.item.CipherColumnItem;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableStatementContext;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.rewrite.sql.token.generator.CollectionSQLTokenGenerator;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.RemoveToken;
-import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.SubstitutableColumnNameToken;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
-import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -46,11 +42,9 @@ import java.util.Optional;
  * Create table token generator for encrypt.
  */
 @Setter
-public final class EncryptCreateTableTokenGenerator implements CollectionSQLTokenGenerator<CreateTableStatementContext>, EncryptRuleAware, DatabaseTypeAware {
+public final class EncryptCreateTableTokenGenerator implements CollectionSQLTokenGenerator<CreateTableStatementContext>, EncryptRuleAware {
     
     private EncryptRule encryptRule;
-    
-    private DatabaseType databaseType;
     
     @Override
     public boolean isGenerateSQLToken(final SQLStatementContext sqlStatementContext) {
@@ -85,21 +79,17 @@ public final class EncryptCreateTableTokenGenerator implements CollectionSQLToke
     }
     
     private SQLToken getCipherColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column, final int stopIndex) {
-        return new SubstitutableColumnNameToken(stopIndex + 1, column.getColumnName().getStopIndex(),
-                getColumnProjections(new IdentifierValue(encryptColumn.getCipher().getName(), column.getColumnName().getIdentifier().getQuoteCharacter())));
+        CipherColumnItem cipherColumnItem = encryptColumn.getCipher();
+        return new EncryptColumnToken(stopIndex + 1, column.getStopIndex(), cipherColumnItem.getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE);
     }
     
     private Optional<? extends SQLToken> getAssistedQueryColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column, final int stopIndex, final boolean lastColumn) {
-        return encryptColumn.getAssistedQuery().map(optional -> new SubstitutableColumnNameToken(stopIndex + 1, column.getColumnName().getStopIndex(),
-                getColumnProjections(new IdentifierValue(optional.getName(), column.getColumnName().getIdentifier().getQuoteCharacter())), lastColumn));
+        return encryptColumn.getAssistedQuery()
+                .map(optional -> new EncryptColumnToken(stopIndex + 1, column.getStopIndex(), encryptColumn.getAssistedQuery().get().getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE, lastColumn));
     }
     
     private Optional<? extends SQLToken> getLikeQueryColumnToken(final EncryptColumn encryptColumn, final ColumnDefinitionSegment column, final int stopIndex, final boolean lastColumn) {
-        return encryptColumn.getLikeQuery().map(optional -> new SubstitutableColumnNameToken(stopIndex + 1, column.getColumnName().getStopIndex(),
-                getColumnProjections(new IdentifierValue(optional.getName(), column.getColumnName().getIdentifier().getQuoteCharacter())), lastColumn));
-    }
-    
-    private Collection<Projection> getColumnProjections(final IdentifierValue columnIdentifier) {
-        return Collections.singleton(new ColumnProjection(null, columnIdentifier, null, databaseType));
+        return encryptColumn.getLikeQuery()
+                .map(optional -> new EncryptColumnToken(stopIndex + 1, column.getStopIndex(), encryptColumn.getLikeQuery().get().getName(), EncryptColumnDataType.DEFAULT_DATA_TYPE, lastColumn));
     }
 }

--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptColumnToken.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/pojo/EncryptColumnToken.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.encrypt.rewrite.token.pojo;
+
+import lombok.Getter;
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
+import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.Substitutable;
+
+/**
+ * Column token for encrypt.
+ */
+@Getter
+public final class EncryptColumnToken extends SQLToken implements Substitutable {
+    
+    private final int stopIndex;
+    
+    private final String columnName;
+    
+    private final String dataType;
+    
+    private final boolean lastColumn;
+    
+    public EncryptColumnToken(final int startIndex, final int stopIndex, final String columnName, final String dataType) {
+        this(startIndex, stopIndex, columnName, dataType, false);
+    }
+    
+    public EncryptColumnToken(final int startIndex, final int stopIndex, final String columnName, final String dataType, final boolean lastColumn) {
+        super(startIndex);
+        this.stopIndex = stopIndex;
+        this.columnName = columnName;
+        this.dataType = dataType;
+        this.lastColumn = lastColumn;
+    }
+    
+    @Override
+    public String toString() {
+        return lastColumn ? String.format(", %s %s", columnName, dataType) : String.format("%s %s", columnName, dataType);
+    }
+}

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptAlterTableTokenGeneratorTest.java
@@ -20,7 +20,7 @@ package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 import org.apache.shardingsphere.encrypt.api.encrypt.assisted.AssistedEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
-import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptAlterTableToken;
+import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptColumnToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
@@ -99,18 +99,18 @@ class EncryptAlterTableTokenGeneratorTest {
         assertThat(actual.size(), is(4));
         Iterator<SQLToken> actualIterator = actual.iterator();
         assertThat(actualIterator.next(), instanceOf(RemoveToken.class));
-        EncryptAlterTableToken cipherToken = (EncryptAlterTableToken) actualIterator.next();
-        assertThat(cipherToken.toString(), is("cipher_certificate_number"));
-        assertThat(cipherToken.getStartIndex(), is(51));
-        assertThat(cipherToken.getStopIndex(), is(50));
-        EncryptAlterTableToken assistedToken = (EncryptAlterTableToken) actualIterator.next();
-        assertThat(assistedToken.toString(), is(", ADD COLUMN assisted_certificate_number"));
+        EncryptColumnToken cipherToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(cipherToken.toString(), is("cipher_certificate_number VARCHAR(4000)"));
+        assertThat(cipherToken.getStartIndex(), is(68));
+        assertThat(cipherToken.getStopIndex(), is(67));
+        EncryptColumnToken assistedToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(assistedToken.toString(), is(", ADD COLUMN assisted_certificate_number VARCHAR(4000)"));
         assertThat(assistedToken.getStartIndex(), is(68));
-        assertThat(assistedToken.getStopIndex(), is(50));
-        EncryptAlterTableToken likeToken = (EncryptAlterTableToken) actualIterator.next();
-        assertThat(likeToken.toString(), is(", ADD COLUMN like_certificate_number"));
+        assertThat(assistedToken.getStopIndex(), is(67));
+        EncryptColumnToken likeToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(likeToken.toString(), is(", ADD COLUMN like_certificate_number VARCHAR(4000)"));
         assertThat(likeToken.getStartIndex(), is(68));
-        assertThat(likeToken.getStopIndex(), is(50));
+        assertThat(likeToken.getStopIndex(), is(67));
     }
     
     private AlterTableStatementContext mockAddColumnStatementContext() {

--- a/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGeneratorTest.java
+++ b/features/encrypt/core/src/test/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptCreateTableTokenGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.encrypt.rewrite.token.generator;
 import org.apache.shardingsphere.encrypt.api.encrypt.assisted.AssistedEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.api.encrypt.like.LikeEncryptAlgorithm;
 import org.apache.shardingsphere.encrypt.api.encrypt.standard.StandardEncryptAlgorithm;
+import org.apache.shardingsphere.encrypt.rewrite.token.pojo.EncryptColumnToken;
 import org.apache.shardingsphere.encrypt.rule.EncryptRule;
 import org.apache.shardingsphere.encrypt.rule.EncryptTable;
 import org.apache.shardingsphere.encrypt.rule.column.EncryptColumn;
@@ -29,8 +30,6 @@ import org.apache.shardingsphere.encrypt.rule.column.item.LikeQueryColumnItem;
 import org.apache.shardingsphere.infra.binder.context.statement.ddl.CreateTableStatementContext;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.SQLToken;
 import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.RemoveToken;
-import org.apache.shardingsphere.infra.rewrite.sql.token.pojo.generic.SubstitutableColumnNameToken;
-import org.apache.shardingsphere.infra.route.context.RouteUnit;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DataTypeSegment;
@@ -86,18 +85,18 @@ class EncryptCreateTableTokenGeneratorTest {
         assertThat(actual.size(), is(4));
         Iterator<SQLToken> actualIterator = actual.iterator();
         assertThat(actualIterator.next(), instanceOf(RemoveToken.class));
-        SubstitutableColumnNameToken cipherToken = (SubstitutableColumnNameToken) actualIterator.next();
-        assertThat(cipherToken.toString(mock(RouteUnit.class)), is("cipher_certificate_number"));
+        EncryptColumnToken cipherToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(cipherToken.toString(), is("cipher_certificate_number VARCHAR(4000)"));
         assertThat(cipherToken.getStartIndex(), is(79));
-        assertThat(cipherToken.getStopIndex(), is(42));
-        SubstitutableColumnNameToken assistedToken = (SubstitutableColumnNameToken) actualIterator.next();
-        assertThat(assistedToken.toString(mock(RouteUnit.class)), is(", assisted_certificate_number"));
+        assertThat(cipherToken.getStopIndex(), is(78));
+        EncryptColumnToken assistedToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(assistedToken.toString(), is(", assisted_certificate_number VARCHAR(4000)"));
         assertThat(assistedToken.getStartIndex(), is(79));
-        assertThat(assistedToken.getStopIndex(), is(42));
-        SubstitutableColumnNameToken likeToken = (SubstitutableColumnNameToken) actualIterator.next();
-        assertThat(likeToken.toString(mock(RouteUnit.class)), is(", like_certificate_number"));
+        assertThat(assistedToken.getStopIndex(), is(78));
+        EncryptColumnToken likeToken = (EncryptColumnToken) actualIterator.next();
+        assertThat(likeToken.toString(), is(", like_certificate_number VARCHAR(4000)"));
         assertThat(likeToken.getStartIndex(), is(79));
-        assertThat(likeToken.getStopIndex(), is(42));
+        assertThat(likeToken.getStopIndex(), is(78));
     }
     
     private CreateTableStatementContext mockCreateTableStatementContext() {

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/ddl/alter/alter-table.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/ddl/alter/alter-table.xml
@@ -29,12 +29,12 @@
 
     <rewrite-assertion id="alter_table_add_column_with_cipher" db-types="MySQL">
         <input sql="ALTER TABLE t_account ADD COLUMN amount INT" />
-        <output sql="ALTER TABLE t_account ADD COLUMN cipher_amount INT" />
+        <output sql="ALTER TABLE t_account ADD COLUMN cipher_amount VARCHAR(4000)" />
     </rewrite-assertion>
     
     <rewrite-assertion id="alter_table_add_column_for_cipher" db-types="MySQL">
         <input sql="ALTER TABLE t_account_bak ADD COLUMN id int not null, ADD COLUMN password varchar(255) not null default ''" />
-        <output sql="ALTER TABLE t_account_bak ADD COLUMN id int not null, ADD COLUMN cipher_password varchar(255) not null default '', ADD COLUMN assisted_query_password varchar(255) not null default '', ADD COLUMN like_query_password varchar(255) not null default ''" />
+        <output sql="ALTER TABLE t_account_bak ADD COLUMN id int not null, ADD COLUMN cipher_password VARCHAR(4000), ADD COLUMN assisted_query_password VARCHAR(4000), ADD COLUMN like_query_password VARCHAR(4000)" />
     </rewrite-assertion>
     
     <rewrite-assertion id="alter_table_add_index_for_cipher" db-types="MySQL">

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/ddl/create/create-table.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/ddl/create/create-table.xml
@@ -19,11 +19,11 @@
 <rewrite-assertions yaml-rule="scenario/encrypt/config/query-with-cipher.yaml">
     <rewrite-assertion id="create_table_for_cipher" db-types="MySQL">
         <input sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', password VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (`id`))" />
-        <output sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', cipher_password VARCHAR(255) NOT NULL DEFAULT '', assisted_query_password VARCHAR(255) NOT NULL DEFAULT '', like_query_password VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (`id`))" />
+        <output sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), like_query_password VARCHAR(4000), PRIMARY KEY (`id`))" />
     </rewrite-assertion>
 
     <rewrite-assertion id="create_table_with_index_for_cipher" db-types="MySQL">
         <input sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', password VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (`id`), KEY `t_account_bak_amount_idx` (`amount`))" />
-        <output sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', cipher_password VARCHAR(255) NOT NULL DEFAULT '', assisted_query_password VARCHAR(255) NOT NULL DEFAULT '', like_query_password VARCHAR(255) NOT NULL DEFAULT '', PRIMARY KEY (`id`), KEY `t_account_bak_amount_idx` (`cipher_amount`))" />
+        <output sql="CREATE TABLE t_account_bak (id INT NOT NULL, name VARCHAR(100) NOT NULL DEFAULT '', cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), like_query_password VARCHAR(4000), PRIMARY KEY (`id`), KEY `t_account_bak_amount_idx` (`cipher_amount`))" />
     </rewrite-assertion>
 </rewrite-assertions>

--- a/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/ddl/create/create-table.xml
+++ b/test/it/rewriter/src/test/resources/scenario/mix/case/query-with-cipher/ddl/create/create-table.xml
@@ -19,25 +19,25 @@
 <rewrite-assertions yaml-rule="scenario/mix/config/query-with-cipher.yaml">
     <rewrite-assertion id="create_table_with_single_cipher_column" db-types="MySQL">
         <input sql="CREATE TABLE t_account_detail_new(account_id INT, password VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_0(account_id INT, cipher_password VARCHAR(100), assisted_query_password VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_1(account_id INT, cipher_password VARCHAR(100), assisted_query_password VARCHAR(100));" />
+        <output sql="CREATE TABLE t_account_detail_new_0(account_id INT, cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000));" />
+        <output sql="CREATE TABLE t_account_detail_new_1(account_id INT, cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000));" />
     </rewrite-assertion>
     
     <rewrite-assertion id="create_table_with_multi_cipher_column" db-types="MySQL">
         <input sql="CREATE TABLE t_account_detail_new(account_id INT, password VARCHAR(100), amount VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_0(account_id INT, cipher_password VARCHAR(100), assisted_query_password VARCHAR(100), cipher_amount VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_1(account_id INT, cipher_password VARCHAR(100), assisted_query_password VARCHAR(100), cipher_amount VARCHAR(100));" />
+        <output sql="CREATE TABLE t_account_detail_new_0(account_id INT, cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), cipher_amount VARCHAR(4000));" />
+        <output sql="CREATE TABLE t_account_detail_new_1(account_id INT, cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), cipher_amount VARCHAR(4000));" />
     </rewrite-assertion>
     
     <rewrite-assertion id="create_table_with_all_cipher_column" db-types="MySQL">
         <input sql="CREATE TABLE t_account_detail_new(password VARCHAR(100), amount VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_0(cipher_password VARCHAR(100), assisted_query_password VARCHAR(100), cipher_amount VARCHAR(100));" />
-        <output sql="CREATE TABLE t_account_detail_new_1(cipher_password VARCHAR(100), assisted_query_password VARCHAR(100), cipher_amount VARCHAR(100));" />
+        <output sql="CREATE TABLE t_account_detail_new_0(cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), cipher_amount VARCHAR(4000));" />
+        <output sql="CREATE TABLE t_account_detail_new_1(cipher_password VARCHAR(4000), assisted_query_password VARCHAR(4000), cipher_amount VARCHAR(4000));" />
     </rewrite-assertion>
     
     <rewrite-assertion id="create_table_with_random_blank_cipher_column" db-types="MySQL">
         <input sql="CREATE TABLE t_account_detail_new( account_id INT  , password VARCHAR(100) ,  amount VARCHAR(100)); " />
-        <output sql="CREATE TABLE t_account_detail_new_0( account_id INT  , cipher_password VARCHAR(100) ,  assisted_query_password VARCHAR(100) ,  cipher_amount VARCHAR(100)); " />
-        <output sql="CREATE TABLE t_account_detail_new_1( account_id INT  , cipher_password VARCHAR(100) ,  assisted_query_password VARCHAR(100) ,  cipher_amount VARCHAR(100)); " />
+        <output sql="CREATE TABLE t_account_detail_new_0( account_id INT  , cipher_password VARCHAR(4000) ,  assisted_query_password VARCHAR(4000) ,  cipher_amount VARCHAR(4000)); " />
+        <output sql="CREATE TABLE t_account_detail_new_1( account_id INT  , cipher_password VARCHAR(4000) ,  assisted_query_password VARCHAR(4000) ,  cipher_amount VARCHAR(4000)); " />
     </rewrite-assertion>
 </rewrite-assertions>


### PR DESCRIPTION
Fixes #27587

Changes proposed in this pull request:
  - Add default data type `VARCHAR(4000)` for encrypt columns.

### Reference
- In MySQL, the maximum length of varchar is variable, determined by the character set (greater than 10000)
  - https://dev.mysql.com/doc/refman/8.0/en/char.html 
- In PG, the maximum length of varchar is 10485760
  - https://www.postgresql.org/docs/15/datatype-character.html
- In Oracle, varchar has a maximum length of 4000 (VARCHAR data type is currently synonymous with VARCHAR2)
  - https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-7B72E154-677A-4342-A1EA-C74C1EA928E6

### Test
- MySQL
<img width="903" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/5733d1a5-fb6c-43b8-ba32-d2b1f267a5f5">

- PG
<img width="654" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/4058376d-2417-4971-b29d-2c480922a279">

- Oracle
<img width="781" alt="image" src="https://github.com/apache/shardingsphere/assets/5668787/68b0a34e-836f-4191-9931-8bd677fdbbb6">

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
