### PR TITLE
Change group id to com.mysql of mysql 8.0.31 in agent

### DIFF
--- a/test/e2e/agent/plugins/logging/file/pom.xml
+++ b/test/e2e/agent/plugins/logging/file/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql-connector-java.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/test/e2e/agent/plugins/metrics/prometheus/pom.xml
+++ b/test/e2e/agent/plugins/metrics/prometheus/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql-connector-java.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/test/e2e/agent/plugins/tracing/jaeger/pom.xml
+++ b/test/e2e/agent/plugins/tracing/jaeger/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql-connector-java.version}</version>
             <scope>runtime</scope>
         </dependency>

--- a/test/e2e/agent/plugins/tracing/zipkin/pom.xml
+++ b/test/e2e/agent/plugins/tracing/zipkin/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
         
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
             <version>${mysql-connector-java.version}</version>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
Fixes #28254.

Changes proposed in this pull request:
  - Change group id to com.mysql of mysql 8.0.31 in agent

---

Before committing this PR, I'm sure that I have checked the following options:
- [ ] My code follows the [code of conduct](https://shardingsphere.apache.org/community/en/involved/conduct/code/) of this project.
- [ ] I have self-reviewed the commit code.
- [ ] I have (or in comment I request) added corresponding labels for the pull request.
- [x] I have passed maven check locally : `./mvnw clean install -B -T1C -Dmaven.javadoc.skip -Dmaven.jacoco.skip -e`.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added corresponding unit tests for my changes.
