### PR TITLE
Fix exception caused by missing like query column in table subquery

### DIFF
--- a/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-sub-query.xml
+++ b/test/e2e/sql/src/test/resources/cases/dql/dql-integration-select-sub-query.xml
@@ -72,6 +72,11 @@
         <assertion expected-data-source-name="read_dataset" />
     </test-case>
     
+    <test-case sql="SELECT merchant_id, business_code, telephone FROM (SELECT * FROM t_merchant) temp WHERE temp.business_code LIKE '_1000018'" db-types="MySQL,PostgreSQL,openGauss" scenario-types="db,encrypt"
+               scenario-comments="Test single table's LIKE operator underscore wildcard in subquery select statement when use sharding feature.|Test encrypt table's LIKE operator underscore wildcard in subquery select statement when use encrypt feature.">
+        <assertion expected-data-source-name="read_dataset" />
+    </test-case>
+    
     <test-case sql="SELECT business_code, telephone, (SELECT password FROM t_user LIMIT 1) AS password FROM t_merchant" db-types="MySQL,PostgreSQL,openGauss" scenario-types="encrypt"
                scenario-comments="Test subquery projection contains encrypt column and config alias when use encrypt feature.">
         <assertion expected-data-source-name="read_dataset" />

--- a/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
+++ b/test/it/rewriter/src/test/resources/scenario/encrypt/case/query-with-cipher/dml/select/select-subquery.xml
@@ -24,32 +24,32 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, assisted_query_certificate_number FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, assisted_query_certificate_number, like_query_certificate_number FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_refed" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT certificate_number FROM t_account_bak) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, assisted_query_certificate_number FROM t_account_bak) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT cipher_certificate_number AS certificate_number, assisted_query_certificate_number, like_query_certificate_number FROM t_account_bak) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_alias" db-types="MySQL">
         <input sql="SELECT o.certificate_number FROM (SELECT a.certificate_number FROM t_account a) o" />
-        <output sql="SELECT o.certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number, a.assisted_query_certificate_number FROM t_account a) o" />
+        <output sql="SELECT o.certificate_number FROM (SELECT a.cipher_certificate_number AS certificate_number, a.assisted_query_certificate_number, a.like_query_certificate_number FROM t_account a) o" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account a) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`assisted_query_certificate_number`, a.`cipher_password` AS `password`, a.`assisted_query_password`, a.`cipher_amount` AS `amount` FROM t_account a) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.`account_id`, a.`cipher_certificate_number` AS `certificate_number`, a.`assisted_query_certificate_number`, a.`like_query_certificate_number`, a.`cipher_password` AS `password`, a.`assisted_query_password`, a.`like_query_password`, a.`cipher_amount` AS `amount` FROM t_account a) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project_alias_quote" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT a.* FROM t_account `a`) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`cipher_password` AS `password`, `a`.`assisted_query_password`, `a`.`cipher_amount` AS `amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT `a`.`account_id`, `a`.`cipher_certificate_number` AS `certificate_number`, `a`.`assisted_query_certificate_number`, `a`.`like_query_certificate_number`, `a`.`cipher_password` AS `password`, `a`.`assisted_query_password`, `a`.`like_query_password`, `a`.`cipher_amount` AS `amount` FROM t_account `a`) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_segment_with_shorthand_project" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT * FROM t_account) o, t_account u WHERE o.certificate_number=u.certificate_number AND u.password=?" parameters="1" />
-        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number`, t_account.`assisted_query_certificate_number`, t_account.`cipher_password` AS `password`, t_account.`assisted_query_password`, t_account.`cipher_amount` AS `amount` FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
+        <output sql="SELECT u.amount, u.password, o.certificate_number FROM (SELECT t_account.`account_id`, t_account.`cipher_certificate_number` AS `certificate_number`, t_account.`assisted_query_certificate_number`, t_account.`like_query_certificate_number`, t_account.`cipher_password` AS `password`, t_account.`assisted_query_password`, t_account.`like_query_password`, t_account.`cipher_amount` AS `amount` FROM t_account) o, t_account u WHERE o.assisted_query_certificate_number=u.assisted_query_certificate_number AND u.assisted_query_password=?" parameters="assisted_query_1" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_right_equal_condition" db-types="MySQL">
@@ -64,7 +64,7 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_table_with_alias" db-types="MySQL">
         <input sql="SELECT count(*) as cnt FROM (SELECT ab.certificate_number FROM t_account ab) X" />
-        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number, ab.assisted_query_certificate_number FROM t_account ab) X" />
+        <output sql="SELECT count(*) as cnt FROM (SELECT ab.cipher_certificate_number AS certificate_number, ab.assisted_query_certificate_number, ab.like_query_certificate_number FROM t_account ab) X" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_left_and_right_equal_condition" db-types="MySQL">
@@ -74,12 +74,12 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_exists" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, u.certificate_number FROM t_account_bak u WHERE EXISTS(SELECT b.certificate_number from t_account b where b.certificate_number=u.certificate_number)" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, u.cipher_certificate_number AS certificate_number FROM t_account_bak u WHERE EXISTS(SELECT b.cipher_certificate_number from t_account b where b.assisted_query_certificate_number=u.assisted_query_certificate_number)" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, u.cipher_certificate_number AS certificate_number FROM t_account_bak u WHERE EXISTS(SELECT b.cipher_certificate_number AS certificate_number from t_account b where b.assisted_query_certificate_number=u.assisted_query_certificate_number)" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_not_exists" db-types="MySQL">
         <input sql="SELECT u.amount, u.password, u.certificate_number FROM t_account_bak u WHERE NOT EXISTS(SELECT b.certificate_number from t_account b where b.certificate_number=u.certificate_number)" />
-        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, u.cipher_certificate_number AS certificate_number FROM t_account_bak u WHERE NOT EXISTS(SELECT b.cipher_certificate_number from t_account b where b.assisted_query_certificate_number=u.assisted_query_certificate_number)" />
+        <output sql="SELECT u.cipher_amount AS amount, u.cipher_password AS password, u.cipher_certificate_number AS certificate_number FROM t_account_bak u WHERE NOT EXISTS(SELECT b.cipher_certificate_number AS certificate_number from t_account b where b.assisted_query_certificate_number=u.assisted_query_certificate_number)" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_not_nested_subquery_in_predicate_in_condition" db-types="MySQL">
@@ -89,12 +89,12 @@
 
     <rewrite-assertion id="select_not_nested_subquery_in_tablesegment_from_alias" db-types="MySQL">
         <input sql="SELECT b.certificate_number, b.amount FROM (SELECT a.certificate_number as certificate_number, a.amount FROM t_account a WHERE a.amount = 1373) b" />
-        <output sql="SELECT b.certificate_number, b.amount FROM (SELECT a.cipher_certificate_number AS certificate_number, a.assisted_query_certificate_number, a.cipher_amount AS amount FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
+        <output sql="SELECT b.certificate_number, b.amount FROM (SELECT a.cipher_certificate_number AS certificate_number, a.assisted_query_certificate_number, a.like_query_certificate_number, a.cipher_amount AS amount FROM t_account a WHERE a.cipher_amount = 'encrypt_1373') b" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_with_exists_sub_query" db-types="MySQL">
         <input sql="SELECT out_table.amount FROM t_account out_table WHERE EXISTS (SELECT inner_table.amount FROM t_account inner_table)" />
-        <output sql="SELECT out_table.cipher_amount AS amount FROM t_account out_table WHERE EXISTS (SELECT inner_table.cipher_amount FROM t_account inner_table)" />
+        <output sql="SELECT out_table.cipher_amount AS amount FROM t_account out_table WHERE EXISTS (SELECT inner_table.cipher_amount AS amount FROM t_account inner_table)" />
     </rewrite-assertion>
 
     <rewrite-assertion id="select_sub_query_with_order_by" db-types="MySQL">


### PR DESCRIPTION
Ref #28016.

Changes proposed in this pull request:
  - Fix exception caused by missing like query column in table subquery
  - add integration test case and sql rewrite test case

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
