### PR TITLE
Refactor e2e jdbc rule config load logic to support database special config

### DIFF
--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/AdapterContainerFactory.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/AdapterContainerFactory.java
@@ -54,7 +54,7 @@ public final class AdapterContainerFactory {
                         ? new ShardingSphereProxyClusterContainer(databaseType, containerConfig)
                         : new ShardingSphereProxyStandaloneContainer(databaseType, containerConfig);
             case JDBC:
-                return new ShardingSphereJdbcContainer(storageContainer, scenario);
+                return new ShardingSphereJdbcContainer(storageContainer, scenario, databaseType);
             default:
                 throw new RuntimeException(String.format("Unknown adapter `%s`.", adapter));
         }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/impl/ShardingSphereJdbcContainer.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/atomic/adapter/impl/ShardingSphereJdbcContainer.java
@@ -20,6 +20,7 @@ package org.apache.shardingsphere.test.e2e.env.container.atomic.adapter.impl;
 import com.google.common.base.Strings;
 import lombok.SneakyThrows;
 import org.apache.shardingsphere.driver.api.yaml.YamlShardingSphereDataSourceFactory;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.util.yaml.YamlEngine;
 import org.apache.shardingsphere.infra.yaml.config.pojo.YamlRootConfiguration;
 import org.apache.shardingsphere.infra.yaml.config.pojo.mode.YamlModeConfiguration;
@@ -45,11 +46,14 @@ public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, A
     
     private final ScenarioCommonPath scenarioCommonPath;
     
+    private final DatabaseType databaseType;
+    
     private final AtomicReference<DataSource> targetDataSourceProvider = new AtomicReference<>();
     
-    public ShardingSphereJdbcContainer(final StorageContainer storageContainer, final String scenario) {
+    public ShardingSphereJdbcContainer(final StorageContainer storageContainer, final String scenario, final DatabaseType databaseType) {
         this.storageContainer = storageContainer;
         scenarioCommonPath = new ScenarioCommonPath(scenario);
+        this.databaseType = databaseType;
     }
     
     @Override
@@ -63,7 +67,7 @@ public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, A
             if (Strings.isNullOrEmpty(serverLists)) {
                 try {
                     targetDataSourceProvider.set(
-                            YamlShardingSphereDataSourceFactory.createDataSource(storageContainer.getActualDataSourceMap(), new File(scenarioCommonPath.getRuleConfigurationFile())));
+                            YamlShardingSphereDataSourceFactory.createDataSource(storageContainer.getActualDataSourceMap(), new File(scenarioCommonPath.getRuleConfigurationFile(databaseType))));
                 } catch (final SQLException | IOException ex) {
                     throw new RuntimeException(ex);
                 }
@@ -76,7 +80,7 @@ public final class ShardingSphereJdbcContainer implements EmbeddedITContainer, A
     
     @SneakyThrows({SQLException.class, IOException.class})
     private DataSource createGovernanceClientDataSource(final String serverLists) {
-        YamlRootConfiguration rootConfig = YamlEngine.unmarshal(new File(scenarioCommonPath.getRuleConfigurationFile()), YamlRootConfiguration.class);
+        YamlRootConfiguration rootConfig = YamlEngine.unmarshal(new File(scenarioCommonPath.getRuleConfigurationFile(databaseType)), YamlRootConfiguration.class);
         rootConfig.setMode(createYamlModeConfiguration(serverLists));
         return YamlShardingSphereDataSourceFactory.createDataSource(storageContainer.getActualDataSourceMap(), YamlEngine.marshal(rootConfig).getBytes(StandardCharsets.UTF_8));
     }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/path/ScenarioCommonPath.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/path/ScenarioCommonPath.java
@@ -18,6 +18,7 @@
 package org.apache.shardingsphere.test.e2e.env.runtime.scenario.path;
 
 import lombok.RequiredArgsConstructor;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 
 import java.net.URL;
 
@@ -30,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 public final class ScenarioCommonPath {
     
     private static final String ROOT_PATH = "env/scenario";
+    
+    private static final String DATABASE_ROOT_PATH = "env/scenario/jdbc/conf";
     
     private static final String RULE_CONFIG_FILE = "rules.yaml";
     
@@ -48,10 +51,12 @@ public final class ScenarioCommonPath {
     /**
      * Get rule configuration file.
      *
+     * @param databaseType database type
      * @return rule configuration file
      */
-    public String getRuleConfigurationFile() {
-        return getFile(RULE_CONFIG_FILE);
+    public String getRuleConfigurationFile(final DatabaseType databaseType) {
+        String databaseFileName = String.join("/", DATABASE_ROOT_PATH, databaseType.getType().toLowerCase(), RULE_CONFIG_FILE);
+        return exists(databaseFileName) ? getFile(databaseFileName) : getFile(String.join("/", ROOT_PATH, scenario, RULE_CONFIG_FILE));
     }
     
     /**
@@ -64,9 +69,13 @@ public final class ScenarioCommonPath {
     }
     
     private String getFile(final String fileName) {
-        String path = String.join("/", ROOT_PATH, scenario, fileName);
-        URL url = Thread.currentThread().getContextClassLoader().getResource(path);
-        assertNotNull(url, String.format("File `%s` must exist.", path));
+        URL url = Thread.currentThread().getContextClassLoader().getResource(fileName);
+        assertNotNull(url, String.format("File `%s` must exist.", fileName));
         return url.getFile();
+    }
+    
+    private boolean exists(final String fileName) {
+        URL url = Thread.currentThread().getContextClassLoader().getResource(fileName);
+        return null != url;
     }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/path/ScenarioCommonPath.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/runtime/scenario/path/ScenarioCommonPath.java
@@ -32,8 +32,6 @@ public final class ScenarioCommonPath {
     
     private static final String ROOT_PATH = "env/scenario";
     
-    private static final String DATABASE_ROOT_PATH = "env/scenario/jdbc/conf";
-    
     private static final String RULE_CONFIG_FILE = "rules.yaml";
     
     private static final String AUTHORITY_FILE = "authority.xml";
@@ -55,7 +53,7 @@ public final class ScenarioCommonPath {
      * @return rule configuration file
      */
     public String getRuleConfigurationFile(final DatabaseType databaseType) {
-        String databaseFileName = String.join("/", DATABASE_ROOT_PATH, databaseType.getType().toLowerCase(), RULE_CONFIG_FILE);
+        String databaseFileName = String.join("/", String.format("env/scenario/%s/jdbc/conf", scenario), databaseType.getType().toLowerCase(), RULE_CONFIG_FILE);
         return exists(databaseFileName) ? getFile(databaseFileName) : getFile(String.join("/", ROOT_PATH, scenario, RULE_CONFIG_FILE));
     }
     


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/27287.

Changes proposed in this pull request:
  - Refactor e2e jdbc rule config load logic to support database special config

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
