### PR TITLE
[Oracle SQL] Support parsing set function for Oracle SQL

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -757,7 +757,11 @@ leadLagInfo
     ;
 
 specialFunction
-    : castFunction | charFunction | extractFunction | formatFunction | firstOrLastValueFunction | trimFunction | featureFunction
+    : castFunction | charFunction | extractFunction | formatFunction | firstOrLastValueFunction | trimFunction | featureFunction | setFunction
+    ;
+
+setFunction
+    : SET LP_ expr RP_
     ;
 
 featureFunction

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -868,7 +868,17 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
         if (null != ctx.featureFunction()) {
             return visit(ctx.featureFunction());
         }
+        if (null != ctx.setFunction()) {
+            return visit(ctx.setFunction());
+        }
         throw new IllegalStateException("SpecialFunctionContext must have castFunction, charFunction, extractFunction, formatFunction, firstOrLastValueFunction, trimFunction or featureFunction.");
+    }
+    
+    @Override
+    public final ASTNode visitSetFunction(final OracleStatementParser.SetFunctionContext ctx) {
+        FunctionSegment result = new FunctionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), ctx.SET().getText(), getOriginalText(ctx));
+        result.getParameters().add((ExpressionSegment) visit(ctx.expr()));
+        return result;
     }
     
     @Override

--- a/test/it/parser/src/main/resources/case/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/case/dml/select-special-function.xml
@@ -546,4 +546,25 @@
             <column-item name="xmlagg" order-direction="ASC" start-index="98" stop-index="103"/>
         </order-by>
     </select>
+
+    <select sql-case-id="select_set_function">
+        <projections start-index="7" stop-index="49">
+            <column-projection name="customer_id" start-index="7" stop-index="17" />
+            <expression-projection text="SET(cust_address_ntab)" alias="address" start-index="20" stop-index="49">
+                <expr>
+                    <function function-name="SET" start-index="20" stop-index="41" text="SET(cust_address_ntab)">
+                        <parameter>
+                            <column name="cust_address_ntab" start-index="24" stop-index="40" />
+                        </parameter>
+                    </function>
+                </expr>
+            </expression-projection>
+        </projections>
+        <from>
+            <simple-table name="customers_demo" start-index="56" stop-index="69" />
+        </from>
+        <order-by>
+            <column-item name="customer_id" order-direction="ASC" start-index="80" stop-index="90" literal-start-index="80" literal-stop-index="90" />
+        </order-by>
+    </select>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dml/select-special-function.xml
@@ -42,4 +42,5 @@
     <sql-case id="select_extract_function_for_oracle" value="SELECT EXTRACT(YEAR FROM TIMESTAMP '2001-02-16 20:38:40') FROM DUAL" db-types="Oracle" />
     <sql-case id="select_mod_function" value="SELECT MOD(order_id, 1) from t_order" db-types="PostgreSQL,openGauss" />
     <sql-case id="select_sys_xml_agg" value="SELECT SYS_XMLAGG(SYS_XMLGEN(last_name)) XMLAGG FROM employees WHERE last_name LIKE 'R%' ORDER BY xmlagg;" db-types="Oracle" />
+    <sql-case id="select_set_function" value="SELECT customer_id, SET(cust_address_ntab) address FROM customers_demo ORDER BY customer_id;" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
In this pr, I supported the parsing of set function for Oracle reffering to: https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/SET.html#GUID-533164AC-B4F0-4FCE-ADA4-85C925CB8D14
Now this SQL can be parsed:
``` SELECT customer_id, SET(cust_address_ntab) address FROM customers_demo ORDER BY customer_id; ```
Relate issue: https://github.com/apache/shardingsphere/issues/27569