### PR TITLE
Fix wrong shorthand expand size when contains more than two tables join

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/from/impl/JoinTableSegmentBinder.java
@@ -67,7 +67,7 @@ public final class JoinTableSegmentBinder {
         result.setCondition(segment.getCondition());
         // TODO bind condition and using column in join table segment
         result.setUsing(segment.getUsing());
-        result.getJoinTableProjectionSegments().addAll(getJoinTableProjectionSegments(segment, databaseType, tableBinderContexts));
+        result.getJoinTableProjectionSegments().addAll(getJoinTableProjectionSegments(result, databaseType, tableBinderContexts));
         return result;
     }
     


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Fix wrong shorthand expand size when contains more than two tables join
  - add unit test

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
