### PR TITLE
Fix LocalDateTime type cast exception after MySQL 8.0.23 driver

### DIFF
--- a/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValue.java
+++ b/db-protocol/mysql/src/main/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValue.java
@@ -60,15 +60,14 @@ public final class MySQLDateBinaryProtocolValue implements MySQLBinaryProtocolVa
     
     @Override
     public void write(final MySQLPacketPayload payload, final Object value) {
-        Timestamp timestamp = new Timestamp(((Date) value).getTime());
-        LocalDateTime dateTime = timestamp.toLocalDateTime();
+        LocalDateTime dateTime = value instanceof LocalDateTime ? (LocalDateTime) value : new Timestamp(((Date) value).getTime()).toLocalDateTime();
         int year = dateTime.getYear();
         int month = dateTime.getMonthValue();
         int dayOfMonth = dateTime.getDayOfMonth();
         int hours = dateTime.getHour();
         int minutes = dateTime.getMinute();
         int seconds = dateTime.getSecond();
-        int nanos = timestamp.getNanos();
+        int nanos = dateTime.getNano();
         boolean isTimeAbsent = 0 == hours && 0 == minutes && 0 == seconds;
         boolean isNanosAbsent = 0 == nanos;
         if (isTimeAbsent && isNanosAbsent) {

--- a/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
+++ b/db-protocol/mysql/src/test/java/org/apache/shardingsphere/db/protocol/mysql/packet/command/query/binary/execute/protocol/MySQLDateBinaryProtocolValueTest.java
@@ -92,6 +92,29 @@ class MySQLDateBinaryProtocolValueTest {
     }
     
     @Test
+    void assertWriteLocalDateTimeTypeFourBytes() {
+        MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
+        actual.write(payload, LocalDateTime.of(1970, 1, 14, 0, 0, 0));
+        verify(payload).writeInt1(4);
+        verify(payload).writeInt2(1970);
+        verify(payload).writeInt1(1);
+        verify(payload).writeInt1(14);
+    }
+    
+    @Test
+    void assertWriteLocalDateTimeTypeSevenBytes() {
+        MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
+        actual.write(payload, LocalDateTime.of(1970, 1, 14, 12, 10, 30));
+        verify(payload).writeInt1(7);
+        verify(payload).writeInt2(1970);
+        verify(payload).writeInt1(1);
+        verify(payload).writeInt1(14);
+        verify(payload).writeInt1(12);
+        verify(payload).writeInt1(10);
+        verify(payload).writeInt1(30);
+    }
+    
+    @Test
     void assertWriteWithFourBytes() {
         MySQLDateBinaryProtocolValue actual = new MySQLDateBinaryProtocolValue();
         actual.write(payload, Timestamp.valueOf("1970-01-14 0:0:0"));


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Fix MySQL 8.0.20 driver returns LocalDateTime type cast exception

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added corresponding unit tests for my changes.
