### PR TITLE
Fix oracle alter table column definition parse error

### DIFF
--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
@@ -530,7 +530,7 @@ public final class OracleDDLStatementVisitor extends OracleStatementVisitor impl
     @Override
     public ASTNode visitModifyColProperties(final ModifyColPropertiesContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
+        DataTypeSegment dataType = null != ctx.dataType() ? (DataTypeSegment) visit(ctx.dataType()) : null;
         // TODO visit pk and reference table
         return new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, false, false);
     }

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/definition/ColumnDefinitionAssert.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/asserts/segment/definition/ColumnDefinitionAssert.java
@@ -26,6 +26,8 @@ import org.apache.shardingsphere.test.it.sql.parser.internal.cases.parser.jaxb.s
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Column definition assert.
@@ -42,7 +44,12 @@ public final class ColumnDefinitionAssert {
      */
     public static void assertIs(final SQLCaseAssertContext assertContext, final ColumnDefinitionSegment actual, final ExpectedColumnDefinition expected) {
         assertThat(assertContext.getText("Column definition name assertion error: "), actual.getColumnName().getIdentifier().getValue(), is(expected.getColumn().getName()));
-        assertThat(assertContext.getText("Column definition data type assertion error: "), actual.getDataType().getDataTypeName(), is(expected.getType()));
+        if (null != expected.getType()) {
+            assertNotNull(actual.getDataType(), assertContext.getText("Column definition data type should exist."));
+            assertThat(assertContext.getText("Column definition data type assertion error: "), actual.getDataType().getDataTypeName(), is(expected.getType()));
+        } else {
+            assertNull(actual.getDataType(), assertContext.getText("Column definition data type should not exist."));
+        }
         assertThat(assertContext.getText("Column definition primary key assertion error: "), actual.isPrimaryKey(), is(expected.isPrimaryKey()));
         TableAssert.assertIs(assertContext, actual.getReferencedTables(), expected.getReferencedTables());
         assertThat(assertContext.getText("Column definition start index assertion error: "), actual.getStartIndex(), is(expected.getStartIndex()));

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1306,4 +1306,17 @@
     <alter-table sql-case-id="alter_table_move">
         <table name="admin_docindex" start-index="12" stop-index="25" />
     </alter-table>
+    
+    <alter-table sql-case-id="alter_table_move_online">
+        <table name="admin_docindex" start-index="12" stop-index="25" />
+    </alter-table>
+    
+    <alter-table sql-case-id="alter_table_modify">
+        <table name="customers" start-index="12" stop-index="20" />
+        <modify-column>
+            <column-definition start-index="30" stop-index="51">
+                <column start-index="30" stop-index="43" name="online_acct_pw" />
+            </column-definition>
+        </modify-column>
+    </alter-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -165,4 +165,6 @@
     <sql-case id="alter_table_add_supplemental_log_data2" value="ALTER TABLE HR.EMPLOYEES ADD SUPPLEMENTAL LOG DATA (UNIQUE) COLUMNS" db-types="Oracle" />
     <sql-case id="alter_table_add_supplemental_log_data3" value="ALTER TABLE HR.EMPLOYEES ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS" db-types="Oracle" />
     <sql-case id="alter_table_move" value="ALTER TABLE admin_docindex MOVE" db-types="Oracle" />
+    <sql-case id="alter_table_move_online" value="ALTER TABLE admin_docindex MOVE ONLINE" db-types="Oracle" />
+    <sql-case id="alter_table_modify" value="ALTER TABLE customers MODIFY (online_acct_pw DECRYPT)" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Ref #26978.

Changes proposed in this pull request:
  - Fix oracle alter table column definition parse error
  - Fix column definition assert NullPointerException
  - The datatype of the Oracle alter table modify column statement column can be omitted

Refer to:
https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/img/modify_col_properties.gif

Test statement execution results:
SQL> CREATE TABLE mytable (id NUMBER, name varchar(30), age NUMBER);

Table created.

SQL> ALTER TABLE mytable MODIFY (name);

Table altered.

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.