### PR TITLE
Fix encrypt e2e error and add init table for H2, PostgreSQL and openGauss

### DIFF
--- a/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
+++ b/features/encrypt/core/src/main/java/org/apache/shardingsphere/encrypt/rewrite/token/generator/EncryptProjectionTokenGenerator.java
@@ -136,9 +136,9 @@ public final class EncryptProjectionTokenGenerator implements CollectionSQLToken
                     projections.addAll(generateProjections(encryptColumn, (ColumnProjection) each, subqueryType, true, segment));
                     continue;
                 }
-                projections.add(each.getAlias().filter(alias -> !DerivedColumn.isDerivedColumnName(alias.getValue()))
-                        .map(optional -> (Projection) new ColumnProjection(null, optional, null, databaseType)).orElse(each));
             }
+            projections.add(each.getAlias().filter(alias -> !DerivedColumn.isDerivedColumnName(alias.getValue()))
+                    .map(optional -> (Projection) new ColumnProjection(null, optional, null, databaseType)).orElse(each));
         }
         int startIndex = segment.getOwner().isPresent() ? segment.getOwner().get().getStartIndex() : segment.getStartIndex();
         previousSQLTokens.removeIf(each -> each.getStartIndex() == startIndex);

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjection.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/context/segment/select/projection/impl/ColumnProjection.java
@@ -24,8 +24,8 @@ import lombok.Setter;
 import lombok.ToString;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.Projection;
 import org.apache.shardingsphere.infra.binder.context.segment.select.projection.util.ProjectionUtils;
-import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.core.type.DatabaseType;
 import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 
@@ -93,7 +93,10 @@ public final class ColumnProjection implements Projection {
      * @return original table
      */
     public IdentifierValue getOriginalTable() {
-        return null == originalTable ? owner : originalTable;
+        if (null == originalTable) {
+            return null == owner ? new IdentifierValue("") : owner;
+        }
+        return originalTable;
     }
     
     /**

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/h2/01-actual-init.sql
@@ -14,11 +14,16 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 --
+
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/opengauss/01-actual-init.sql
@@ -21,11 +21,15 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt TO test_user;
 
 \c encrypt
 
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/actual/init-sql/postgresql/01-actual-init.sql
@@ -21,11 +21,15 @@ GRANT ALL PRIVILEGES ON DATABASE encrypt TO test_user;
 
 \c encrypt
 
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name_cipher VARCHAR(50) NOT NULL, user_name_like VARCHAR(50) NOT NULL, password_cipher VARCHAR(50) NOT NULL, email_cipher VARCHAR(50) NOT NULL, telephone_cipher CHAR(50) NOT NULL, telephone_like CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/h2/01-expected-init.sql
@@ -15,11 +15,15 @@
 -- limitations under the License.
 --
 
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/opengauss/01-expected-init.sql
@@ -22,11 +22,15 @@ GRANT ALL PRIVILEGES ON DATABASE expected_dataset TO test_user;
 
 \c expected_dataset;
 
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));

--- a/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
+++ b/test/e2e/sql/src/test/resources/env/scenario/encrypt/data/expected/init-sql/postgresql/01-expected-init.sql
@@ -22,11 +22,15 @@ GRANT ALL PRIVILEGES ON DATABASE expected_dataset TO test_user;
 
 \c expected_dataset;
 
+DROP TABLE IF EXISTS t_order;
+DROP TABLE IF EXISTS t_order_item;
 DROP TABLE IF EXISTS t_user;
 DROP TABLE IF EXISTS t_user_item;
 DROP TABLE IF EXISTS t_single_table;
 DROP TABLE IF EXISTS t_merchant;
 
+CREATE TABLE t_order (order_id INT PRIMARY KEY, user_id INT NOT NULL, status VARCHAR(50) NOT NULL, merchant_id INT, remark VARCHAR(50) NOT NULL, creation_date DATE NOT NULL);
+CREATE TABLE t_order_item (item_id INT PRIMARY KEY, order_id INT NOT NULL, user_id INT NOT NULL, product_id INT NOT NULL, quantity INT NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user (user_id INT PRIMARY KEY, user_name VARCHAR(50) NOT NULL, password VARCHAR(50) NOT NULL, email VARCHAR(50) NOT NULL, telephone CHAR(11) NOT NULL, creation_date DATE NOT NULL);
 CREATE TABLE t_user_item (item_id INT NOT NULL, user_id INT NOT NULL, status VARCHAR(45) NULL, creation_date DATE, PRIMARY KEY (item_id));
 CREATE TABLE t_single_table (single_id INT NOT NULL, id INT NOT NULL, status VARCHAR(45) NULL, PRIMARY KEY (single_id));


### PR DESCRIPTION
Ref #27287.

Changes proposed in this pull request:
  - Fix encrypt e2e error and add init table for H2, PostgreSQL and openGauss

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
