### PR TITLE
Fix StringPrimaryKeyPosition handle empty string

### DIFF
--- a/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/ingest/position/pk/type/StringPrimaryKeyPosition.java
+++ b/kernel/data-pipeline/core/src/main/java/org/apache/shardingsphere/data/pipeline/common/ingest/position/pk/type/StringPrimaryKeyPosition.java
@@ -17,20 +17,24 @@
 
 package org.apache.shardingsphere.data.pipeline.common.ingest.position.pk.type;
 
+import com.google.common.base.Strings;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import org.apache.shardingsphere.data.pipeline.common.ingest.position.pk.PrimaryKeyPosition;
 
 /**
  * String primary key position.
  */
-@RequiredArgsConstructor
 @Getter
 public final class StringPrimaryKeyPosition implements PrimaryKeyPosition<String> {
     
     private final String beginValue;
     
     private final String endValue;
+    
+    public StringPrimaryKeyPosition(final String beginValue, final String endValue) {
+        this.beginValue = Strings.emptyToNull(beginValue);
+        this.endValue = Strings.emptyToNull(endValue);
+    }
     
     @Override
     public String convert(final String value) {

--- a/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/ingest/position/pk/type/StringPrimaryKeyPositionTest.java
+++ b/kernel/data-pipeline/core/src/test/java/org/apache/shardingsphere/data/pipeline/common/ingest/position/pk/type/StringPrimaryKeyPositionTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class StringPrimaryKeyPositionTest {
     
@@ -35,5 +36,12 @@ class StringPrimaryKeyPositionTest {
     @Test
     void assertToString() {
         assertThat(new StringPrimaryKeyPosition("hi", "jk").toString(), is("s,hi,jk"));
+    }
+    
+    @Test
+    void assertEmptyToNull() {
+        StringPrimaryKeyPosition actual = (StringPrimaryKeyPosition) PrimaryKeyPositionFactory.newInstance("s,,");
+        assertNull(actual.getBeginValue());
+        assertNull(actual.getEndValue());
     }
 }

--- a/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
+++ b/test/e2e/operation/pipeline/src/test/java/org/apache/shardingsphere/test/e2e/data/pipeline/cases/migration/general/MySQLMigrationGeneralE2EIT.java
@@ -83,6 +83,8 @@ class MySQLMigrationGeneralE2EIT extends AbstractMigrationE2EIT {
                     new E2EIncrementalTask(containerComposer.getSourceDataSource(), SOURCE_TABLE_NAME, new SnowflakeKeyGenerateAlgorithm(), containerComposer.getDatabaseType(), 30));
             TimeUnit.SECONDS.timedJoin(containerComposer.getIncreaseTaskThread(), 30);
             containerComposer.sourceExecuteWithLog(String.format("INSERT INTO %s (order_id, user_id, status) VALUES (10000, 1, 'OK')", SOURCE_TABLE_NAME));
+            stopMigrationByJobId(containerComposer, orderJobId);
+            startMigrationByJobId(containerComposer, orderJobId);
             DataSource jdbcDataSource = containerComposer.generateShardingSphereDataSourceFromProxy();
             containerComposer.assertOrderRecordExist(jdbcDataSource, "t_order", 10000);
             assertMigrationSuccessById(containerComposer, orderJobId, "DATA_MATCH");


### PR DESCRIPTION


Changes proposed in this pull request:
  - Fix StringPrimaryKeyPosition handle empty string 

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
