### PR TITLE
Refactor : remove openGauss from sql-e2e workflow

### DIFF
--- a/.github/workflows/e2e-sql.yml
+++ b/.github/workflows/e2e-sql.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         adapter: [ proxy, jdbc ]
         mode: [ Standalone, Cluster ]
-        database: [ MySQL, PostgreSQL, openGauss ]
+        database: [ MySQL, PostgreSQL ]
         # Fix me #25051
         #scenario: [ dbtbl_with_readwrite_splitting, dbtbl_with_readwrite_splitting_and_encrypt, sharding_and_encrypt, encrypt_and_readwrite_splitting, encrypt_shadow, readwrite_splitting_and_shadow, sharding_and_shadow, sharding_encrypt_shadow, mask_encrypt, mask_sharding, mask_encrypt_sharding ]
         scenario: [ empty_rules, rdl_empty_rules, passthrough, tbl, encrypt, readwrite_splitting, shadow, mask, dbtbl_with_readwrite_splitting_and_encrypt, sharding_and_encrypt, encrypt_and_readwrite_splitting, encrypt_shadow, readwrite_splitting_and_shadow, sharding_and_shadow, sharding_encrypt_shadow, mask_encrypt, mask_sharding, mask_encrypt_sharding ]


### PR DESCRIPTION
Changes proposed in this pull request:
  - Refactor : remove openGauss from sql-e2e workflow

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
