### PR TITLE
Fix NumberFormatException when loadng persisted datasource pool config

### DIFF
--- a/infra/datasource/core/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesCreator.java
+++ b/infra/datasource/core/src/main/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesCreator.java
@@ -143,16 +143,47 @@ public final class DataSourcePropertiesCreator {
     
     private static PoolConfiguration getPoolConfiguration(final PoolPropertySynonyms poolPropertySynonyms, final CustomDataSourceProperties customDataSourceProperties) {
         Map<String, Object> standardProperties = poolPropertySynonyms.getStandardProperties();
-        Long connectionTimeoutMilliseconds = standardProperties.containsKey("connectionTimeoutMilliseconds")
-                ? Long.valueOf(String.valueOf(standardProperties.get("connectionTimeoutMilliseconds")))
-                : null;
-        Long idleTimeoutMilliseconds = standardProperties.containsKey("idleTimeoutMilliseconds") ? Long.valueOf(String.valueOf(standardProperties.get("idleTimeoutMilliseconds"))) : null;
-        Long maxLifetimeMilliseconds = standardProperties.containsKey("maxLifetimeMilliseconds") ? Long.valueOf(String.valueOf(standardProperties.get("maxLifetimeMilliseconds"))) : null;
-        Integer maxPoolSize = standardProperties.containsKey("maxPoolSize") ? Integer.valueOf(String.valueOf(standardProperties.get("maxPoolSize"))) : null;
-        Integer minPoolSize = standardProperties.containsKey("minPoolSize") ? Integer.valueOf(String.valueOf(standardProperties.get("minPoolSize"))) : null;
-        Boolean readOnly = standardProperties.containsKey("readOnly") ? Boolean.valueOf(String.valueOf(standardProperties.get("readOnly"))) : null;
+        Long connectionTimeoutMilliseconds = toLong(standardProperties, "connectionTimeoutMilliseconds", null);
+        Long idleTimeoutMilliseconds = toLong(standardProperties, "idleTimeoutMilliseconds", null);
+        Long maxLifetimeMilliseconds = toLong(standardProperties, "maxLifetimeMilliseconds", null);
+        Integer maxPoolSize = toInt(standardProperties, "maxPoolSize", null);
+        Integer minPoolSize = toInt(standardProperties, "minPoolSize", null);
+        Boolean readOnly = toBoolean(standardProperties, "readOnly", null);
         Properties customProperties = new Properties();
         customProperties.putAll(customDataSourceProperties.getProperties());
         return new PoolConfiguration(connectionTimeoutMilliseconds, idleTimeoutMilliseconds, maxLifetimeMilliseconds, maxPoolSize, minPoolSize, readOnly, customProperties);
+    }
+    
+    private static Long toLong(final Map<String, Object> properties, final String name, final Long defaultValue) {
+        if (!properties.containsKey(name)) {
+            return defaultValue;
+        }
+        try {
+            return Long.parseLong(String.valueOf(properties.get(name)));
+        } catch (final NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+    
+    private static Integer toInt(final Map<String, Object> properties, final String name, final Integer defaultValue) {
+        if (!properties.containsKey(name)) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(String.valueOf(properties.get(name)));
+        } catch (final NumberFormatException ex) {
+            return defaultValue;
+        }
+    }
+    
+    private static Boolean toBoolean(final Map<String, Object> properties, final String name, final Boolean defaultValue) {
+        if (!properties.containsKey(name)) {
+            return defaultValue;
+        }
+        try {
+            return Boolean.parseBoolean(String.valueOf(properties.get(name)));
+        } catch (final NumberFormatException ex) {
+            return defaultValue;
+        }
     }
 }

--- a/infra/datasource/core/src/test/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesCreatorTest.java
+++ b/infra/datasource/core/src/test/java/org/apache/shardingsphere/infra/datasource/props/DataSourcePropertiesCreatorTest.java
@@ -105,7 +105,6 @@ class DataSourcePropertiesCreatorTest {
     
     private Map<String, Object> createStandardProperties() {
         Map<String, Object> result = new LinkedHashMap<>(6, 1F);
-        // This is to test the case where the property type is mismatched.
         result.put("connectionTimeoutMilliseconds", "null");
         result.put("idleTimeoutMilliseconds", 180000);
         result.put("maxLifetimeMilliseconds", 180000);


### PR DESCRIPTION
Fixes #27927.

Changes proposed in this pull request:
  - handling correctly when parsing non-numeric values

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [X] I have self-reviewed the commit code.
- [X] I have (or in comment I request) added corresponding labels for the pull request.
- [X] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [X] I have added corresponding unit tests for my changes.
