### PR TITLE
Fixes `OutOfMemoryError` unique to building GraalVM Native Image on Github Actions devices

### DIFF
--- a/distribution/proxy-native/pom.xml
+++ b/distribution/proxy-native/pom.xml
@@ -107,6 +107,7 @@
                             <verbose>true</verbose>
                             <buildArgs>
                                 <arg>--report-unsupported-elements-at-runtime</arg>
+                                <arg>-J-Xmx7g</arg>
                             </buildArgs>
                             <metadataRepository>
                                 <enabled>true</enabled>


### PR DESCRIPTION
For #21347.

Changes proposed in this pull request:
  - Fixes `OutOfMemoryError` unique to building GraalVM Native Image on Github Actions devices. Refer to https://github.com/apache/shardingsphere/actions/runs/5928664616/job/16074760055 .
  - Discussions about this CI are located in https://github.com/oracle/graal/issues/7214 .

---

Before committing this PR, I'm sure that I have checked the following options:
- [x] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [x] I have self-reviewed the commit code.
- [x] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
