### PR TITLE
Fix SwitchingResource in compatible cluster mode.

### DIFF
--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereResourceMetaData.java
@@ -57,7 +57,7 @@ public final class ShardingSphereResourceMetaData {
         Map<String, DataSource> enabledDataSources = DataSourceStateManager.getInstance().getEnabledDataSourceMap(databaseName, dataSources);
         Map<String, DatabaseType> storageTypes = createStorageTypes(dataSources, enabledDataSources);
         this.dataSourcePropsMap = DataSourcePropertiesCreator.create(dataSources);
-        storageNodeMetaData = new ShardingSphereStorageNodeMetaData(dataSources, storageTypes);
+        storageNodeMetaData = new ShardingSphereStorageNodeMetaData(dataSources);
         storageUnitMetaData = new ShardingSphereStorageUnitMetaData(dataSources, storageTypes, StorageUtils.getStorageUnits(dataSources), enabledDataSources);
         
     }
@@ -65,7 +65,7 @@ public final class ShardingSphereResourceMetaData {
     public ShardingSphereResourceMetaData(final String databaseName, final StorageResource storageResource, final Map<String, DataSourceProperties> dataSourcePropsMap) {
         Map<String, DataSource> enabledDataSources = DataSourceStateManager.getInstance().getEnabledDataSourceMap(databaseName, storageResource.getStorageNodes());
         Map<String, DatabaseType> storageTypes = createStorageTypes(storageResource.getStorageNodes(), enabledDataSources);
-        storageNodeMetaData = new ShardingSphereStorageNodeMetaData(storageResource.getStorageNodes(), storageTypes);
+        storageNodeMetaData = new ShardingSphereStorageNodeMetaData(storageResource.getStorageNodes());
         storageUnitMetaData = new ShardingSphereStorageUnitMetaData(storageResource.getStorageNodes(), storageTypes, storageResource.getStorageUnits(), enabledDataSources);
         this.dataSourcePropsMap = dataSourcePropsMap;
     }

--- a/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereStorageNodeMetaData.java
+++ b/infra/common/src/main/java/org/apache/shardingsphere/infra/metadata/database/resource/ShardingSphereStorageNodeMetaData.java
@@ -18,7 +18,7 @@
 package org.apache.shardingsphere.infra.metadata.database.resource;
 
 import lombok.Getter;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
+import lombok.RequiredArgsConstructor;
 
 import javax.sql.DataSource;
 import java.util.Map;
@@ -27,14 +27,8 @@ import java.util.Map;
  * ShardingSphere storage node meta data.
  */
 @Getter
+@RequiredArgsConstructor
 public final class ShardingSphereStorageNodeMetaData {
     
     private final Map<String, DataSource> dataSources;
-    
-    private final Map<String, DatabaseType> storageTypes;
-    
-    public ShardingSphereStorageNodeMetaData(final Map<String, DataSource> dataSources, final Map<String, DatabaseType> storageTypes) {
-        this.dataSources = dataSources;
-        this.storageTypes = storageTypes;
-    }
 }

--- a/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/switcher/ResourceSwitchManager.java
+++ b/mode/core/src/main/java/org/apache/shardingsphere/mode/manager/switcher/ResourceSwitchManager.java
@@ -46,6 +46,7 @@ public final class ResourceSwitchManager {
      * @return created switching resource
      */
     public SwitchingResource create(final ShardingSphereResourceMetaData resourceMetaData, final Map<String, DataSourceProperties> toBeChangedDataSourceProps) {
+        resourceMetaData.getDataSourcePropsMap().putAll(toBeChangedDataSourceProps);
         StorageResourceWithProperties toBeChangedStorageResource = DataSourcePoolCreator.createStorageResourceWithoutDataSource(toBeChangedDataSourceProps);
         return new SwitchingResource(resourceMetaData, createNewStorageResource(resourceMetaData, toBeChangedStorageResource),
                 getStaleDataSources(resourceMetaData, toBeChangedStorageResource), toBeChangedDataSourceProps);
@@ -59,6 +60,7 @@ public final class ResourceSwitchManager {
      * @return created switching resource
      */
     public SwitchingResource createByDropResource(final ShardingSphereResourceMetaData resourceMetaData, final Map<String, DataSourceProperties> toBeDeletedDataSourceProps) {
+        resourceMetaData.getDataSourcePropsMap().keySet().removeIf(toBeDeletedDataSourceProps::containsKey);
         StorageResourceWithProperties toToBeRemovedStorageResource = DataSourcePoolCreator.createStorageResourceWithoutDataSource(toBeDeletedDataSourceProps);
         return new SwitchingResource(resourceMetaData, new StorageResource(Collections.emptyMap(), Collections.emptyMap()),
                 getToBeRemovedStaleDataSources(resourceMetaData, toToBeRemovedStorageResource),
@@ -77,6 +79,8 @@ public final class ResourceSwitchManager {
      * @return created switching resource
      */
     public SwitchingResource createByAlterDataSourceProps(final ShardingSphereResourceMetaData resourceMetaData, final Map<String, DataSourceProperties> toBeChangedDataSourceProps) {
+        resourceMetaData.getDataSourcePropsMap().keySet().removeIf(each -> !toBeChangedDataSourceProps.containsKey(each));
+        resourceMetaData.getDataSourcePropsMap().putAll(toBeChangedDataSourceProps);
         StorageResourceWithProperties toBeChangedStorageResource = DataSourcePoolCreator.createStorageResourceWithoutDataSource(toBeChangedDataSourceProps);
         StorageResource staleStorageResource = getStaleDataSources(resourceMetaData, toBeChangedStorageResource);
         staleStorageResource.getStorageNodes().putAll(getToBeDeletedDataSources(resourceMetaData.getStorageNodeMetaData().getDataSources(), toBeChangedStorageResource.getStorageNodes().keySet()));


### PR DESCRIPTION
Fixes #27888.

Changes proposed in this pull request:
  - Fix SwitchingResource in compatible cluster mode.
  - Remove useless storageTypes in ShardingSphereStorageNodeMetaData

---
```sql
mysql> REGISTER STORAGE UNIT ds_0 (
    ->     HOST="127.0.0.1",
    ->     PORT=3306,
    ->     DB="demo_ds_0",
    ->     USER="root",
    ->     PASSWORD="123456",
    ->     PROPERTIES("maximumPoolSize"=10)
    -> );
Query OK, 0 rows affected (0.48 sec)

mysql> EXPORT DATABASE CONFIGURATION;
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
| result                                                                                                                                                     |
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
| databaseName: test
dataSources:
  ds_0:
    password: 123456
    url: jdbc:mysql://127.0.0.1:3306/demo_ds_0
    username: root
    maxPoolSize: 10
rules:
 |
+------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.08 sec)
```
