### PR TITLE
Support oracle modifyTableDefaultAttrs and setSubpartitionTemplate syntax

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -261,6 +261,7 @@ relationalProperty
 
 columnDefinition
     : columnName dataType SORT? visibleClause (defaultNullClause expr | identityClause)? (ENCRYPT encryptionSpecification)? (inlineConstraint+ | inlineRefConstraint)?
+    | REF LP_ columnName RP_ WITH ROWID
     ;
 
 visibleClause

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -1274,11 +1274,22 @@ alterSynonym
     ;
 
 alterTablePartitioning
-    : modifyTablePartition
+    : modifyTableDefaultAttrs
+    | setSubpartitionTemplate
+    | modifyTablePartition
     | moveTablePartition
     | addTablePartition
     | coalesceTablePartition
     | dropTablePartition
+    ;
+
+modifyTableDefaultAttrs
+    : MODIFY DEFAULT ATTRIBUTES (FOR partitionExtendedName)? (DEFAULT DIRECTORY directoryName)? deferredSegmentCreation? readOnlyClause? indexingClause? segmentAttributesClause? alterOverflowClause?
+    ( ((LOB LP_ lobItem RP_ | VARRAY varrayType) LP_ lobParameters RP_)+)?
+    ;
+
+setSubpartitionTemplate
+    : SET SUBPARTITION TEMPLATE (LP_ (rangeSubpartitionDesc (COMMA_ rangeSubpartitionDesc)* | listSubpartitionDesc (COMMA_ listSubpartitionDesc)* | individualHashSubparts (COMMA_ individualHashSubparts)*)? RP_ | hashSubpartitionQuantity)
     ;
 
 modifyTablePartition
@@ -1329,7 +1340,7 @@ addListSubpartition
     ;
 
 coalesceTableSubpartition
-    : COALESCE SUBPARTITION subpartitionName updateIndexClauses? parallelClause? allowDisallowClustering?
+    : COALESCE SUBPARTITION subpartitionName? updateIndexClauses? parallelClause? allowDisallowClustering?
     ;
 
 allowDisallowClustering

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
@@ -385,7 +385,7 @@ public final class OracleDDLStatementVisitor extends OracleStatementVisitor impl
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
+        DataTypeSegment dataType = null != ctx.dataType() ? (DataTypeSegment) visit(ctx.dataType()) : null;
         boolean isPrimaryKey = ctx.inlineConstraint().stream().anyMatch(each -> null != each.primaryKey());
         boolean isNotNull = ctx.inlineConstraint().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull);

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1380,4 +1380,13 @@
     <alter-table sql-case-id="alter_table_modify_default_attributes_for_partition_tablespace">
         <table name="emp" start-index="12" stop-index="14" />
     </alter-table>
+    
+    <alter-table sql-case-id="alter_table_ref_with_rowid">
+        <table name="emp" start-index="12" stop-index="14" />
+        <add-column>
+            <column-definition start-index="21" stop-index="48">
+                <column name="column_value" />
+            </column-definition>
+        </add-column>
+    </alter-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/case/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/alter-table.xml
@@ -1364,4 +1364,20 @@
     <alter-table sql-case-id="alter_table_enable_novalidate_primary_key_enable_novalidate_constraint">
         <table name="mytable" start-index="12" stop-index="18" />
     </alter-table>
+    
+    <alter-table sql-case-id="alter_table_modify_partition_coalesce_subpartition">
+        <table name="mytable" start-index="12" stop-index="18" />
+    </alter-table>
+    
+    <alter-table sql-case-id="alter_table_set_subpartition_template1">
+        <table name="mytable" start-index="12" stop-index="18" />
+    </alter-table>
+    
+    <alter-table sql-case-id="alter_table_set_subpartition_template2">
+        <table name="emp_sub_template" start-index="12" stop-index="27" />
+    </alter-table>
+    
+    <alter-table sql-case-id="alter_table_modify_default_attributes_for_partition_tablespace">
+        <table name="emp" start-index="12" stop-index="14" />
+    </alter-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -176,4 +176,8 @@
     <sql-case id="alter_table_enable_novalidate_constraint" value="ALTER TABLE dept ENABLE NOVALIDATE CONSTRAINT dname_ukey" db-types="Oracle" />
     <sql-case id="alter_table_add_encrypt_no_salt" value="ALTER TABLE mytable ADD (online_acct_pw VARCHAR2(8) ENCRYPT NO SALT 'NOMAC')" db-types="Oracle" />
     <sql-case id="alter_table_enable_novalidate_primary_key_enable_novalidate_constraint" value="ALTER TABLE mytable ENABLE NOVALIDATE PRIMARY KEY ENABLE NOVALIDATE CONSTRAINT emp_last_name_nn" db-types="Oracle" />
+    <sql-case id="alter_table_modify_partition_coalesce_subpartition" value="ALTER TABLE mytable MODIFY PARTITION us_locations COALESCE SUBPARTITION" db-types="Oracle" />
+    <sql-case id="alter_table_set_subpartition_template1" value="ALTER TABLE mytable SET SUBPARTITION TEMPLATE (SUBPARTITION e TABLESPACE ts1, SUBPARTITION f TABLESPACE ts2, SUBPARTITION g TABLESPACE ts3, SUBPARTITION h TABLESPACE ts4)" db-types="Oracle" />
+    <sql-case id="alter_table_set_subpartition_template2" value="ALTER TABLE emp_sub_template SET SUBPARTITION TEMPLATE()" db-types="Oracle" />
+    <sql-case id="alter_table_modify_default_attributes_for_partition_tablespace" value="ALTER TABLE emp MODIFY DEFAULT ATTRIBUTES FOR PARTITION p1 TABLESPACE ts1" db-types="Oracle" />
 </sql-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/alter-table.xml
@@ -180,4 +180,5 @@
     <sql-case id="alter_table_set_subpartition_template1" value="ALTER TABLE mytable SET SUBPARTITION TEMPLATE (SUBPARTITION e TABLESPACE ts1, SUBPARTITION f TABLESPACE ts2, SUBPARTITION g TABLESPACE ts3, SUBPARTITION h TABLESPACE ts4)" db-types="Oracle" />
     <sql-case id="alter_table_set_subpartition_template2" value="ALTER TABLE emp_sub_template SET SUBPARTITION TEMPLATE()" db-types="Oracle" />
     <sql-case id="alter_table_modify_default_attributes_for_partition_tablespace" value="ALTER TABLE emp MODIFY DEFAULT ATTRIBUTES FOR PARTITION p1 TABLESPACE ts1" db-types="Oracle" />
+    <sql-case id="alter_table_ref_with_rowid" value="ALTER TABLE emp ADD (REF(column_value) WITH ROWID)" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
Fixes #26980.

Changes proposed in this pull request:
  - Support oracle modifyTableDefaultAttrs and setSubpartitionTemplate syntax
  - Add test sql

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ✓] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ✓] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ✓] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ✓] I have added corresponding unit tests for my changes.
