### PR TITLE
Fix cursor e2e test exception caused by select statement context projection logic change

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/SQLBindEngine.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/engine/SQLBindEngine.java
@@ -19,13 +19,19 @@ package org.apache.shardingsphere.infra.binder.engine;
 
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContext;
 import org.apache.shardingsphere.infra.binder.context.statement.SQLStatementContextFactory;
+import org.apache.shardingsphere.infra.binder.statement.ddl.CursorStatementBinder;
+import org.apache.shardingsphere.infra.binder.statement.dml.InsertStatementBinder;
 import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementBinder;
 import org.apache.shardingsphere.infra.hint.HintValueContext;
 import org.apache.shardingsphere.infra.hint.SQLHintUtils;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.AbstractSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.DDLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.DMLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCursorStatement;
 
 import java.util.List;
 
@@ -59,8 +65,11 @@ public final class SQLBindEngine {
         if (containsDataSourceNameSQLHint(statement)) {
             return statement;
         }
-        if (statement instanceof SelectStatement) {
-            return new SelectStatementBinder().bind((SelectStatement) statement, metaData, defaultDatabaseName);
+        if (statement instanceof DMLStatement) {
+            return bindDMLStatement(statement, metaData, defaultDatabaseName);
+        }
+        if (statement instanceof DDLStatement) {
+            return bindDDLStatement(statement, metaData, defaultDatabaseName);
         }
         return statement;
     }
@@ -70,5 +79,22 @@ public final class SQLBindEngine {
             return SQLHintUtils.extractHint(((AbstractSQLStatement) sqlStatement).getCommentSegments().iterator().next().getText()).flatMap(HintValueContext::findHintDataSourceName).isPresent();
         }
         return false;
+    }
+    
+    private static SQLStatement bindDMLStatement(final SQLStatement statement, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        if (statement instanceof SelectStatement) {
+            return new SelectStatementBinder().bind((SelectStatement) statement, metaData, defaultDatabaseName);
+        }
+        if (statement instanceof InsertStatement) {
+            return new InsertStatementBinder().bind((InsertStatement) statement, metaData, defaultDatabaseName);
+        }
+        return statement;
+    }
+    
+    private static SQLStatement bindDDLStatement(final SQLStatement statement, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        if (statement instanceof OpenGaussCursorStatement) {
+            return new CursorStatementBinder().bind((OpenGaussCursorStatement) statement, metaData, defaultDatabaseName);
+        }
+        return statement;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/SubquerySegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/SubquerySegmentBinder.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementBinder;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubquerySegment;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.SelectStatement;
+
+/**
+ * Subquery segment binder.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class SubquerySegmentBinder {
+    
+    /**
+     * Bind subquery segment with metadata.
+     *
+     * @param segment subquery segment
+     * @param metaData metaData
+     * @param defaultDatabaseName default database name
+     * @return bounded subquery segment
+     */
+    public static SubquerySegment bind(final SubquerySegment segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        SelectStatement boundedSelectStatement = new SelectStatementBinder().bind(segment.getSelect(), metaData, defaultDatabaseName);
+        SubquerySegment result = new SubquerySegment(segment.getStartIndex(), segment.getStopIndex(), boundedSelectStatement);
+        result.setSubqueryType(segment.getSubqueryType());
+        return result;
+    }
+}

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementBinder.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.statement.ddl;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinder;
+import org.apache.shardingsphere.infra.binder.statement.dml.SelectStatementBinder;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.ddl.OpenGaussCursorStatement;
+
+/**
+ * Cursor statement binder.
+ */
+public final class CursorStatementBinder implements SQLStatementBinder<OpenGaussCursorStatement> {
+    
+    @SneakyThrows
+    @Override
+    public OpenGaussCursorStatement bind(final OpenGaussCursorStatement sqlStatement, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        OpenGaussCursorStatement result = new OpenGaussCursorStatement();
+        result.setCursorName(sqlStatement.getCursorName());
+        result.setSelect(new SelectStatementBinder().bind(sqlStatement.getSelect(), metaData, defaultDatabaseName));
+        result.addParameterMarkerSegments(sqlStatement.getParameterMarkerSegments());
+        return result;
+    }
+}

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/ddl/CursorStatementBinder.java
@@ -35,6 +35,7 @@ public final class CursorStatementBinder implements SQLStatementBinder<OpenGauss
         result.setCursorName(sqlStatement.getCursorName());
         result.setSelect(new SelectStatementBinder().bind(sqlStatement.getSelect(), metaData, defaultDatabaseName));
         result.addParameterMarkerSegments(sqlStatement.getParameterMarkerSegments());
+        result.getCommentSegments().addAll(sqlStatement.getCommentSegments());
         return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementBinder.java
@@ -44,6 +44,7 @@ public final class InsertStatementBinder implements SQLStatementBinder<InsertSta
         InsertStatementHandler.getInsertMultiTableElementSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setInsertMultiTableElementSegment(result, optional));
         InsertStatementHandler.getReturningSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setReturningSegment(result, optional));
         result.addParameterMarkerSegments(sqlStatement.getParameterMarkerSegments());
+        result.getCommentSegments().addAll(sqlStatement.getCommentSegments());
         return result;
     }
 }

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/InsertStatementBinder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.statement.dml;
+
+import lombok.SneakyThrows;
+import org.apache.shardingsphere.infra.binder.segment.expression.SubquerySegmentBinder;
+import org.apache.shardingsphere.infra.binder.statement.SQLStatementBinder;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.handler.dml.InsertStatementHandler;
+
+/**
+ * Select statement binder.
+ */
+public final class InsertStatementBinder implements SQLStatementBinder<InsertStatement> {
+    
+    @SneakyThrows
+    @Override
+    public InsertStatement bind(final InsertStatement sqlStatement, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        InsertStatement result = sqlStatement.getClass().getDeclaredConstructor().newInstance();
+        result.setTable(sqlStatement.getTable());
+        sqlStatement.getInsertColumns().ifPresent(result::setInsertColumns);
+        sqlStatement.getInsertSelect().ifPresent(optional -> result.setInsertSelect(SubquerySegmentBinder.bind(optional, metaData, defaultDatabaseName)));
+        result.getValues().addAll(sqlStatement.getValues());
+        InsertStatementHandler.getOnDuplicateKeyColumnsSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setOnDuplicateKeyColumnsSegment(result, optional));
+        InsertStatementHandler.getSetAssignmentSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setSetAssignmentSegment(result, optional));
+        InsertStatementHandler.getWithSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setWithSegment(result, optional));
+        InsertStatementHandler.getOutputSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setOutputSegment(result, optional));
+        InsertStatementHandler.getInsertMultiTableElementSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setInsertMultiTableElementSegment(result, optional));
+        InsertStatementHandler.getReturningSegment(sqlStatement).ifPresent(optional -> InsertStatementHandler.setReturningSegment(result, optional));
+        result.addParameterMarkerSegments(sqlStatement.getParameterMarkerSegments());
+        return result;
+    }
+}

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/statement/dml/SelectStatementBinder.java
@@ -56,6 +56,7 @@ public final class SelectStatementBinder implements SQLStatementBinder<SelectSta
         SelectStatementHandler.getWithSegment(sqlStatement).ifPresent(optional -> SelectStatementHandler.setWithSegment(result, optional));
         SelectStatementHandler.getModelSegment(sqlStatement).ifPresent(optional -> SelectStatementHandler.setModelSegment(result, optional));
         result.addParameterMarkerSegments(sqlStatement.getParameterMarkerSegments());
+        result.getCommentSegments().addAll(sqlStatement.getCommentSegments());
         return result;
     }
 }

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactoryTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/context/statement/SQLStatementContextFactoryTest.java
@@ -124,7 +124,9 @@ class SQLStatementContextFactoryTest {
         OpenGaussCursorStatement cursorStatement = mock(OpenGaussCursorStatement.class, RETURNS_DEEP_STUBS);
         MySQLSelectStatement selectStatement = mock(MySQLSelectStatement.class, RETURNS_DEEP_STUBS);
         when(selectStatement.getProjections().isDistinctRow()).thenReturn(false);
+        when(selectStatement.getCommentSegments()).thenReturn(Collections.emptyList());
         when(cursorStatement.getSelect()).thenReturn(selectStatement);
+        when(cursorStatement.getCommentSegments()).thenReturn(Collections.emptyList());
         SQLStatementContext actual = new SQLBindEngine(mockMetaData(), DefaultDatabase.LOGIC_NAME).bind(cursorStatement, Collections.emptyList());
         assertThat(actual, instanceOf(CursorStatementContext.class));
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/dml/InsertStatementHandler.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/handler/dml/InsertStatementHandler.java
@@ -27,15 +27,10 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.OutputSeg
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.WithSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.InsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.handler.SQLStatementHandler;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.MySQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.mysql.dml.MySQLInsertStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.OpenGaussStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.opengauss.dml.OpenGaussInsertStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.OracleStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.oracle.dml.OracleInsertStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.PostgreSQLStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.postgresql.dml.PostgreSQLInsertStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.SQLServerStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.sqlserver.dml.SQLServerInsertStatement;
 
 import java.util.Optional;
@@ -53,16 +48,34 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return on duplicate key columns segment
      */
     public static Optional<OnDuplicateKeyColumnsSegment> getOnDuplicateKeyColumnsSegment(final InsertStatement insertStatement) {
-        if (insertStatement instanceof MySQLStatement) {
+        if (insertStatement instanceof MySQLInsertStatement) {
             return ((MySQLInsertStatement) insertStatement).getOnDuplicateKeyColumns();
         }
-        if (insertStatement instanceof OpenGaussStatement) {
+        if (insertStatement instanceof OpenGaussInsertStatement) {
             return ((OpenGaussInsertStatement) insertStatement).getOnDuplicateKeyColumns();
         }
-        if (insertStatement instanceof PostgreSQLStatement) {
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
             return ((PostgreSQLInsertStatement) insertStatement).getOnDuplicateKeyColumns();
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Set on duplicate key columns segment.
+     * 
+     * @param insertStatement insert statement
+     * @param onDuplicateKeyColumnsSegment on duplicate key columns segment
+     */
+    public static void setOnDuplicateKeyColumnsSegment(final InsertStatement insertStatement, final OnDuplicateKeyColumnsSegment onDuplicateKeyColumnsSegment) {
+        if (insertStatement instanceof MySQLInsertStatement) {
+            ((MySQLInsertStatement) insertStatement).setOnDuplicateKeyColumns(onDuplicateKeyColumnsSegment);
+        }
+        if (insertStatement instanceof OpenGaussInsertStatement) {
+            ((OpenGaussInsertStatement) insertStatement).setOnDuplicateKeyColumnsSegment(onDuplicateKeyColumnsSegment);
+        }
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
+            ((PostgreSQLInsertStatement) insertStatement).setOnDuplicateKeyColumnsSegment(onDuplicateKeyColumnsSegment);
+        }
     }
     
     /**
@@ -72,7 +85,19 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return set assignment segment
      */
     public static Optional<SetAssignmentSegment> getSetAssignmentSegment(final InsertStatement insertStatement) {
-        return insertStatement instanceof MySQLStatement ? ((MySQLInsertStatement) insertStatement).getSetAssignment() : Optional.empty();
+        return insertStatement instanceof MySQLInsertStatement ? ((MySQLInsertStatement) insertStatement).getSetAssignment() : Optional.empty();
+    }
+    
+    /**
+     * Set set assignment segment.
+     * 
+     * @param insertStatement insert statement
+     * @param setAssignmentSegment set assignment segment
+     */
+    public static void setSetAssignmentSegment(final InsertStatement insertStatement, final SetAssignmentSegment setAssignmentSegment) {
+        if (insertStatement instanceof MySQLInsertStatement) {
+            ((MySQLInsertStatement) insertStatement).setSetAssignment(setAssignmentSegment);
+        }
     }
     
     /**
@@ -82,16 +107,34 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return with segment
      */
     public static Optional<WithSegment> getWithSegment(final InsertStatement insertStatement) {
-        if (insertStatement instanceof PostgreSQLStatement) {
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
             return ((PostgreSQLInsertStatement) insertStatement).getWithSegment();
         }
-        if (insertStatement instanceof SQLServerStatement) {
+        if (insertStatement instanceof SQLServerInsertStatement) {
             return ((SQLServerInsertStatement) insertStatement).getWithSegment();
         }
-        if (insertStatement instanceof OpenGaussStatement) {
+        if (insertStatement instanceof OpenGaussInsertStatement) {
             return ((OpenGaussInsertStatement) insertStatement).getWithSegment();
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Set with segment.
+     * 
+     * @param insertStatement insert statement
+     * @param withSegment with segment
+     */
+    public static void setWithSegment(final InsertStatement insertStatement, final WithSegment withSegment) {
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
+            ((PostgreSQLInsertStatement) insertStatement).setWithSegment(withSegment);
+        }
+        if (insertStatement instanceof SQLServerInsertStatement) {
+            ((SQLServerInsertStatement) insertStatement).setWithSegment(withSegment);
+        }
+        if (insertStatement instanceof OpenGaussInsertStatement) {
+            ((OpenGaussInsertStatement) insertStatement).setWithSegment(withSegment);
+        }
     }
     
     /**
@@ -101,10 +144,22 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return output segment
      */
     public static Optional<OutputSegment> getOutputSegment(final InsertStatement insertStatement) {
-        if (insertStatement instanceof SQLServerStatement) {
+        if (insertStatement instanceof SQLServerInsertStatement) {
             return ((SQLServerInsertStatement) insertStatement).getOutputSegment();
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Set output segment.
+     * 
+     * @param insertStatement insert statement
+     * @param outputSegment output segment
+     */
+    public static void setOutputSegment(final InsertStatement insertStatement, final OutputSegment outputSegment) {
+        if (insertStatement instanceof SQLServerInsertStatement) {
+            ((SQLServerInsertStatement) insertStatement).setOutputSegment(outputSegment);
+        }
     }
     
     /**
@@ -114,10 +169,22 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return insert multi table element segment
      */
     public static Optional<InsertMultiTableElementSegment> getInsertMultiTableElementSegment(final InsertStatement insertStatement) {
-        if (insertStatement instanceof OracleStatement) {
+        if (insertStatement instanceof OracleInsertStatement) {
             return ((OracleInsertStatement) insertStatement).getInsertMultiTableElementSegment();
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Set insert multi table element segment.
+     * 
+     * @param insertStatement insert statement
+     * @param insertMultiTableElementSegment insert multi table element segment
+     */
+    public static void setInsertMultiTableElementSegment(final InsertStatement insertStatement, final InsertMultiTableElementSegment insertMultiTableElementSegment) {
+        if (insertStatement instanceof OracleInsertStatement) {
+            ((OracleInsertStatement) insertStatement).setInsertMultiTableElementSegment(insertMultiTableElementSegment);
+        }
     }
     
     /**
@@ -127,12 +194,27 @@ public final class InsertStatementHandler implements SQLStatementHandler {
      * @return returning segment
      */
     public static Optional<ReturningSegment> getReturningSegment(final InsertStatement insertStatement) {
-        if (insertStatement instanceof PostgreSQLStatement) {
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
             return ((PostgreSQLInsertStatement) insertStatement).getReturningSegment();
         }
-        if (insertStatement instanceof OpenGaussStatement) {
+        if (insertStatement instanceof OpenGaussInsertStatement) {
             return ((OpenGaussInsertStatement) insertStatement).getReturningSegment();
         }
         return Optional.empty();
+    }
+    
+    /**
+     * Set returning segment of insert statement.
+     * 
+     * @param insertStatement insert statement
+     * @param returningSegment returning segment
+     */
+    public static void setReturningSegment(final InsertStatement insertStatement, final ReturningSegment returningSegment) {
+        if (insertStatement instanceof PostgreSQLInsertStatement) {
+            ((PostgreSQLInsertStatement) insertStatement).setReturningSegment(returningSegment);
+        }
+        if (insertStatement instanceof OpenGaussInsertStatement) {
+            ((OpenGaussInsertStatement) insertStatement).setReturningSegment(returningSegment);
+        }
     }
 }

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
@@ -114,6 +114,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
         PostgreSQLInsertStatement insertStatement = mock(PostgreSQLInsertStatement.class, RETURNS_DEEP_STUBS);
         when(insertStatement.getTable().getTableName().getIdentifier().getValue()).thenReturn("t");
         when(insertStatement.getValues()).thenReturn(Collections.emptyList());
+        when(insertStatement.getCommentSegments()).thenReturn(Collections.emptyList());
         InsertStatementContext result = mock(InsertStatementContext.class);
         when(result.getSqlStatement()).thenReturn(insertStatement);
         return result;

--- a/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
+++ b/proxy/frontend/type/postgresql/src/test/java/org/apache/shardingsphere/proxy/frontend/postgresql/command/query/extended/PostgreSQLBatchedStatementsExecutorTest.java
@@ -113,6 +113,7 @@ class PostgreSQLBatchedStatementsExecutorTest {
     private InsertStatementContext mockInsertStatementContext() {
         PostgreSQLInsertStatement insertStatement = mock(PostgreSQLInsertStatement.class, RETURNS_DEEP_STUBS);
         when(insertStatement.getTable().getTableName().getIdentifier().getValue()).thenReturn("t");
+        when(insertStatement.getValues()).thenReturn(Collections.emptyList());
         InsertStatementContext result = mock(InsertStatementContext.class);
         when(result.getSqlStatement()).thenReturn(insertStatement);
         return result;


### PR DESCRIPTION
Ref https://github.com/apache/shardingsphere/issues/27287.

Changes proposed in this pull request:
  - Fix cursor e2e test exception caused by select statement context projection logic change

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
