### PR TITLE
Fix oracle parse wrong result when sql statement contains ANY subquery

### DIFF
--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/ExpressionSegmentBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/ExpressionSegmentBinder.java
@@ -22,12 +22,14 @@ import lombok.NoArgsConstructor;
 import org.apache.shardingsphere.infra.binder.segment.expression.impl.BinaryOperationExpressionBinder;
 import org.apache.shardingsphere.infra.binder.segment.expression.impl.ExistsSubqueryExpressionBinder;
 import org.apache.shardingsphere.infra.binder.segment.expression.impl.InExpressionBinder;
+import org.apache.shardingsphere.infra.binder.segment.expression.impl.NotExpressionBinder;
 import org.apache.shardingsphere.infra.binder.segment.expression.impl.SubqueryExpressionSegmentBinder;
 import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.BinaryOperationExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExistsSubqueryExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.InExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.NotExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
 
 /**
@@ -56,6 +58,9 @@ public final class ExpressionSegmentBinder {
         }
         if (segment instanceof InExpression) {
             return InExpressionBinder.bind((InExpression) segment, metaData, defaultDatabaseName);
+        }
+        if (segment instanceof NotExpression) {
+            return NotExpressionBinder.bind((NotExpression) segment, metaData, defaultDatabaseName);
         }
         // TODO support more ExpressionSegment bind
         return segment;

--- a/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/NotExpressionBinder.java
+++ b/infra/binder/src/main/java/org/apache/shardingsphere/infra/binder/segment/expression/impl/NotExpressionBinder.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.infra.binder.segment.expression.impl;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.apache.shardingsphere.infra.binder.segment.expression.ExpressionSegmentBinder;
+import org.apache.shardingsphere.infra.metadata.ShardingSphereMetaData;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.NotExpression;
+
+/**
+ * Not expression binder.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class NotExpressionBinder {
+    
+    /**
+     * Bind not expression segment with metadata.
+     *
+     * @param segment not expression
+     * @param metaData metaData
+     * @param defaultDatabaseName default database name
+     * @return bounded not expression
+     */
+    public static NotExpression bind(final NotExpression segment, final ShardingSphereMetaData metaData, final String defaultDatabaseName) {
+        ExpressionSegment boundedExpression = ExpressionSegmentBinder.bind(segment.getExpression(), metaData, defaultDatabaseName);
+        return new NotExpression(segment.getStartIndex(), segment.getStopIndex(), boundedExpression, segment.getNotSign());
+    }
+}

--- a/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/util/ProjectionUtilsTest.java
+++ b/infra/binder/src/test/java/org/apache/shardingsphere/infra/binder/segment/select/projection/util/ProjectionUtilsTest.java
@@ -17,11 +17,12 @@
 
 package org.apache.shardingsphere.infra.binder.segment.select.projection.util;
 
-import org.apache.shardingsphere.infra.database.enums.QuoteCharacter;
-import org.apache.shardingsphere.infra.database.mysql.MySQLDatabaseType;
-import org.apache.shardingsphere.infra.database.opengauss.OpenGaussDatabaseType;
-import org.apache.shardingsphere.infra.database.oracle.OracleDatabaseType;
-import org.apache.shardingsphere.infra.database.postgresql.PostgreSQLDatabaseType;
+import org.apache.shardingsphere.infra.binder.context.segment.select.projection.util.ProjectionUtils;
+import org.apache.shardingsphere.infra.database.core.metadata.database.enums.QuoteCharacter;
+import org.apache.shardingsphere.infra.database.mysql.type.MySQLDatabaseType;
+import org.apache.shardingsphere.infra.database.opengauss.type.OpenGaussDatabaseType;
+import org.apache.shardingsphere.infra.database.oracle.type.OracleDatabaseType;
+import org.apache.shardingsphere.infra.database.postgresql.type.PostgreSQLDatabaseType;
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.junit.jupiter.api.Test;
 
@@ -30,10 +31,9 @@ import static org.hamcrest.Matchers.is;
 
 class ProjectionUtilsTest {
     
-    private final IdentifierValue alias = new IdentifierValue("Data", QuoteCharacter.NONE);
-    
     @Test
     void assertGetColumnLabelFromAlias() {
+        IdentifierValue alias = new IdentifierValue("Data", QuoteCharacter.NONE);
         assertThat(ProjectionUtils.getColumnLabelFromAlias(new IdentifierValue("Data", QuoteCharacter.QUOTE), new PostgreSQLDatabaseType()), is("Data"));
         assertThat(ProjectionUtils.getColumnLabelFromAlias(alias, new PostgreSQLDatabaseType()), is("data"));
         assertThat(ProjectionUtils.getColumnLabelFromAlias(alias, new OpenGaussDatabaseType()), is("data"));
@@ -43,11 +43,11 @@ class ProjectionUtilsTest {
     
     @Test
     void assertGetColumnNameFromFunction() {
-        String functionName = "Function";
-        String functionExpression = "FunctionExpression";
-        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new PostgreSQLDatabaseType()), is("function"));
-        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new OpenGaussDatabaseType()), is("function"));
-        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new OracleDatabaseType()), is("FUNCTIONEXPRESSION"));
-        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new MySQLDatabaseType()), is("FunctionExpression"));
+        String functionName = "Cast";
+        String functionExpression = "Cast(order_id AS INT)";
+        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new PostgreSQLDatabaseType()), is("cast"));
+        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new OpenGaussDatabaseType()), is("cast"));
+        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new OracleDatabaseType()), is("CAST(ORDER_IDASINT)"));
+        assertThat(ProjectionUtils.getColumnNameFromFunction(functionName, functionExpression, new MySQLDatabaseType()), is("Cast(order_id AS INT)"));
     }
 }

--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/BaseRule.g4
@@ -667,8 +667,8 @@ booleanPrimary
     | PRIOR predicate
     | CONNECT_BY_ROOT predicate
     | booleanPrimary SAFE_EQ_ predicate
-    | booleanPrimary comparisonOperator predicate
     | booleanPrimary comparisonOperator (ALL | ANY) subquery
+    | booleanPrimary comparisonOperator predicate
     | predicate
     ;
 

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/OracleStatementVisitor.java
@@ -393,46 +393,44 @@ public abstract class OracleStatementVisitor extends OracleStatementBaseVisitor<
     
     @Override
     public final ASTNode visitBooleanPrimary(final BooleanPrimaryContext ctx) {
-        if (null == ctx.IS()) {
-            return null == ctx.comparisonOperator() && null == ctx.SAFE_EQ_() ? visit(ctx.predicate()) : createCompareSegment(ctx);
+        if (null != ctx.IS()) {
+            String rightText = "";
+            if (null != ctx.NOT()) {
+                rightText = rightText.concat(ctx.start.getInputStream().getText(new Interval(ctx.NOT().getSymbol().getStartIndex(), ctx.NOT().getSymbol().getStopIndex()))).concat(" ");
+            }
+            Token operatorToken = null;
+            if (null != ctx.NULL()) {
+                operatorToken = ctx.NULL().getSymbol();
+            }
+            if (null != ctx.TRUE()) {
+                operatorToken = ctx.TRUE().getSymbol();
+            }
+            if (null != ctx.FALSE()) {
+                operatorToken = ctx.FALSE().getSymbol();
+            }
+            int startIndex = null == operatorToken ? ctx.IS().getSymbol().getStopIndex() + 2 : operatorToken.getStartIndex();
+            rightText = rightText.concat(ctx.start.getInputStream().getText(new Interval(startIndex, ctx.stop.getStopIndex())));
+            ExpressionSegment right = new LiteralExpressionSegment(ctx.IS().getSymbol().getStopIndex() + 2, ctx.stop.getStopIndex(), rightText);
+            String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
+            ExpressionSegment left = (ExpressionSegment) visit(ctx.booleanPrimary());
+            String operator = "IS";
+            return new BinaryOperationExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), left, right, operator, text);
         }
-        String rightText = "";
-        if (null != ctx.NOT()) {
-            rightText = rightText.concat(ctx.start.getInputStream().getText(new Interval(ctx.NOT().getSymbol().getStartIndex(), ctx.NOT().getSymbol().getStopIndex()))).concat(" ");
+        if (null != ctx.comparisonOperator() || null != ctx.SAFE_EQ_()) {
+            return createCompareSegment(ctx);
         }
-        Token operatorToken = null;
-        if (null != ctx.NULL()) {
-            operatorToken = ctx.NULL().getSymbol();
-        }
-        if (null != ctx.TRUE()) {
-            operatorToken = ctx.TRUE().getSymbol();
-        }
-        if (null != ctx.FALSE()) {
-            operatorToken = ctx.FALSE().getSymbol();
-        }
-        int startIndex = null == operatorToken ? ctx.IS().getSymbol().getStopIndex() + 2 : operatorToken.getStartIndex();
-        rightText = rightText.concat(ctx.start.getInputStream().getText(new Interval(startIndex, ctx.stop.getStopIndex())));
-        ExpressionSegment right = new LiteralExpressionSegment(ctx.IS().getSymbol().getStopIndex() + 2, ctx.stop.getStopIndex(), rightText);
-        String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
-        ExpressionSegment left = (ExpressionSegment) visit(ctx.booleanPrimary());
-        String operator = "IS";
-        return new BinaryOperationExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), left, right, operator, text);
+        return visit(ctx.predicate());
     }
     
     private ASTNode createCompareSegment(final BooleanPrimaryContext ctx) {
         ExpressionSegment left = (ExpressionSegment) visit(ctx.booleanPrimary());
         ExpressionSegment right;
-        String operator;
-        if (null != ctx.ALL()) {
-            operator = null != ctx.SAFE_EQ_() ? ctx.SAFE_EQ_().getText() : ctx.comparisonOperator().getText() + " ALL";
-        } else {
-            operator = null != ctx.SAFE_EQ_() ? ctx.SAFE_EQ_().getText() : ctx.comparisonOperator().getText();
-        }
         if (null != ctx.predicate()) {
             right = (ExpressionSegment) visit(ctx.predicate());
         } else {
             right = new SubqueryExpressionSegment(new SubquerySegment(ctx.subquery().start.getStartIndex(), ctx.subquery().stop.getStopIndex(), (OracleSelectStatement) visit(ctx.subquery())));
         }
+        String operator = null != ctx.SAFE_EQ_() ? ctx.SAFE_EQ_().getText() : ctx.comparisonOperator().getText();
         String text = ctx.start.getInputStream().getText(new Interval(ctx.start.getStartIndex(), ctx.stop.getStopIndex()));
         return new BinaryOperationExpression(ctx.start.getStartIndex(), ctx.stop.getStopIndex(), left, right, operator, text);
     }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtils.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/util/SubqueryExtractUtils.java
@@ -27,6 +27,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExistsSu
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.InExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.ListExpression;
+import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.NotExpression;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubqueryExpressionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.expr.subquery.SubquerySegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.item.ProjectionSegment;
@@ -145,6 +146,9 @@ public final class SubqueryExtractUtils {
         if (expressionSegment instanceof BetweenExpression) {
             extractSubquerySegmentsFromWhere(result, ((BetweenExpression) expressionSegment).getBetweenExpr());
             extractSubquerySegmentsFromWhere(result, ((BetweenExpression) expressionSegment).getAndExpr());
+        }
+        if (expressionSegment instanceof NotExpression) {
+            extractSubquerySegmentsFromWhere(result, ((NotExpression) expressionSegment).getExpression());
         }
     }
 }


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix oracle parse wrong result when sql statement contains ANY subquery

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
