### PR TITLE
Support parsing openGauss DROP USER sql

### DIFF
--- a/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DCLStatement.g4
+++ b/parser/sql/dialect/opengauss/src/main/antlr4/imports/opengauss/DCLStatement.g4
@@ -56,8 +56,12 @@ alterOptRoleElem
     | identifier
     ;
 
+dropBehavior
+    : CASCADE | RESTRICT
+    ;
+
 dropUser
-    : DROP USER ifExists? roleList
+    : DROP USER ifExists? nameList dropBehavior?
     ;
 
 alterUser

--- a/test/it/parser/src/main/resources/case/dcl/drop-user.xml
+++ b/test/it/parser/src/main/resources/case/dcl/drop-user.xml
@@ -21,6 +21,7 @@
     <drop-user sql-case-id="drop_user_with_hostname" />
     <drop-user sql-case-id="drop_user_with_ip" />
     <drop-user sql-case-id="drop_user_cascade" />
+    <drop-user sql-case-id="drop_user_restrict" />
     <drop-user sql-case-id="drop_user" />
     <drop-user sql-case-id="drop_users" />
     <drop-user sql-case-id="drop_user_if_exists" />

--- a/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
+++ b/test/it/parser/src/main/resources/sql/supported/dcl/drop-user.xml
@@ -20,7 +20,8 @@
     <sql-case id="drop_user_without_hostname" value="DROP USER user_dev" db-types="Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_user_with_hostname" value="DROP USER user_dev@localhost" db-types="MySQL,Oracle" />
     <sql-case id="drop_user_with_ip" value="DROP USER u1@120.0.0.1" db-types="MySQL,Oracle" />
-    <sql-case id="drop_user_cascade" value="DROP USER user_dev CASCADE" db-types="Oracle" />
+    <sql-case id="drop_user_cascade" value="DROP USER user_dev CASCADE" db-types="Oracle,openGauss" />
+    <sql-case id="drop_user_restrict" value="DROP USER user_name RESTRICT" db-types="openGauss" />
     <sql-case id="drop_user" value="DROP USER user1" db-types="MySQL,Oracle,PostgreSQL,openGauss,SQLServer" />
     <sql-case id="drop_users" value="DROP USER user1, user2" db-types="MySQL,PostgreSQL,openGauss" />
     <sql-case id="drop_user_if_exists" value="DROP USER IF EXISTS user1" db-types="MySQL,PostgreSQL,openGauss,SQLServer" />


### PR DESCRIPTION
Fixes #27640.

Changes proposed in this pull request:
  - Add support for parsing `DROP USER` with `CASCADE` and `RESTRICT`
  - Add tests

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
