### PR TITLE
Refactor PostgreSQLShardingSphereStatisticsBuilderTest logic

### DIFF
--- a/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/statistics/builder/PostgreSQLShardingSphereStatisticsBuilderTest.java
+++ b/infra/common/src/test/java/org/apache/shardingsphere/infra/metadata/statistics/builder/PostgreSQLShardingSphereStatisticsBuilderTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -51,7 +52,7 @@ class PostgreSQLShardingSphereStatisticsBuilderTest {
     }
     
     private Map<String, ShardingSphereDatabase> mockDatabaseMap() {
-        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class);
+        ShardingSphereDatabase database = mock(ShardingSphereDatabase.class, RETURNS_DEEP_STUBS);
         Map<String, ShardingSphereSchema> schemaMap = mockSchemaMap();
         when(database.getSchemas()).thenReturn(schemaMap);
         return Collections.singletonMap("logic_db", database);


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
  - Refactor PostgreSQLShardingSphereStatisticsBuilderTest logic

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
