### PR TITLE
Use Awaitility replace Unreliables at E2E

### DIFF
--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
@@ -37,17 +37,13 @@ public final class JdbcConnectionWaitStrategy extends AbstractWaitStrategy {
     
     @Override
     protected void waitUntilReady() {
-        Awaitility.await().ignoreException(RuntimeException.class).atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::checkConnection);
+        Awaitility.await().ignoreExceptions().atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::checkConnection);
     }
     
-    private boolean checkConnection() {
+    private boolean checkConnection() throws Exception {
         try (Connection ignored = connectionSupplier.call()) {
             log.info("Container ready.");
             return true;
-            // CHECKSTYLE:OFF
-        } catch (final Exception ex) {
-            // CHECKSTYLE:ON
-            throw new RuntimeException("Not Ready yet.", ex);
         }
     }
 }

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
@@ -37,7 +37,7 @@ public final class JdbcConnectionWaitStrategy extends AbstractWaitStrategy {
     
     @Override
     protected void waitUntilReady() {
-        Awaitility.await().atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::mockRateLimiter);
+        Awaitility.await().ignoreException(RuntimeException.class).atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::mockRateLimiter);
     }
     
     private boolean mockRateLimiter() {

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
@@ -19,8 +19,8 @@ package org.apache.shardingsphere.test.e2e.env.container.wait;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
 
 import java.sql.Connection;
 import java.util.concurrent.Callable;
@@ -37,7 +37,7 @@ public final class JdbcConnectionWaitStrategy extends AbstractWaitStrategy {
     
     @Override
     protected void waitUntilReady() {
-        Unreliables.retryUntilSuccess((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, this::mockRateLimiter);
+        Awaitility.await().atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::mockRateLimiter);
     }
     
     private boolean mockRateLimiter() {

--- a/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
+++ b/test/e2e/env/src/test/java/org/apache/shardingsphere/test/e2e/env/container/wait/JdbcConnectionWaitStrategy.java
@@ -37,19 +37,17 @@ public final class JdbcConnectionWaitStrategy extends AbstractWaitStrategy {
     
     @Override
     protected void waitUntilReady() {
-        Awaitility.await().ignoreException(RuntimeException.class).atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::mockRateLimiter);
+        Awaitility.await().ignoreException(RuntimeException.class).atMost(startupTimeout.getSeconds(), TimeUnit.SECONDS).pollInterval(1L, TimeUnit.SECONDS).until(this::checkConnection);
     }
     
-    private boolean mockRateLimiter() {
-        getRateLimiter().doWhenReady(() -> {
-            try (Connection ignored = connectionSupplier.call()) {
-                log.info("Container ready.");
-                // CHECKSTYLE:OFF
-            } catch (final Exception ex) {
-                // CHECKSTYLE:ON
-                throw new RuntimeException("Not Ready yet.", ex);
-            }
-        });
-        return true;
+    private boolean checkConnection() {
+        try (Connection ignored = connectionSupplier.call()) {
+            log.info("Container ready.");
+            return true;
+            // CHECKSTYLE:OFF
+        } catch (final Exception ex) {
+            // CHECKSTYLE:ON
+            throw new RuntimeException("Not Ready yet.", ex);
+        }
     }
 }

--- a/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/mysql.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/mysql.xml
@@ -25,12 +25,4 @@
         INDEX ( `user_id` )
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
     </create-table-order>
-
-    <update-table-order-status>
-        UPDATE t_order SET status= 'unlock'
-    </update-table-order-status>
-
-    <create-index-status>
-        CREATE index idx_order_status ON t_order (status)
-    </create-index-status>
 </command>

--- a/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/postgresql.xml
+++ b/test/e2e/operation/pipeline/src/test/resources/env/scenario/primary_key/text_primary_key/postgresql.xml
@@ -23,12 +23,4 @@
         PRIMARY KEY (order_id)
         )
     </create-table-order>
-    
-    <update-table-order-status>
-        UPDATE t_order SET status= 'unlock'
-    </update-table-order-status>
-    
-    <create-index-status>
-        CREATE INDEX "idx_user_status" ON t_order ( status )
-    </create-index-status>
 </command>


### PR DESCRIPTION


Changes proposed in this pull request:
  - Use Awaitility replace Unreliables
  - Remove unused code

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [ ] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
