### PR TITLE
Fix e2e test when case contains dataSourceName sql hint

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/merge/dql/EncryptMergedResult.java
@@ -62,7 +62,7 @@ public final class EncryptMergedResult implements MergedResult {
         }
         TablesContext tablesContext = selectStatementContext.getTablesContext();
         String schemaName = tablesContext.getSchemaName().orElseGet(() -> new DatabaseTypeRegistry(selectStatementContext.getDatabaseType()).getDefaultSchemaName(database.getName()));
-        ColumnProjection originalColumn = new ColumnProjection(columnProjection.get().getOriginalOwner(), columnProjection.get().getOriginalName(), null, selectStatementContext.getDatabaseType());
+        ColumnProjection originalColumn = new ColumnProjection(columnProjection.get().getOriginalTable(), columnProjection.get().getOriginalColumn(), null, selectStatementContext.getDatabaseType());
         Map<String, String> expressionTableNames = tablesContext.findTableNamesByColumnProjection(Collections.singletonList(originalColumn), database.getSchema(schemaName));
         Optional<String> tableName = findTableName(originalColumn, expressionTableNames);
         if (!tableName.isPresent()) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContext.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/ProjectionsContext.java
@@ -124,7 +124,7 @@ public final class ProjectionsContext {
     }
     
     private String getOriginalColumnName(final Projection projection) {
-        return projection instanceof ColumnProjection ? ((ColumnProjection) projection).getOriginalName().getValue() : projection.getExpression();
+        return projection instanceof ColumnProjection ? ((ColumnProjection) projection).getOriginalColumn().getValue() : projection.getExpression();
     }
     
     /**

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
@@ -109,8 +109,11 @@ public final class ProjectionEngine {
     
     private ColumnProjection createProjection(final ColumnProjectionSegment projectionSegment) {
         IdentifierValue owner = projectionSegment.getColumn().getOwner().isPresent() ? projectionSegment.getColumn().getOwner().get().getIdentifier() : null;
-        return new ColumnProjection(owner, projectionSegment.getColumn().getIdentifier(), projectionSegment.getAliasName().isPresent() ? projectionSegment.getAlias().orElse(null) : null,
-                databaseType);
+        IdentifierValue alias = projectionSegment.getAliasName().isPresent() ? projectionSegment.getAlias().orElse(null) : null;
+        ColumnProjection result = new ColumnProjection(owner, projectionSegment.getColumn().getIdentifier(), alias, databaseType);
+        result.setOriginalName(projectionSegment.getColumn().getOriginalColumn());
+        result.setOriginalOwner(projectionSegment.getColumn().getOriginalTable());
+        return result;
     }
     
     private ExpressionProjection createProjection(final ExpressionProjectionSegment projectionSegment) {

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/engine/ProjectionEngine.java
@@ -111,8 +111,8 @@ public final class ProjectionEngine {
         IdentifierValue owner = projectionSegment.getColumn().getOwner().isPresent() ? projectionSegment.getColumn().getOwner().get().getIdentifier() : null;
         IdentifierValue alias = projectionSegment.getAliasName().isPresent() ? projectionSegment.getAlias().orElse(null) : null;
         ColumnProjection result = new ColumnProjection(owner, projectionSegment.getColumn().getIdentifier(), alias, databaseType);
-        result.setOriginalName(projectionSegment.getColumn().getOriginalColumn());
-        result.setOriginalOwner(projectionSegment.getColumn().getOriginalTable());
+        result.setOriginalColumn(projectionSegment.getColumn().getOriginalColumn());
+        result.setOriginalTable(projectionSegment.getColumn().getOriginalTable());
         return result;
     }
     

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjection.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 @Getter
 @Setter
-@EqualsAndHashCode(exclude = {"originalOwner", "originalName"})
+@EqualsAndHashCode(exclude = {"originalTable", "originalColumn"})
 @ToString
 public final class ColumnProjection implements Projection {
     
@@ -49,9 +49,9 @@ public final class ColumnProjection implements Projection {
     
     private final DatabaseType databaseType;
     
-    private IdentifierValue originalOwner;
+    private IdentifierValue originalTable;
     
-    private IdentifierValue originalName;
+    private IdentifierValue originalColumn;
     
     public ColumnProjection(final String owner, final String name, final String alias, final DatabaseType databaseType) {
         this(null == owner ? null : new IdentifierValue(owner, QuoteCharacter.NONE), new IdentifierValue(name, QuoteCharacter.NONE),
@@ -88,20 +88,20 @@ public final class ColumnProjection implements Projection {
     }
     
     /**
-     * Get original owner.
+     * Get original table.
      *
-     * @return original owner
+     * @return original table
      */
-    public IdentifierValue getOriginalOwner() {
-        return null == originalOwner ? owner : originalOwner;
+    public IdentifierValue getOriginalTable() {
+        return null == originalTable ? owner : originalTable;
     }
     
     /**
-     * Get original name.
+     * Get original column.
      * 
-     * @return original name
+     * @return original column
      */
-    public IdentifierValue getOriginalName() {
-        return null == originalName ? name : originalName;
+    public IdentifierValue getOriginalColumn() {
+        return null == originalColumn ? name : originalColumn;
     }
 }

--- a/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
+++ b/proxy/frontend/type/mysql/src/main/java/org/apache/shardingsphere/proxy/frontend/mysql/command/query/binary/prepare/MySQLComStmtPrepareExecutor.java
@@ -148,9 +148,9 @@ public final class MySQLComStmtPrepareExecutor implements CommandExecutor {
         Collection<MySQLPacket> result = new ArrayList<>(projections.size());
         for (Projection each : projections) {
             // TODO Calculate column definition flag for other projection types
-            if (each instanceof ColumnProjection && null != ((ColumnProjection) each).getOriginalName()) {
+            if (each instanceof ColumnProjection && null != ((ColumnProjection) each).getOriginalColumn()) {
                 result.add(Optional.ofNullable(columnToTableMap.get(each.getExpression())).map(schema::getTable)
-                        .map(table -> table.getColumns().get(((ColumnProjection) each).getOriginalName().getValue()))
+                        .map(table -> table.getColumns().get(((ColumnProjection) each).getOriginalColumn().getValue()))
                         .map(column -> createMySQLColumnDefinition41Packet(characterSet, calculateColumnDefinitionFlag(column), MySQLBinaryColumnType.valueOfJDBCType(column.getDataType())))
                         .orElseGet(() -> createMySQLColumnDefinition41Packet(characterSet, 0, MySQLBinaryColumnType.VAR_STRING)));
             } else {


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/27287.

Changes proposed in this pull request:
  - Fix e2e test when case contains dataSourceName sql hint
  - rename originalOwner and originalName in ColumnProjection

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
