### PR TITLE
[Oracle SQL] Support REF column in create table clause

### DIFF
--- a/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
+++ b/parser/sql/dialect/oracle/src/main/antlr4/imports/oracle/DDLStatement.g4
@@ -260,7 +260,7 @@ relationalProperty
     ;
 
 columnDefinition
-    : columnName dataType SORT? visibleClause (defaultNullClause expr | identityClause)? (ENCRYPT encryptionSpecification)? (inlineConstraint+ | inlineRefConstraint)?
+    : columnName REF? dataType SORT? visibleClause (defaultNullClause expr | identityClause)? (ENCRYPT encryptionSpecification)? (inlineConstraint+ | inlineRefConstraint)?
     | REF LP_ columnName RP_ WITH ROWID
     ;
 

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
@@ -391,7 +391,6 @@ public final class OracleDDLStatementVisitor extends OracleStatementVisitor impl
         boolean isNotNull = ctx.inlineConstraint().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull);
         if (null != ctx.REF() && null != ctx.dataType()) {
-            // Indicate that this column is a REF
             result.setRef(true);
         }
         for (InlineConstraintContext each : ctx.inlineConstraint()) {

--- a/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
+++ b/parser/sql/dialect/oracle/src/main/java/org/apache/shardingsphere/sql/parser/oracle/visitor/statement/type/OracleDDLStatementVisitor.java
@@ -390,6 +390,10 @@ public final class OracleDDLStatementVisitor extends OracleStatementVisitor impl
         boolean isPrimaryKey = ctx.inlineConstraint().stream().anyMatch(each -> null != each.primaryKey());
         boolean isNotNull = ctx.inlineConstraint().stream().anyMatch(each -> null != each.NOT() && null != each.NULL());
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, isNotNull);
+        if (null != ctx.REF() && null != ctx.dataType()) {
+            // Indicate that this column is a REF
+            result.setRef(true);
+        }
         for (InlineConstraintContext each : ctx.inlineConstraint()) {
             if (null != each.referencesClause()) {
                 result.getReferencedTables().add((SimpleTableSegment) visit(each.referencesClause().tableName()));

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
@@ -47,4 +47,10 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     private final boolean notNull;
     
     private final Collection<SimpleTableSegment> referencedTables = new LinkedList<>();
+    
+    private boolean isRef;
+    
+    public void setRef(boolean ref) {
+        isRef = ref;
+    }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
@@ -50,7 +50,7 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     
     private boolean isRef;
     
-    public void setRef(boolean ref) {
+    public void setRef(final boolean ref) {
         isRef = ref;
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/common/segment/ddl/column/ColumnDefinitionSegment.java
@@ -19,6 +19,7 @@ package org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.column.ColumnSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.generic.DataTypeSegment;
@@ -48,9 +49,6 @@ public final class ColumnDefinitionSegment implements CreateDefinitionSegment {
     
     private final Collection<SimpleTableSegment> referencedTables = new LinkedList<>();
     
+    @Setter
     private boolean isRef;
-    
-    public void setRef(final boolean ref) {
-        isRef = ref;
-    }
 }

--- a/test/it/parser/src/main/resources/case/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/case/ddl/create-table.xml
@@ -2021,4 +2021,15 @@
             <column name="COL4" />
         </column-definition>
     </create-table>
+
+    <create-table sql-case-id="create_table_with_ref_data_type">
+        <table name="location_table" start-index="13" stop-index="26"  />
+        <column-definition type="NUMBER" start-index="29" stop-index="50">
+            <column name="location_number" />
+        </column-definition>
+        <column-definition type="warehouse_typ" start-index="53" stop-index="103">
+            <column name="building" />
+            <referenced-table name="warehouse_table" start-index="89" stop-index="103" />
+        </column-definition>
+    </create-table>
 </sql-parser-test-cases>

--- a/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
+++ b/test/it/parser/src/main/resources/sql/supported/ddl/create-table.xml
@@ -148,4 +148,5 @@
     <sql-case id="create_table_with_unsigned_int" value="CREATE TABLE t_order (order_id INT, user_id INT, status UNSIGNED INT)" db-types="MySQL" />
     <sql-case id="create_table_with_partition_less_than" value="CREATE TABLE t_sales (order_id INTEGER NOT NULL, goods_name CHAR(20) NOT NULL, sales_date DATE NOT NULL, sales_volume INTEGER, sales_store CHAR(20), PRIMARY KEY ( order_id )) PARTITION BY RANGE (sales_date) (PARTITION season1 VALUES LESS THAN('2023-04-01 00:00:00'),PARTITION season2 VALUES LESS THAN('2023-07-01 00:00:00'),PARTITION season3 VALUES LESS THAN('2023-10-01 00:00:00'),PARTITION season4 VALUES LESS THAN(MAXVALUE))" db-types="openGauss"/>
     <sql-case id="create_table_with_negative_data_type" value="CREATE TABLE T(COL1 NUMBER, COL2 NUMBER(3), COL3 NUMBER(3,2), COL4 NUMBER(6,-2))" db-types="Oracle" />
+    <sql-case id="create_table_with_ref_data_type" value="CREATE TABLE location_table (location_number NUMBER, building REF warehouse_typ SCOPE IS warehouse_table);" db-types="Oracle" />
 </sql-cases>


### PR DESCRIPTION
In this PR, I fixed the follwing SQL:
`CREATE TABLE location_table (location_number NUMBER, building REF warehouse_typ SCOPE IS warehouse_table);`
REF column is allowd in ColumnDefinitionClause of Oracle, the references are listed here:
https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/CREATE-TABLE.html#GUID-F9CE0CC3-13AE-4744-A43C-EAC7A71AAAB6
https://docs.oracle.com/en/database/oracle/oracle-database/21/adobj/design-considerations-for-REFs.html#GUID-078BD058-FE2C-4FC5-8418-CD95F085CBD6

<img width="941" alt="截屏2023-08-26 12 05 28" src="https://github.com/apache/shardingsphere/assets/108499334/620c8fdd-9f36-4c9a-9813-0237cf482b6f">

The related issue: https://github.com/apache/shardingsphere/issues/27569
